### PR TITLE
Update agent config for CoreOS

### DIFF
--- a/config/coreos/waagent.conf
+++ b/config/coreos/waagent.conf
@@ -17,19 +17,19 @@ Role.TopologyConsumer=None
 Provisioning.Enabled=y
 
 # Password authentication for root account will be unavailable.
-Provisioning.DeleteRootPassword=y
+Provisioning.DeleteRootPassword=n
 
 # Generate fresh host key pair.
-Provisioning.RegenerateSshHostKeyPair=y
+Provisioning.RegenerateSshHostKeyPair=n
 
 # Supported values are "rsa", "dsa" and "ecdsa".
-Provisioning.SshHostKeyPairType=rsa
+Provisioning.SshHostKeyPairType=ed25519
 
 # Monitor host name changes and publish changes via DHCP requests.
 Provisioning.MonitorHostName=y
 
 # Decode CustomData from Base64.
-Provisioning.DecodeCustomData=y
+Provisioning.DecodeCustomData=n
 
 # Execute CustomData after provisioning.
 Provisioning.ExecuteCustomData=n
@@ -58,6 +58,9 @@ ResourceDisk.EnableSwap=n
 
 # Size of the swapfile.
 ResourceDisk.SwapSizeMB=0
+
+# Respond to load balancer probes if requested by Windows Azure.
+LBProbeResponder=y
 
 # Enable verbose logging (y|n)
 Logs.Verbose=n


### PR DESCRIPTION
These are the settings that ship with CoreOS currently. We have our own [copy of this config](https://github.com/coreos/coreos-overlay/blob/master/app-emulation/wa-linux-agent/files/waagent.conf), but we might as well try to keep them in sync.