### PR TITLE
Fix sudo asking for password

### DIFF
--- a/azurelinuxagent/distro/default/osutil.py
+++ b/azurelinuxagent/distro/default/osutil.py
@@ -124,7 +124,7 @@ class DefaultOSUtil(object):
             fileutil.append_file('/etc/sudoers', sudoers)
         sudoer = None
         if nopasswd:
-            sudoer = "{0} ALL = (ALL) NOPASSWD\n".format(username)
+            sudoer = "{0} ALL = (ALL) NOPASSWD: ALL\n".format(username)
         else:
             sudoer = "{0} ALL = (ALL) ALL\n".format(username)
         fileutil.append_file('/etc/sudoers.d/waagent', sudoer)


### PR DESCRIPTION
On current latest version, Agent fails to properly set sudoers as NOPASSWD when password auth is disabled.

This patch fixes that.