### PR TITLE
Allow provisioning with existing system user

### DIFF
--- a/waagent
+++ b/waagent
@@ -1838,7 +1838,7 @@ class FreeBSDDistro(AbstractDistro):
             pass
         if uidmin == None:
             uidmin = 100
-        if userentry != None and userentry[2] < uidmin:
+        if userentry != None and userentry[2] < uidmin and password != None:
             Error("CreateAccount: " + user + " is a system user. Will not set password.")
             return "Failed to set password for system user: " + user + " (0x06)."
         if userentry == None:
@@ -2241,7 +2241,7 @@ def CreateAccount(user, password, expiration, thumbprint):
         pass
     if uidmin == None:
         uidmin = 100
-    if userentry != None and userentry[2] < uidmin:
+    if userentry != None and userentry[2] < uidmin and password != None:
         Error("CreateAccount: " + user + " is a system user. Will not set password.")
         return "Failed to set password for system user: " + user + " (0x06)."
     if userentry == None:

--- a/waagent
+++ b/waagent
@@ -1095,7 +1095,7 @@ class CoreOSDistro(AbstractDistro):
             pass
         if uidmin == None:
             uidmin = 100
-        if userentry != None and userentry[2] < uidmin and userentry[2] != self.CORE_UID:
+        if userentry != None and userentry[2] < uidmin and userentry[2] != self.CORE_UID and password != None:
             Error("CreateAccount: " + user + " is a system user. Will not set password.")
             return "Failed to set password for system user: " + user + " (0x06)."
         if userentry == None:


### PR DESCRIPTION
I used `azure vm create --no-ssh-password --user admin` with a VM image that already had an admin user created on it with the uid 501. The VM failed to come up fully, failing on the following provisioning error:

```
2015/03/16 22:26:47 ERROR:CreateAccount: admin is a system user. Will not set password.
2015/03/16 22:26:47 ERROR:Provisioning image FAILED Failed to set password for system user: admin (0x06).
```

Since I am not requesting a password to be set, it does not make sense for provisioning to fail here. I have updated the code in this PR to avoid the failure for this case.