### PR TITLE
Multi-nic improvements

### DIFF
--- a/azurelinuxagent/common/dhcp.py
+++ b/azurelinuxagent/common/dhcp.py
@@ -84,6 +84,8 @@ class DhcpHandler(object):
         logger.info("test for route to {0}".format(KNOWN_WIRESERVER_IP))
         try:
             route = shellutil.run_get_output("grep -c {0} /proc/net/route".format(KNOWN_WIRESERVER_IP_ENTRY))
+            # route[0]: (int) return code
+            # route[1]: (str) output
             if route is not None and route[0] == 0 and int(route[1]) > 0:
                 # reset self.gateway and self.routes; we do not need to alter the routing table
                 self.endpoint = KNOWN_WIRESERVER_IP

--- a/azurelinuxagent/common/dhcp.py
+++ b/azurelinuxagent/common/dhcp.py
@@ -56,7 +56,7 @@ class DhcpHandler(object):
         Configure default gateway and routes
         Save wire server endpoint if found
         """
-        if not self.wireserver_route_exists:
+        if not self.wireserver_route_exists and not self.dhcp_lease_exists:
             self.send_dhcp_req()
             self.conf_routes()
 
@@ -99,6 +99,21 @@ class DhcpHandler(object):
             logger.error("could not determine whether route exists to {0}: {1}".format(KNOWN_WIRESERVER_IP, e))
 
         return route_exists
+
+    @property
+    def dhcp_lease_exists(self):
+        """
+        Check whether the dhcp options cache exists and contains the
+        wireserver endpoint.
+        :return: True if the cached endpoint was found in the dhcp lease
+        """
+        exists = False
+        cached_endpoint = self.osutil.get_dhcp_lease_endpoint()
+        if cached_endpoint is not None:
+            self.endpoint = cached_endpoint
+            exists = True
+        return exists
+
 
     def conf_routes(self):
         logger.info("Configure routes")

--- a/azurelinuxagent/common/dhcp.py
+++ b/azurelinuxagent/common/dhcp.py
@@ -32,6 +32,10 @@ from azurelinuxagent.common.utils.textutil import hex_dump, hex_dump2, \
 from azurelinuxagent.common.exception import DhcpError
 from azurelinuxagent.common.osutil import get_osutil
 
+# the kernel routing table representation of 168.63.129.16
+KNOWN_WIRESERVER_IP_ENTRY = '10813FA8'
+KNOWN_WIRESERVER_IP = '168.63.129.16'
+
 def get_dhcp_handler():
     return DhcpHandler()
 
@@ -52,8 +56,9 @@ class DhcpHandler(object):
         Configure default gateway and routes
         Save wire server endpoint if found
         """
-        self.send_dhcp_req()
-        self.conf_routes()
+        if not self.wireserver_route_exists:
+            self.send_dhcp_req()
+            self.conf_routes()
 
     def wait_for_network(self):
         """
@@ -66,6 +71,32 @@ class DhcpHandler(object):
             logger.info("Try to start network interface.")
             self.osutil.start_network()
             ipv4 = self.osutil.get_ip4_addr()
+
+    @property
+    def wireserver_route_exists(self):
+        """
+        Determine whether a route to the known wireserver
+        ip already exists, and if so use that as the endpoint.
+        This is true when running in a virtual network.
+        :return: True if a route to KNOWN_WIRESERVER_IP exists.
+        """
+        route_exists=False
+        logger.info("test for route to {0}".format(KNOWN_WIRESERVER_IP))
+        try:
+            route = shellutil.run_get_output("grep -c {0} /proc/net/route".format(KNOWN_WIRESERVER_IP_ENTRY))
+            if route is not None and route[0] == 0 and int(route[1]) > 0:
+                # reset self.gateway and self.routes; we do not need to alter the routing table
+                self.endpoint = KNOWN_WIRESERVER_IP
+                self.gateway = None
+                self.routes = None
+                route_exists=True
+                logger.info("route to {0} exists".format(KNOWN_WIRESERVER_IP))
+            else:
+                logger.warn("no route exists to {0}".format(KNOWN_WIRESERVER_IP))
+        except Exception as e:
+            logger.error("could not determine whether route exists to {0}: {1}".format(KNOWN_WIRESERVER_IP, e))
+
+        return route_exists
 
     def conf_routes(self):
         logger.info("Configure routes")

--- a/azurelinuxagent/common/osutil/default.py
+++ b/azurelinuxagent/common/osutil/default.py
@@ -442,7 +442,7 @@ class DefaultOSUtil(object):
             logger.warn(('SIOCGIFCONF returned more than {0} up '
                          'network interfaces.'), expected)
         sock = buff.tostring()
-        primary = self.get_primary_interface()
+        primary = bytearray(self.get_primary_interface(), encoding='utf-8')
         for i in range(0, struct_size * expected, struct_size):
             iface=sock[i:i+16].split(b'\0', 1)[0]
             if len(iface) == 0 or self.is_loopback(iface) or iface != primary:
@@ -512,7 +512,7 @@ class DefaultOSUtil(object):
 
     def is_loopback(self, ifname):
         s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
-        result = fcntl.ioctl(s.fileno(), 0x8913, ifname + '\0'*256)
+        result = fcntl.ioctl(s.fileno(), 0x8913, struct.pack('256s', ifname[:15]))
         flags, = struct.unpack('H', result[16:18])
         return flags & 8 == 8
 

--- a/azurelinuxagent/common/osutil/ubuntu.py
+++ b/azurelinuxagent/common/osutil/ubuntu.py
@@ -16,19 +16,7 @@
 # Requires Python 2.4+ and Openssl 1.0+
 #
 
-import os
-import re
-import pwd
-import shutil
-import socket
-import array
-import struct
-import fcntl
-import time
-import azurelinuxagent.common.logger as logger
-import azurelinuxagent.common.utils.fileutil as fileutil
 import azurelinuxagent.common.utils.shellutil as shellutil
-import azurelinuxagent.common.utils.textutil as textutil
 from azurelinuxagent.common.osutil.default import DefaultOSUtil
 
 class Ubuntu14OSUtil(DefaultOSUtil):
@@ -49,6 +37,9 @@ class Ubuntu14OSUtil(DefaultOSUtil):
 
     def restore_rules_files(self, rules_files=""):
         pass
+
+    def get_dhcp_lease_endpoint(self):
+        return self.get_endpoint_from_leases_path('/var/lib/dhcp/dhclient.*.leases')
 
 class Ubuntu12OSUtil(Ubuntu14OSUtil):
     def __init__(self):

--- a/azurelinuxagent/distro/__init__.py
+++ b/azurelinuxagent/distro/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 2014 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Requires Python 2.4+ and Openssl 1.0+
+#
+

--- a/azurelinuxagent/distro/default/__init__.py
+++ b/azurelinuxagent/distro/default/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 2014 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Requires Python 2.4+ and Openssl 1.0+
+#
+

--- a/azurelinuxagent/distro/suse/__init__.py
+++ b/azurelinuxagent/distro/suse/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 2014 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Requires Python 2.4+ and Openssl 1.0+
+#
+

--- a/tests/common/dhcp/__init__.py
+++ b/tests/common/dhcp/__init__.py
@@ -1,0 +1,16 @@
+# Copyright 2014 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Requires Python 2.4+ and Openssl 1.0+
+#

--- a/tests/common/dhcp/test_dhcp.py
+++ b/tests/common/dhcp/test_dhcp.py
@@ -16,6 +16,7 @@
 #
 
 import azurelinuxagent.common.dhcp as dhcp
+import azurelinuxagent.common.osutil.default as osutil
 from tests.tools import *
 
 
@@ -52,3 +53,13 @@ class TestDHCP(AgentTestCase):
         self.assertIsNone(dhcp_handler.routes)
         self.assertIsNone(dhcp_handler.gateway)
 
+    def test_dhcp_lease_exists(self):
+        dhcp_handler = dhcp.get_dhcp_handler()
+        dhcp_handler.osutil = osutil.DefaultOSUtil()
+        with patch.object(osutil.DefaultOSUtil, 'get_dhcp_lease_endpoint', return_value=None):
+            self.assertFalse(dhcp_handler.dhcp_lease_exists)
+            self.assertIsNone(dhcp_handler.endpoint)
+        with patch.object(osutil.DefaultOSUtil, 'get_dhcp_lease_endpoint', return_value="foo"):
+            self.assertTrue(dhcp_handler.dhcp_lease_exists)
+            self.assertIsNotNone(dhcp_handler.endpoint)
+            self.assertEqual(dhcp_handler.endpoint, "foo")

--- a/tests/common/dhcp/test_dhcp.py
+++ b/tests/common/dhcp/test_dhcp.py
@@ -1,0 +1,54 @@
+# Copyright 2014 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Requires Python 2.4+ and Openssl 1.0+
+#
+
+import azurelinuxagent.common.dhcp as dhcp
+from tests.tools import *
+
+
+class TestDHCP(AgentTestCase):
+    def test_wireserver_route_exists(self):
+        # setup
+        dhcp_handler = dhcp.get_dhcp_handler()
+        self.assertIsNone(dhcp_handler.endpoint)
+        self.assertIsNone(dhcp_handler.routes)
+        self.assertIsNone(dhcp_handler.gateway)
+
+        # execute
+        with patch("subprocess.check_output", return_value="1"):
+            self.assertTrue(dhcp_handler.wireserver_route_exists)
+
+        # test
+        self.assertIsNotNone(dhcp_handler.endpoint)
+        self.assertIsNone(dhcp_handler.routes)
+        self.assertIsNone(dhcp_handler.gateway)
+
+
+    def test_wireserver_route_not_exists(self):
+        # setup
+        dhcp_handler = dhcp.get_dhcp_handler()
+        self.assertIsNone(dhcp_handler.endpoint)
+        self.assertIsNone(dhcp_handler.routes)
+        self.assertIsNone(dhcp_handler.gateway)
+
+        # execute
+        self.assertFalse(dhcp_handler.wireserver_route_exists)
+
+        # test
+        self.assertIsNone(dhcp_handler.endpoint)
+        self.assertIsNone(dhcp_handler.routes)
+        self.assertIsNone(dhcp_handler.gateway)
+

--- a/tests/common/dhcp/test_dhcp.py
+++ b/tests/common/dhcp/test_dhcp.py
@@ -24,42 +24,40 @@ class TestDHCP(AgentTestCase):
     def test_wireserver_route_exists(self):
         # setup
         dhcp_handler = dhcp.get_dhcp_handler()
-        self.assertIsNone(dhcp_handler.endpoint)
-        self.assertIsNone(dhcp_handler.routes)
-        self.assertIsNone(dhcp_handler.gateway)
+        self.assertTrue(dhcp_handler.endpoint is None)
+        self.assertTrue(dhcp_handler.routes is None)
+        self.assertTrue(dhcp_handler.gateway is None)
 
         # execute
-        with patch("subprocess.check_output", return_value="1"):
+        with patch("subprocess.check_output", return_value=b'1'):
             self.assertTrue(dhcp_handler.wireserver_route_exists)
 
         # test
-        self.assertIsNotNone(dhcp_handler.endpoint)
-        self.assertIsNone(dhcp_handler.routes)
-        self.assertIsNone(dhcp_handler.gateway)
-
+        self.assertTrue(dhcp_handler.endpoint is not None)
+        self.assertTrue(dhcp_handler.routes is None)
+        self.assertTrue(dhcp_handler.gateway is None)
 
     def test_wireserver_route_not_exists(self):
         # setup
         dhcp_handler = dhcp.get_dhcp_handler()
-        self.assertIsNone(dhcp_handler.endpoint)
-        self.assertIsNone(dhcp_handler.routes)
-        self.assertIsNone(dhcp_handler.gateway)
+        self.assertTrue(dhcp_handler.endpoint is None)
+        self.assertTrue(dhcp_handler.routes is None)
+        self.assertTrue(dhcp_handler.gateway is None)
 
         # execute
         self.assertFalse(dhcp_handler.wireserver_route_exists)
 
         # test
-        self.assertIsNone(dhcp_handler.endpoint)
-        self.assertIsNone(dhcp_handler.routes)
-        self.assertIsNone(dhcp_handler.gateway)
+        self.assertTrue(dhcp_handler.endpoint is None)
+        self.assertTrue(dhcp_handler.routes is None)
+        self.assertTrue(dhcp_handler.gateway is None)
 
     def test_dhcp_lease_exists(self):
         dhcp_handler = dhcp.get_dhcp_handler()
         dhcp_handler.osutil = osutil.DefaultOSUtil()
         with patch.object(osutil.DefaultOSUtil, 'get_dhcp_lease_endpoint', return_value=None):
             self.assertFalse(dhcp_handler.dhcp_lease_exists)
-            self.assertIsNone(dhcp_handler.endpoint)
+            self.assertEqual(dhcp_handler.endpoint, None)
         with patch.object(osutil.DefaultOSUtil, 'get_dhcp_lease_endpoint', return_value="foo"):
             self.assertTrue(dhcp_handler.dhcp_lease_exists)
-            self.assertIsNotNone(dhcp_handler.endpoint)
             self.assertEqual(dhcp_handler.endpoint, "foo")

--- a/tests/common/osutil/test_default.py
+++ b/tests/common/osutil/test_default.py
@@ -17,10 +17,10 @@
 
 import socket
 import glob
+import mock
 import azurelinuxagent.common.osutil.default as osutil
 import azurelinuxagent.common.utils.shellutil as shellutil
 from azurelinuxagent.common.osutil import get_osutil
-import mock
 from tests.tools import *
 
 
@@ -39,40 +39,39 @@ class TestOSUtil(AgentTestCase):
             self.assertEqual(run_patch.call_count, retries)
             self.assertEqual(run_patch.call_args_list[0][0][0], 'ifdown {0} && ifup {0}'.format(ifname))
 
-
     def test_get_first_if(self):
         ifname, ipaddr = osutil.DefaultOSUtil().get_first_if()
         self.assertTrue(ifname.startswith('eth'))
-        self.assertIsNotNone(ipaddr)
+        self.assertTrue(ipaddr is not None)
         try:
             socket.inet_aton(ipaddr)
         except socket.error:
             self.fail("not a valid ip address")
 
     def test_isloopback(self):
-        self.assertTrue(osutil.DefaultOSUtil().is_loopback('lo'))
-        self.assertFalse(osutil.DefaultOSUtil().is_loopback('eth0'))
+        self.assertTrue(osutil.DefaultOSUtil().is_loopback(b'lo'))
+        self.assertFalse(osutil.DefaultOSUtil().is_loopback(b'eth0'))
 
     def test_isprimary(self):
-        routing_table="\
+        routing_table = "\
         Iface	Destination	Gateway 	Flags	RefCnt	Use	Metric	Mask		MTU	Window	IRTT \n\
         eth0	00000000	01345B0A	0003	0	    0	5	00000000	0	0	0   \n\
         eth0	00345B0A	00000000	0001	0	    0	5	00000000	0	0	0   \n\
         lo	    00000000	01345B0A	0003	0	    0	1	00FCFFFF	0	0	0   \n"
 
         mo = mock.mock_open(read_data=routing_table)
-        with patch('__builtin__.open', mo):
+        with patch(open_patch(), mo):
             self.assertFalse(osutil.DefaultOSUtil().is_primary_interface('lo'))
             self.assertTrue(osutil.DefaultOSUtil().is_primary_interface('eth0'))
 
     def test_multiple_default_routes(self):
-        routing_table="\
+        routing_table = "\
         Iface	Destination	Gateway 	Flags	RefCnt	Use	Metric	Mask		MTU	Window	IRTT \n\
         high	00000000	01345B0A	0003	0	    0	5	00000000	0	0	0   \n\
         low1	00000000	01345B0A	0003	0	    0	1	00FCFFFF	0	0	0   \n"
 
         mo = mock.mock_open(read_data=routing_table)
-        with patch('__builtin__.open', mo):
+        with patch(open_patch(), mo):
             self.assertTrue(osutil.DefaultOSUtil().is_primary_interface('low1'))
 
     def test_multiple_interfaces(self):
@@ -82,9 +81,8 @@ class TestOSUtil(AgentTestCase):
         secnd	00000000	01345B0A	0003	0	    0	1	00FCFFFF	0	0	0   \n"
 
         mo = mock.mock_open(read_data=routing_table)
-        with patch('__builtin__.open', mo):
+        with patch(open_patch(), mo):
             self.assertTrue(osutil.DefaultOSUtil().is_primary_interface('first'))
-
 
     def test_interface_flags(self):
         routing_table = "\
@@ -93,9 +91,8 @@ class TestOSUtil(AgentTestCase):
         flgs	00000000	01345B0A	0003	0	    0	1	00FCFFFF	0	0	0   \n"
 
         mo = mock.mock_open(read_data=routing_table)
-        with patch('__builtin__.open', mo):
+        with patch(open_patch(), mo):
             self.assertTrue(osutil.DefaultOSUtil().is_primary_interface('flgs'))
-
 
     def test_no_interface(self):
         routing_table = "\
@@ -104,25 +101,28 @@ class TestOSUtil(AgentTestCase):
         nflg	00000000	01345B0A	0001	0	    0	1	00FCFFFF	0	0	0   \n"
 
         mo = mock.mock_open(read_data=routing_table)
-        with patch('__builtin__.open', mo):
+        with patch(open_patch(), mo):
             self.assertFalse(osutil.DefaultOSUtil().is_primary_interface('ndst'))
             self.assertFalse(osutil.DefaultOSUtil().is_primary_interface('nflg'))
             self.assertFalse(osutil.DefaultOSUtil().is_primary_interface('invalid'))
 
     def test_dhcp_lease_default(self):
-        self.assertIsNone(osutil.DefaultOSUtil().get_dhcp_lease_endpoint())
+        self.assertTrue(osutil.DefaultOSUtil().get_dhcp_lease_endpoint() is None)
 
     def test_dhcp_lease_ubuntu(self):
         with patch.object(glob, "glob", return_value=['/var/lib/dhcp/dhclient.eth0.leases']):
-            with patch('__builtin__.open', mock.mock_open(read_data=load_data("dhcp.leases"))):
-                endpoint = get_osutil(distro_name='ubuntu').get_dhcp_lease_endpoint()
-                self.assertIsNotNone(endpoint)
+            with patch(open_patch(), mock.mock_open(read_data=load_data("dhcp.leases"))):
+                endpoint = get_osutil(distro_name='ubuntu', distro_version='12.04').get_dhcp_lease_endpoint()
+                self.assertTrue(endpoint is not None)
                 self.assertEqual(endpoint, "168.63.129.16")
 
-                self.assertIsNotNone(get_osutil(distro_name='ubuntu', distro_version='12.04').get_dhcp_lease_endpoint())
-                self.assertIsNotNone(get_osutil(distro_name='ubuntu', distro_version='14.04').get_dhcp_lease_endpoint())
+                endpoint = get_osutil(distro_name='ubuntu', distro_version='12.04').get_dhcp_lease_endpoint()
+                self.assertTrue(endpoint is not None)
+                self.assertEqual(endpoint, "168.63.129.16")
 
+                endpoint = get_osutil(distro_name='ubuntu', distro_version='14.04').get_dhcp_lease_endpoint()
+                self.assertTrue(endpoint is not None)
+                self.assertEqual(endpoint, "168.63.129.16")
 
 if __name__ == '__main__':
     unittest.main()
-

--- a/tests/common/osutil/test_default.py
+++ b/tests/common/osutil/test_default.py
@@ -15,6 +15,7 @@
 # Requires Python 2.4+ and Openssl 1.0+
 #
 
+import socket
 import azurelinuxagent.common.osutil.default as osutil
 import azurelinuxagent.common.utils.shellutil as shellutil
 import mock
@@ -36,6 +37,18 @@ class TestOSUtil(AgentTestCase):
             self.assertEqual(run_patch.call_count, retries)
             self.assertEqual(run_patch.call_args_list[0][0][0], 'ifdown {0} && ifup {0}'.format(ifname))
 
+
+    def test_get_first_if(self):
+        ifname, ipaddr = osutil.DefaultOSUtil().get_first_if()
+        self.assertTrue(ifname.startswith('eth'))
+        self.assertIsNotNone(ipaddr)
+        try:
+            socket.inet_aton(ipaddr)
+        except socket.error:
+            self.fail("not a valid ip address")
+
+    def test_isloopback(self):
+        self.assertTrue(osutil.DefaultOSUtil().is_loopback('lo'))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/data/dhcp.leases
+++ b/tests/data/dhcp.leases
@@ -1,0 +1,56 @@
+lease {
+  interface "eth0";
+  fixed-address 10.0.1.4;
+  server-name "RDE41D2D9BB18C";
+  option subnet-mask 255.255.255.0;
+  option dhcp-lease-time 4294967295;
+  option routers 10.0.1.1;
+  option dhcp-message-type 5;
+  option dhcp-server-identifier 168.63.129.16;
+  option domain-name-servers expired;
+  option dhcp-renewal-time 4294967295;
+  option unknown-245 a8:3f:81:10;
+  option dhcp-rebinding-time 4294967295;
+  option domain-name "qylsde3bnlhu5dstzf3bav5inc.fx.internal.cloudapp.net";
+  renew 4 2015/06/16 16:58:54;
+  rebind 4 2015/06/16 16:58:54;
+  expire 4 2015/06/16 16:58:54;
+}
+lease {
+  interface "eth0";
+  fixed-address 10.0.1.4;
+  server-name "RDE41D2D9BB18C";
+  option subnet-mask 255.255.255.0;
+  option dhcp-lease-time 4294967295;
+  option routers 10.0.1.1;
+  option dhcp-message-type 5;
+  option dhcp-server-identifier 168.63.129.16;
+  option domain-name-servers 168.63.129.16;
+  option dhcp-renewal-time 4294967295;
+  option rfc3442-classless-static-routes 0,10,0,1,1,32,168,63,129,16,10,0,1,1;
+  option unknown-245 a8:3f:81:10;
+  option dhcp-rebinding-time 4294967295;
+  option domain-name "qylsde3bnlhu5dstzf3bav5inc.fx.internal.cloudapp.net";
+  renew 0 2152/07/23 23:27:10;
+  rebind 0 2152/07/23 23:27:10;
+  expire 0 2152/07/23 23:27:10;
+}
+lease {
+  interface "eth0";
+  fixed-address 10.0.1.4;
+  server-name "RDE41D2D9BB18C";
+  option subnet-mask 255.255.255.0;
+  option dhcp-lease-time 4294967295;
+  option routers 10.0.1.1;
+  option dhcp-message-type 5;
+  option dhcp-server-identifier 168.63.129.16;
+  option domain-name-servers invalid;
+  option dhcp-renewal-time 4294967295;
+  option rfc3442-classless-static-routes 0,10,0,1,1,32,168,63,129,16,10,0,1,1;
+  option unknown-245 a8:3f:81:10;
+  option dhcp-rebinding-time 4294967295;
+  option domain-name "qylsde3bnlhu5dstzf3bav5inc.fx.internal.cloudapp.net";
+  renew 0 2152/07/23 23:27:10;
+  rebind 0 2152/07/23 23:27:10;
+  expire 0 never;
+}

--- a/tests/distro/__init__.py
+++ b/tests/distro/__init__.py
@@ -1,0 +1,16 @@
+# Copyright 2014 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Requires Python 2.4+ and Openssl 1.0+
+#

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -30,6 +30,7 @@ from functools import wraps
 import azurelinuxagent.common.conf as conf
 import azurelinuxagent.common.logger as logger
 import azurelinuxagent.common.event as event
+from azurelinuxagent.common.version import PY_VERSION_MAJOR
 
 #Import mock module for Python2 and Python3
 try:
@@ -94,6 +95,12 @@ supported_distro = [
     ["redhat", "7.0", ""],
 
 ]
+
+def open_patch():
+    open_name = '__builtin__.open'
+    if PY_VERSION_MAJOR == 3:
+        open_name = 'builtins.open'
+    return open_name
 
 def distros(distro_name=".*", distro_version=".*", distro_full_name=".*"):
     """Run test on multiple distros"""


### PR DESCRIPTION
Several distinct pieces here, so I have left them as separate commits for the PR. 

- update loopback detection to use SIOCGIFFLAGS and IFF_LOOPBACK
- examine the routing table for known wireserver ip, then skip the dhcp lookup and route manipulation
- ensure the first selected interface is the primary, which has the default route
- parse the wireserver from the dhcp leases file on disk; distro-specific, this is the ubuntu implementation with common parsing logic
- unit tests for each scenario
- addresses #188, #190, and #212 