### PR TITLE
Un-revert gentoo changes and fix licensng issues

### DIFF
--- a/waagent
+++ b/waagent
@@ -533,8 +533,6 @@ class AbstractDistro(object):
 ############################################################
 gentoo_init_file = """\
 #!/sbin/runscript
-# Copyright 2014 Austen Dicken <cvpcsm@gmail.com>
-# All rights reserved. Released under the GNU Public License v2
 
 command=/usr/sbin/waagent
 pidfile=/var/run/waagent.pid


### PR DESCRIPTION
My original pull request included a GPLv2 license statement in the Gentoo WALA init script, which made it incompatible with WALA's Apache 2.0 license so it was reverted. This pull request includes an un-revert of the Gentoo bits as well as a removal of the copyright and licensing statement in the submitted code so that it should no longer conflict and will fall under the umbrella of WALA's Apache 2.0 license.
