### PR TITLE
Dhcp caching

### DIFF
--- a/azurelinuxagent/common/osutil/default.py
+++ b/azurelinuxagent/common/osutil/default.py
@@ -73,7 +73,7 @@ class DefaultOSUtil(object):
         userentry = self.get_userentry(username)
         uidmin = None
         try:
-            uidmin_def = fileutil.get_line_startingwith("UID_MIN", 
+            uidmin_def = fileutil.get_line_startingwith("UID_MIN",
                                                         "/etc/login.defs")
             if uidmin_def is not None:
                 uidmin = int(uidmin_def.split()[1])
@@ -215,7 +215,7 @@ class DefaultOSUtil(object):
             pub_path = os.path.join(lib_dir, thumbprint + '.pub')
             pub = crytputil.get_pubkey_from_crt(crt_path)
             fileutil.write_file(pub_path, pub)
-            self.set_selinux_context(pub_path, 
+            self.set_selinux_context(pub_path,
                                      'unconfined_u:object_r:ssh_home_t:s0')
             self.openssl_to_openssh(pub_path, path)
             fileutil.chmod(pub_path, 0o600)
@@ -320,7 +320,7 @@ class DefaultOSUtil(object):
         retcode = self.umount(mount_point, chk_err=chk_err)
         if chk_err and retcode != 0:
             raise OSUtilError("Failed to umount dvd.")
-    
+
     def eject_dvd(self, chk_err=True):
         dvd = self.get_dvd_device()
         retcode = shellutil.run("eject {0}".format(dvd))
@@ -572,12 +572,11 @@ class DefaultOSUtil(object):
                                 expire_date = datetime.datetime.strptime(expire_string, FORMAT_DATETIME)
                                 if expire_date > datetime.datetime.utcnow():
                                     expired = False
-                                    logger.info("entry is not expired")
-                                else:
-                                    logger.info("entry is expired")
                             except:
                                 logger.error("could not parse expiry token '{0}'".format(line))
                     elif FOOTER_LEASE in line:
+                        logger.info("dhcp entry:{0}, 245:{1}, expired:{2}".format(
+                            cached_endpoint, has_option_245, expired))
                         if not expired and cached_endpoint is not None and has_option_245:
                             endpoint = cached_endpoint
                             logger.info("found endpoint [{0}]".format(endpoint))
@@ -771,7 +770,7 @@ class DefaultOSUtil(object):
             return int(ret[1])
         else:
             raise OSUtilError("Failed to get processor cores")
-    
+
     def set_admin_access_to_ip(self, dest_ip):
         #This allows root to access dest_ip
         rm_old= "iptables -D OUTPUT -d {0} -j ACCEPT -m owner --uid-owner 0"

--- a/azurelinuxagent/common/protocol/util.py
+++ b/azurelinuxagent/common/protocol/util.py
@@ -139,6 +139,7 @@ class ProtocolUtil(object):
         except ProtocolError as e:
             logger.info("WireServer is not responding. Reset endpoint")
             self.dhcp_handler.endpoint = None
+            self.dhcp_handler.skip_cache = True
             raise e
 
     def _detect_metadata_protocol(self):

--- a/tests/common/osutil/test_default.py
+++ b/tests/common/osutil/test_default.py
@@ -124,5 +124,12 @@ class TestOSUtil(AgentTestCase):
                 self.assertTrue(endpoint is not None)
                 self.assertEqual(endpoint, "168.63.129.16")
 
+    def test_dhcp_lease_multi(self):
+        with patch.object(glob, "glob", return_value=['/var/lib/dhcp/dhclient.eth0.leases']):
+            with patch(open_patch(), mock.mock_open(read_data=load_data("dhcp.leases.multi"))):
+                endpoint = get_osutil(distro_name='ubuntu', distro_version='12.04').get_dhcp_lease_endpoint()
+                self.assertTrue(endpoint is not None)
+                self.assertEqual(endpoint, "second")
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/data/dhcp.leases.multi
+++ b/tests/data/dhcp.leases.multi
@@ -7,7 +7,7 @@ lease {
   option routers 10.0.1.1;
   option dhcp-message-type 5;
   option dhcp-server-identifier 168.63.129.16;
-  option domain-name-servers invalid;
+  option domain-name-servers first;
   option dhcp-renewal-time 4294967295;
   option rfc3442-classless-static-routes 0,10,0,1,1,32,168,63,129,16,10,0,1,1;
   option unknown-245 a8:3f:81:10;
@@ -15,7 +15,26 @@ lease {
   option domain-name "qylsde3bnlhu5dstzf3bav5inc.fx.internal.cloudapp.net";
   renew 0 2152/07/23 23:27:10;
   rebind 0 2152/07/23 23:27:10;
-  expire 0 never;
+  expire 0 2152/07/23 23:27:10;
+}
+lease {
+  interface "eth0";
+  fixed-address 10.0.1.4;
+  server-name "RDE41D2D9BB18C";
+  option subnet-mask 255.255.255.0;
+  option dhcp-lease-time 4294967295;
+  option routers 10.0.1.1;
+  option dhcp-message-type 5;
+  option dhcp-server-identifier 168.63.129.16;
+  option domain-name-servers second;
+  option dhcp-renewal-time 4294967295;
+  option rfc3442-classless-static-routes 0,10,0,1,1,32,168,63,129,16,10,0,1,1;
+  option unknown-245 a8:3f:81:10;
+  option dhcp-rebinding-time 4294967295;
+  option domain-name "qylsde3bnlhu5dstzf3bav5inc.fx.internal.cloudapp.net";
+  renew 0 2152/07/23 23:27:10;
+  rebind 0 2152/07/23 23:27:10;
+  expire 0 2152/07/23 23:27:10;
 }
 lease {
   interface "eth0";
@@ -28,29 +47,11 @@ lease {
   option dhcp-server-identifier 168.63.129.16;
   option domain-name-servers expired;
   option dhcp-renewal-time 4294967295;
-  option unknown-245 a8:3f:81:10;
-  option dhcp-rebinding-time 4294967295;
-  option domain-name "qylsde3bnlhu5dstzf3bav5inc.fx.internal.cloudapp.net";
-  renew 4 2015/06/16 16:58:54;
-  rebind 4 2015/06/16 16:58:54;
-  expire 4 2015/06/16 16:58:54;
-}
-lease {
-  interface "eth0";
-  fixed-address 10.0.1.4;
-  server-name "RDE41D2D9BB18C";
-  option subnet-mask 255.255.255.0;
-  option dhcp-lease-time 4294967295;
-  option routers 10.0.1.1;
-  option dhcp-message-type 5;
-  option dhcp-server-identifier 168.63.129.16;
-  option domain-name-servers 168.63.129.16;
-  option dhcp-renewal-time 4294967295;
   option rfc3442-classless-static-routes 0,10,0,1,1,32,168,63,129,16,10,0,1,1;
   option unknown-245 a8:3f:81:10;
   option dhcp-rebinding-time 4294967295;
   option domain-name "qylsde3bnlhu5dstzf3bav5inc.fx.internal.cloudapp.net";
   renew 0 2152/07/23 23:27:10;
   rebind 0 2152/07/23 23:27:10;
-  expire 0 2152/07/23 23:27:10;
+  expire 0 2012/07/23 23:27:10;
 }


### PR DESCRIPTION
When we generalize and capture an image, dhcp options exist on disk. When that image is used to create a vm, communication with the cached endpoint will fail, so we need to allow for both cache invalidation and multiple valid but distinct entries in the leases file. 

- fix bug in cache lookup logic - take the the last valid entry, not the first
- allow skipping the cache in failure mode