### PR TITLE
Workaround for race condition between azurelinuxagent and scvmmagent

### DIFF
--- a/azurelinuxagent/daemon/scvmm.py
+++ b/azurelinuxagent/daemon/scvmm.py
@@ -21,6 +21,7 @@ import re
 import os
 import sys
 import subprocess
+import time
 import azurelinuxagent.common.logger as logger
 import azurelinuxagent.common.conf as conf
 from azurelinuxagent.common.osutil import get_osutil
@@ -70,4 +71,5 @@ class ScvmmHandler(object):
         if self.detect_scvmm_env():
             self.start_scvmm_agent()
             logger.info("Exiting")
+            time.sleep(300)
             sys.exit(0)


### PR DESCRIPTION
This fixes a race condition between azurelinuxagent  and scvmmagent when systemd is used.
The problem is due to the fact that systemd restarts walinuxagent once it finishes its job. The sleep delays the restart and leaves scvmmagent  enough time for finishing its job.