### PR TITLE
Encoding fix [2.0.x]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ var/
 .installed.cfg
 *.egg
 
+# PyCharm
+.idea/
+
 # PyInstaller
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.

--- a/bin/waagent2.0
+++ b/bin/waagent2.0
@@ -4607,7 +4607,7 @@ class OvfEnv(object):
             if len(CDSection) > 0 :
                 self.CustomData=GetNodeTextData(CDSection[0])
                 if len(self.CustomData)>0:
-                    SetFileContents(LibDir + '/CustomData', bytearray(MyDistro.translateCustomData(self.CustomData)))
+                    SetFileContents(LibDir + '/CustomData', bytearray(MyDistro.translateCustomData(self.CustomData), 'utf-8'))
                     Log('Wrote ' + LibDir + '/CustomData')
                 else :
                     Error('<CustomData> contains no data!')


### PR DESCRIPTION
In case we ever need it, porting fix from issue #146 to the 2.0 agent in the 2.1 branch; note that in the 2.1 agent itself, fileutil.write_file uses utf-8 encoding by default, therefore the same bug should not exist.