### PR TITLE
- Handle ValueError

### DIFF
--- a/azurelinuxagent/distro/loader.py
+++ b/azurelinuxagent/distro/loader.py
@@ -25,7 +25,7 @@ def get_distro_loader():
         logger.verb("Loading distro implemetation from: {0}", DISTRO_NAME)
         pkg_name = "azurelinuxagent.distro.{0}.loader".format(DISTRO_NAME)
         return __import__(pkg_name, fromlist="loader")
-    except ImportError as e:
+    except (ImportError, ValueError):
         logger.warn("Unable to load distro implemetation for {0}.", DISTRO_NAME)
         logger.warn("Use default distro implemetation instead.")
         return default_loader


### PR DESCRIPTION
  + If/when the distribution name is empty the __import__ function throws
    a ValueError because an attemot is made to import a module represented
    by the empty string. This generates a traceback insteda of falling back
    to teh default loader.
- Do not manage the exception object caught
  + The exception object is not used for any purpose in the exception handler
    thus we do not need to assign it and manage it