### PR TITLE
Fixed ReplaceStringInFile clears file when pattern to replace is not found

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,6 +14,8 @@
 #
 
 import unittest
+import tempfile
+import os
 from env import waagent
 
 sample_mount_list = """\
@@ -42,6 +44,40 @@ class TestWAAgentUtils(unittest.TestCase):
         malformed = 'asdfasdfasdfa aasdf'
         mp = waagent.GetMountPoint(malformed, device_name)
         self.assertEqual(mp, None)
+
+    def test_replace_in_file_found(self):
+        tmpfilename = tempfile.mkstemp('', 'tmp', None, True)[1]
+        try:
+            tmpfile = open(tmpfilename, 'w')
+            tmpfile.write('Replace Me')
+            tmpfile.close()
+
+            result = waagent.ReplaceStringInFile(tmpfilename, r'c. ', 'ced ')
+
+            tmpfile = open(tmpfilename, 'r')
+            newcontents = tmpfile.read();
+            tmpfile.close()
+
+            self.assertEqual('Replaced Me', str(newcontents))
+        finally:
+            os.remove(tmpfilename)
+
+    def test_replace_in_file_not_found(self):
+        tmpfilename = tempfile.mkstemp('', 'tmp', None, True)[1]
+        try:
+            tmpfile = open(tmpfilename, 'w')
+            tmpfile.write('Replace Me')
+            tmpfile.close()
+
+            result = waagent.ReplaceStringInFile(tmpfilename, r'not here ', 'ced ')
+
+            tmpfile = open(tmpfilename, 'r')
+            newcontents = tmpfile.read();
+            tmpfile.close()
+
+            self.assertEqual('Replace Me', str(newcontents))
+        finally:
+            os.remove(tmpfilename)
 
 if __name__ == '__main__':
     unittest.main()

--- a/waagent
+++ b/waagent
@@ -5514,14 +5514,14 @@ def ReplaceStringInFile(fname,src,repl):
     """
     Replace 'src' with 'repl' in file.
     """
-    updated=''
     try:
         sr=re.compile(src)
         if FindStringInFile(fname,src):
+            updated=''
             for l in (open(fname,'r')).readlines():
                 n=re.sub(sr,repl,l)
                 updated+=n
-        ReplaceFileContentsAtomic(fname,updated)
+            ReplaceFileContentsAtomic(fname,updated)
     except :
         raise
     return


### PR DESCRIPTION
When `ReplaceStringInFile` is invoked (for instance when using `-serialconsole`) and the string or pattern to be replaced is not found, the entire file is cleared.

This PR fixes that and adds two unit tests.