### PR TITLE
Update README.md #107

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Upgrading via your distribution's package repository is preferred.
 
 If upgrading manually, same with installation above by running:
 
-    #sudo python setup.py install -force
+    #sudo python setup.py install --force
 
 Restart waagent service,for most of linux distributions:
 


### PR DESCRIPTION
The latest setup.py no longer expects -force and only --force, making the previous instructions invalid.