### PR TITLE
Fix CoreOS implementation of restartSshService

### DIFF
--- a/waagent
+++ b/waagent
@@ -1060,12 +1060,9 @@ class CoreOSDistro(AbstractDistro):
 
     def restartSshService(self):
         """
-        Service call to re(start) the SSH service
+        SSH is socket activated on CoreOS. No need to restart it.
         """
-        retcode = Run("systemctl restart sshd")
-        if retcode > 0:
-            Error("Failed to restart SSH service with return code:" + str(retcode))
-        return retcode
+        return 0
 
     def sshDeployPublicKey(self,fprint,path):
         """


### PR DESCRIPTION
Because SSH is socket activated on CoreOS, there is no need to restart it. In fact, starting it at all causes it to fail while binding to port 22, which sshd.socket has already bound.