### PR TITLE
SLES12 fix for wickedd-dhcp4

### DIFF
--- a/waagent
+++ b/waagent
@@ -655,6 +655,8 @@ class SuSEDistro(AbstractDistro):
         self.requiredDeps += [ "/sbin/insserv" ]
         self.init_file=suse_init_file
         self.dhcp_client_name='dhcpcd'
+        if (DistInfo(fullname=1)[0] == 'SUSE Linux Enterprise Server') and (DistInfo()[1] >= '12'):
+            self.dhcp_client_name='wickedd-dhcp4'
         self.grubKernelBootOptionsFile = '/boot/grub/menu.lst'
         self.grubKernelBootOptionsLine = 'kernel'
         self.getpidcmd='pidof '
@@ -3886,6 +3888,8 @@ class Agent(Util):
                     ifname=MyDistro.GetInterfaceName()
                     Log("DoDhcpWork: Missing default route - adding broadcast route for DHCP.")
                     Run("route add 255.255.255.255 dev " + ifname,chk_err=False)   # We supress error logging on error.
+                if MyDistro.dhcp_client_name == 'wickedd-dhcp4':
+                    Run("service " + MyDistro.dhcp_client_name + " stop",chk_err=False)
                 sock.bind(("0.0.0.0", 68)) 
                 sock.sendto(sendData, ("<broadcast>", 67))
                 sock.settimeout(10)
@@ -3913,6 +3917,8 @@ class Agent(Util):
                     #We added this route - delete it
                     Run("route del 255.255.255.255 dev " + ifname,chk_err=False)  # We supress error logging on error.
                     Log("DoDhcpWork: Removing broadcast route for DHCP.")
+                if MyDistro.dhcp_client_name == 'wickedd-dhcp4':
+                    Run("service " + MyDistro.dhcp_client_name + " start",chk_err=False)
         return None
 
     def UpdateAndPublishHostName(self, name):


### PR DESCRIPTION
- set dhcp_client_name correctly for SLES12
- temporarily turn off the wickedd-dhcp4 service to enable our DHCP
  client to obtain wire server endpoint address
