### PR TITLE
Adding SSH Host Key regeneration for SCVMM based deployments.

### DIFF
--- a/waagent
+++ b/waagent
@@ -1880,7 +1880,7 @@ class Agent(Util):
             if IsUbuntu() or IsDebian():
                 Run("dpkg-reconfigure openssh-server")
             if IsRedHat():
-                Run("service ssh restart")
+                Run("service sshd restart")
 		
         Log("Starting Microsoft System Center VMM Initialization Process")
         pid = subprocess.Popen(["/bin/bash","/mnt/cdrom/secure/"+VMM_STARTUP_SCRIPT_NAME,"-p /mnt/cdrom/secure/ "]).pid


### PR DESCRIPTION
For some reason when waagent attempts to call the scvmmagent, the agent
seems to skip SSH Host Key re-generation. This patch forces the regeneration
to occur.
