### PR TITLE
Add feature to disable password reset and user creation

### DIFF
--- a/README
+++ b/README
@@ -161,6 +161,7 @@ LBProbeResponder=y
 Logs.Verbose=n
 OS.RootDeviceScsiTimeout=300
 OS.OpensslPath=None
+Agent.DisableUserManipulation=n
 
 The various configuration options are described in detail below. Configuration
 options are of three types : Boolean, String or Integer. The Boolean
@@ -296,6 +297,13 @@ Type: String Default: None
 
 This can be used to specify an alternate path for the openssl binary to use for
 cryptographic operations.
+
+Agent.DisableUserManipulation:
+Type: Boolean Default: n
+
+If set, `waagent` will not create or update local users. This means you will also
+lose the ability to reset user passwords. If you wish to set this to `y`, be aware
+that it will likely affect provisioning.
 
 
 APPENDIX

--- a/waagent
+++ b/waagent
@@ -294,6 +294,11 @@ def CreateDir(dirpath, user, mode):
     ChangeOwner(dirpath, user)
 
 def CreateAccount(user, password, expiration, thumbprint):
+    disabled = Config.get("Agent.DisableUserManipulation")
+    if disabled != None and disabled.lower().startswith("y"):
+        Error("User manipulation is disabled for " + user)
+        return "User manipulation is disabled"
+
     userentry = None
     try:
         userentry = pwd.getpwnam(user)
@@ -2346,6 +2351,8 @@ Logs.Verbose=n                          #
 
 OS.RootDeviceScsiTimeout=300            # Root device timeout in seconds.
 OS.OpensslPath=None                     # If "None", the system default version is used.
+
+Agent.DisableUserManipulation=n         # If set, removes the agent's ability to create/modify local users
 """
 
 WaagentLogrotate = """\


### PR DESCRIPTION
Introduce config variable `Agent.DisableUserManipulation`, which neuters
`CreateAccount`, and registers a relevant error when invoked. This option is
useful for those who wish to revoke VM user management rights from the
Azure Portal. It should be noted that `CreateAccount` is used during
provisioning, so only set this to `y` once the VM has been created and
fully provisioned.

This functionality is disabled by default for backwards compatibility.