### PR TITLE
Update RDMA IB interface from SharedConfig

### DIFF
--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -684,7 +684,7 @@ class WireClient(object):
                     else:
                         logger.info("RDMA capabilities are enabled in configuration")
                         rdma_device_configured = True # do not run again
-                        self.write_ip_on_rdma()
+                        self.setup_rdma_dev()
                 else:
                     logger.info("RDMA capabilities are not enabled, skipping")
 
@@ -884,7 +884,7 @@ class WireClient(object):
             "x-ms-guest-agent-public-x509-cert": cert
         }
 
-    def write_ip_on_rdma(self):
+    def setup_rdma_dev(self):
         logger.verbose("Parsing SharedConfig XML contents for RDMA details")
         xml_doc = parse_doc(self.shared_conf.xml_text)
         if xml_doc is None:

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -24,6 +24,7 @@ from azurelinuxagent.common.future import httpclient, bytebuffer
 from azurelinuxagent.common.utils.textutil import parse_doc, findall, find, findtext, \
     getattrib, gettext, remove_bom, get_bytes_from_pem
 import azurelinuxagent.common.utils.fileutil as fileutil
+from azurelinuxagent.common.rdma import RDMADeviceHandler
 from azurelinuxagent.common.utils.cryptutil import CryptUtil
 from azurelinuxagent.common.protocol.restapi import *
 from azurelinuxagent.common.protocol.hostplugin import HostPluginProtocol
@@ -53,6 +54,9 @@ ENDPOINT_FINE_NAME = "WireServer"
 SHORT_WAITING_INTERVAL = 1  # 1 second
 LONG_WAITING_INTERVAL = 15  # 15 seconds
 
+# rdma_device_configured variable limits RDMA device updating code within the
+# GoalState loop to be executed only once
+rdma_device_configured = False
 
 class UploadError(HttpError):
     pass
@@ -642,6 +646,8 @@ class WireClient(object):
         self.ext_conf = ExtensionsConfig(xml_text)
 
     def update_goal_state(self, forced=False, max_retry=3):
+        global rdma_device_configured
+
         uri = GOAL_STATE_URI.format(self.endpoint)
         xml_text = self.fetch_config(uri, self.get_header())
         goal_state = GoalState(xml_text)
@@ -671,6 +677,17 @@ class WireClient(object):
                 self.update_shared_conf(goal_state)
                 self.update_certs(goal_state)
                 self.update_ext_conf(goal_state)
+
+                if conf.enable_rdma():
+                    if rdma_device_configured:
+                        logger.info("RDMA device already configured, skipping")
+                    else:
+                        logger.info("RDMA capabilities are enabled in configuration")
+                        rdma_device_configured = True # do not run again
+                        self.write_ip_on_rdma()
+                else:
+                    logger.info("RDMA capabilities are not enabled, skipping")
+
                 return
             except WireProtocolResourceGone:
                 logger.info("Incarnation is out of date. Update goalstate.")
@@ -867,6 +884,33 @@ class WireClient(object):
             "x-ms-guest-agent-public-x509-cert": cert
         }
 
+    def write_ip_on_rdma(self):
+        logger.verbose("Parsing SharedConfig XML contents for RDMA details")
+        xml_doc = parse_doc(self.shared_conf.xml_text)
+        if xml_doc is None:
+            logger.error("Could not parse SharedConfig XML document")
+            return
+        instance_elem = find(xml_doc, "Instance")
+        if not instance_elem:
+            logger.error("Could not find <Instance> in SharedConfig document")
+            return
+
+        rdma_ipv4_addr = getattrib(instance_elem, "rdmaIPv4Address")
+        if not rdma_ipv4_addr:
+            logger.error("Could not find rdmaIPv4Address attribute on Instance element of SharedConfig.xml document")
+
+        rdma_mac_addr = getattrib(instance_elem, "rdmaMacAddress")
+        if not rdma_mac_addr:
+            logger.error("Could not find rdmaMacAddress attribute on Instance element of SharedConfig.xml document")
+        rdma_mac_addr=self.format_mac_addr(rdma_mac_addr)
+        logger.info("Found RDMA details. IPv4={0} MAC={1}".format(rdma_ipv4_addr, rdma_mac_addr))
+        RDMADeviceHandler(rdma_ipv4_addr, rdma_mac_addr).start()
+
+    def format_mac_addr(self, addr):
+        """
+        Formats a MAC addr like 00155D33FF1D into "00:15:5D:33:FF:1D"
+        """
+        return ':'.join([addr[i:i+2] for i in range(0, len(addr), 2)])
 
 class VersionInfo(object):
     def __init__(self, xml_text):
@@ -967,20 +1011,16 @@ class HostingEnv(object):
 
 class SharedConfig(object):
     """
-    parse role endpoint server and goal state config.
+    Holds SharedConfig XML data
     """
+    xml_text=None
 
     def __init__(self, xml_text):
-        logger.verbose("Load SharedConfig.xml")
-        self.parse(xml_text)
+        logger.verbose("Loading SharedConfig.xml")
+        self.xml_text=xml_text
 
-    def parse(self, xml_text):
-        """
-        parse and write configuration to file SharedConfig.xml.
-        """
-        # Not used currently
-        return self
-
+    def parse(self):
+       pass
 
 class Certificates(object):
     """

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -898,10 +898,13 @@ class WireClient(object):
         rdma_ipv4_addr = getattrib(instance_elem, "rdmaIPv4Address")
         if not rdma_ipv4_addr:
             logger.error("Could not find rdmaIPv4Address attribute on Instance element of SharedConfig.xml document")
+            return
 
         rdma_mac_addr = getattrib(instance_elem, "rdmaMacAddress")
         if not rdma_mac_addr:
             logger.error("Could not find rdmaMacAddress attribute on Instance element of SharedConfig.xml document")
+            return
+
         rdma_mac_addr=self.format_mac_addr(rdma_mac_addr)
         logger.info("Found RDMA details. IPv4={0} MAC={1}".format(rdma_ipv4_addr, rdma_mac_addr))
         RDMADeviceHandler(rdma_ipv4_addr, rdma_mac_addr).start()

--- a/azurelinuxagent/common/rdma.py
+++ b/azurelinuxagent/common/rdma.py
@@ -186,7 +186,7 @@ class RDMADeviceHandler(object):
 
     @staticmethod
     def wait_rdma_device(path, timeout_sec, check_interval_sec):
-        logger.info("RDMA: waiting for device={0} timeout={0}s".format(path, timeout_sec))
+        logger.info("RDMA: waiting for device={0} timeout={1}s".format(path, timeout_sec))
         total_retries = timeout_sec/check_interval_sec
         n = 0
         while n < total_retries:

--- a/azurelinuxagent/common/rdma.py
+++ b/azurelinuxagent/common/rdma.py
@@ -234,4 +234,3 @@ class RDMADeviceHandler(object):
         if eths is None or len(eths) == 0:
             raise Exception("ifname with mac: {0} not found".format(mac))
         return eths[-1]
->>>>>>> Update RDMA IB interface from SharedConfig

--- a/azurelinuxagent/common/rdma.py
+++ b/azurelinuxagent/common/rdma.py
@@ -186,14 +186,14 @@ class RDMADeviceHandler(object):
 
     @staticmethod
     def wait_rdma_device(path, timeout_sec, check_interval_sec):
-        logger.info("RDMA: waiting for device {0}".format(path))
+        logger.info("RDMA: waiting for device={0} timeout={0}s".format(path, timeout_sec))
         total_retries = timeout_sec/check_interval_sec
         n = 0
         while n < total_retries:
             if os.path.exists(path):
                 logger.info("RDMA: device ready")
                 return
-            logger.info(
+            logger.verbose(
                 "RDMA: device not ready, sleep {0}s".format(check_interval_sec))
             time.sleep(check_interval_sec)
             n += 1

--- a/azurelinuxagent/common/rdma.py
+++ b/azurelinuxagent/common/rdma.py
@@ -21,8 +21,14 @@ Handle packages and modules to enable RDMA for IB networking
 
 import os
 import re
+import threading
+import time
 import azurelinuxagent.common.logger as logger
+import azurelinuxagent.common.utils.fileutil as fileutil
 import azurelinuxagent.common.utils.shellutil as shellutil
+
+dapl_config_paths = ['/etc/dat.conf', '/etc/rdma/dat.conf',
+                     '/usr/local/etc/dat.conf']
 
 
 class RDMAHandler(object):
@@ -97,3 +103,135 @@ class RDMAHandler(object):
         ret = shellutil.run('shutdown -r now')
         if ret != 0:
             logger.error('RDMA: Failed to reboot the system')
+
+
+dapl_config_paths = [
+    '/etc/dat.conf', '/etc/rdma/dat.conf', '/usr/local/etc/dat.conf']
+
+class RDMADeviceHandler(object):
+
+    """
+    Responsible for writing RDMA IP and MAC address to the /dev/hvnd_rdma
+    interface.
+    """
+
+    rdma_dev = '/dev/hvnd_rdma'
+    device_check_timeout_sec = 120
+    device_check_interval_sec = 1
+
+    ipv4_addr = None
+    mac_adr = None
+
+    def __init__(self, ipv4_addr, mac_addr):
+        self.ipv4_addr = ipv4_addr
+        self.mac_addr = mac_addr
+
+    def start(self):
+        """
+        Start a thread in the background to process the RDMA tasks and returns.
+        """
+        logger.info("RDMA: starting device processing in the background.")
+        threading.Thread(target=self.process).start()
+
+    def process(self):
+        RDMADeviceHandler.update_dat_conf(dapl_config_paths, self.ipv4_addr)
+        RDMADeviceHandler.wait_rdma_device(
+            self.rdma_dev, self.device_check_timeout_sec, self.device_check_interval_sec)
+        RDMADeviceHandler.write_rdma_config_on_device(
+            self.rdma_dev, self.ipv4_addr, self.mac_addr)
+        RDMADeviceHandler.update_network_interface(self.mac_addr, self.ipv4_addr)
+
+    @staticmethod
+    def update_dat_conf(paths, ipv4_addr):
+        """
+        Looks at paths for dat.conf file and updates the ip address for the
+        infiniband interface.
+        """
+        logger.info("Updating DAPL configuration file")
+        for f in paths:
+            logger.info("RDMA: trying {0}".format(f))
+            if not os.path.isfile(f):
+                logger.info(
+                    "RDMA: DAPL config not found at {0}".format(f))
+                continue
+            logger.info("RDMA: DAPL config is at: {0}".format(f))
+            cfg = fileutil.read_file(f)
+            new_cfg = RDMADeviceHandler.replace_dat_conf_contents(
+                cfg, ipv4_addr)
+            fileutil.write_file(f, new_cfg)
+            logger.info("RDMA: DAPL configuration is updated")
+            return
+
+        raise Exception("RDMA: DAPL configuration file not found at predefined paths")
+
+    @staticmethod
+    def replace_dat_conf_contents(cfg, ipv4_addr):
+        old = "ofa-v2-ib0 u2.0 nonthreadsafe default libdaplofa.so.2 dapl.2.0 \"\S+ 0\""
+        new = "ofa-v2-ib0 u2.0 nonthreadsafe default libdaplofa.so.2 dapl.2.0 \"{0} 0\"".format(
+            ipv4_addr)
+        return re.sub(old, new, cfg)
+
+    @staticmethod
+    def write_rdma_config_on_device(path, ipv4_addr, mac_addr):
+        data = RDMADeviceHandler.get_rdma_config(ipv4_addr, mac_addr)
+        logger.info(
+            "RDMA: Updating device with configuration: {0}".format(data))
+        with open(path, "w") as c:
+            c.write(data)
+        logger.info("RDMA: Updated device with IPv4/MAC addr successfully")
+
+    @staticmethod
+    def get_rdma_config(ipv4_addr, mac_addr):
+        return 'rdmaMacAddress="{0}" rdmaIPv4Address="{1}"'.format(mac_addr, ipv4_addr)
+
+    @staticmethod
+    def wait_rdma_device(path, timeout_sec, check_interval_sec):
+        logger.info("RDMA: waiting for device {0}".format(path))
+        total_retries = timeout_sec/check_interval_sec
+        n = 0
+        while n < total_retries:
+            if os.path.exists(path):
+                logger.info("RDMA: device ready")
+                return
+            logger.info(
+                "RDMA: device not ready, sleep {0}s".format(check_interval_sec))
+            time.sleep(check_interval_sec)
+            n += 1
+        logger.error("RDMA device wait timed out")
+        raise Exception("The device did not show up in {0} seconds ({1} retries)".format(
+            timeout_sec, total_retries))
+
+    @staticmethod
+    def update_network_interface(mac_addr, ipv4_addr):
+        netmask=16
+        
+        logger.info("RDMA: will update the network interface with IPv4/MAC")
+
+        if_name=RDMADeviceHandler.get_interface_by_mac(mac_addr)
+        logger.info("RDMA: network interface found: {0}", if_name)
+        logger.info("RDMA: bringing network interface up")
+        if shellutil.run("ifconfig {0} up".format(if_name)) != 0:
+            raise Exception("Could not bring up RMDA interface: {0}".format(if_name))
+
+        logger.info("RDMA: configuring IPv4 addr and netmask on interface")
+        addr = '{0}/{1}'.format(ipv4_addr, netmask)
+        if shellutil.run("ifconfig {0} {1}".format(if_name, addr)) != 0:
+            raise Exception("Could set addr to {1} on {0}".format(if_name, addr))
+        logger.info("RDMA: network address and netmask configured on interface")
+
+    @staticmethod
+    def get_interface_by_mac(mac):
+        ret, output = shellutil.run_get_output("ifconfig -a")
+        if ret != 0:
+            raise Exception("Failed to list network interfaces")
+        output = output.replace('\n', '')
+        match = re.search(r"(eth\d).*(HWaddr|ether) {0}".format(mac), 
+                          output, re.IGNORECASE)
+        if match is None:
+            raise Exception("Failed to get ifname with mac: {0}".format(mac))
+        output = match.group(0)
+        eths = re.findall(r"eth\d", output)
+        if eths is None or len(eths) == 0:
+            raise Exception("ifname with mac: {0} not found".format(mac))
+        return eths[-1]
+>>>>>>> Update RDMA IB interface from SharedConfig

--- a/azurelinuxagent/common/rdma.py
+++ b/azurelinuxagent/common/rdma.py
@@ -134,9 +134,9 @@ class RDMADeviceHandler(object):
         threading.Thread(target=self.process).start()
 
     def process(self):
-        RDMADeviceHandler.update_dat_conf(dapl_config_paths, self.ipv4_addr)
         RDMADeviceHandler.wait_rdma_device(
             self.rdma_dev, self.device_check_timeout_sec, self.device_check_interval_sec)
+        RDMADeviceHandler.update_dat_conf(dapl_config_paths, self.ipv4_addr)
         RDMADeviceHandler.write_rdma_config_on_device(
             self.rdma_dev, self.ipv4_addr, self.mac_addr)
         RDMADeviceHandler.update_network_interface(self.mac_addr, self.ipv4_addr)

--- a/azurelinuxagent/common/rdma.py
+++ b/azurelinuxagent/common/rdma.py
@@ -137,7 +137,7 @@ class RDMADeviceHandler(object):
         RDMADeviceHandler.wait_rdma_device(
             self.rdma_dev, self.device_check_timeout_sec, self.device_check_interval_sec)
         RDMADeviceHandler.update_dat_conf(dapl_config_paths, self.ipv4_addr)
-        RDMADeviceHandler.write_rdma_config_on_device(
+        RDMADeviceHandler.write_rdma_config_to_device(
             self.rdma_dev, self.ipv4_addr, self.mac_addr)
         RDMADeviceHandler.update_network_interface(self.mac_addr, self.ipv4_addr)
 
@@ -172,16 +172,16 @@ class RDMADeviceHandler(object):
         return re.sub(old, new, cfg)
 
     @staticmethod
-    def write_rdma_config_on_device(path, ipv4_addr, mac_addr):
-        data = RDMADeviceHandler.get_rdma_config(ipv4_addr, mac_addr)
+    def write_rdma_config_to_device(path, ipv4_addr, mac_addr):
+        data = RDMADeviceHandler.generate_rdma_config(ipv4_addr, mac_addr)
         logger.info(
             "RDMA: Updating device with configuration: {0}".format(data))
-        with open(path, "w") as c:
-            c.write(data)
+        with open(path, "w") as f:
+            f.write(data)
         logger.info("RDMA: Updated device with IPv4/MAC addr successfully")
 
     @staticmethod
-    def get_rdma_config(ipv4_addr, mac_addr):
+    def generate_rdma_config(ipv4_addr, mac_addr):
         return 'rdmaMacAddress="{0}" rdmaIPv4Address="{1}"'.format(mac_addr, ipv4_addr)
 
     @staticmethod

--- a/azurelinuxagent/daemon/main.py
+++ b/azurelinuxagent/daemon/main.py
@@ -30,8 +30,10 @@ from azurelinuxagent.common.version import AGENT_LONG_NAME, AGENT_VERSION, \
                                      DISTRO_NAME, DISTRO_VERSION, \
                                      DISTRO_FULL_NAME, PY_VERSION_MAJOR, \
                                      PY_VERSION_MINOR, PY_VERSION_MICRO
+from azurelinuxagent.common.protocol.wire import SHARED_CONF_FILE_NAME
 import azurelinuxagent.common.event as event
 import azurelinuxagent.common.utils.fileutil as fileutil
+from azurelinuxagent.common.utils.textutil import parse_doc, find, getattrib
 from azurelinuxagent.common.osutil import get_osutil
 from azurelinuxagent.common.protocol import get_protocol_util
 from azurelinuxagent.daemon.scvmm import get_scvmm_handler
@@ -41,6 +43,7 @@ from azurelinuxagent.daemon.env import get_env_handler
 from azurelinuxagent.pa.provision import get_provision_handler
 from azurelinuxagent.pa.rdma import get_rdma_handler
 from azurelinuxagent.ga.update import get_update_handler
+from azurelinuxagent.common.rdma import RDMADeviceHandler
 
 def get_daemon_handler():
     return DaemonHandler()
@@ -118,6 +121,52 @@ class DaemonHandler(object):
         self.monitor_handler.run()
 
         self.env_handler.run()
+
+        # Enable RDMA, continue in errors
+        if conf.enable_rdma():
+                logger.info("RDMA capabilities are enabled in configuration")
+                try:
+                    self.setup_rdma_device()
+                except Exception as e:
+                    logger.error("Error setting up rdma device: %s" % e)
+        else:
+            logger.info("RDMA capabilities are not enabled, skipping")
         
         while self.running:
             self.update_handler.run_latest()
+
+
+    def setup_rdma_device(self):
+        logger.verbose("Parsing SharedConfig XML contents for RDMA details")
+        xml_doc = parse_doc(
+            fileutil.read_file(os.path.join(conf.get_lib_dir(), SHARED_CONF_FILE_NAME)))
+        if xml_doc is None:
+            logger.error("Could not parse SharedConfig XML document")
+            return
+        instance_elem = find(xml_doc, "Instance")
+        if not instance_elem:
+            logger.error("Could not find <Instance> in SharedConfig document")
+            return
+
+        rdma_ipv4_addr = getattrib(instance_elem, "rdmaIPv4Address")
+        if not rdma_ipv4_addr:
+            logger.error(
+                "Could not find rdmaIPv4Address attribute on Instance element of SharedConfig.xml document")
+            return
+
+        rdma_mac_addr = getattrib(instance_elem, "rdmaMacAddress")
+        if not rdma_mac_addr:
+            logger.error(
+                "Could not find rdmaMacAddress attribute on Instance element of SharedConfig.xml document")
+            return
+
+        # add colons to the MAC address (e.g. 00155D33FF1D ->
+        # 00:15:5D:33:FF:1D)
+        rdma_mac_addr = ':'.join([rdma_mac_addr[i:i+2]
+                                  for i in range(0, len(rdma_mac_addr), 2)])
+        logger.info("Found RDMA details. IPv4={0} MAC={1}".format(
+            rdma_ipv4_addr, rdma_mac_addr))
+
+        # Set up the RDMA device with collected informatino
+        RDMADeviceHandler(rdma_ipv4_addr, rdma_mac_addr).start()
+        logger.info("RDMA: device is set up")


### PR DESCRIPTION
This change ports https://github.com/Azure/WALinuxAgent/blob/adfb590ad3904e261da5605b36c3924afa22b2c5/waagent#L4239-L4324 and https://github.com/Azure/WALinuxAgent/blob/adfb590ad3904e261da5605b36c3924afa22b2c5/waagent#L4197-L4203 of v2.0 code to v2.1.

The code flow did not change. In the GoalState parsing, we parse SharedConfig for the first time we and spin up a thread to:

* parse `rdmaMacAddress`/`rdmaIPv4Address` from SharedConfig.xml
* update `dat.conf` with rdma IPv4 addr
* wait for `/dev/hvnd_rdma`
* write IPv4/MAC addrs to `/dev/hvnd_rdma`
* find network interface name for infiniband
* `ifconfig up` && `ifconfig [...] $IPv4Addr/16`

On errors, we throw exceptions but we catch them, so we do not crash the agent (keeping the current behavior).

Mostly manually tested and it seems to be working fine on CentOS.

**The only problem is** it looks like we run the agent twice:
```
  ├─python -u /usr/sbin/waagent -daemon
  │   ├─python /usr/sbin/waagent run-exthandlers
```

and if I add this change to GoalState processing, the code is being executed twice in separate processes. How do we prevent this? (Ideally this should be done in `daemon` and not `exthandlers`)

@rjschwei I encourage you to pick this up and test it on  SUSE. (although the issue above should be fixed, the code is testable.) I also appreciate the code reviews!

Here's how logs should look like (in journalctl, waagent.log will have duplications due to issue above):

```diff


Jun 23 00:08:38 centos python[49540]: 2016/06/23 00:08:38.678873 INFO Azure Linux Agent Version:2.1.5.rc0
Jun 23 00:08:38 centos python[49540]: 2016/06/23 00:08:38.680079 INFO OS: centos 7.1.1503
Jun 23 00:08:38 centos python[49540]: 2016/06/23 00:08:38.680768 INFO Python: 2.7.5
Jun 23 00:08:38 centos python[49540]: 2016/06/23 00:08:38.681222 INFO Run daemon
Jun 23 00:08:38 centos python[49540]: 2016/06/23 00:08:38.681819 ERROR RDMAHandler.install_driver not implemented
Jun 23 00:08:38 centos python[49540]: 2016/06/23 00:08:38.682168 INFO Activate resource disk
Jun 23 00:08:38 centos python[49540]: 2016/06/23 00:08:38.688779 INFO Resource disk /dev/sdb1 is already mounted
Jun 23 00:08:38 centos python[49540]: 2016/06/23 00:08:38.689844 INFO Clean protocol
Jun 23 00:08:38 centos python[49540]: 2016/06/23 00:08:38.690377 INFO Start env monitor service.
Jun 23 00:08:38 centos python[49540]: 2016/06/23 00:08:38.692337 INFO Configure routes
Jun 23 00:08:38 centos python[49540]: 2016/06/23 00:08:38.692666 INFO Gateway:None
Jun 23 00:08:38 centos python[49540]: 2016/06/23 00:08:38.693016 INFO Routes:None
Jun 23 00:08:38 centos python[49540]: 2016/06/23 00:08:38.707830 INFO Detect protocol endpoints
Jun 23 00:08:38 centos python[49540]: 2016/06/23 00:08:38.709284 INFO Clean protocol
Jun 23 00:08:38 centos python[49540]: 2016/06/23 00:08:38.710388 INFO WireServer endpoint is not found. Rerun dhcp handler
Jun 23 00:08:38 centos python[49540]: 2016/06/23 00:08:38.711386 INFO test for route to 168.63.129.16
Jun 23 00:08:38 centos python[49540]: 2016/06/23 00:08:38.714847 INFO route to 168.63.129.16 exists
Jun 23 00:08:38 centos python[49540]: 2016/06/23 00:08:38.715688 INFO Wire server endpoint:168.63.129.16
Jun 23 00:08:38 centos python[49540]: 2016/06/23 00:08:38.720836 INFO Fabric preferred wire protocol version:2015-04-05
Jun 23 00:08:38 centos python[49540]: 2016/06/23 00:08:38.723281 INFO Wire protocol version:2012-11-30
Jun 23 00:08:38 centos python[49540]: 2016/06/23 00:08:38.724916 WARNING Server prefered version:2015-04-05
+Jun 23 00:08:42 centos python[49540]: 2016/06/23 00:08:42.850724 INFO RDMA capabilities are enabled in configuration
+Jun 23 00:08:42 centos python[49540]: 2016/06/23 00:08:42.852225 INFO Found RDMA details. IPv4=172.16.1.20 MAC=00:15:5D:33:FF:1D
+Jun 23 00:08:42 centos python[49540]: 2016/06/23 00:08:42.852406 INFO RDMA: starting device processing in the background.
+Jun 23 00:08:42 centos python[49540]: 2016/06/23 00:08:42.852936 INFO Updating DAPL configuration file
Jun 23 00:08:42 centos python[49540]: 2016/06/23 00:08:42.853899 INFO Event: name=WALA, op=HeartBeat, message=
+Jun 23 00:08:42 centos python[49540]: 2016/06/23 00:08:42.854191 INFO RDMA: trying /etc/dat.conf
+Jun 23 00:08:42 centos python[49540]: 2016/06/23 00:08:42.855335 INFO RDMA: DAPL config not found at /etc/dat.conf
+Jun 23 00:08:42 centos python[49540]: 2016/06/23 00:08:42.856497 INFO RDMA: trying /etc/rdma/dat.conf
+Jun 23 00:08:42 centos python[49540]: 2016/06/23 00:08:42.857421 INFO RDMA: DAPL config is at: /etc/rdma/dat.conf
+Jun 23 00:08:42 centos python[49540]: 2016/06/23 00:08:42.858466 INFO RDMA: DAPL configuration is updated
+Jun 23 00:08:42 centos python[49540]: 2016/06/23 00:08:42.859412 INFO RDMA: waiting for device /dev/hvnd_rdma
+Jun 23 00:08:42 centos python[49540]: 2016/06/23 00:08:42.859845 INFO RDMA: device ready
+Jun 23 00:08:42 centos python[49540]: 2016/06/23 00:08:42.860166 INFO RDMA: Updating device with configuration: rdmaMacAddress="00:15:5D:33:FF:1D" rdmaIPv4Address="172.16.1.20"
+Jun 23 00:08:42 centos python[49540]: 2016/06/23 00:08:42.864575 INFO RDMA: Updated device with IPv4/MAC addr successfully
+Jun 23 00:08:42 centos python[49540]: 2016/06/23 00:08:42.864915 INFO RDMA: will update the network interface with IPv4/MAC
+Jun 23 00:08:42 centos python[49540]: 2016/06/23 00:08:42.869903 INFO RDMA: network interface found: eth1
+Jun 23 00:08:42 centos python[49540]: 2016/06/23 00:08:42.870169 INFO RDMA: bringing network interface up
+Jun 23 00:08:42 centos python[49540]: 2016/06/23 00:08:42.873663 INFO RDMA: configuring IPv4 addr and netmask on interface
+Jun 23 00:08:42 centos python[49540]: 2016/06/23 00:08:42.876738 INFO RDMA: network address and netmask configured on interface
```
