### PR TITLE
Do not assume custom data is text

### DIFF
--- a/waagent
+++ b/waagent
@@ -4488,7 +4488,7 @@ class OvfEnv(object):
             if len(CDSection) > 0 :
                 self.CustomData=GetNodeTextData(CDSection[0])
                 if len(self.CustomData)>0:
-                    SetFileContents(LibDir + '/CustomData', MyDistro.translateCustomData(self.CustomData))
+                    SetFileContents(LibDir + '/CustomData', bytearray(MyDistro.translateCustomData(self.CustomData)))
                     Log('Wrote ' + LibDir + '/CustomData')
                 else :
                     Error('<CustomData> contains no data!')


### PR DESCRIPTION
Currently, if you attempt to pass non-ascii data through CustomData you get the following error:
```UnicodeDecodeError: 'ascii' codec can't decode byte 0x8b in position 1: ordinal not in range(128)```

I want to be able to pass a gzipped archive, which currently is not supported without first doing something like double base64 encoding the file when passing it through an ARM template.