### PR TITLE
fix error when active resource disk in BSD

### DIFF
--- a/waagent
+++ b/waagent
@@ -1661,7 +1661,7 @@ __name__='setupmain' #prevent waagent.__main__ from executing
 waagent=imp.load_source('waagent','/tmp/waagent') 
 waagent.LoggerInit('/var/log/waagent.log','/dev/console')
 from waagent import RunGetOutput,Run
-Config=waagent.ConfigurationProvider()
+Config=waagent.ConfigurationProvider(None)
 format = Config.get("ResourceDisk.Format")
 if format == None or format.lower().startswith("n"):
     sys.exit(0)


### PR DESCRIPTION
The error report is:
Traceback (most recent call last):
  File "/tmp/bsd_activate_resource_disk.py", line 12, in <module>
    Config=waagent.ConfigurationProvider()
TypeError: __init__() takes exactly 2 arguments (1 given)

ConfigurationProvider is changed to accept two arguments from
commit 88e8d5f47, but it doesn't update ConfigurationProvider
in bsd_activate_resource_disk.py.

Signed-off-by: Jincheng Miao <jincheng.miao@gmail.com>