### PR TITLE
Use fallocate instead of dd for swapfile creation

### DIFF
--- a/waagent
+++ b/waagent
@@ -2579,14 +2579,15 @@ class FreeBSDDistro(AbstractDistro):
         if os.path.isfile(filename):
             os.remove(filename)
         
-        fn_sh = ShellEscape(filename)
+        fn_sh = ShellQuote(filename)
         
         if nbytes < max_blocksize:
             exitcode = Run(dd_cmd.format(bs=bytes, fn=fn_sh, n=1))
         else:
-            exitcode = Run(dd_cmd.format(bs=max_blocksize, fn=filename, n=bytes/max_blocksize))
+            exitcode = Run(dd_cmd.format(bs=max_blocksize, fn=fn_sh, n=bytes/max_blocksize))
             exitcode <<= 8 # lshift so we have space for another exitcode
-            exitcode += Run(dd.cmd.format(bs=nbytes%max_blocksize, fn=fn_sh, n=1))
+            if nbytes%max_blocksize:
+                exitcode += Run(dd_cmd.format(bs=nbytes%max_blocksize, fn=fn_sh, n=1))
         return exitcode
 
     def GetHome(self):
@@ -2729,13 +2730,16 @@ def GetLineStartingWith(prefix, filepath):
             return line
     return None
 
-def ShellEscape(wordList):
+def ShellQuote(wordList):
     """
-    Escape a list or tuple of strings for Unix Shell as words, using the
+    Quote a list or tuple of strings for Unix Shell as words, using the
     byte-literal single quote.
     
     The resulting string is safe for use with ``shell=True`` in ``subprocess``,
-    and in ``os.system``. ``assert shlex.split(ShellEscape(wordList)) == wordList``.
+    and in ``os.system``. ``assert shlex.split(ShellQuote(wordList)) == wordList``.
+    
+    See POSIX.1:2013 Vol 3, Chap 2, Sec 2.2.2:
+    http://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_02_02
     """
     if not isinstance(wordList, (tuple, list)):
         wordList = (wordList,)

--- a/waagent
+++ b/waagent
@@ -586,11 +586,11 @@ class AbstractDistro(object):
         
         See also:
           - os.posix_fallocate(filename,0,bytes) # py 3.3+
-          - Run('mkfile {nbytes} {fn}'.format(fn=filename, nbytes=nbytes)) # even slower than dd, xfs_mkfile on Linux
+          - Run('mkfile {nbytes} {fn}'.format(fn=filename, nbytes=nbytes)) # BSD, xfs_mkfile (slow) on Linux
         """
         if os.path.isfile(filename)
             os.remove(filename)
-        return Run(ShellEscape(['fallocate', '-l', str(bytes), filename]))
+        return Run(['fallocate', '-l', str(bytes), filename])
     
     def GetHome(self):
         return GetHome()
@@ -2735,7 +2735,7 @@ def ShellEscape(wordList):
     byte-literal single quote.
     
     The resulting string is safe for use with ``shell=True`` in ``subprocess``,
-    and ``assert shlex.split(ShellEscape(wordList)) == wordList``.
+    and in ``os.system``. ``assert shlex.split(ShellEscape(wordList)) == wordList``.
     """
     if not isinstance(wordList, (tuple, list)):
         wordList = (wordList,)
@@ -2755,12 +2755,18 @@ def RunGetOutput(cmd, chk_err=True, log_cmd=True):
     """
     Wrapper for subprocess.check_output.
     Execute 'cmd'.  Returns return code and STDOUT, trapping expected exceptions.
-    Reports exceptions to Error if chk_err parameter is True
+    Reports exceptions to Error if chk_err parameter is True.
+    
+    When 'cmd' is a list or a tuple instead of a string, the process ``cmd[0]`` with
+    args ``cmd[1:]`` is started. This gives a safer and more determistic behavior
+    by avoiding all kinds of expansions. Otherwise, the shell will handle the
+    splitting, as well as processing of syntax elemenets like 'if', '&&' and globs.
     """
     if log_cmd:
-        LogIfVerbose(cmd)
+        LogIfVerbose(str(cmd))
     try:
-        output=subprocess.check_output(cmd,stderr=subprocess.STDOUT,shell=True)
+        output=subprocess.check_output(cmd,stderr=subprocess.STDOUT,
+                                       shell=(not isinstance(cmd,(tuple, list))))
     except subprocess.CalledProcessError,e :
         if chk_err and log_cmd:
             Error('CalledProcessError.  Error Code is ' + str(e.returncode)  )
@@ -2775,21 +2781,24 @@ def RunSendStdin(cmd, input, chk_err=True, log_cmd=True):
     Execute 'cmd', sending 'input' to STDIN of 'cmd'.
     Returns return code and STDOUT, trapping expected exceptions.
     Reports exceptions to Error if chk_err parameter is True
+    
+    See RunGetOutput for notes on non-string 'cmd'.
     """
     if log_cmd:
-        LogIfVerbose(cmd+input)
+        LogIfVerbose(str(cmd)+input)
     try:                                     
-        me=subprocess.Popen([cmd], shell=True, stdin=subprocess.PIPE,stderr=subprocess.STDOUT,stdout=subprocess.PIPE)
+        me=subprocess.Popen(cmd, stdin=subprocess.PIPE,stderr=subprocess.STDOUT,stdout=subprocess.PIPE,
+                                 shell=(not isinstance(cmd,(tuple, list))))
         output=me.communicate(input)
     except OSError , e :
         if chk_err and log_cmd:
             Error('CalledProcessError.  Error Code is ' + str(me.returncode)  )
-            Error('CalledProcessError.  Command string was ' + cmd  )
+            Error('CalledProcessError.  Command string was ' + str(cmd)  )
             Error('CalledProcessError.  Command result was ' + output[0].decode('latin-1'))
             return 1,output[0].decode('latin-1')
     if me.returncode is not 0 and chk_err is True and log_cmd:
             Error('CalledProcessError.  Error Code is ' + str(me.returncode)  )
-            Error('CalledProcessError.  Command string was ' + cmd  )
+            Error('CalledProcessError.  Command string was ' + str(cmd)  )
             Error('CalledProcessError.  Command result was ' + output[0].decode('latin-1'))
     return me.returncode,output[0].decode('latin-1')
 

--- a/waagent
+++ b/waagent
@@ -558,9 +558,10 @@ class AbstractDistro(object):
         if os.path.isfile(mountpoint + "/swapfile") and os.path.getsize(mountpoint + "/swapfile") != (sizeKB * 1024):
             os.remove(mountpoint + "/swapfile")
         if not os.path.isfile(mountpoint + "/swapfile"):
-            Run("dd if=/dev/zero of=" + mountpoint + "/swapfile bs=1024 count=" + str(sizeKB))
+            self.mkfile(mountpoint + "/swapfile", sizeKB * 1024)
             Run("mkswap " + mountpoint + "/swapfile")
         Run("chmod 600 " + mountpoint + "/swapfile")
+        Run("chmod +t " + mountpoint + "/swapfile") # Try setting sticky too.
         if not Run("swapon " + mountpoint + "/swapfile"):
             Log("Enabled " + str(sizeKB) + " KB of swap at " + mountpoint + "/swapfile")
         else:
@@ -579,6 +580,18 @@ class AbstractDistro(object):
     def mountDVD(self,dvd,location):
         return RunGetOutput(self.mount_dvd_cmd + ' ' + dvd + ' ' + location)
 
+    def mkfile(self,filename,nbytes):
+        """
+        Create a non-sparse file of that size. Replace existing file.
+        
+        See also:
+          - os.posix_fallocate(filename,0,bytes) # py 3.3+
+          - Run('mkfile {nbytes} {fn}'.format(fn=filename, nbytes=nbytes)) # even slower than dd, xfs_mkfile on Linux
+        """
+        if os.path.isfile(filename)
+            os.remove(filename)
+        return Run(ShellEscape(['fallocate', '-l', str(bytes), filename]))
+    
     def GetHome(self):
         return GetHome()
 
@@ -2551,6 +2564,31 @@ class FreeBSDDistro(AbstractDistro):
         SetFileContents(location+"/ovf-env.xml", ovfxml)
         return retcode,out
 
+    def mkfile(self,filename,nbytes):
+        """
+        Create a non-sparse file of that size. Replace existing file. BSD-compatible dd version.
+        
+        For sizes < 64M, a single-pass dd is used. Otherwise use two-pass dd.
+        """
+        max_blocksize = 64 * 1024 ** 2
+        dd_cmd = "dd if=/dev/zero bs={bs} count={n} conv=notrunc of={fn}"
+        
+        if not type(nbytes) is int:
+           nbytes = int(nbytes)
+        
+        if os.path.isfile(filename):
+            os.remove(filename)
+        
+        fn_sh = ShellEscape(filename)
+        
+        if nbytes < max_blocksize:
+            exitcode = Run(dd_cmd.format(bs=bytes, fn=fn_sh, n=1))
+        else:
+            exitcode = Run(dd_cmd.format(bs=max_blocksize, fn=filename, n=bytes/max_blocksize))
+            exitcode <<= 8 # lshift so we have space for another exitcode
+            exitcode += Run(dd.cmd.format(bs=nbytes%max_blocksize, fn=fn_sh, n=1))
+        return exitcode
+
     def GetHome(self):
         return '/home'
 
@@ -2690,6 +2728,19 @@ def GetLineStartingWith(prefix, filepath):
         if line.startswith(prefix):
             return line
     return None
+
+def ShellEscape(wordList):
+    """
+    Escape a list or tuple of strings for Unix Shell as words, using the
+    byte-literal single quote.
+    
+    The resulting string is safe for use with ``shell=True`` in ``subprocess``,
+    and ``assert shlex.split(ShellEscape(wordList)) == wordList``.
+    """
+    if not isinstance(wordList, (tuple, list)):
+        wordList = (wordList,)
+
+    return " ".join("'{0}'".format(s.replace("'","'\\''") for s in wordList))
 
 def Run(cmd,chk_err=True):
     """


### PR DESCRIPTION
This saves time and disk life. Fix #127.

You may want to cherry-pick this commit to all other branches.

`fallocate` comes from the `util-linux` (or `util-linux-ng`) package, and is widely adopted across distros. It appears that you have already listed `util-linux` as a dependency of waagent in your control and spec files.