### PR TITLE
2.1.2

### DIFF
--- a/README
+++ b/README
@@ -199,6 +199,8 @@ Provisioning.SshHostKeyPairType=rsa
 Provisioning.MonitorHostName=y
 Provisioning.DecodeCustomData=n
 Provisioning.ExecuteCustomData=n
+Provisioning.PasswordCryptId=6
+Provisioning.PasswordCryptSaltLength=10
 ResourceDisk.Format=y
 ResourceDisk.Filesystem=ext4
 ResourceDisk.MountPoint=/mnt/resource
@@ -299,6 +301,20 @@ Provisioning.ExecuteCustomData:
 Type: Boolean Default: n
 
 If set, waagent will execute CustomData after provisioning.
+
+Provisioning.PasswordCryptId:
+Type:String Default:6
+
+Algorithm used by crypt when generating password hash.
+    1 - MD5
+    2a - Blowfish
+    5 - SHA-256
+    6 - SHA-512
+
+Provisioning.PasswordCryptSaltLength
+Type:String Default:10
+
+Length of random salt used when generating password hash.
 
 ResourceDisk.Format:
 Type: Boolean Default: y

--- a/azurelinuxagent/distro/coreos/osutil.py
+++ b/azurelinuxagent/distro/coreos/osutil.py
@@ -37,7 +37,7 @@ class CoreOSUtil(DefaultOSUtil):
         super(CoreOSUtil, self).__init__()
         self.waagent_path='/usr/share/oem/bin/waagent'
         self.python_path='/usr/share/oem/python/bin'
-        self.conf_path = '/usr/share/oem/waagent.conf'
+        self.conf_file_path = '/usr/share/oem/waagent.conf'
         if 'PATH' in os.environ:
             path = "{0}:{1}".format(os.environ['PATH'], self.python_path)
         else:
@@ -55,7 +55,7 @@ class CoreOSUtil(DefaultOSUtil):
        #User 'core' is not a sysuser
        if username == 'core':
            return False
-       return super(CoreOSUtil, self).IsSysUser(username)
+       return super(CoreOSUtil, self).is_sys_user(username)
 
     def is_dhcp_enabled(self):
         return True

--- a/azurelinuxagent/distro/coreos/osutil.py
+++ b/azurelinuxagent/distro/coreos/osutil.py
@@ -88,3 +88,11 @@ class CoreOSUtil(DefaultOSUtil):
     def decode_customdata(self, data):
         return base64.b64decode(data)
 
+    def set_ssh_client_alive_interval(self):
+        #In CoreOS, /etc/sshd_config is mount readonly. Skip the setting
+        pass
+
+    def conf_sshd(self, disable_password):
+        #In CoreOS, /etc/sshd_config is mount readonly. Skip the setting
+        pass
+

--- a/azurelinuxagent/distro/default/extension.py
+++ b/azurelinuxagent/distro/default/extension.py
@@ -31,6 +31,9 @@ import azurelinuxagent.utils.fileutil as fileutil
 import azurelinuxagent.utils.restutil as restutil
 import azurelinuxagent.utils.shellutil as shellutil
 
+#HandlerEnvironment.json schema version
+HANDLER_ENVIRONMENT_VERSION = 1.0
+
 VALID_EXTENSION_STATUS = ['transitioning', 'error', 'success', 'warning']
 
 def validate_has_key(obj, key, fullname):
@@ -482,13 +485,10 @@ class ExtensionInstance(object):
         }
         fileutil.write_file(self.get_settings_file(), json.dumps(ext_settings))
 
-        latest = os.path.join(self.get_conf_dir(), "latest")
-        fileutil.write_file(latest, self.settings.sequenceNumber)
 
     def create_handler_env(self):
         env = [{
-            "name": self.get_name(),
-            "version" : self.get_version(),
+            "version" : HANDLER_ENVIRONMENT_VERSION,
             "handlerEnvironment" : {
                 "logFolder" : self.get_log_dir(),
                 "configFolder" : self.get_conf_dir(),

--- a/azurelinuxagent/distro/default/extension.py
+++ b/azurelinuxagent/distro/default/extension.py
@@ -257,6 +257,7 @@ class ExtHandlerInstance(object):
 
     def handle_enable(self):
         target_version = self.get_target_version()
+        logger.info("Target version: {0}", target_version)
         if self.installed:
             if Version(target_version) > Version(self.curr_version):
                 self.upgrade(target_version)
@@ -536,6 +537,7 @@ class ExtHandlerInstance(object):
 
     def create_handler_env(self):
         env = [{
+            "name": self.name,
             "version" : HANDLER_ENVIRONMENT_VERSION,
             "handlerEnvironment" : {
                 "logFolder" : self.get_log_dir(),
@@ -548,7 +550,7 @@ class ExtHandlerInstance(object):
                                  json.dumps(env))
 
     def get_target_version(self):
-        version = self.curr_version
+        version = self.version
         update_policy = self.update_policy
         if update_policy is None or update_policy.lower() != 'auto':
             return version

--- a/azurelinuxagent/distro/default/extension.py
+++ b/azurelinuxagent/distro/default/extension.py
@@ -25,6 +25,7 @@ import azurelinuxagent.logger as logger
 from azurelinuxagent.future import text
 from azurelinuxagent.utils.osutil import OSUTIL
 import azurelinuxagent.protocol as prot
+from azurelinuxagent.metadata import AGENT_VERSION
 from azurelinuxagent.event import add_event, WALAEventOperation
 from azurelinuxagent.exception import ExtensionError
 import azurelinuxagent.utils.fileutil as fileutil
@@ -45,13 +46,7 @@ def validate_in_range(val, valid_range, name):
     if val not in valid_range:
         raise ExtensionError("Invalid {0}: {1}".format(name, val))
 
-def try_get(dictionary, key, default=None):
-    try:
-        return dictionary[key]
-    except KeyError:
-        return default
-
-def extension_sub_status_to_v2(substatus):
+def parse_ext_substatus(substatus):
     #Check extension sub status format
     validate_has_key(substatus, 'name', 'substatus/name')
     validate_has_key(substatus, 'status', 'substatus/status')
@@ -65,83 +60,46 @@ def extension_sub_status_to_v2(substatus):
     validate_in_range(substatus['status'], VALID_EXTENSION_STATUS,
                       'substatus/status')
     status = prot.ExtensionSubStatus()
-    status.name = try_get(substatus, 'name')
-    status.status = try_get(substatus, 'status')
-    status.code = try_get(substatus, 'code')
-    status.message = try_get(substatus['formattedMessage'], 'message')
+    status.name = substatus.get('name')
+    status.status = substatus.get('status')
+    status.code = substatus.get('code')
+    status.message  =  substatus.get('formattedMessage').get('message')
     return status
 
-def ext_status_to_v2(ext_status, seq_no):
+def parse_ext_status(ext_status, data):
+    if data is None or len(data) is None:
+        return
+    #Currently, only the first status will be reported
+    data = data[0]
     #Check extension status format
-    validate_has_key(ext_status, 'status', 'status')
-    validate_has_key(ext_status['status'], 'status', 'status/status')
-    validate_has_key(ext_status['status'], 'operation', 'status/operation')
-    validate_has_key(ext_status['status'], 'code', 'status/code')
-    validate_has_key(ext_status['status'], 'name', 'status/name')
-    validate_has_key(ext_status['status'], 'formattedMessage',
-                     'status/formattedMessage')
-    validate_has_key(ext_status['status']['formattedMessage'], 'lang',
+    validate_has_key(data, 'status', 'status')
+    status_data = data['status']
+    validate_has_key(status_data, 'status', 'status/status')
+    validate_has_key(status_data, 'operation', 'status/operation')
+    validate_has_key(status_data, 'code', 'status/code')
+    validate_has_key(status_data, 'name', 'status/name')
+    validate_has_key(status_data, 'formattedMessage', 'status/formattedMessage')
+    validate_has_key(status_data['formattedMessage'], 'lang',
                      'status/formattedMessage/lang')
-    validate_has_key(ext_status['status']['formattedMessage'], 'message',
+    validate_has_key(status_data['formattedMessage'], 'message',
                      'status/formattedMessage/message')
 
-    validate_in_range(ext_status['status']['status'], VALID_EXTENSION_STATUS,
+    validate_in_range(status_data['status'], VALID_EXTENSION_STATUS,
                       'status/status')
 
-    status = prot.ExtensionStatus()
-    status.name = try_get(ext_status['status'], 'name')
-    status.configurationAppliedTime = try_get(ext_status['status'],
-                                              'configurationAppliedTime')
-    status.operation = try_get(ext_status['status'], 'operation')
-    status.status = try_get(ext_status['status'], 'status')
-    status.code = try_get(ext_status['status'], 'code')
-    status.message = try_get(ext_status['status']['formattedMessage'], 'message')
-    status.sequenceNumber = seq_no
+    applied_time = status_data.get('configurationAppliedTime')
+    ext_status.configurationAppliedTime = applied_time
+    ext_status.operation = status_data.get('operation')
+    ext_status.status = status_data.get('status')
 
-    substatus_list = try_get(ext_status['status'], 'substatus', [])
+    ext_status.code = status_data.get('code')
+    ext_status.message =status_data['formattedMessage'].get('message')
+
+    substatus_list = status_data.get('substatus')
+    if substatus_list is None:
+        return
     for substatus in substatus_list:
-        status.substatusList.extend(extension_sub_status_to_v2(substatus))
-    return status
-
-class ExtensionsHandler(object):
-
-    def process(self):
-        protocol = prot.FACTORY.get_default_protocol()
-        ext_list = protocol.get_extensions()
-
-        h_status_list = []
-        for extension in ext_list.extensions:
-            #TODO handle extension in parallel
-            pkg_list = protocol.get_extension_pkgs(extension)
-            h_status = self.process_extension(extension, pkg_list)
-            h_status_list.append(h_status)
-
-        return h_status_list
-
-    def process_extension(self, extension, pkg_list):
-        installed_version = get_installed_version(extension.name)
-        if installed_version is not None:
-            ext = ExtensionInstance(extension, pkg_list,
-                                    installed_version, installed=True)
-        else:
-            ext = ExtensionInstance(extension, pkg_list,
-                                    extension.properties.version)
-        try:
-            ext.init_logger()
-            ext.handle()
-            status = ext.collect_handler_status()
-        except ExtensionError as e:
-            logger.error("Failed to handle extension: {0}-{1}\n {2}",
-                         ext.get_name(), ext.get_version(), e)
-            add_event(name=ext.get_name(), is_success=False,
-                              op=ext.get_curr_op(), message = text(e))
-            ext_status = prot.ExtensionStatus(status='error', code='-1',
-                                             operation = ext.get_curr_op(),
-                                             message = text(e),
-                                             seq_no = ext.get_seq_no())
-            status = ext.create_handler_status(ext_status)
-            status.status = "Ready"
-        return status
+        ext_status.substatusList.append(parse_ext_substatus(substatus))
 
 def parse_extension_dirname(dirname):
     """
@@ -169,51 +127,128 @@ def get_installed_version(target_name):
                     installed_version = version
     return installed_version
 
-class ExtensionInstance(object):
-    def __init__(self, extension, pkg_list, curr_version, installed=False):
-        self.extension = extension
-        self.pkg_list = pkg_list
-        self.curr_version = curr_version
-        self.lib_dir = OSUTIL.get_lib_dir()
-        self.installed = installed
-        self.settings = None
+class ExtHandlersHandler(object):
 
-        #Extension will have no more than 1 settings instance
-        if len(extension.properties.extensions) > 0:
-            self.settings = extension.properties.extensions[0]
+    def process(self):
+        try:
+            protocol = prot.FACTORY.get_default_protocol()
+            ext_handlers = protocol.get_ext_handlers()
+        except prot.ProtocolError as e:
+            add_event(name="WALA", is_success=False, message = text(e))
+            return
+
+        vm_status = prot.VMStatus()
+        vm_status.vmAgent.version = AGENT_VERSION
+        vm_status.vmAgent.status = "Ready"
+        vm_status.vmAgent.message = "Guest Agent is running"
+
+        for ext_handler in ext_handlers.extHandlers:
+            #TODO handle extension in parallel
+            try:
+                pkg_list = protocol.get_ext_handler_pkgs(ext_handler)
+            except prot.ProtocolError as e:
+                add_event(name="WALA", is_success=False, message=text(e))
+                continue
+                
+            handler_status = self.process_extension(ext_handler, pkg_list)
+            if handler_status is not None:
+                vm_status.vmAgent.extensionHandlers.append(handler_status)
+        
+        try:
+            logger.info("Report vm agent status")
+            protocol.report_vm_status(vm_status)
+        except prot.ProtocolError as e:
+            add_event(name="WALA", is_success=False, message = text(e))
+
+    def process_extension(self, ext_handler, pkg_list):
+        installed_version = get_installed_version(ext_handler.name)
+        if installed_version is not None:
+            handler = ExtHandlerInstance(ext_handler, pkg_list, 
+                                         installed_version, installed=True)
+        else:
+            handler = ExtHandlerInstance(ext_handler, pkg_list,
+                                         ext_handler.properties.version)
+        handler.handle() 
+        
+        if handler.ext_status is not None:
+            try:
+                protocol = prot.FACTORY.get_default_protocol()
+                protocol.report_ext_status(handler.name, handler.ext.name, 
+                                           handler.ext_status)
+            except prot.ProtocolError as e:
+                add_event(name="WALA", is_success=False, message=text(e))
+        
+        return handler.handler_status
+
+class ExtHandlerInstance(object):
+    def __init__(self, ext_handler, pkg_list, curr_version, installed=False):
+        self.ext_handler = ext_handler
+        self.name = ext_handler.name
+        self.version = ext_handler.properties.version
+        self.pkg_list = pkg_list
+        self.state = ext_handler.properties.state
+        self.update_policy  = ext_handler.properties.upgradePolicy
+
+        self.curr_version = curr_version
         self.enabled = False
-        self.curr_op = None
+        self.installed = installed
+        self.lib_dir = OSUTIL.get_lib_dir()
+        
+        self.ext_status = prot.ExtensionStatus()
+        self.handler_status = prot.ExtHandlerStatus()
+        self.handler_status.name = self.name
+        self.handler_status.version = self.curr_version
+
+        self.ext = None
+        #Currently, extension will have no more than 1 instance
+        if len(ext_handler.properties.extensions) > 0:
+            self.ext = ext_handler.properties.extensions[0]
+            self.ext_status.sequenceNumber = self.ext.sequenceNumber
+            self.handler_status.extensions = [self.ext.name]
 
         prefix = "[{0}]".format(self.get_full_name())
         self.logger = logger.Logger(logger.DEFAULT_LOGGER, prefix)
 
     def init_logger(self):
         #Init logger appender for extension
-        fileutil.mkdir(self.get_log_dir(), mode=0o700)
+        fileutil.mkdir(self.get_log_dir(), mode=0o644)
         log_file = os.path.join(self.get_log_dir(), "CommandExecution.log")
         self.logger.add_appender(logger.AppenderType.FILE,
-                                      logger.LogLevel.INFO, log_file)
+                                 logger.LogLevel.INFO, log_file)
 
     def handle(self):
-        self.logger.info("Process extension settings:")
-        self.logger.info("  Name: {0}", self.get_name())
-        self.logger.info("  Version: {0}", self.get_version())
+        self.init_logger()
+        self.logger.info("Start processing extension handler")
+        try: 
+            self.handle_state()
+            self.collect_ext_status()
+            self.collect_handler_status()
+        except ExtensionError as e:
+            #TODO add None check for azure stack test
+            if self.ext_status is not None:
+                self.ext_status.status = 'error'
+            if self.handler_status is not None:
+                self.handler_status.status = "NotReady"
+                self.handler_status.message =  text(e)
+            self.report_event(is_success=False, message=text(e))
 
+        self.logger.info("Finished processing extension handler")
+
+    def handle_state(self):
         if self.installed:
             self.logger.info("Installed version:{0}", self.curr_version)
-            h_status = self.get_handler_status()
-            self.enabled = (h_status == "Ready")
+            handler_state = self.get_state()
+            self.enabled = (handler_state == "Ready")
 
-        state = self.get_state()
-        if state == 'enabled':
+        if self.state == 'enabled':
             self.handle_enable()
-        elif state == 'disabled':
+        elif self.state == 'disabled':
             self.handle_disable()
-        elif state == 'uninstall':
+        elif self.state == 'uninstall':
             self.handle_disable()
             self.handle_uninstall()
         else:
-            raise ExtensionError("Unknown extension state:{0}".format(state))
+            raise ExtensionError("Unknown state:{0}".format(self.state))
 
     def handle_enable(self):
         target_version = self.get_target_version()
@@ -223,9 +258,9 @@ class ExtensionInstance(object):
             elif Version(target_version) == Version(self.curr_version):
                 self.enable()
             else:
-                raise ExtensionError("A newer version has already been installed")
+                raise ExtensionError("A newer version is already installed")
         else:
-            if Version(target_version) > Version(self.curr_version):
+            if Version(target_version) > Version(self.version):
                 #This will happen when auto upgrade policy is enabled
                 self.logger.info("Auto upgrade to new version:{0}",
                                  target_version)
@@ -245,12 +280,22 @@ class ExtensionInstance(object):
             return
         self.uninstall()
 
+    def report_event(self, is_success=True, message=""):
+        add_event(name=self.name, op=self.ext_status.operation, 
+                  is_success=is_success, message=message)
+
+    def set_operation(self, operation):
+        if self.ext_status.operation != WALAEventOperation.Upgrade:
+            self.ext_status.operation = operation 
+
     def upgrade(self, target_version):
         self.logger.info("Upgrade from: {0} to {1}", self.curr_version,
                          target_version)
-        self.curr_op=WALAEventOperation.Upgrade
+        self.set_operation(WALAEventOperation.Upgrade)
+
         old = self
-        new = ExtensionInstance(self.extension, self.pkg_list, target_version)
+        new = ExtHandlerInstance(self.ext_handler, self.pkg_list, 
+                                 target_version)
         self.logger.info("Download new extension package")
         new.init_logger()
         new.download()
@@ -267,19 +312,19 @@ class ExtensionInstance(object):
             new.install()
         self.logger.info("Enable new extension")
         new.enable()
-        add_event(name=self.get_name(), is_success=True,
-                  op=self.curr_op, message="")
 
     def download(self):
         self.logger.info("Download extension package")
-        self.curr_op=WALAEventOperation.Download
+        self.set_operation(WALAEventOperation.Download)
+
         uris = self.get_package_uris()
         package = None
         for uri in uris:
             try:
                 resp = restutil.http_get(uri.uri, chk_proxy=True)
-                package = resp.read()
-                break
+                if resp.status == restutil.httpclient.OK:
+                    package = resp.read()
+                    break
             except restutil.HttpError as e:
                 self.logger.warn("Failed download extension from: {0}", uri.uri)
 
@@ -292,14 +337,13 @@ class ExtensionInstance(object):
         zipfile.ZipFile(pkg_file).extractall(self.get_base_dir())
         chmod = "find {0} -type f | xargs chmod u+x".format(self.get_base_dir())
         shellutil.run(chmod)
-        add_event(name=self.get_name(), is_success=True,
-                  op=self.curr_op, message="")
+        self.report_event()
 
     def init_dir(self):
         self.logger.info("Initialize extension directory")
         #Save HandlerManifest.json
         man_file = fileutil.search_file(self.get_base_dir(),
-                                         'HandlerManifest.json')
+                                        'HandlerManifest.json')
         man = fileutil.read_file(man_file, remove_bom=True)
         fileutil.write_file(self.get_manifest_file(), man)
 
@@ -310,102 +354,98 @@ class ExtensionInstance(object):
         fileutil.mkdir(conf_dir, mode=0o700)
 
         #Init handler state to uninstall
-        self.set_handler_status("NotReady")
+        self.set_state("NotReady")
 
         #Save HandlerEnvironment.json
         self.create_handler_env()
 
     def enable(self):
         self.logger.info("Enable extension.")
-        self.curr_op=WALAEventOperation.Enable
+        self.set_operation(WALAEventOperation.Enable)
+
         man = self.load_manifest()
         self.launch_command(man.get_enable_command())
-        self.set_handler_status("Ready")
-        add_event(name=self.get_name(), is_success=True,
-                          op=self.curr_op, message="")
+        self.set_state("Ready")
 
     def disable(self):
         self.logger.info("Disable extension.")
-        self.curr_op=WALAEventOperation.Disable
+        self.set_operation(WALAEventOperation.Disable)
+
         man = self.load_manifest()
         self.launch_command(man.get_disable_command(), timeout=900)
-        self.set_handler_status("Ready")
-        add_event(name=self.get_name(), is_success=True,
-                          op=self.curr_op, message="")
+        self.set_state("NotReady")
 
     def install(self):
         self.logger.info("Install extension.")
-        self.curr_op=WALAEventOperation.Install
+        self.set_operation(WALAEventOperation.Install)
+
         man = self.load_manifest()
-        self.set_handler_status("Installing")
+        self.set_state("Installing")
         self.launch_command(man.get_install_command(), timeout=900)
-        self.set_handler_status("Ready")
-        add_event(name=self.get_name(), is_success=True,
-                          op=self.curr_op, message="")
+        self.set_state("Ready")
 
     def uninstall(self):
         self.logger.info("Uninstall extension.")
-        self.curr_op=WALAEventOperation.UnInstall
+        self.set_operation(WALAEventOperation.UnInstall)
+
         man = self.load_manifest()
         self.launch_command(man.get_uninstall_command())
-        self.set_handler_status("NotReady")
-        add_event(name=self.get_name(), is_success=True,
-                          op=self.curr_op, message="")
+        #TODO for azure stack test
+        #self.set_state("NotReady")
+        self.handler_status = None
+        self.ext_status = None
 
     def update(self):
         self.logger.info("Update extension.")
-        self.curr_op=WALAEventOperation.Update
+        self.set_operation(WALAEventOperation.Update)
+
         man = self.load_manifest()
         self.launch_command(man.get_update_command(), timeout=900)
-        add_event(name=self.get_name(), is_success=True,
-                          op=self.curr_op, message="")
-
-    def create_handler_status(self, ext_status, heartbeat=None):
-        status = prot.ExtensionHandlerStatus()
-        status.handlerName = self.get_name()
-        status.handlerVersion = self.get_version()
-        status.status = self.get_handler_status()
-        status.extensionStatusList.append(ext_status)
-        return status
 
     def collect_handler_status(self):
+        self.logger.info("Collect extension handler status")
+        #TODO for azure stack test
+        if self.handler_status is None:
+            return
+
+        self.handler_status.status = self.get_state()
         man = self.load_manifest()
-        heartbeat=None
         if man.is_report_heartbeat():
             heartbeat = self.collect_heartbeat()
-        ext_status = self.collect_extension_status()
-        status= self.create_handler_status(ext_status, heartbeat)
-        status.status = self.get_handler_status()
-        if heartbeat is not None:
-            status.status = heartbeat['status']
-        status.extensionStatusList.append(ext_status)
-        return status
+            if heartbeat is not None:
+                self.handler_status.status = heartbeat['status']
 
-    def collect_extension_status(self):
+    def collect_ext_status(self):
+        self.logger.info("Collect extension status")
+        #TODO for azure stack test
+        if self.handler_status is None:
+            return
+
+        if self.ext is None:
+            return
+
         ext_status_file = self.get_status_file()
         try:
-            ext_status_str = fileutil.read_file(ext_status_file)
-            ext_status = json.loads(ext_status_str)
+            data_str = fileutil.read_file(ext_status_file)
+            data = json.loads(data_str)
+            parse_ext_status(self.ext_status, data)
         except IOError as e:
             raise ExtensionError("Failed to get status file: {0}".format(e))
         except ValueError as e:
             raise ExtensionError("Malformed status file: {0}".format(e))
-        return ext_status_to_v2(ext_status[0],
-                                      self.settings.sequenceNumber)
 
-    def get_handler_status(self):
-        h_status = "uninstalled"
-        h_status_file = self.get_handler_state_file()
+    def get_state(self):
+        handler_state_file = self.get_handler_state_file()
         try:
-            h_status = fileutil.read_file(h_status_file)
-            return h_status
+            handler_state = fileutil.read_file(handler_state_file)
+            return handler_state
         except IOError as e:
             raise ExtensionError("Failed to get handler status: {0}".format(e))
 
-    def set_handler_status(self, status):
-        h_status_file = self.get_handler_state_file()
+    def set_state(self, state):
+        handler_state_file = self.get_handler_state_file()
         try:
-            fileutil.write_file(h_status_file, status)
+            fileutil.write_file(handler_state_file, state)
         except IOError as e:
             raise ExtensionError("Failed to set handler status: {0}".format(e))
 
@@ -431,7 +471,7 @@ class ExtensionInstance(object):
         return heartbeat
 
     def is_responsive(self, heartbeat_file):
-        last_update=int(time.time()-os.stat(heartbeat_file).st_mtime)
+        last_update=int(time.time() - os.stat(heartbeat_file).st_mtime)
         return  last_update > 600    # not updated for more than 10 min
 
     def launch_command(self, cmd, timeout=300):
@@ -457,6 +497,7 @@ class ExtensionInstance(object):
         ret = child.wait()
         if ret == None or ret != 0:
             raise ExtensionError("Non-zero exit code: {0}, {1}".format(ret, cmd))
+        self.report_event()
 
     def load_manifest(self):
         man_file = self.get_manifest_file()
@@ -469,16 +510,15 @@ class ExtensionInstance(object):
 
         return HandlerManifest(data[0])
 
-
     def update_settings(self):
-        if self.settings is None:
+        if self.ext is None:
             self.logger.verbose("Extension has no settings")
             return
 
         settings = {
-            'publicSettings': self.settings.publicSettings,
-            'protectedSettings': self.settings.privateSettings,
-            'protectedSettingsCertThumbprint': self.settings.certificateThumbprint
+            'publicSettings': self.ext.publicSettings,
+            'protectedSettings': self.ext.privateSettings,
+            'protectedSettingsCertThumbprint': self.ext.certificateThumbprint
         }
         ext_settings = {
             "runtimeSettings":[{
@@ -486,7 +526,6 @@ class ExtensionInstance(object):
             }]
         }
         fileutil.write_file(self.get_settings_file(), json.dumps(ext_settings))
-
 
     def create_handler_env(self):
         env = [{
@@ -502,8 +541,8 @@ class ExtensionInstance(object):
                                  json.dumps(env))
 
     def get_target_version(self):
-        version = self.get_version()
-        update_policy = self.get_upgrade_policy()
+        version = self.curr_version
+        update_policy = self.update_policy
         if update_policy is None or update_policy.lower() != 'auto':
             return version
 
@@ -531,27 +570,9 @@ class ExtensionInstance(object):
                 return package.uris
 
         raise ExtensionError("Can't get package uris for {0}.".format(version))
-
-    def get_curr_op(self):
-        return self.curr_op
-
-    def get_name(self):
-        return self.extension.name
-
-    def get_version(self):
-        return self.extension.properties.version
-
-    def get_state(self):
-        return self.extension.properties.state
-
-    def get_seq_no(self):
-        return self.settings.sequenceNumber
-
-    def get_upgrade_policy(self):
-        return self.extension.properties.upgradePolicy
-
+    
     def get_full_name(self):
-        return "{0}-{1}".format(self.get_name(), self.curr_version)
+        return "{0}-{1}".format(self.name, self.curr_version)
 
     def get_base_dir(self):
         return os.path.join(OSUTIL.get_lib_dir(), self.get_full_name())
@@ -561,14 +582,14 @@ class ExtensionInstance(object):
 
     def get_status_file(self):
         return os.path.join(self.get_status_dir(),
-                            "{0}.status".format(self.settings.sequenceNumber))
+                            "{0}.status".format(self.ext.sequenceNumber))
 
     def get_conf_dir(self):
         return os.path.join(self.get_base_dir(), 'config')
 
     def get_settings_file(self):
         return os.path.join(self.get_conf_dir(),
-                            "{0}.settings".format(self.settings.sequenceNumber))
+                            "{0}.settings".format(self.ext.sequenceNumber))
 
     def get_handler_state_file(self):
         return os.path.join(self.get_conf_dir(), 'HandlerState')
@@ -583,7 +604,7 @@ class ExtensionInstance(object):
         return os.path.join(self.get_base_dir(), 'HandlerEnvironment.json')
 
     def get_log_dir(self):
-        return os.path.join(OSUTIL.get_ext_log_dir(), self.get_name(),
+        return os.path.join(OSUTIL.get_ext_log_dir(), self.name,
                             self.curr_version)
 
 class HandlerEnvironment(object):

--- a/azurelinuxagent/distro/default/handlerFactory.py
+++ b/azurelinuxagent/distro/default/handlerFactory.py
@@ -23,7 +23,7 @@ from .dhcp import DhcpHandler
 from .env import EnvHandler
 from .provision import ProvisionHandler
 from .resourceDisk import ResourceDiskHandler
-from .extension import ExtensionsHandler
+from .extension import ExtHandlersHandler
 from .deprovision import DeprovisionHandler
 
 class DefaultHandlerFactory(object):
@@ -35,6 +35,6 @@ class DefaultHandlerFactory(object):
         self.env_handler = EnvHandler(self)
         self.provision_handler = ProvisionHandler()
         self.resource_disk_handler = ResourceDiskHandler()
-        self.extension_handler = ExtensionsHandler()
+        self.ext_handlers_handler = ExtHandlersHandler()
         self.deprovision_handler = DeprovisionHandler()
 

--- a/azurelinuxagent/distro/default/osutil.py
+++ b/azurelinuxagent/distro/default/osutil.py
@@ -122,8 +122,8 @@ class DefaultOSUtil(object):
             raise OSUtilError(("User {0} is a system user. "
                                "Will not set passwd.").format(username))
         passwd_hash = textutil.gen_password_hash(password, crypt_id, salt_len)
-        cmd = "usermod {0} -p '{1}'".format(username, passwd_hash)
-        ret, output = shellutil.run_get_output(cmd)
+        cmd = "usermod -p '{0}' {1}".format(passwd_hash, username)
+        ret, output = shellutil.run_get_output(cmd, log_cmd=False)
         if ret != 0:
             raise OSUtilError(("Failed to set password for {0}: {1}"
                                "").format(username, output))

--- a/azurelinuxagent/distro/default/osutil.py
+++ b/azurelinuxagent/distro/default/osutil.py
@@ -122,15 +122,11 @@ class DefaultOSUtil(object):
             raise OSUtilError(("User {0} is a system user. "
                                "Will not set passwd.").format(username))
         passwd_hash = textutil.gen_password_hash(password, crypt_id, salt_len)
-        try:
-            passwd_content = fileutil.read_file(self.passwd_file_path)
-            passwd = passwd_content.split("\n")
-            new_passwd = [x for x in passwd if not x.startswith(username)]
-            new_passwd.append("{0}:{1}:14600::::::".format(username, passwd_hash))
-            fileutil.write_file(self.passwd_file_path, "\n".join(new_passwd))
-        except IOError as e:
+        cmd = "usermod {0} -p '{1}'".format(username, passwd_hash)
+        ret, output = shellutil.run_get_output(cmd)
+        if ret != 0:
             raise OSUtilError(("Failed to set password for {0}: {1}"
-                               "").format(username, e))
+                               "").format(username, output))
 
     def conf_sudoer(self, username, nopasswd):
         # for older distros create sudoers.d

--- a/azurelinuxagent/distro/default/osutil.py
+++ b/azurelinuxagent/distro/default/osutil.py
@@ -117,13 +117,11 @@ class DefaultOSUtil(object):
                                "retcode:{1}, "
                                "output:{2}").format(username, retcode, out))
 
-    def chpasswd(self, username, password, use_salt=True, salt_type=6,
-                 salt_len=10):
+    def chpasswd(self, username, password, crypt_id=6, salt_len=10):
         if self.is_sys_user(username):
             raise OSUtilError(("User {0} is a system user. "
                                "Will not set passwd.").format(username))
-        passwd_hash = textutil.gen_password_hash(password, use_salt, salt_type,
-                                                 salt_len)
+        passwd_hash = textutil.gen_password_hash(password, crypt_id, salt_len)
         try:
             passwd_content = fileutil.read_file(self.passwd_file_path)
             passwd = passwd_content.split("\n")

--- a/azurelinuxagent/distro/default/provision.py
+++ b/azurelinuxagent/distro/default/provision.py
@@ -120,10 +120,10 @@ class ProvisionHandler(object):
 
         if ovfenv.user_password is not None:
             logger.info("Set user password.")
-            use_salt = conf.get_switch("Provision.UseSalt", True)
-            salt_type = conf.get_switch("Provision.SaltType", 6)
-            OSUTIL.chpasswd(ovfenv.username, ovfenv.user_password, 
-                            use_salt,salt_type)
+            crypt_id = conf.get("Provision.PasswordCryptId", "6")
+            salt_len = conf.get_int("Provision.PasswordCryptSaltLength", 10)
+            OSUTIL.chpasswd(ovfenv.username, ovfenv.user_password,
+                            crypt_id=crypt_id, salt_len=salt_len)
          
         logger.info("Configure sudoer")
         OSUTIL.conf_sudoer(ovfenv.username, ovfenv.user_password is None)

--- a/azurelinuxagent/distro/default/run.py
+++ b/azurelinuxagent/distro/default/run.py
@@ -27,8 +27,8 @@ from azurelinuxagent.metadata import AGENT_LONG_NAME, AGENT_VERSION, \
                                      DISTRO_NAME, DISTRO_VERSION, \
                                      DISTRO_FULL_NAME, PY_VERSION_MAJOR, \
                                      PY_VERSION_MINOR, PY_VERSION_MICRO
-import azurelinuxagent.protocol as prot
 import azurelinuxagent.event as event
+import azurelinuxagent.protocol as prot
 from azurelinuxagent.utils.osutil import OSUTIL
 import azurelinuxagent.utils.fileutil as fileutil
 
@@ -65,22 +65,7 @@ class MainHandler(object):
 
         protocol = prot.FACTORY.get_default_protocol()
         while True:
-
             #Handle extensions
-            h_status_list = self.handlers.extension_handler.process()
-
-            #Report status
-            vm_status = prot.VMStatus()
-            vm_status.vmAgent.agentVersion = AGENT_LONG_NAME
-            vm_status.vmAgent.status = "Ready"
-            vm_status.vmAgent.message = "Guest Agent is running"
-            for h_status in h_status_list:
-                vm_status.extensionHandlers.append(h_status)
-            try:
-                logger.info("Report vm status")
-                protocol.report_status(vm_status)
-            except prot.ProtocolError as e:
-                logger.error("Failed to report vm status: {0}", e)
-
+            self.handlers.ext_handlers_handler.process()
             time.sleep(25)
 

--- a/azurelinuxagent/event.py
+++ b/azurelinuxagent/event.py
@@ -111,7 +111,7 @@ class EventMonitor(object):
                 continue
 
             event = prot.TelemetryEvent()
-            prot.set_properties(event, data)
+            prot.set_properties("event", event, data)
             event.parameters.extend(self.sysinfo)
             event_list.events.append(event)
         if len(event_list.events) == 0:
@@ -151,8 +151,10 @@ def save_event(data):
     except IOError as e:
         raise EventError("Failed to write events to file:{0}", e)
 
-def add_event(name, op, is_success, duration=0, version="1.0",
+def add_event(name, op="", is_success=True, duration=0, version="1.0",
               message="", evt_type="", is_internal=False):
+    log = logger.info if is_success else logger.error
+    log("Event: name={0}, op={1}, message={2}", name, op, message)
     event = prot.TelemetryEvent(1, "69B669B9-4AF8-4C50-BDC4-6006FA76E975")
     event.parameters.append(prot.TelemetryEventParam('Name', name))
     event.parameters.append(prot.TelemetryEventParam('Version', version))

--- a/azurelinuxagent/event.py
+++ b/azurelinuxagent/event.py
@@ -82,9 +82,11 @@ class EventMonitor(object):
 
     def collect_event(self, evt_file_name):
         try:
+            logger.info("Found event file: {0}", evt_file_name)
             with open(evt_file_name, "rb") as evt_file:
             #if fail to open or delete the file, throw exception
                 json_str = evt_file.read().decode("utf-8",'ignore')
+            logger.info("Processed event file: {0}", evt_file_name)
             os.remove(evt_file_name)
             return json_str
         except IOError as e:
@@ -181,7 +183,6 @@ def dump_unhandled_err(name):
         error = traceback.format_exception(last_type, last_value,
                                            last_traceback)
         message= "".join(error)
-        logger.error(message)
         add_event(name, is_success=False, message=message,
                           op=WALAEventOperation.UnhandledError)
 

--- a/azurelinuxagent/logger.py
+++ b/azurelinuxagent/logger.py
@@ -23,7 +23,6 @@ Log utils
 
 import sys
 from azurelinuxagent.future import text
-import azurelinuxagent.utils.textutil as textutil
 from datetime import datetime
 
 class Logger(object):
@@ -49,6 +48,9 @@ class Logger(object):
         self.log(LogLevel.ERROR, msg_format, *args)
 
     def log(self, level, msg_format, *args):
+        #if msg_format is not unicode convert it to unicode
+        if type(msg_format) is not text:
+            msg_format = text(msg_format, errors="backslashreplace")
         if len(args) > 0:
             msg = msg_format.format(*args)
         else:
@@ -60,7 +62,8 @@ class Logger(object):
                                                    msg)
         else:
             log_item = u"{0} {1} {2}\n".format(time, level_str, msg)
-        log_item = text(log_item.encode("ascii", "backslashreplace"), encoding='ascii')
+
+        log_item = text(log_item.encode('ascii', "backslashreplace"))
         for appender in self.appenders:
             appender.write(level, log_item)
 

--- a/azurelinuxagent/logger.py
+++ b/azurelinuxagent/logger.py
@@ -20,7 +20,7 @@
 """
 Log utils
 """
-
+import os
 import sys
 from azurelinuxagent.future import text
 from datetime import datetime
@@ -63,7 +63,8 @@ class Logger(object):
         else:
             log_item = u"{0} {1} {2}\n".format(time, level_str, msg)
 
-        log_item = text(log_item.encode('ascii', "backslashreplace"))
+        log_item = text(log_item.encode('ascii', "backslashreplace"), 
+                        encoding="ascii")
         for appender in self.appenders:
             appender.write(level, log_item)
 
@@ -109,7 +110,6 @@ class StdoutAppender(object):
                 sys.stdout.write(msg)
             except IOError:
                 pass
-
 
 #Initialize logger instance
 DEFAULT_LOGGER = Logger()

--- a/azurelinuxagent/metadata.py
+++ b/azurelinuxagent/metadata.py
@@ -46,7 +46,7 @@ def get_distro():
 
 AGENT_NAME = "WALinuxAgent"
 AGENT_LONG_NAME = "Azure Linux Agent"
-AGENT_VERSION = '2.1.1'
+AGENT_VERSION = '2.1.2-pre'
 AGENT_LONG_VERSION = "{0}-{1}".format(AGENT_NAME, AGENT_VERSION)
 AGENT_DESCRIPTION = """\
 The Azure Linux Agent supports the provisioning and running of Linux

--- a/azurelinuxagent/protocol/v1.py
+++ b/azurelinuxagent/protocol/v1.py
@@ -256,6 +256,10 @@ def ext_handler_status_to_v1(handler_status, ext_statuses, timestamp):
         'handlerVersion' : handler_status.version,
         'handlerName' : handler_status.name,
         'status' : handler_status.status,
+        "formattedMessage": {
+            "lang":"en-US",
+            "message": handler_status.message
+        },
         'runtimeSettingsStatus' : {
         }
     }

--- a/azurelinuxagent/protocol/v1.py
+++ b/azurelinuxagent/protocol/v1.py
@@ -77,31 +77,36 @@ class WireProtocol(Protocol):
         certificates = self.client.get_certs()
         return certificates.cert_list
 
-    def get_extensions(self):
+    def get_ext_handlers(self):
         #Update goal state to get latest extensions config
         self.client.update_goal_state()
         ext_conf = self.client.get_ext_conf()
-        return ext_conf.ext_list
+        return ext_conf.ext_handlers
 
-    def get_extension_pkgs(self, extension):
+    def get_ext_handler_pkgs(self, ext_handler):
         goal_state = self.client.get_goal_state()
-        man = self.client.get_ext_manifest(extension, goal_state)
+        man = self.client.get_ext_manifest(ext_handler, goal_state)
         return man.pkg_list
    
-    def report_provision_status(self, provisionStatus):
-        validata_param("provisionStatus", provisionStatus, ProvisionStatus)
+    def report_provision_status(self, provision_status):
+        validata_param("provision_status", provision_status, ProvisionStatus)
 
-        if provisionStatus.status is not None:
-            self.client.report_health(provisionStatus.status,
-                                     provisionStatus.subStatus,
-                                     provisionStatus.description)
-        if provisionStatus.properties.certificateThumbprint is not None:
-            thumbprint = provisionStatus.properties.certificateThumbprint
+        if provision_status.status is not None:
+            self.client.report_health(provision_status.status,
+                                      provision_status.subStatus,
+                                      provision_status.description)
+        if provision_status.properties.certificateThumbprint is not None:
+            thumbprint = provision_status.properties.certificateThumbprint
             self.client.report_role_prop(thumbprint)
 
-    def report_status(self, vmStatus):
-        validata_param("vmStatus", vmStatus, VMStatus)
-        self.client.upload_status_blob(vmStatus)
+    def report_vm_status(self, vm_status):
+        validata_param("vm_status", vm_status, VMStatus)
+        self.client.status_blob.set_vm_status(vm_status)
+        self.client.upload_status_blob()
+
+    def report_ext_status(self, ext_handler_name, ext_name, ext_status):
+        validata_param("ext_status", ext_status, ExtensionStatus)
+        self.client.status_blob.set_ext_status(ext_handler_name, ext_status)
 
     def report_event(self, events):
         validata_param("events", events, TelemetryEventList)
@@ -193,19 +198,19 @@ def _build_health_report(incarnation, container_id, role_instance_id,
 """
 Convert VMStatus object to status blob format
 """
-def guest_agent_status_to_v1(ga_status):
+def ga_status_to_v1(ga_status):
     formatted_msg = {
         'lang' : 'en-US',
         'message' : ga_status.message
     }
     v1_ga_status = {
-        'version' : ga_status.agentVersion,
+        'version' : ga_status.version,
         'status' : ga_status.status,
         'formattedMessage' : formatted_msg
     }
     return v1_ga_status
 
-def extension_substatus_to_v1(sub_status_list):
+def ext_substatus_to_v1(sub_status_list):
     status_list = []
     for substatus in sub_status_list:
         status = {
@@ -220,14 +225,14 @@ def extension_substatus_to_v1(sub_status_list):
         status_list.append(status)
     return status_list
 
-def extension_handler_status_to_v1(handler_status, timestamp):
-    if handler_status is None or len(handler_status.extensionStatusList) == 0:
-        return
-    ext_status = handler_status.extensionStatusList[0]
-    sub_status = extension_substatus_to_v1(ext_status.substatusList)
-    ext_in_status = {
+def ext_status_to_v1(ext_name, ext_status):
+    if ext_status is None:
+        return None
+    timestamp = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    v1_sub_status = ext_substatus_to_v1(ext_status.substatusList)
+    v1_ext_status = {
         "status":{
-            "name": ext_status.name,
+            "name": ext_name,
             "configurationAppliedTime": ext_status.configurationAppliedTime,
             "operation": ext_status.operation,
             "status": ext_status.status,
@@ -239,31 +244,41 @@ def extension_handler_status_to_v1(handler_status, timestamp):
         },
         "timestampUTC": timestamp
     }
-
-    if len(sub_status) != 0:
-        ext_in_status['substatus'] = sub_status
-
+    if len(v1_sub_status) != 0:
+        v1_ext_status['substatus'] = v1_sub_status
+    return v1_ext_status
+    
+def ext_handler_status_to_v1(handler_status, ext_statuses, timestamp):
     v1_handler_status = {
-        'handlerVersion' : handler_status.handlerVersion,
-        'handlerName' : handler_status.handlerName,
+        'handlerVersion' : handler_status.version,
+        'handlerName' : handler_status.name,
         'status' : handler_status.status,
         'runtimeSettingsStatus' : {
-            'settingsStatus' : ext_in_status,
-            'sequenceNumber' : ext_status.sequenceNumber
         }
     }
+
+    if len(handler_status.extensions) > 0:
+        #Currently, no more than one extension per handler
+        ext_name = handler_status.extensions[0]
+        ext_status = ext_statuses.get(ext_name)
+        v1_ext_status = ext_status_to_v1(ext_name, ext_status)
+        if ext_status is not None and v1_ext_status is not None:
+            v1_handler_status["runtimeSettingsStatus"] = {
+                'settingsStatus' : v1_ext_status,
+                'sequenceNumber' : ext_status.sequenceNumber
+            }
     return v1_handler_status
 
-
-def vm_status_to_v1(vm_status):
+def vm_status_to_v1(vm_status, ext_statuses):
     timestamp = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
 
-    v1_ga_status = guest_agent_status_to_v1(vm_status.vmAgent)
+    v1_ga_status = ga_status_to_v1(vm_status.vmAgent)
     v1_handler_status_list = []
-    for handler_status in vm_status.extensionHandlers:
-        v1_handler_status = extension_handler_status_to_v1(handler_status,
-                                                          timestamp)
-        v1_handler_status_list.append(v1_handler_status)
+    for handler_status in vm_status.vmAgent.extensionHandlers:
+        v1_handler_status = ext_handler_status_to_v1(handler_status, 
+                                                     ext_statuses, timestamp)
+        if v1_handler_status is not None:
+            v1_handler_status_list.append(v1_handler_status)
 
     v1_agg_status = {
         'guestAgentStatus': v1_ga_status,
@@ -278,16 +293,26 @@ def vm_status_to_v1(vm_status):
 
 
 class StatusBlob(object):
-    def __init__(self, vm_status):
-        self.vm_status = vm_status
+    def __init__(self):
+        self.vm_status = None
+        self.ext_statuses = {}
 
+    def set_vm_status(self, vm_status):
+        validata_param("vmAgent", vm_status, VMStatus)
+        self.vm_status = vm_status
+    
+    def set_ext_status(self, ext_handler_name, ext_status):
+        validata_param("extensionStatus", ext_status, ExtensionStatus)
+        self.ext_statuses[ext_handler_name]= ext_status
+        
     def to_json(self):
-        report = vm_status_to_v1(self.vm_status)
+        report = vm_status_to_v1(self.vm_status, self.ext_statuses)
         return json.dumps(report)
 
     __storage_version__ = "2014-02-14"
 
     def upload(self, url):
+        #TODO upload extension only if content has changed
         logger.info("Upload status blob")
         blob_type = self.get_blob_type(url)
 
@@ -416,6 +441,7 @@ class WireClient(object):
         self.certs = None
         self.ext_conf = None
         self.req_count = 0
+        self.status_blob = StatusBlob()
 
     def update_hosting_env(self, goal_state):
         if goal_state.hosting_env_uri is None:
@@ -450,13 +476,13 @@ class WireClient(object):
                             self.get_header())
         fileutil.write_file(local_file, xml_text)
         self.ext_conf = ExtensionsConfig(xml_text)
-        for extension in self.ext_conf.ext_list.extensions:
-            self.update_ext_manifest(extension, goal_state)
+        for ext_handler in self.ext_conf.ext_handlers.extHandlers:
+            self.update_ext_handler_manifest(ext_handler, goal_state)
 
-    def update_ext_manifest(self, extension, goal_state):
-        local_file = MANIFEST_FILE_NAME.format(extension.name,
-                                        goal_state.incarnation)
-        xml_text = _fetch_manifest(extension.version_uris)
+    def update_ext_handler_manifest(self, ext_handler, goal_state):
+        local_file = MANIFEST_FILE_NAME.format(ext_handler.name,
+                                               goal_state.incarnation)
+        xml_text = _fetch_manifest(ext_handler.versionUris)
         fileutil.write_file(local_file, xml_text)
 
     def update_goal_state(self, forced=False, max_retry=3):
@@ -551,11 +577,10 @@ class WireClient(object):
             error = ("Agent supported wire protocol version: {0} was not "
                      "advised by Fabric.").format(PROTOCOL_VERSION)
             raise ProtocolNotFound(error)
-
-    def upload_status_blob(self, vm_status):
+   
+    def upload_status_blob(self):
         ext_conf = self.get_ext_conf()
-        status_blob = StatusBlob(vm_status)
-        status_blob.upload(ext_conf.status_upload_blob)
+        self.status_blob.upload(ext_conf.status_upload_blob)
 
     def report_role_prop(self, thumbprint):
         goal_state = self.get_goal_state()
@@ -851,7 +876,7 @@ class Certificates(object):
 
         for v1_cert in v1_cert_list:
             cert = Cert()
-            set_properties(cert, v1_cert)
+            set_properties("certs", cert, v1_cert)
             self.cert_list.certificates.append(cert)
 
     def write_to_tmp_file(self, index, suffix, buf):
@@ -871,7 +896,7 @@ class ExtensionsConfig(object):
         if xml_text is None:
             raise ValueError("ExtensionsConfig is None")
         logger.verb("Load ExtensionsConfig.xml")
-        self.ext_list = ExtensionList()
+        self.ext_handlers = ExtHandlerList()
         self.status_upload_blob = None
         self.parse(xml_text)
 
@@ -886,38 +911,38 @@ class ExtensionsConfig(object):
         plugin_settings = findall(plugin_settings_list, "Plugin")
 
         for plugin in plugins:
-            ext = self.parse_ext(plugin)
-            self.ext_list.extensions.append(ext)
-            self.parse_ext_settings(ext, plugin_settings)
+            ext_handler = self.parse_plugin(plugin)
+            self.ext_handlers.extHandlers.append(ext_handler)
+            self.parse_plugin_settings(ext_handler, plugin_settings)
 
         self.status_upload_blob = findtext(xml_doc, "StatusUploadBlob")
 
-    def parse_ext(self, plugin):
-        ext = Extension()
-        ext.name = getattrib(plugin, "name")
-        ext.properties.version = getattrib(plugin, "version")
-        ext.properties.state = getattrib(plugin, "state")
+    def parse_plugin(self, plugin):
+        ext_handler = ExtHandler()
+        ext_handler.name = getattrib(plugin, "name")
+        ext_handler.properties.version = getattrib(plugin, "version")
+        ext_handler.properties.state = getattrib(plugin, "state")
 
         auto_upgrade = getattrib(plugin, "autoUpgrade")
         if auto_upgrade is not None and auto_upgrade.lower() == "true":
-            ext.properties.upgradePolicy = "auto"
+            ext_handler.properties.upgradePolicy = "auto"
         else:
-            ext.properties.upgradePolicy = "manual"
+            ext_handler.properties.upgradePolicy = "manual"
 
         location = getattrib(plugin, "location")
         failover_location = getattrib(plugin, "failoverlocation")
         for uri in [location, failover_location]:
-            version_uri = ExtensionVersionUri()
+            version_uri = ExtHandlerVersionUri()
             version_uri.uri = uri
-            ext.version_uris.append(version_uri)
-        return ext
+            ext_handler.versionUris.append(version_uri)
+        return ext_handler
 
-    def parse_ext_settings(self, ext, plugin_settings):
+    def parse_plugin_settings(self, ext_handler, plugin_settings):
         if plugin_settings is None:
             return 
 
-        name = ext.name
-        version = ext.properties.version
+        name = ext_handler.name
+        version = ext_handler.properties.version
         settings = [x for x in plugin_settings \
                           if getattrib(x, "name") == name and \
                              getattrib(x ,"version") == version]
@@ -937,20 +962,23 @@ class ExtensionsConfig(object):
 
         for plugin_settings_list in runtime_settings["runtimeSettings"]:
             handler_settings = plugin_settings_list["handlerSettings"]
-            ext_settings = ExtensionSettings()
-            ext_settings.sequenceNumber = seqNo
-            ext_settings.publicSettings = handler_settings.get("publicSettings", None)
-            ext_settings.privateSettings = handler_settings.get("protectedSettings", None)
-            thumbprint = handler_settings.get("protectedSettingsCertThumbprint", None)
-            ext_settings.certificateThumbprint = thumbprint
-            ext.properties.extensions.append(ext_settings)
+            ext = Extension()
+            #There is no "extension name" in wire protocol.
+            #Put
+            ext.name = ext_handler.name
+            ext.sequenceNumber = seqNo
+            ext.publicSettings = handler_settings.get("publicSettings")
+            ext.privateSettings = handler_settings.get("protectedSettings")
+            thumbprint = handler_settings.get("protectedSettingsCertThumbprint")
+            ext.certificateThumbprint = thumbprint
+            ext_handler.properties.extensions.append(ext)
 
 class ExtensionManifest(object):
     def __init__(self, xml_text):
         if xml_text is None:
             raise ValueError("ExtensionManifest is None")
         logger.verb("Load ExtensionManifest.xml")
-        self.pkg_list = ExtensionPackageList()
+        self.pkg_list = ExtHandlerPackageList()
         self.parse(xml_text)
 
     def parse(self, xml_text):
@@ -961,10 +989,10 @@ class ExtensionManifest(object):
             uris = find(package, "Uris")
             uri_list = findall(uris, "Uri")
             uri_list = [gettext(x) for x in uri_list]
-            package = ExtensionPackage()
+            package = ExtHandlerPackage()
             package.version = version
             for uri in uri_list:
-                pkg_uri = ExtensionPackageUri()
+                pkg_uri = ExtHandlerVersionUri()
                 pkg_uri.uri = uri
                 package.uris.append(pkg_uri)
             self.pkg_list.versions.append(package)

--- a/azurelinuxagent/protocol/v2.py
+++ b/azurelinuxagent/protocol/v2.py
@@ -98,7 +98,6 @@ class MetadataProtocol(Protocol):
         return vminfo
 
     def get_certs(self):
-        #TODO walk arround for azure pack test
         #TODO download and save certs
         return CertList()
 

--- a/azurelinuxagent/protocol/v2.py
+++ b/azurelinuxagent/protocol/v2.py
@@ -25,7 +25,7 @@ ENDPOINT='169.254.169.254'
 #TODO use http for azure pack test
 #ENDPOINT='localhost'
 APIVERSION='2015-05-01-preview'
-BASE_URI = "http://{0}/Microsoft.Compute/{1}?api-version={{{2}}}{3}"
+BASE_URI = "http://{0}/Microsoft.Compute/{1}?api-version={2}{3}"
 
 def _add_content_type(headers):
     if headers is None:
@@ -47,12 +47,15 @@ class MetadataProtocol(Protocol):
         self.provision_status_uri = BASE_URI.format(self.endpoint,
                                                     "provisioningStatus",
                                                     self.apiversion, "")
-        self.status_uri = BASE_URI.format(self.endpoint, "status",
-                                          self.apiversion, "")
+        self.vm_status_uri = BASE_URI.format(self.endpoint, "status/vmagent",
+                                             self.apiversion, "")
+        self.ext_status_uri = BASE_URI.format(self.endpoint, 
+                                              "status/extensions/{0}",
+                                              self.apiversion, "")
         self.event_uri = BASE_URI.format(self.endpoint, "status/telemetry",
                                          self.apiversion, "")
 
-    def _get_data(self, data_type, url, headers=None):
+    def _get_data(self, url, headers=None):
         try:
             resp = restutil.http_get(url, headers=headers)
         except restutil.HttpError as e:
@@ -60,20 +63,15 @@ class MetadataProtocol(Protocol):
 
         if resp.status != httpclient.OK:
             raise ProtocolError("{0} - GET: {1}".format(resp.status, url))
-        try:
-            data = resp.read()
-            if data is None:
-                return None
-            data = json.loads(text(data, encoding="utf-8"))
-        except ValueError as e:
-            raise ProtocolError(text(e))
-        obj = data_type()
-        set_properties(obj, data)
-        return obj
 
-    def _put_data(self, url, obj, headers=None):
+        data = resp.read()
+        if data is None:
+            return None
+        data = json.loads(text(data, encoding="utf-8"))
+        return data
+
+    def _put_data(self, url, data, headers=None):
         headers = _add_content_type(headers) 
-        data = get_properties(obj)
         try:
             resp = restutil.http_put(url, json.dumps(data), headers=headers)
         except restutil.HttpError as e:
@@ -81,9 +79,8 @@ class MetadataProtocol(Protocol):
         if resp.status != httpclient.OK:
             raise ProtocolError("{0} - PUT: {1}".format(resp.status, url))
 
-    def _post_data(self, url, obj, headers=None):
+    def _post_data(self, url, data, headers=None):
         headers = _add_content_type(headers) 
-        data = get_properties(obj)
         try:
             resp = restutil.http_post(url, json.dumps(data), headers=headers)
         except restutil.HttpError as e:
@@ -95,28 +92,55 @@ class MetadataProtocol(Protocol):
         pass
 
     def get_vminfo(self):
-        return self._get_data(VMInfo, self.identity_uri)
+        vminfo = VMInfo()
+        data = self._get_data(self.identity_uri)
+        set_properties("vminfo", vminfo, data)
+        return vminfo
 
     def get_certs(self):
         #TODO walk arround for azure pack test
+        #TODO download and save certs
         return CertList()
 
-        certs = self._get_data(CertList, self.cert_uri)
-        #TODO download pfx and convert to pem
-        return certs
+    def get_ext_handlers(self):
+        ext_list = ExtHandlerList()
+        data = self._get_data(self.ext_uri)
+        set_properties("extensionHandlers", ext_list.extHandlers, data)
+        return ext_list
 
-    def get_extensions(self):
-        return self._get_data(ExtensionList, self.ext_uri)
+    def get_ext_handler_pkgs(self, ext_handler):
+        ext_handler_pkgs = ExtHandlerPackageList()
+        data = None
+        for version_uri in ext_handler.versionUris:
+            try:
+                data = self._get_data(version_uri.uri)
+                break
+            except ProtocolError as e:
+                logger.warn("Failed to get version uris: {0}", e)
+                logger.info("Retry getting version uris")
+        set_properties("extensionPackages", ext_handler_pkgs, data)
+        return ext_handler_pkgs
 
-    def report_provision_status(self, status):
-        validata_param('status', status, ProvisionStatus)
-        self._put_data(self.provision_status_uri, status)
+    def report_provision_status(self, provision_status):
+        validata_param('provisionStatus', provision_status, ProvisionStatus)
+        data = get_properties(provision_status)
+        self._put_data(self.provision_status_uri, data)
 
-    def report_status(self, status):
-        validata_param('status', status, VMStatus)
-        self._put_data(self.status_uri, status)
+    def report_vm_status(self, vm_status):
+        validata_param('vmStatus', vm_status, VMStatus)
+        data = get_properties(vm_status)
+        self._put_data(self.vm_status_uri, data)
+
+    def report_ext_status(self, ext_handler_name, ext_name, ext_status):
+        validata_param('extensionStatus', ext_status, ExtensionStatus)
+        data = get_properties(ext_status)
+        uri = self.ext_status_uri.format(ext_name)
+        self._put_data(uri, data)
 
     def report_event(self, events):
-        validata_param('events', events, TelemetryEventList)
-        self._post_data(self.event_uri, events)
+        #TODO disable telemetry for azure stack test
+        #validata_param('events', events, TelemetryEventList)
+        #data = get_properties(events)
+        #self._post_data(self.event_uri, data)
+        pass
 

--- a/azurelinuxagent/utils/shellutil.py
+++ b/azurelinuxagent/utils/shellutil.py
@@ -65,21 +65,25 @@ def run(cmd, chk_err=True):
     retcode,out=run_get_output(cmd,chk_err)
     return retcode
 
-def run_get_output(cmd, chk_err=True):
+def run_get_output(cmd, chk_err=True, log_cmd=True):
     """
     Wrapper for subprocess.check_output.
     Execute 'cmd'.  Returns return code and STDOUT, trapping expected exceptions.
     Reports exceptions to Error if chk_err parameter is True
     """
-    logger.verb("run cmd '{0}'", cmd)
+    if log_cmd:
+        logger.verb(u"run cmd '{0}'", cmd)
     try:
         output=subprocess.check_output(cmd,stderr=subprocess.STDOUT,shell=True)
+        output = text(output, encoding='utf-8', errors="backslashreplace")
     except subprocess.CalledProcessError as e :
-        if chk_err :
-            logger.error("run cmd '{0}' failed", e.cmd)
-            logger.error("Error Code:{0}", e.returncode)
-            logger.error("Result:{0}", e.output[:-1].decode('latin-1'))
-        return e.returncode, e.output.decode('latin-1')
-    return 0, text(output, encoding="utf-8")
+        output = text(e.output, encoding='utf-8', errors="backslashreplace")
+        if chk_err:
+            if log_cmd:
+                logger.error(u"run cmd '{0}' failed", e.cmd)
+            logger.error(u"Error Code:{0}", e.returncode)
+            logger.error(u"Result:{0}", output)
+        return e.returncode, output 
+    return 0, output
 
 #End shell command util functions

--- a/azurelinuxagent/utils/textutil.py
+++ b/azurelinuxagent/utils/textutil.py
@@ -225,3 +225,4 @@ def gen_password_hash(password, crypt_id, salt_len):
     return crypt.crypt(password, salt)
 
 Version = LooseVersion
+

--- a/azurelinuxagent/utils/textutil.py
+++ b/azurelinuxagent/utils/textutil.py
@@ -22,6 +22,7 @@ import string
 import struct
 import xml.dom.minidom as minidom
 import sys
+from distutils.version import LooseVersion
 
 def parse_doc(xml_text):
     """
@@ -223,4 +224,4 @@ def gen_password_hash(password, crypt_id, salt_len):
     salt = "${0}${1}".format(crypt_id, salt)
     return crypt.crypt(password, salt)
 
-
+Version = LooseVersion

--- a/azurelinuxagent/utils/textutil.py
+++ b/azurelinuxagent/utils/textutil.py
@@ -217,12 +217,10 @@ def remove_bom(c):
         c = c[3:]
     return c
 
-def gen_password_hash(password, use_salt, salt_type, salt_len):
-    salt="$6$"
-    if use_salt:
-        collection = string.ascii_letters + string.digits
-        salt = ''.join(random.choice(collection) for _ in range(salt_len))
-        salt = "${0}${1}".format(salt_type, salt)
+def gen_password_hash(password, crypt_id, salt_len):
+    collection = string.ascii_letters + string.digits
+    salt = ''.join(random.choice(collection) for _ in range(salt_len))
+    salt = "${0}${1}".format(crypt_id, salt)
     return crypt.crypt(password, salt)
 
 

--- a/config/suse/waagent.conf
+++ b/config/suse/waagent.conf
@@ -34,6 +34,12 @@ Provisioning.DecodeCustomData=n
 # Execute CustomData after provisioning.
 Provisioning.ExecuteCustomData=n
 
+# Algorithm used by crypt when generating password hash.
+#Provisioning.PasswordCryptId=6
+
+# Length of random salt used when generating password hash.
+#Provisioning.PasswordCryptSaltLength=10
+
 # Format if unformatted. If 'n', resource disk will not be mounted.
 ResourceDisk.Format=y
 

--- a/config/ubuntu/waagent.conf
+++ b/config/ubuntu/waagent.conf
@@ -34,6 +34,12 @@ Provisioning.DecodeCustomData=n
 # Execute CustomData after provisioning.
 Provisioning.ExecuteCustomData=n
 
+# Algorithm used by crypt when generating password hash.
+#Provisioning.PasswordCryptId=6
+
+# Length of random salt used when generating password hash.
+#Provisioning.PasswordCryptSaltLength=10
+
 # Format if unformatted. If 'n', resource disk will not be mounted.
 ResourceDisk.Format=n
 

--- a/config/waagent.conf
+++ b/config/waagent.conf
@@ -34,6 +34,12 @@ Provisioning.DecodeCustomData=n
 # Execute CustomData after provisioning.
 Provisioning.ExecuteCustomData=n
 
+# Algorithm used by crypt when generating password hash.
+#Provisioning.PasswordCryptId=6
+
+# Length of random salt used when generating password hash.
+#Provisioning.PasswordCryptSaltLength=10
+
 # Format if unformatted. If 'n', resource disk will not be mounted.
 ResourceDisk.Format=y
 

--- a/tests/test_datacontract.py
+++ b/tests/test_datacontract.py
@@ -1,0 +1,54 @@
+# Copyright 2014 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Requires Python 2.4+ and Openssl 1.0+
+#
+# Implements parts of RFC 2131, 1541, 1497 and
+# http://msdn.microsoft.com/en-us/library/cc227282%28PROT.10%29.aspx
+# http://msdn.microsoft.com/en-us/library/cc227259%28PROT.13%29.aspx
+
+import tests.env
+from tests.tools import *
+import uuid
+import unittest
+import os
+import shutil
+import time
+from azurelinuxagent.protocol.common import *
+
+class SampleDataContract(DataContract):
+    def __init__(self):
+        self.foo = None
+        self.bar = DataContractList(int)
+
+class TestDataContract(unittest.TestCase):
+    def test_get_properties(self):
+        obj = SampleDataContract()
+        obj.foo = "foo"
+        obj.bar.append(1)
+        data = get_properties(obj)
+        self.assertEquals("foo", data["foo"])
+        self.assertEquals(list, type(data["bar"]))
+
+    def test_set_properties(self):
+        obj = SampleDataContract()
+        data = {
+                'foo' : 1, 
+                'baz': 'a'
+        }
+        set_properties('sample', obj, data)
+        self.assertFalse(hasattr(obj, 'baz'))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_ext.py
+++ b/tests/test_ext.py
@@ -51,8 +51,8 @@ ext_sample_json = {
         }]
     }
 }
-ext_sample = prot.Extension()
-prot.set_properties(ext_sample, ext_sample_json)
+ext_sample = prot.ExtHandler()
+prot.set_properties("extensions", ext_sample, ext_sample_json)
 
 pkd_list_sample_str={
     "versions": [{
@@ -67,8 +67,8 @@ pkd_list_sample_str={
          }]
     }]
 }
-pkg_list_sample = prot.ExtensionPackageList()
-prot.set_properties(pkg_list_sample, pkd_list_sample_str)
+pkg_list_sample = prot.ExtHandlerPackageList()
+prot.set_properties("packages", pkg_list_sample, pkd_list_sample_str)
 
 manifest_sample_str = {
     "handlerManifest":{
@@ -85,7 +85,7 @@ def mock_load_manifest(self):
     return manifest_sample
 
 mock_launch_command = MockFunc()
-mock_set_handler_status = MockFunc()
+mock_set_state = MockFunc()
 
 def mock_download(self):
     fileutil.mkdir(self.get_base_dir())
@@ -106,8 +106,8 @@ class TestExtensions(unittest.TestCase):
         self.assertEqual('2.1', test_ext)
 
     def test_getters(self):
-        test_ext = ext.ExtensionInstance(ext_sample, pkg_list_sample, 
-                                        ext_sample.properties.version, False)
+        test_ext = ext.ExtHandlerInstance(ext_sample, pkg_list_sample, 
+                                          ext_sample.properties.version, False)
         self.assertEqual("/tmp/TestExt-2.0", test_ext.get_base_dir())
         self.assertEqual("/tmp/TestExt-2.0/status", test_ext.get_status_dir())
         self.assertEqual("/tmp/TestExt-2.0/status/0.status", 
@@ -125,53 +125,51 @@ class TestExtensions(unittest.TestCase):
                          test_ext.get_env_file())
         self.assertEqual("/tmp/log/TestExt/2.0", test_ext.get_log_dir())
 
-        test_ext = ext.ExtensionInstance(ext_sample, pkg_list_sample, "2.1", False)
+        test_ext = ext.ExtHandlerInstance(ext_sample, pkg_list_sample, 
+                                          "2.1", False)
         self.assertEqual("/tmp/TestExt-2.1", test_ext.get_base_dir())
         self.assertEqual("2.1", test_ext.get_target_version())
    
-    @mock(ext.ExtensionInstance, 'load_manifest', mock_load_manifest)
-    @mock(ext.ExtensionInstance, 'launch_command', mock_launch_command)
-    @mock(ext.ExtensionInstance, 'set_handler_status', mock_set_handler_status)
+    @mock(ext.ExtHandlerInstance, 'load_manifest', mock_load_manifest)
+    @mock(ext.ExtHandlerInstance, 'launch_command', mock_launch_command)
+    @mock(ext.ExtHandlerInstance, 'set_state', mock_set_state)
     def test_handle_uninstall(self):
         mock_launch_command.args = None
-        mock_set_handler_status.args = None
-        test_ext = ext.ExtensionInstance(ext_sample, pkg_list_sample, 
-                                        ext_sample.properties.version, False)
+        mock_set_state.args = None
+        test_ext = ext.ExtHandlerInstance(ext_sample, pkg_list_sample, 
+                                          ext_sample.properties.version, False)
         test_ext.handle_uninstall()
         self.assertEqual(None, mock_launch_command.args)
-        self.assertEqual(None, mock_set_handler_status.args)
-        self.assertEqual(None, test_ext.get_curr_op())
+        self.assertEqual(None, mock_set_state.args)
+        self.assertEqual(None, test_ext.ext_status.operation)
 
-        test_ext = ext.ExtensionInstance(ext_sample, pkg_list_sample, 
-                                        ext_sample.properties.version, True)
+        test_ext = ext.ExtHandlerInstance(ext_sample, pkg_list_sample, 
+                                          ext_sample.properties.version, True)
         test_ext.handle_uninstall()
         self.assertEqual(manifest_sample.get_uninstall_command(), mock_launch_command.args[0])
-        self.assertEqual("UnInstall", test_ext.get_curr_op())
-        self.assertEqual("NotReady", mock_set_handler_status.args[0])
-
-    @mock(ext.ExtensionInstance, 'load_manifest', mock_load_manifest)
-    @mock(ext.ExtensionInstance, 'launch_command', mock_launch_command)
-    @mock(ext.ExtensionInstance, 'download', mock_download)
-    @mock(ext.ExtensionInstance, 'get_handler_status', MockFunc(retval="enabled"))
-    @mock(ext.ExtensionInstance, 'set_handler_status', mock_set_handler_status)
-    def test_handle(self):
+        #self.assertEqual("UnInstall", test_ext.ext_status.operation)
+        #self.assertEqual("NotReady", mock_set_state.args[0])
+    
+    @mock(ext.ExtHandlerInstance, 'upgrade', MockFunc())
+    @mock(ext.ExtHandlerInstance, 'enable', MockFunc())
+    @mock(ext.ExtHandlerInstance, 'download', MockFunc())
+    @mock(ext.ExtHandlerInstance, 'init_dir', MockFunc())
+    @mock(ext.ExtHandlerInstance, 'install', MockFunc())
+    def test_handle_enable(self):
         #Test enable
-        test_ext = ext.ExtensionInstance(ext_sample, pkg_list_sample, 
-                                        ext_sample.properties.version, False)
-        test_ext.init_logger()
-        self.assertEqual(1, len(test_ext.logger.appenders) - len(logger.DEFAULT_LOGGER.appenders))
-        test_ext.handle()
-        
+        test_ext = ext.ExtHandlerInstance(ext_sample, pkg_list_sample, 
+                                          ext_sample.properties.version, False)
+        test_ext.handle_enable()
+     
         #Test upgrade 
-        test_ext = ext.ExtensionInstance(ext_sample, pkg_list_sample, 
-                                        ext_sample.properties.version, False)
-        test_ext.init_logger()
-        self.assertEqual(1, len(test_ext.logger.appenders) - len(logger.DEFAULT_LOGGER.appenders))
-        test_ext.handle()
+        test_ext = ext.ExtHandlerInstance(ext_sample, pkg_list_sample, 
+                                          "2.0" , True)
+        test_ext.handle_enable()
 
     def test_status_convert(self):
-        ext_status = json.loads('[{"status": {"status": "success", "formattedMessage": {"lang": "en-US", "message": "Script is finished"}, "operation": "Enable", "code": "0", "name": "Microsoft.OSTCExtensions.CustomScriptForLinux"}, "version": "1.0", "timestampUTC": "2015-06-27T08:34:50Z"}]')
-        ext.ext_status_to_v2(ext_status[0], 0)
+        data = json.loads('[{"status": {"status": "success", "formattedMessage": {"lang": "en-US", "message": "Script is finished"}, "operation": "Enable", "code": "0", "name": "Microsoft.OSTCExtensions.CustomScriptForLinux"}, "version": "1.0", "timestampUTC": "2015-06-27T08:34:50Z"}]')
+        ext_status = prot.ExtensionStatus()
+        ext.parse_ext_status(ext_status, data)
 
 
 if __name__ == '__main__':

--- a/tests/test_ext.py
+++ b/tests/test_ext.py
@@ -138,6 +138,8 @@ class TestExtensions(unittest.TestCase):
         mock_set_state.args = None
         test_ext = ext.ExtHandlerInstance(ext_sample, pkg_list_sample, 
                                           ext_sample.properties.version, False)
+        if not os.path.isdir(test_ext.get_base_dir()):
+            os.makedirs(test_ext.get_base_dir())
         test_ext.handle_uninstall()
         self.assertEqual(None, mock_launch_command.args)
         self.assertEqual(None, mock_set_state.args)
@@ -145,10 +147,11 @@ class TestExtensions(unittest.TestCase):
 
         test_ext = ext.ExtHandlerInstance(ext_sample, pkg_list_sample, 
                                           ext_sample.properties.version, True)
+        if not os.path.isdir(test_ext.get_base_dir()):
+            os.makedirs(test_ext.get_base_dir())
         test_ext.handle_uninstall()
-        self.assertEqual(manifest_sample.get_uninstall_command(), mock_launch_command.args[0])
-        #self.assertEqual("UnInstall", test_ext.ext_status.operation)
-        #self.assertEqual("NotReady", mock_set_state.args[0])
+        self.assertEqual(manifest_sample.get_uninstall_command(), 
+                         mock_launch_command.args[0])
     
     @mock(ext.ExtHandlerInstance, 'upgrade', MockFunc())
     @mock(ext.ExtHandlerInstance, 'enable', MockFunc())

--- a/tests/test_extensionsconfig.py
+++ b/tests/test_extensionsconfig.py
@@ -128,7 +128,7 @@ EmptyPublicSettings=u"""\
 class TestExtensionsConfig(unittest.TestCase):
     def test_extensions_config(self):
         config = v1.ExtensionsConfig(ext_conf_sample)
-        extensions = config.ext_list.extensions
+        extensions = config.ext_handlers.extHandlers
         self.assertNotEquals(None, extensions)
         self.assertEquals(1, len(extensions))
         self.assertNotEquals(None, extensions[0])

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2014 Microsoft Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -45,9 +46,9 @@ class TestLogger(unittest.TestCase):
         _logger.info("{0} {1}", 0, 1)
         _logger.warn("{0} {1}", 0, 1)
         _logger.error("{0} {1}", 0, 1)
-        _logger.info("this is a unicode {0}", '\u6211')
-        _logger.info("this is a utf-8 {0}", '\u6211'.encode('utf-8'))
-        _logger.info("this is a gbk {0}", 0xff )
+        _logger.add_appender(logger.AppenderType.STDOUT, 
+                             logger.LogLevel.INFO, None)
+        _logger.info(u"啊哈this is a utf-8 {0}", u'呵呵')
 
     def test_file_appender(self):
         _logger = logger.Logger()
@@ -63,9 +64,6 @@ class TestLogger(unittest.TestCase):
         _logger.verbose("Verbose should not be logged: {0}", msg)
         self.assertFalse(tools.simple_file_grep('/tmp/testlog', msg))
 
-        _logger.info("this is a unicode {0}", '\u6211')
-        _logger.info("this is a utf-8 {0}", '\u6211'.encode('utf-8'))
-        _logger.info("this is a gbk {0}", 0xff)
 
     def test_concole_appender(self):
         _logger = logger.Logger()

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -19,8 +19,7 @@
 # http://msdn.microsoft.com/en-us/library/cc227259%28PROT.13%29.aspx
 
 import tests.env
-import tests.tools as tools
-from .tools import *
+from tests.tools import *
 import uuid
 import unittest
 import os
@@ -33,29 +32,15 @@ extensionDataStr = """
     "vmAgent": {
         "agentVersion": "2.4.1198.689",
         "status": "Ready",
-        "message": "GuestAgent is running and accepting new configurations."
-    },
-    "extensionHandlers": [{
-            "handlerName": "Microsoft.Compute.CustomScript",
-            "handlerVersion": "1.0.0.0",
+        "message": "GuestAgent is running and accepting new configurations.",
+        "extensionHandlers": [{
+            "name": "Microsoft.Compute.CustomScript",
+            "version": "1.0.0.0",
             "status": "Ready",
             "message": "Plugin enabled (name: Microsoft.Compute.CustomScript, version: 1.0.0.0).",
-            "extensionStatusList": [{
-                "name": "MyDomainJoinScript",
-                "configurationAppliedTime": "2014-08-12T19:20:18Z",
-                "operation": "CommandExecutionFinished",
-                "status": "Success",
-                "sequenceNumber": "0",
-                "substatusList": [{
-                    "name": "StdOut",
-                    "status": "Info",
-                    "code": "0",
-                    "message": "Joiningdomainfoo"
-                }]
-            }]
-        }
-
-    ]
+            "extensions": []
+        }]
+    }
 }
 """
 
@@ -63,25 +48,24 @@ class TestProtocolContract(unittest.TestCase):
     def test_get_properties(self):
         data = get_properties(VMInfo())
         data = get_properties(Cert())
-        data = get_properties(ExtensionPackageList())
-        data = get_properties(InstanceMetadata())
+        data = get_properties(ExtHandlerPackageList())
         data = get_properties(VMStatus())
         data = get_properties(TelemetryEventList())
-        data = get_properties(Extension(name="hehe"))
+        data = get_properties(ExtHandler(name="hehe"))
         self.assertTrue("name" in data)
         self.assertTrue("properties" in data)
         self.assertEquals(dict, type(data["properties"]))
-        self.assertTrue("versionUris" not in data)
+        self.assertTrue("versionUris" in data)
 
     def test_set_properties(self):
         data = json.loads(extensionDataStr)
         obj = VMStatus()
-        set_properties(obj, data)
+        set_properties("vmStatus", obj, data)
         self.assertNotEquals(None, obj.vmAgent)
         self.assertEquals(VMAgentStatus, type(obj.vmAgent))
         self.assertNotEquals(None, obj.vmAgent.status)
-        self.assertNotEquals(None, obj.extensionHandlers)
-        self.assertEquals(DataContractList, type(obj.extensionHandlers))
+        self.assertNotEquals(None, obj.vmAgent.extensionHandlers)
+        self.assertEquals(DataContractList, type(obj.vmAgent.extensionHandlers))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_shell_util.py
+++ b/tests/test_shell_util.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2014 Microsoft Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,15 +26,19 @@ import unittest
 import os
 import azurelinuxagent.utils.shellutil as shellutil
 import test
+from azurelinuxagent.future import text
 
 class TestrunCmd(unittest.TestCase):
     def test_run_get_output(self):
-        output = shellutil.run_get_output("ls /")
+        output = shellutil.run_get_output(u"ls /")
         self.assertNotEquals(None, output)
         self.assertEquals(0, output[0])
 
-        err = shellutil.run_get_output("ls /not-exists")
+        err = shellutil.run_get_output(u"ls /not-exists")
         self.assertNotEquals(0, err[0])
             
+        err = shellutil.run_get_output(u"ls 我")
+        self.assertNotEquals(0, err[0])
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_text_util.py
+++ b/tests/test_text_util.py
@@ -28,7 +28,9 @@ import azurelinuxagent.utils.textutil as textutil
 
 class TestTextUtil(unittest.TestCase):
     def test_get_password_hash(self):
-        password_hash = textutil.gen_password_hash("asdf", True, 6, 10)
+        password_hash = textutil.gen_password_hash("asdf", 6, 10)
+        self.assertNotEquals(None, password_hash)
+        password_hash = textutil.gen_password_hash("asdf", 6, 0)
         self.assertNotEquals(None, password_hash)
 
     def test_remove_bom(self):

--- a/tests/test_text_util.py
+++ b/tests/test_text_util.py
@@ -25,6 +25,7 @@ import unittest
 import os
 from azurelinuxagent.future import text
 import azurelinuxagent.utils.textutil as textutil
+from azurelinuxagent.utils.textutil import Version
 
 class TestTextUtil(unittest.TestCase):
     def test_get_password_hash(self):
@@ -44,6 +45,22 @@ class TestTextUtil(unittest.TestCase):
         data = textutil.remove_bom(data)
         self.assertEquals(u"h", data[0])
 
-   
+    def test_version_compare(self) :
+        self.assertTrue(Version("1.0") < Version("1.1"))
+        self.assertTrue(Version("1.9") < Version("1.10"))
+        self.assertTrue(Version("1.9.9") < Version("1.10.0"))
+        self.assertTrue(Version("1.0.0.0") < Version("1.2.0.0"))
+
+        self.assertTrue(Version("1.0") <= Version("1.1"))
+        self.assertTrue(Version("1.1") > Version("1.0"))
+        self.assertTrue(Version("1.1") >= Version("1.0"))
+
+        self.assertTrue(Version("1.0") == Version("1.0"))
+        self.assertTrue(Version("1.0") >= Version("1.0"))
+        self.assertTrue(Version("1.0") <= Version("1.0"))
+
+        self.assertTrue(Version("1.9") < "1.10")
+        self.assertTrue("1.9" < Version("1.10"))
+        
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_v1.py
+++ b/tests/test_v1.py
@@ -134,32 +134,37 @@ class TestWireClint(unittest.TestCase):
 class TestStatusBlob(unittest.TestCase):
     def testToJson(self):
         vm_status = v1.VMStatus()
-        status_blob = v1.StatusBlob(vm_status)
+        status_blob = v1.StatusBlob()
+        status_blob.set_vm_status(vm_status)
         self.assertNotEquals(None, status_blob.to_json())
 
     @mock(v1.restutil, 'http_put', MockFunc(retval=MockResp(httpclient.CREATED)))
     @mock(v1.restutil, 'http_head', MockFunc(retval=MockResp(httpclient.OK)))
     def test_put_page_blob(self):
         vm_status = v1.VMStatus()
-        status_blob = v1.StatusBlob(vm_status)
+        status_blob = v1.StatusBlob()
+        status_blob.set_vm_status(vm_status)
         data = 'a' * 100
         status_blob.put_page_blob("http://foo.bar", data)
 
 class TestConvert(unittest.TestCase):
     def test_status(self):
         vm_status = v1.VMStatus() 
-        handler_status = v1.ExtensionHandlerStatus()
-        substatus = v1.ExtensionSubStatus()
+        handler_status = v1.ExtHandlerStatus(name="foo")
+
+        ext_statuses = {}
+
+        ext_name="bar"
         ext_status = v1.ExtensionStatus()
+        handler_status.extensions.append(ext_name)
+        ext_statuses[ext_name] = ext_status
 
-        vm_status.extensionHandlers.append(handler_status)
-        v1.vm_status_to_v1(vm_status)
-
-        handler_status.extensionStatusList.append(ext_status)
-        v1.vm_status_to_v1(vm_status)
-
+        substatus = v1.ExtensionSubStatus()
         ext_status.substatusList.append(substatus)
-        v1.vm_status_to_v1(vm_status)
+
+        vm_status.vmAgent.extensionHandlers.append(handler_status)
+        v1_status = v1.vm_status_to_v1(vm_status, ext_statuses)
+        print(v1_status)
 
     def test_param(self):
         param = v1.TelemetryEventParam()

--- a/tests/test_v2.py
+++ b/tests/test_v2.py
@@ -1,0 +1,120 @@
+# Copyright 2014 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Requires Python 2.4+ and Openssl 1.0+
+#
+# Implements parts of RFC 2131, 1541, 1497 and
+# http://msdn.microsoft.com/en-us/library/cc227282%28PROT.10%29.aspx
+# http://msdn.microsoft.com/en-us/library/cc227259%28PROT.13%29.aspx
+
+import tests.env
+from tests.tools import *
+import unittest
+import json
+import azurelinuxagent.protocol.v2 as v2
+
+SAMPLE_IDENTITY=u"""{
+    "vmName":"foo", 
+    "subscriptionId":"bar"
+}"""
+
+SAMPLE_CERTS=u"""{
+    "certificates":[{
+        "name":"foo", 
+        "thumbprint":"bar",
+        "certificateDataUri":"baz"
+    }]
+}"""
+
+SAMPLE_EXT_HANDLER=u"""[{
+    "name":"foo",
+    "properties":{
+        "version":"bar",
+        "upgradePolicy": "manual",
+        "state": "enabled",
+        "extensions":[{
+            "name":"baz",
+            "sequenceNumber":0,
+            "publicSettings":{
+                "commandToExecute": "echo 123",
+                "uris":[]
+            }
+        }]
+    },
+    "versionUris":[{
+        "uri":"versionUri.foo"
+    }]
+}]"""
+
+SAMPLE_EXT_HANDLER_PKGS=u"""{
+    "versions": [{
+        "version":"foo",
+        "uris":[{
+            "uri":"bar"
+        },{
+            "uri":"baz"
+        }]
+    }]
+}"""
+
+def mock_get_data(self, url, headers=None):
+    data = u"{}"
+    if url.count(u"identity") > 0:
+        data = SAMPLE_IDENTITY
+    elif url.count(u"certificates") > 0:
+        data = SAMPLE_CERTS
+    elif url.count(u"extensionHandlers") > 0:
+        data = SAMPLE_EXT_HANDLER
+    elif url.count(u"versionUri") > 0:
+        data = SAMPLE_EXT_HANDLER_PKGS
+    return json.loads(data)
+
+class TestMetadataProtocol(unittest.TestCase):
+    @mock(v2.MetadataProtocol, '_get_data', mock_get_data)
+    def test_getters(self):
+        protocol = v2.MetadataProtocol()
+        vminfo = protocol.get_vminfo()
+        self.assertNotEquals(None, vminfo)
+        self.assertNotEquals(None, vminfo.vmName)
+        self.assertNotEquals(None, vminfo.subscriptionId)
+
+        protocol.get_certs()
+
+        ext_handers = protocol.get_ext_handlers()
+        self.assertNotEquals(None, ext_handers)
+        self.assertNotEquals(None, ext_handers.extHandlers)
+        self.assertNotEquals(0, len(ext_handers.extHandlers))
+        
+        ext_hander = ext_handers.extHandlers[0] 
+        self.assertNotEquals(None, ext_hander)
+        self.assertNotEquals(0, len(ext_hander.properties.extensions))
+
+        ext = ext_hander.properties.extensions[0]
+        self.assertNotEquals(None, ext)
+        self.assertNotEquals(None, ext.publicSettings)
+        self.assertEquals("echo 123", ext.publicSettings.get('commandToExecute'))
+
+        packages = protocol.get_ext_handler_pkgs(ext_handers.extHandlers[0])
+        self.assertNotEquals(None, packages)
+    
+    @mock(v2.MetadataProtocol, '_put_data', MockFunc())
+    def test_reporters(self):
+        protocol = v2.MetadataProtocol()
+        protocol.report_provision_status(v2.ProvisionStatus())
+        protocol.report_vm_status(v2.VMStatus())
+        protocol.report_ext_status("foo", "baz", v2.ExtensionStatus())
+        protocol.report_event(v2.TelemetryEventList())
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
1. Fixed HandlerEnvironment.json
Removed "seqNo" field to align the agent implementation to document, "User Guide for writing extension handlers". 

2. Fixed ExtensionsConfig uri is empty
In 2.1.1, the agent will crash if "install agent" option is unchecked during creating. Fixed the agent to prevent crash.

3. Fixed status report on page blob
In 2.1.1, agent couldn't upload status blob if it is a page blob. 

4. Fixed extension version compare
Agent used to use simple string compare for extension versions from day 0. It will introduce issue when the version jumps from "9" to "10".  

5. Fixed update user password by using "usermod" command
It is safer to use "usermod" command to update password hash instead of update shadow file directly.

6. Updated extension handler for metadata protocol
Updated extension status format