### PR TITLE
Add udev rules to the 2.1 branch

### DIFF
--- a/config/66-azure-storage.rules
+++ b/config/66-azure-storage.rules
@@ -1,0 +1,18 @@
+ACTION!="add|change", GOTO="azure_end"
+SUBSYSTEM!="block", GOTO="azure_end"
+ATTRS{ID_VENDOR}!="Msft", GOTO="azure_end"
+ATTRS{ID_MODEL}!="Virtual_Disk", GOTO="azure_end"
+
+# Root has a GUID of 0000 as the second value
+# The resource/resource has GUID of 0001 as the second value
+ATTRS{device_id}=="?00000000-0000-*", ENV{fabric_name}="root", GOTO="azure_names"
+ATTRS{device_id}=="?00000000-0001-*", ENV{fabric_name}="resource", GOTO="azure_names"
+GOTO="azure_end"
+
+# Create the symlinks
+LABEL="azure_names"
+ENV{DEVTYPE}=="disk", SYMLINK+="disk/azure/$env{fabric_name}"
+ENV{DEVTYPE}=="partition", SYMLINK+="disk/azure/$env{fabric_name}-part%n"
+
+LABEL="azure_end"
+

--- a/config/99-azure-product-uuid.rules
+++ b/config/99-azure-product-uuid.rules
@@ -1,0 +1,9 @@
+SUBSYSTEM!="dmi", GOTO="product_uuid-exit"
+ATTR{sys_vendor}!="Microsoft Corporation", GOTO="product_uuid-exit"
+ATTR{product_name}!="Virtual Machine", GOTO="product_uuid-exit"
+TEST!="/sys/devices/virtual/dmi/id/product_uuid", GOTO="product_uuid-exit"
+
+RUN+="/bin/chmod 0444 /sys/devices/virtual/dmi/id/product_uuid"
+
+LABEL="product_uuid-exit"
+


### PR DESCRIPTION
- 99-azure-product-uuid sets permissions on product_uuid from SMBIOS
file in sysfs
- 66-azure-storage help identify the OS and ephemeral disks on Azure