### PR TITLE
Support arch distro

### DIFF
--- a/waagent
+++ b/waagent
@@ -2117,6 +2117,56 @@ class FreeBSDDistro(AbstractDistro):
         Run("/sbin/route add -net " + net + " " + mask + " " + gateway, chk_err=False)
 
 ############################################################
+#	archDistro
+############################################################
+class archDistro(AbstractDistro):
+    """
+    Arch Distro concrete class
+    Put Arch specific behavior here...
+    """
+
+    def __init__(self):
+        super(archDistro, self).__init__()
+        self.requiredDeps += [ "/usr/bin/systemctl" ]
+        self.service_cmd = '/usr/bin/systemctl'
+        self.ssh_service_name='sshd'
+        self.requiredPackages = ['net-tools', 'parted']
+
+    """
+        Check that the package is installed.
+        Return 1 if installed, 0 if not installed.
+    """
+    def checkPackageInstalled(self,p):
+        if Run('pacman -Qq ' + p,chk_err=False):
+            return 0
+        else:
+            return 1
+
+    def checkDependencies(self):
+        """
+        Arch dependency check.  python-pyasn1 is NOT needed.
+        Return 1 unless all dependencies are satisfied.
+        """
+        for a in self.requiredPackages :
+            if not self.checkPackageInstalled(a):
+                Error("Package " + a + " is required but not installed.")
+                return 1
+
+        for a in self.requiredDeps:
+            if Run("which " + a + " > /dev/null 2>&1",chk_err=False):
+                Error("Missing required dependency: " + a)
+                return 1
+        return 0
+
+    def sshDeployPublicKey(self,fprint,path):
+        """
+        We support PKCS8.
+        """
+        if Run("ssh-keygen -i -m PKCS8 -f " + fprint + " >> " + path):
+            return 1
+        else :
+            return 0
+############################################################
 # END DISTRO CLASS DEFS
 ############################################################  
 

--- a/waagent
+++ b/waagent
@@ -2148,7 +2148,9 @@ class archDistro(AbstractDistro):
         self.init_script_file = '/usr/lib/systemd/system/' + self.agent_service_name + '.service'
         self.init_file = arch_systemd_service
         self.ssh_service_name='sshd'
-        self.requiredPackages = ['net-tools', 'parted']
+        self.requiredPackages = ['net-tools', 'parted', 'sudo']
+        self.dhcp_client_name='systemd-networkd'
+        self.dhcp_enabled = True
 
     def installAgentServiceScriptFiles(self):
         SetFileContents(self.init_script_file, self.init_file)
@@ -2171,8 +2173,24 @@ class archDistro(AbstractDistro):
         return Run(self.service_cmd + ' start ' + self.agent_service_name)
 
     def stopAgentService(self):
-        return Run(self.service_cmd + ' stop '  + self.agent_service_name, False)
-        
+        return Run(self.service_cmd + ' stop '  + self.agent_service_name)
+
+    def restartSshService(self):
+        sshRestartCmd = self.service_cmd + " " +  self.ssh_service_restart_option + " " + self.ssh_service_name
+        retcode = Run(sshRestartCmd)
+        if retcode > 0:
+            Error("Failed to restart SSH service with return code:" + str(retcode))
+        return retcode
+
+    def RestartInterface(self, iface):
+        Run(self.service_cmd + " restart systemd-networkd")
+
+    def startDHCP(self):
+        Run(self.service_cmd + " start " + self.dhcp_client_name, chk_err=False)
+
+    def stopDHCP(self):
+        Run(self.service_cmd + " stop " + self.dhcp_client_name, chk_err=False)
+
     def checkPackageInstalled(self,p):
         """
         Check that the package is installed.

--- a/waagent
+++ b/waagent
@@ -2119,6 +2119,21 @@ class FreeBSDDistro(AbstractDistro):
 ############################################################
 #	archDistro
 ############################################################
+arch_systemd_service = """\
+[Unit]
+Description=Azure Linux Agent
+After=network.target
+After=sshd.service
+ConditionFileIsExecutable=/usr/sbin/waagent
+ConditionPathExists=/etc/waagent.conf
+
+[Service]
+Type=simple
+ExecStart=/usr/sbin/python2 /usr/sbin/waagent -daemon
+
+[Install]
+WantedBy=multi-user.target
+"""
 class archDistro(AbstractDistro):
     """
     Arch Distro concrete class
@@ -2129,14 +2144,40 @@ class archDistro(AbstractDistro):
         super(archDistro, self).__init__()
         self.requiredDeps += [ "/usr/bin/systemctl" ]
         self.service_cmd = '/usr/bin/systemctl'
+        self.agent_service_name = 'waagent'
+        self.init_script_file = '/usr/lib/systemd/system/' + self.agent_service_name + '.service'
+        self.init_file = arch_systemd_service
         self.ssh_service_name='sshd'
         self.requiredPackages = ['net-tools', 'parted']
 
-    """
+    def installAgentServiceScriptFiles(self):
+        SetFileContents(self.init_script_file, self.init_file)
+        os.chmod(self.init_script_file, 0644)
+        return Run(self.service_cmd + ' daemon-reload')
+
+    def uninstallAgentService(self):
+        return Run("rm -f " + self.init_script_file)
+
+    def registerAgentService(self):
+        self.installAgentServiceScriptFiles()
+        return Run(self.service_cmd + ' enable ' + self.agent_service_name)
+
+    def unregisterAgentService(self):
+        self.stopAgentService()
+        Run(self.service_cmd + ' disable ' + self.agent_service_name)
+        self.uninstallAgentService()
+        
+    def startAgentService(self):
+        return Run(self.service_cmd + ' start ' + self.agent_service_name)
+
+    def stopAgentService(self):
+        return Run(self.service_cmd + ' stop '  + self.agent_service_name, False)
+        
+    def checkPackageInstalled(self,p):
+        """
         Check that the package is installed.
         Return 1 if installed, 0 if not installed.
-    """
-    def checkPackageInstalled(self,p):
+        """
         if Run('pacman -Qq ' + p,chk_err=False):
             return 0
         else:
@@ -2166,6 +2207,7 @@ class archDistro(AbstractDistro):
             return 1
         else :
             return 0
+
 ############################################################
 # END DISTRO CLASS DEFS
 ############################################################  

--- a/waagent
+++ b/waagent
@@ -5914,6 +5914,9 @@ def GetMyDistro(dist_class_name=''):
         dist_class_name=Distro+'Distro'
     else:
         Distro=dist_class_name
+    if dist_class_name == 'Distro':
+        print 'Cannot detect distribution type.'
+        return None
     if not globals().has_key(dist_class_name):
         print Distro+' is not a supported distribution.'
         return None

--- a/waagent
+++ b/waagent
@@ -5927,13 +5927,17 @@ def DistInfo(fullname=0):
         release = re.sub('\-.*\Z', '', str(platform.release()))
         distinfo = ['FreeBSD', release]
         return distinfo
-    
+
+    distinfo = ['', '', '']
     if 'linux_distribution' in dir(platform):
         distinfo = list(platform.linux_distribution(full_distribution_name=fullname))
         distinfo[0] = distinfo[0].strip() # remove trailing whitespace in distro name
-        return distinfo
     else:
-        return platform.dist()
+        distinfo = platform.dist()
+    if distinfo[0] == '' :
+        distinfo = platform.dist(supported_dists=('arch'))
+
+    return distinfo
 
 def PackagedInstall(buildroot):
     """


### PR DESCRIPTION
notes:
1. python2 has some issue in platform.dist() for detecting arch (py3 works), adding supported_dists explicitly;
2. Current default service manager is based on systemd;
3. python version was default to python3, updated the init script cmd here.