### PR TITLE
Fix NOPASSWD sudoers line in osutil.py by adding : ALL 

### DIFF
--- a/azurelinuxagent/distro/default/osutil.py
+++ b/azurelinuxagent/distro/default/osutil.py
@@ -124,7 +124,7 @@ class DefaultOSUtil(object):
             fileutil.append_file('/etc/sudoers', sudoers)
         sudoer = None
         if nopasswd:
-            sudoer = "{0} ALL = (ALL) NOPASSWD\n".format(username)
+            sudoer = "{0} ALL = (ALL) NOPASSWD: ALL\n".format(username)
         else:
             sudoer = "{0} ALL = (ALL) ALL\n".format(username)
         fileutil.append_file('/etc/sudoers.d/waagent', sudoer)


### PR DESCRIPTION
Without ": ALL" after NOPASSWD user without password is unable to use sudo like in [issue 248](https://github.com/Azure/WALinuxAgent/issues/248)