### PR TITLE
Fixes a race condition with kernel partition read and resource disk mount

### DIFF
--- a/waagent
+++ b/waagent
@@ -602,13 +602,24 @@ class AbstractDistro(object):
                 if existingFS == "7" and fs != "ntfs":
                     Run("sfdisk -c " + device + " 1 83")
                     Run("mkfs." + fs + " " + partition)
+
+            Log("Mounting Resource Disk (" + partition + ").")
             if Run("mount " + partition + " " + mountpoint, chk_err=False):
-                #If mount failed, try to format the partition and mount again
-                Warn("Failed to mount resource disk. Retry mounting.")            
-                Run("mkfs." + fs + " " + partition + " -F")
-                if Run("mount " + partition + " " + mountpoint):
-                    Error("ActivateResourceDisk: Failed to mount resource disk (" + partition + ").")
-                    return
+                Warn("Failed to mount resource disk. Retry mounting after re-reading partition info.")
+                # Some kernels seem to issue an async partition re-read after a 'parted' command
+                # invocation. This causes mount to fail if the partition re-read isn't complete
+                # by the time mount is attempted. Seen in CentOS 7.2
+                # Force a sequential re-read of the partition and try mounting.
+                Run("sfdisk -R " + device)
+
+                if Run("mount " + partition + " " + mountpoint, chk_err=False):
+                    #If mount failed, try to format the partition and mount again
+                    Warn("Failed to mount resource disk. Will format " + partition + " and retry.")
+                    Run("mkfs." + fs + " " + partition + " -F")
+                    if Run("mount " + partition + " " + mountpoint):
+                        Error("ActivateResourceDisk: Failed to mount resource disk (" + partition + ").")
+                        return
+
             Log("Resource disk (" + partition + ") is mounted at " + mountpoint + " with fstype " + fs)
 
         #Create README file under the root of resource disk


### PR DESCRIPTION
Problem: 
On CentOS 7.2 waagent ends up formatting the resource disk on every reboot. 

Running the parted command seems to trigger an async partition re-read in the kernel that doesn't seem to have completed when we issue a mount. If the re-read hasn't completed, the mount of the resource partition fails and waagent ends up formatting the drive and mounting again. 

You can simulate by creating a Azure CentOS 7.2 image and rebooting. Or on CentOS 7.2 try 
```
$ parted /dev/sdb print; blkid 
$ blkid 
```

Solution:
Is to do trigger a partition re-read sequentially via 'sfdisk -R <partition>' and then attempt mount again. This works and have tested on CentOS 7.2.
