### PR TITLE
This commit is fixing the network-manager package detection (use dpkg-query instead of dpkg -l)

### DIFF
--- a/waagent
+++ b/waagent
@@ -1843,7 +1843,7 @@ class Agent(Util):
         if os.path.exists("/dev/sr0"):
             dvd = "/dev/sr0"
         modloaded=False
-        if Run("fdisk -l " + dvd + " | grep Disk",chk_err=False):
+        if Run("LC_ALL=C fdisk -l " + dvd + " | grep Disk",chk_err=False):
             # Is it possible to load a module for ata_piix?
             retcode,krn=RunGetOutput('uname -r')
             if retcode:


### PR DESCRIPTION
Using dpkg-query -s is more appropriate than using dpkg -l and grep -q.
The only way to have 0 returned by dpkg-query -s is to have NM installed
and dpkg -l |grep -q may return 1 if the package is not yet known in the
base (for instance, right after installing).

Signed-off-by: Arnaud Patard apatard@hupstream.com
