### PR TITLE
Fix for stuck "Waiting for network." on 32-bit Linux

### DIFF
--- a/waagent
+++ b/waagent
@@ -2526,7 +2526,8 @@ def GetFirstActiveNetworkInterfaceNonLoopback():
     """
     iface=''
     expected=16 # how many devices should I expect...
-    struct_size=40 # for 64bit the size is 40 bytes
+    is_64bits = sys.maxsize > 2**32
+    struct_size=if is_64bits 40 else 32 # for 64bit the size is 40 bytes, for32 bits it is 32 bytes.
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     buff=array.array('B', b'\0' * (expected*struct_size))
     retsize=(struct.unpack('iL', fcntl.ioctl(s.fileno(), 0x8912, struct.pack('iL',expected*struct_size,buff.buffer_info()[0]))))[0]

--- a/waagent
+++ b/waagent
@@ -2527,7 +2527,7 @@ def GetFirstActiveNetworkInterfaceNonLoopback():
     iface=''
     expected=16 # how many devices should I expect...
     is_64bits = sys.maxsize > 2**32
-    struct_size=if is_64bits 40 else 32 # for 64bit the size is 40 bytes, for32 bits it is 32 bytes.
+    struct_size=40 if is_64bits else 32 # for 64bit the size is 40 bytes, for 32bits it is 32 bytes.
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     buff=array.array('B', b'\0' * (expected*struct_size))
     retsize=(struct.unpack('iL', fcntl.ioctl(s.fileno(), 0x8912, struct.pack('iL',expected*struct_size,buff.buffer_info()[0]))))[0]


### PR DESCRIPTION
Please accept this pull request to add support for 32-bit Linux platforms to the waaagent script. The only change is the size of the structure used to read the available interfaces depends on executing platform.

Thanks!