### PR TITLE
Changes to allow WALA to support Gentoo Linux

### DIFF
--- a/waagent
+++ b/waagent
@@ -599,12 +599,6 @@ class gentooDistro(AbstractDistro):
         else:
             return 1
 
-    def load_ata_piix(self):
-        return 0
-
-    def unload_ata_piix(self):
-        return 0
-
     def RestartInterface(self, iface):
         Run("/etc/init.d/net." + iface + " restart")
 


### PR DESCRIPTION
This pull request moves the network interface restart logic into the distribution classes to make it easier to override, and then adds a Gentoo Linux (http://gentoo.org) distribution class to the script to allow the use of WALA with Gentoo.
