### PR TITLE
Improved logic to find non-lo interfaces

### DIFF
--- a/azurelinuxagent/common/osutil/default.py
+++ b/azurelinuxagent/common/osutil/default.py
@@ -430,7 +430,7 @@ class DefaultOSUtil(object):
         sock = buff.tostring()
         for i in range(0, struct_size * expected, struct_size):
             iface=sock[i:i+16].split(b'\0', 1)[0]
-            if iface == b'lo':
+            if iface == b'lo' or iface.startswith('lo:'):
                 continue
             else:
                 break


### PR DESCRIPTION
This will treat interface names such as 'lo:1' as loopback
as well. The ultimate solution is to use sysfs+procfs in this
method to check the flags and find the ipv4 addr. However sticking
to an extended check for now.

Fixes #188.