### PR TITLE
Fix - Agent hangs during provisioning processes

### DIFF
--- a/waagent
+++ b/waagent
@@ -1583,7 +1583,7 @@ class Agent(Util):
                 sendData = self.BuildDhcpRequest()
                 LogWithPrefixIfVerbose("DHCP request:", HexDump(sendData, len(sendData)))
                 sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
-                # Set timeout to handle < 1024 sock.recv responces
+                # Set timeout to handle smaller than 1024 sized sock.recv responses
                 sock.settimeout(5)
                 sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
                 sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)


### PR DESCRIPTION
set socket timeout on dhcp request to handle < 1024 sized responses

blocking socket.recv without timeout would hang indefinitely, causing VM to never fully provision.
