### PR TITLE
Port over retry logic

### DIFF
--- a/azurelinuxagent/common/osutil/default.py
+++ b/azurelinuxagent/common/osutil/default.py
@@ -516,8 +516,18 @@ class DefaultOSUtil(object):
                                       'send host-name',
                                       'send host-name "{0}";'.format(hostname))
 
-    def restart_if(self, ifname):
-        shellutil.run("ifdown {0} && ifup {1}".format(ifname, ifname))
+    def restart_if(self, ifname, retries=3, wait=5):
+        retry_limit=retries+1
+        for attempt in range(1, retry_limit):
+            return_code=shellutil.run("ifdown {0} && ifup {0}".format(ifname))
+            if return_code == 0:
+                return
+            logger.warn("failed to restart {0}: return code {1}".format(ifname, return_code))
+            if attempt < retry_limit:
+                logger.info("retrying in {0} seconds".format(wait))
+                time.sleep(wait)
+            else:
+                logger.warn("exceeded restart retries")
 
     def publish_hostname(self, hostname):
         self.set_dhcp_hostname(hostname)

--- a/tests/common/osutil/__init__.py
+++ b/tests/common/osutil/__init__.py
@@ -1,0 +1,16 @@
+# Copyright 2014 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Requires Python 2.4+ and Openssl 1.0+
+#

--- a/tests/common/osutil/test_default.py
+++ b/tests/common/osutil/test_default.py
@@ -1,0 +1,42 @@
+# Copyright 2014 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Requires Python 2.4+ and Openssl 1.0+
+#
+
+import azurelinuxagent.common.osutil.default as osutil
+import azurelinuxagent.common.utils.shellutil as shellutil
+import mock
+from tests.tools import *
+
+
+class TestOSUtil(AgentTestCase):
+    def test_restart(self):
+        # setup
+        retries = 3
+        ifname = 'dummy'
+        patch = mock.patch.object(shellutil, 'run')
+        patch.return_value = 1
+        patch_run = patch.start()
+
+        # execute
+        osutil.DefaultOSUtil.restart_if(osutil.DefaultOSUtil(), ifname=ifname,retries=retries, wait=0)
+
+        # assert
+        self.assertEqual(patch_run.call_count, retries)
+        self.assertEqual(patch_run.call_args_list[0][0][0], 'ifdown {0} && ifup {0}'.format(ifname))
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
The 2.0 agent contains retry logic when restarting the network interface, [here](https://github.com/Azure/WALinuxAgent/blob/b05e389088d5a6d741dd4dfd7d05624bad09e297/bin/waagent2.0#L474-480).

This ports the logic over and adds a simple unit test.