### PR TITLE
Add monitoring of fstab changes  (develop branch)

### DIFF
--- a/azurelinuxagent/daemon/env.py
+++ b/azurelinuxagent/daemon/env.py
@@ -21,6 +21,8 @@ import os
 import socket
 import threading
 import time
+import datetime
+import azurelinuxagent.common.utils.shellutil as shellutil 
 import azurelinuxagent.common.logger as logger
 import azurelinuxagent.common.conf as conf
 from azurelinuxagent.common.osutil import get_osutil
@@ -44,6 +46,8 @@ class EnvHandler(object):
         self.hostname = None
         self.dhcpid = None
         self.server_thread=None
+        self.lastNotice = datetime.datetime.min
+        self.fstabModTime = None 
 
     def run(self):
         if not self.stopped:
@@ -51,6 +55,7 @@ class EnvHandler(object):
             self.stop()
 
         self.stopped = False
+        self.fstabModTime = os.path.getmtime("/etc/fstab")
         logger.info("Start env monitor service.")
         self.dhcp_handler.conf_routes()
         self.hostname = socket.gethostname()
@@ -62,6 +67,7 @@ class EnvHandler(object):
     def monitor(self):
         """
         Monitor dhcp client pid and hostname.
+        Montor for changes in fstab, warn if content is invalid
         If dhcp clinet process re-start has occurred, reset routes.
         """
         while not self.stopped:
@@ -72,6 +78,7 @@ class EnvHandler(object):
             if conf.get_monitor_hostname():
                 self.handle_hostname_update()
             self.handle_dhclient_restart()
+            self.handle_fstab_update() 
             time.sleep(5)
 
     def handle_hostname_update(self):
@@ -100,6 +107,33 @@ class EnvHandler(object):
            self.dhcp_handler.conf_routes()
            self.dhcpid = newpid
 
+    def handle_fstab_update(self):
+        """
+        Look for changes in fstab, mount if the fstab has new modified stamp 
+        If error, only re-check every minute to give an admin
+         time to correct it and avoid filling the log
+        """
+        fstabCurrentModifiedStamp = os.path.getmtime("/etc/fstab")
+        if fstabCurrentModifiedStamp != self.fstabModTime and \
+                            datetime.datetime.now() >  \
+                            self.lastNotice + datetime.timedelta(seconds=60):
+            ret, output = shellutil.run_get_output("mount -av")
+            if ret != 0:
+                logger.error(output)
+                # Notify the logged on users to take action
+                notice = "[AZURE AGENT] Current boot settings are invalid. " \
+                      "Please correct the /etc/fstab file contents before " \
+                      "rebooting using the error information " \
+                      "in /var/log/waagent.log"
+                quotedNotice = shellutil.quote(notice)
+                shellutil.run("echo '{0}' | wall".format(quotedNotice))
+                self.lastNotice = datetime.datetime.now()
+            else:
+                # no errors during the mount, avoid any warnings
+                self.fstabModTime = fstabCurrentModifiedStamp
+                logger.info("A fstab modification passed mount validation.")
+
+
     def stop(self):
         """
         Stop server comminucation and join the thread to main thread.
@@ -107,4 +141,5 @@ class EnvHandler(object):
         self.stopped = True
         if self.server_thread is not None:
             self.server_thread.join()
+
 


### PR DESCRIPTION
I am creating this new PR request based on the great feedback I received from the [previous version](https://github.com/Azure/WALinuxAgent/pull/226).  As before, Microsoft CSS is requesting additions to the Azure Linux agent to validate fstab file changes prior to a VM reboot.  We believe this will help prevent no-boot conditions brought about by incorrect or malformed fstab files.  Please find more info in the [1-pager here](https://github.com/Azure/WALinuxAgent/files/305715/fstab.checking_public_1-pager.docx)

With this updated PR I attempt to incorporate the items in the list below from the prior [conversation] (https://github.com/Azure/WALinuxAgent/pull/226).  I will also attempt to comment directly on some there.  Tagging the prior reviewers for their additional input: @ahmetalpbalkan @jasonzio  @hglkrijger

Thanks!

```
-if you could actually make this change on top of develop branch and send the PR against it (on github PR UI), it would be great
-fstabModTime is better.
-please use os.stat() or ()os.path.getmtime
-monitor method description needs updating as well now that this functionality is added.
-Please stick to 80-character wide lines. If you get notices about this, please run pep8 command on the source code
-parentheses are not necessary. - if (fstabCurrentModifiedStamp != self.fstabModifiedStamp)
-Single and double quotes are interchangeable string delimiters.   run_get_output('wall "{0}"'.format(notice))
-Perhaps something like  run_get_output('echo "{0}" | wall'.format(notice))  is necessary here?
-you are correct about wall getting the message-to-display from stdin. Using the pipe syntax means the shell gets a crack at interpreting the text, so quoting becomes far more problematic.
```
