### PR TITLE
Fix comparison of `sfdisk` output.

### DIFF
--- a/waagent
+++ b/waagent
@@ -2145,7 +2145,7 @@ def RunGetOutput(cmd,chk_err=True):
     """
     LogIfVerbose(cmd)
     try:                                     
-        output=subprocess.check_output(cmd,stderr=subprocess.STDOUT,shell=True)
+        output=subprocess.check_output(cmd,shell=True)
     except subprocess.CalledProcessError,e :
         if chk_err :
             Error('CalledProcessError.  Error Code is ' + str(e.returncode)  )

--- a/waagent
+++ b/waagent
@@ -495,7 +495,7 @@ class AbstractDistro(object):
                     Run("parted {0} mkpart primary 0% 100%".format(device))
                     Run("mkfs." + fs + " " + partition + " -F")
             else:
-                existingFS = RunGetOutput("sfdisk -q -c " + device + " 1", chk_err=False)[1].rstrip()
+                existingFS = RunGetOutput("sfdisk -q -c " + device + " 1", chk_err=False)[1].strip()
                 if existingFS == "7" and fs != "ntfs":
                     Run("sfdisk -c " + device + " 1 83")
                     Run("mkfs." + fs + " " + partition)


### PR DESCRIPTION
```
$ sudo sfdisk -q -c /dev/sdb 1
sfdisk: --id is deprecated in favour of --part-type
 7
```

Both the leading and trailing whitespace needs to be trimmed from
" 7\n" in order for the comparison to succeed.