### PR TITLE
fix bug: waagent could not get IPv4 if IPv6 is enabled on FreeBSD

### DIFF
--- a/waagent
+++ b/waagent
@@ -1788,7 +1788,7 @@ class FreeBSDDistro(AbstractDistro):
         code,output=RunGetOutput("ifconfig",chk_err=False)
         Log(output)
         retries=10
-        cmd='ifconfig | grep -A1 -B2 ether | grep -B3 inet | grep -A3 UP '
+        cmd='ifconfig | grep -A2 -B2 ether | grep -B3 inet | grep -A4 UP '
         code=1
 
         while code > 0 :


### PR DESCRIPTION
1. Customer Scenario Impact
=======================
waagent could get IPv4 if IPv6 is enabled on FreeBSD, thus FreeBSD VM provioning always fail in azure. Attach the error log of waagent.

2. Repro Steps
In FreeBSD VM:
1. Enable both IPv4 and IPv6:
    vi /etc/rc.conf
ifconfig_hn0="SYNCDHCP"
ifconfig_hn0_ipv6="inet6 accept_rtadv"

.     3. Root Cause
=======================
In GetFreeBSDEthernetInfo function in waagent.py:
cmd='ifconfig | grep -A1 -B2 ether | grep -B3 inet | grep -A3 UP '
When IPv6 is enabled, it will always get the IPv6 address


4. Fix & Work around:
========================
Disable IPv6 in the FreeBSD vhd