### PR TITLE
[2.1] Support persistent hostname for FreeBSD.

### DIFF
--- a/azurelinuxagent/distro/freebsd/osutil.py
+++ b/azurelinuxagent/distro/freebsd/osutil.py
@@ -30,7 +30,10 @@ class FreeBSDOSUtil(DefaultOSUtil):
         self._scsi_disks_timeout_set = False
 
     def set_hostname(self, hostname):
-        fileutil.append_file("/etc/rc.conf", "hostname=\"{0}\"\n".format(hostname));
+        rc_file_path = '/etc/rc.conf'
+        conf_file = fileutil.read_file(rc_file_path).split("\n")
+        textutil.set_ini_config(conf_file, "hostname", hostname)
+        fileutil.write_file(rc_file_path, "\n".join(conf_file))
         shellutil.run("hostname {0}".format(hostname), chk_err=False)
 
     def restart_ssh_service(self):

--- a/azurelinuxagent/distro/freebsd/osutil.py
+++ b/azurelinuxagent/distro/freebsd/osutil.py
@@ -16,6 +16,7 @@
 #
 # Requires Python 2.4+ and Openssl 1.0+
 
+import azurelinuxagent.utils.fileutil as fileutil
 import azurelinuxagent.utils.shellutil as shellutil
 import azurelinuxagent.utils.textutil as textutil
 import azurelinuxagent.logger as logger
@@ -27,6 +28,10 @@ class FreeBSDOSUtil(DefaultOSUtil):
     def __init__(self):
         super(FreeBSDOSUtil, self).__init__()
         self._scsi_disks_timeout_set = False
+
+    def set_hostname(self, hostname):
+        fileutil.append_file("/etc/rc.conf", "hostname=\"{0}\"\n".format(hostname));
+        shellutil.run("hostname {0}".format(hostname), chk_err=False)
 
     def restart_ssh_service(self):
         return shellutil.run('service sshd restart', chk_err=False)

--- a/azurelinuxagent/utils/textutil.py
+++ b/azurelinuxagent/utils/textutil.py
@@ -212,6 +212,23 @@ def set_ssh_config(config, name, val):
         config.insert(i, "{0} {1}".format(name, val))
     return config
 
+
+def set_ini_config(config, name, val):
+    notfound = True
+    nameEqual = name + '='
+    length = len(config)
+    text = "{0}=\"{1}\"".format(name, val)
+
+    for i in reversed(range(0, length)):
+        if config[i].startswith(nameEqual):
+            config[i] = text
+            notfound = False
+            break
+
+    if notfound:
+        config.insert(length - 1, text)
+
+
 def remove_bom(c):
     if str_to_ord(c[0]) > 128 and str_to_ord(c[1]) > 128 and \
             str_to_ord(c[2]) > 128:


### PR DESCRIPTION
FreeBSD uses '/etc/rc.conf' instead of '/etc/hostname' for hostname configuration. The following change makes hostname persistent after rebooting on FreeBSD.