### PR TITLE
Fix CustomData encoding

### DIFF
--- a/waagent
+++ b/waagent
@@ -5393,7 +5393,7 @@ class OvfEnv(object):
             if len(CDSection) > 0 :
                 self.CustomData=GetNodeTextData(CDSection[0])
                 if len(self.CustomData)>0:
-                    SetFileContents(LibDir + '/CustomData', bytearray(MyDistro.translateCustomData(self.CustomData)))
+                    SetFileContents(LibDir + '/CustomData', bytearray(MyDistro.translateCustomData(self.CustomData), 'utf-8'))
                     Log('Wrote ' + LibDir + '/CustomData')
                 else :
                     Error('<CustomData> contains no data!')


### PR DESCRIPTION
The Linux agent currently fails to write /var/lib/waagent/CustomData.  This should close issue 146.