### PR TITLE
Add feature to disable password reset and user creation 21

### DIFF
--- a/README
+++ b/README
@@ -359,6 +359,13 @@ HttpProxy.Host=None
 HttpProxy.Port=None
 Type: String Default: None
 
+Agent.DisableUserManipulation:
+Type: Boolean Default: n
+
+If set, `waagent` will not create or update local users. This means you will also
+lose the ability to reset user passwords. If you wish to set this to `y`, be aware
+that it will likely affect provisioning.
+
 If set, agent will use proxy server to access internet
 
 APPENDIX

--- a/azurelinuxagent/distro/default/osutil.py
+++ b/azurelinuxagent/distro/default/osutil.py
@@ -83,6 +83,9 @@ class DefaultOSUtil(object):
         Update password and ssh key for user account.
         New account will be created if not exists.
         """
+        if conf.get_switch("Agent.DisableUserManipulation", False):
+            raise OSUtilError("User manipulation is disabled")
+
         if username is None:
             raise OSUtilError("User name is empty")
 
@@ -119,6 +122,9 @@ class DefaultOSUtil(object):
             return False
 
     def useradd(self, username, expiration=None):
+        if conf.get_switch("Agent.DisableUserManipulation", False):
+            raise OSUtilError("User manipulation is disabled")
+
         if expiration is not None:
             cmd = "useradd -m {0} -e {1}".format(username, expiration)
         else:
@@ -131,6 +137,9 @@ class DefaultOSUtil(object):
 
     def chpasswd(self, username, password, use_salt=True, salt_type=6,
                        salt_len=10):
+        if conf.get_switch("Agent.DisableUserManipulation", False):
+            raise OSUtilError("User manipulation is disabled")
+
         passwd_hash = textutil.gen_password_hash(password, use_salt, salt_type,
                                                  salt_len)
         try:
@@ -144,6 +153,9 @@ class DefaultOSUtil(object):
                                "").format(username, e))
 
     def conf_sudoer(self, username, nopasswd):
+        if conf.get_switch("Agent.DisableUserManipulation", False):
+            raise OSUtilError("User manipulation is disabled")
+
         # for older distros create sudoers.d
         if not os.path.isdir('/etc/sudoers.d/'):
             # create the /etc/sudoers.d/ directory
@@ -227,6 +239,9 @@ class DefaultOSUtil(object):
         """
         Deploy authorized_key
         """
+        if conf.get_switch("Agent.DisableUserManipulation", False):
+            raise OSUtilError("User manipulation is disabled")
+
         path = self._norm_path(path)
         dir_path = os.path.dirname(path)
         fileutil.mkdir(dir_path, mode=0700, owner=username)

--- a/bin/waagent
+++ b/bin/waagent
@@ -139,6 +139,8 @@ Logs.Verbose=n                          # Enable verbose logs
 
 OS.RootDeviceScsiTimeout=300            # Root device timeout in seconds.
 OS.OpensslPath=None                     # If "None", the system default version is used.
+
+Agent.DisableUserManipulation=n         # If "n", disable user creation and modification
 """
 README_FILENAME="DATALOSS_WARNING_README.txt"
 README_FILECONTENT="""\
@@ -1119,6 +1121,11 @@ class CoreOSDistro(AbstractDistro):
         and sudo permissions.
         Returns None if successful, error string on failure.
         """
+        disabled = Config.get("Agent.DisableUserManipulation")
+        if disabled != None and disabled.lower().startswith("y"):
+            Error("User manipulation is disabled for " + user)
+            return "User manipulation is disabled"
+
         userentry = None
         try:
             userentry = pwd.getpwnam(user)
@@ -1581,6 +1588,12 @@ class fedoraDistro(redhatDistro):
         self.installAgentServiceScriptFiles()
 
     def CreateAccount(self, user, password, expiration, thumbprint):
+        # Explicitly check for DisableUserManipulation here due to `usermod` invocation
+        disabled = Config.get("Agent.DisableUserManipulation")
+        if disabled != None and disabled.lower().startswith("y"):
+            Error("User manipulation is disabled for " + user)
+            return "User manipulation is disabled"
+
         super(fedoraDistro, self).CreateAccount(user, password, expiration, thumbprint)
         Run('/sbin/usermod ' + user + ' -G wheel')
 
@@ -1619,6 +1632,8 @@ Logs.Verbose=n                          # Enable verbose logs
 
 OS.RootDeviceScsiTimeout=300            # Root device timeout in seconds.
 OS.OpensslPath=None                     # If "None", the system default version is used.
+
+Agent.DisableUserManipulation=n         # If "n", disable user creation and modification
 """
 
 bsd_init_file="""\
@@ -1861,6 +1876,11 @@ class FreeBSDDistro(AbstractDistro):
         and sudo permissions.
         Returns None if successful, error string on failure.
         """
+        disabled = Config.get("Agent.DisableUserManipulation")
+        if disabled != None and disabled.lower().startswith("y"):
+            Error("User manipulation is disabled for " + user)
+            return "User manipulation is disabled"
+
         userentry = None
         try:
             userentry = pwd.getpwnam(user)
@@ -2265,6 +2285,11 @@ def CreateAccount(user, password, expiration, thumbprint):
     and sudo permissions.
     Returns None if successful, error string on failure.
     """
+    disabled = Config.get("Agent.DisableUserManipulation")
+    if disabled != None and disabled.lower().startswith("y"):
+        Error("User manipulation is disabled for " + user)
+        return "User manipulation is disabled"
+
     userentry = None
     try:
         userentry = pwd.getpwnam(user)

--- a/config/suse/waagent.conf
+++ b/config/suse/waagent.conf
@@ -68,3 +68,6 @@ OS.OpensslPath=None
 
 # Detect Scvmm environment, default is n
 # DetectScvmmEnv=n
+
+# If set, agent will not create or modify user accounts
+Agent.DisableUserManipulation=n

--- a/config/ubuntu/waagent.conf
+++ b/config/ubuntu/waagent.conf
@@ -68,3 +68,6 @@ OS.OpensslPath=None
 
 # Detect Scvmm environment, default is n
 # DetectScvmmEnv=n
+
+# If set, agent will not create or modify user accounts
+Agent.DisableUserManipulation=n

--- a/config/waagent.conf
+++ b/config/waagent.conf
@@ -65,3 +65,6 @@ OS.OpensslPath=None
 
 # Detect Scvmm environment, default is n
 # DetectScvmmEnv=n
+
+# If set, agent will not create or modify user accounts
+Agent.DisableUserManipulation=n


### PR DESCRIPTION
New PR against 2.1 branch to replace https://github.com/Azure/WALinuxAgent/pull/98

This introduces a knob named `Agent.DisableUserManipulation`. It disables the agent's ability to:
* Create new users
* Modify existing users

The intent is to prevent any possibility that someone who has gained unauthorized access to the Azure control panel could, as a result, gain unauthorized access to the VMs running there. With that in mind, destructive actions are fine, but actions which could allow someone to access the VM are not OK.

I realize that these functions are critical for provisioning, and have documented that fact. The default is `n`, so functionality will remain the same unless the knob is turned. Since the default is `n`, provisioning images will work, and the user has the option to disable this functionality after the VM is initially provisioned.

I am unsure as to the state of this project. It looks like the 'new' agent is not ready yet, and that the 'old' monolithic agent is still present and in use. I have patched the monolithic agent, and have also taken a stab at applying a similar patch to the new hotness. If you can provide some guidance here, I will update the docs to reflect the current state.

Given the nature and intention of the change, it is possible that this knob encompasses more than just user creation/modification in the future... I am open to changing the name to `Agent.Harden` or something similar.