### PR TITLE
remove the print e in LogToCon

### DIFF
--- a/waagent
+++ b/waagent
@@ -2543,7 +2543,6 @@ class Logger(object):
                     message = filter(lambda x : x in string.printable, message)
                     C.write(message.encode('ascii','ignore') + "\n")
             except IOError, e:
-                print e
                 pass
                 
     def Log(self,message):


### PR DESCRIPTION
remove the print e, when logging to the c
onsole, because when IOError occurs, the print would also rais a IOError