### PR TITLE
Move monitoring threads to child process and fix #297

### DIFF
--- a/azurelinuxagent/common/rdma.py
+++ b/azurelinuxagent/common/rdma.py
@@ -21,15 +21,56 @@ Handle packages and modules to enable RDMA for IB networking
 
 import os
 import re
-import threading
 import time
+import threading
+
 import azurelinuxagent.common.logger as logger
 import azurelinuxagent.common.utils.fileutil as fileutil
 import azurelinuxagent.common.utils.shellutil as shellutil
 
-dapl_config_paths = ['/etc/dat.conf', '/etc/rdma/dat.conf',
-                     '/usr/local/etc/dat.conf']
+from azurelinuxagent.common.protocol.wire import SHARED_CONF_FILE_NAME
 
+dapl_config_paths = [
+    '/etc/dat.conf',
+    '/etc/rdma/dat.conf',
+    '/usr/local/etc/dat.conf'
+]
+
+def setup_rdma_device(self):
+    logger.verbose("Parsing SharedConfig XML contents for RDMA details")
+    xml_doc = parse_doc(
+        fileutil.read_file(os.path.join(conf.get_lib_dir(), SHARED_CONF_FILE_NAME)))
+    if xml_doc is None:
+        logger.error("Could not parse SharedConfig XML document")
+        return
+    instance_elem = find(xml_doc, "Instance")
+    if not instance_elem:
+        logger.error("Could not find <Instance> in SharedConfig document")
+        return
+
+    rdma_ipv4_addr = getattrib(instance_elem, "rdmaIPv4Address")
+    if not rdma_ipv4_addr:
+        logger.error(
+            "Could not find rdmaIPv4Address attribute on Instance element of SharedConfig.xml document")
+        return
+
+    rdma_mac_addr = getattrib(instance_elem, "rdmaMacAddress")
+    if not rdma_mac_addr:
+        logger.error(
+            "Could not find rdmaMacAddress attribute on Instance element of SharedConfig.xml document")
+        return
+
+    # add colons to the MAC address (e.g. 00155D33FF1D ->
+    # 00:15:5D:33:FF:1D)
+    rdma_mac_addr = ':'.join([rdma_mac_addr[i:i+2]
+                              for i in range(0, len(rdma_mac_addr), 2)])
+    logger.info("Found RDMA details. IPv4={0} MAC={1}".format(
+        rdma_ipv4_addr, rdma_mac_addr))
+
+    # Set up the RDMA device with collected informatino
+    RDMADeviceHandler(rdma_ipv4_addr, rdma_mac_addr).start()
+    logger.info("RDMA: device is set up")
+    return
 
 class RDMAHandler(object):
 

--- a/azurelinuxagent/daemon/main.py
+++ b/azurelinuxagent/daemon/main.py
@@ -18,32 +18,31 @@
 #
 
 import os
-import time
 import sys
+import time
 import traceback
+
 import azurelinuxagent.common.conf as conf
+import azurelinuxagent.common.event as event
+import azurelinuxagent.common.utils.fileutil as fileutil
 import azurelinuxagent.common.logger as logger
+
 from azurelinuxagent.common.future import ustr
 from azurelinuxagent.common.event import add_event, WALAEventOperation
 from azurelinuxagent.common.exception import ProtocolError
+from azurelinuxagent.common.osutil import get_osutil
+from azurelinuxagent.common.protocol import get_protocol_util
+from azurelinuxagent.common.rdma import RDMADeviceHandler, setup_rdma_device
+from azurelinuxagent.common.utils.textutil import parse_doc, find, getattrib
 from azurelinuxagent.common.version import AGENT_LONG_NAME, AGENT_VERSION, \
                                      DISTRO_NAME, DISTRO_VERSION, \
                                      DISTRO_FULL_NAME, PY_VERSION_MAJOR, \
                                      PY_VERSION_MINOR, PY_VERSION_MICRO
-from azurelinuxagent.common.protocol.wire import SHARED_CONF_FILE_NAME
-import azurelinuxagent.common.event as event
-import azurelinuxagent.common.utils.fileutil as fileutil
-from azurelinuxagent.common.utils.textutil import parse_doc, find, getattrib
-from azurelinuxagent.common.osutil import get_osutil
-from azurelinuxagent.common.protocol import get_protocol_util
-from azurelinuxagent.daemon.scvmm import get_scvmm_handler
 from azurelinuxagent.daemon.resourcedisk import get_resourcedisk_handler
-from azurelinuxagent.daemon.monitor import get_monitor_handler
-from azurelinuxagent.daemon.env import get_env_handler
+from azurelinuxagent.daemon.scvmm import get_scvmm_handler
 from azurelinuxagent.pa.provision import get_provision_handler
 from azurelinuxagent.pa.rdma import get_rdma_handler
 from azurelinuxagent.ga.update import get_update_handler
-from azurelinuxagent.common.rdma import RDMADeviceHandler
 
 def get_daemon_handler():
     return DaemonHandler()
@@ -95,12 +94,10 @@ class DaemonHandler(object):
         self.scvmm_handler = get_scvmm_handler()
         self.resourcedisk_handler = get_resourcedisk_handler()
         self.rdma_handler = get_rdma_handler()
-        self.monitor_handler = get_monitor_handler()
-        self.env_handler = get_env_handler()
         self.provision_handler = get_provision_handler()
         self.update_handler = get_update_handler()
 
-        #Create lib dir
+        # Create lib dir
         if not os.path.isdir(conf.get_lib_dir()):
             fileutil.mkdir(conf.get_lib_dir(), mode=0o700)
             os.chdir(conf.get_lib_dir())
@@ -110,63 +107,24 @@ class DaemonHandler(object):
 
         if conf.get_resourcedisk_format():
             self.resourcedisk_handler.run()
-        
+
+        # Always redetermine the protocol start (e.g., wireserver vs.
+        # on-premise) since a VHD can move between environments        
         self.protocol_util.clear_protocol()
 
         self.provision_handler.run()
 
+        # Enable RDMA, continue in errors
         if conf.enable_rdma():
             self.rdma_handler.install_driver()
 
-        self.monitor_handler.run()
-
-        self.env_handler.run()
-
-        # Enable RDMA, continue in errors
-        if conf.enable_rdma():
-                logger.info("RDMA capabilities are enabled in configuration")
-                try:
-                    self.setup_rdma_device()
-                except Exception as e:
-                    logger.error("Error setting up rdma device: %s" % e)
+            logger.info("RDMA capabilities are enabled in configuration")
+            try:
+                setup_rdma_device()
+            except Exception as e:
+                logger.error("Error setting up rdma device: %s" % e)
         else:
             logger.info("RDMA capabilities are not enabled, skipping")
         
         while self.running:
             self.update_handler.run_latest()
-
-
-    def setup_rdma_device(self):
-        logger.verbose("Parsing SharedConfig XML contents for RDMA details")
-        xml_doc = parse_doc(
-            fileutil.read_file(os.path.join(conf.get_lib_dir(), SHARED_CONF_FILE_NAME)))
-        if xml_doc is None:
-            logger.error("Could not parse SharedConfig XML document")
-            return
-        instance_elem = find(xml_doc, "Instance")
-        if not instance_elem:
-            logger.error("Could not find <Instance> in SharedConfig document")
-            return
-
-        rdma_ipv4_addr = getattrib(instance_elem, "rdmaIPv4Address")
-        if not rdma_ipv4_addr:
-            logger.error(
-                "Could not find rdmaIPv4Address attribute on Instance element of SharedConfig.xml document")
-            return
-
-        rdma_mac_addr = getattrib(instance_elem, "rdmaMacAddress")
-        if not rdma_mac_addr:
-            logger.error(
-                "Could not find rdmaMacAddress attribute on Instance element of SharedConfig.xml document")
-            return
-
-        # add colons to the MAC address (e.g. 00155D33FF1D ->
-        # 00:15:5D:33:FF:1D)
-        rdma_mac_addr = ':'.join([rdma_mac_addr[i:i+2]
-                                  for i in range(0, len(rdma_mac_addr), 2)])
-        logger.info("Found RDMA details. IPv4={0} MAC={1}".format(
-            rdma_ipv4_addr, rdma_mac_addr))
-
-        # Set up the RDMA device with collected informatino
-        RDMADeviceHandler(rdma_ipv4_addr, rdma_mac_addr).start()
-        logger.info("RDMA: device is set up")

--- a/azurelinuxagent/ga/env.py
+++ b/azurelinuxagent/ga/env.py
@@ -19,12 +19,14 @@
 
 import os
 import socket
-import threading
 import time
-import azurelinuxagent.common.logger as logger
+import threading
+
 import azurelinuxagent.common.conf as conf
-from azurelinuxagent.common.osutil import get_osutil
+import azurelinuxagent.common.logger as logger
+
 from azurelinuxagent.common.dhcp import get_dhcp_handler
+from azurelinuxagent.common.osutil import get_osutil
 
 def get_env_handler():
     return EnvHandler()

--- a/azurelinuxagent/ga/monitor.py
+++ b/azurelinuxagent/ga/monitor.py
@@ -15,28 +15,28 @@
 # Requires Python 2.4+ and Openssl 1.0+
 #
 
-import os
-import json
-import time
 import datetime
-import threading
+import json
+import os
 import platform
-import azurelinuxagent.common.logger as logger
+import time
+import threading
+
 import azurelinuxagent.common.conf as conf
+import azurelinuxagent.common.logger as logger
+
 from azurelinuxagent.common.event import WALAEventOperation, add_event
-from azurelinuxagent.common.exception import EventError, ProtocolError, \
-    OSUtilError
+from azurelinuxagent.common.exception import EventError, ProtocolError, OSUtilError
 from azurelinuxagent.common.future import ustr
-from azurelinuxagent.common.utils.textutil import parse_doc, findall, find, \
-    getattrib
-from azurelinuxagent.common.protocol.restapi import TelemetryEventParam, \
-    TelemetryEventList, \
-    TelemetryEvent, \
-    set_properties
-from azurelinuxagent.common.version import DISTRO_NAME, DISTRO_VERSION, \
-    DISTRO_CODE_NAME, AGENT_LONG_VERSION
 from azurelinuxagent.common.osutil import get_osutil
 from azurelinuxagent.common.protocol import get_protocol_util
+from azurelinuxagent.common.protocol.restapi import TelemetryEventParam, \
+                                                    TelemetryEventList, \
+                                                    TelemetryEvent, \
+                                                    set_properties
+from azurelinuxagent.common.utils.textutil import parse_doc, findall, find, getattrib
+from azurelinuxagent.common.version import DISTRO_NAME, DISTRO_VERSION, \
+                                            DISTRO_CODE_NAME, AGENT_LONG_VERSION
 
 
 def parse_event(data_str):

--- a/tests/ga/test_monitor.py
+++ b/tests/ga/test_monitor.py
@@ -17,7 +17,7 @@
 
 from tests.tools import *
 from azurelinuxagent.common.exception import *
-from azurelinuxagent.daemon.monitor import *
+from azurelinuxagent.ga.monitor import *
 
 class TestMonitor(AgentTestCase):
     def test_parse_xml_event(self):

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -7,9 +7,9 @@ import azurelinuxagent.pa.deprovision as deprovision
 import azurelinuxagent.daemon as daemon
 import azurelinuxagent.daemon.resourcedisk as resourcedisk
 import azurelinuxagent.daemon.scvmm as scvmm
-import azurelinuxagent.daemon.monitor as monitor
-import azurelinuxagent.ga.update as update
 import azurelinuxagent.ga.exthandlers as exthandlers
+import azurelinuxagent.ga.monitor as monitor
+import azurelinuxagent.ga.update as update
 
 class TestImportHandler(AgentTestCase):
     def test_get_handler(self):

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -36,9 +36,9 @@ from azurelinuxagent.common.version import PY_VERSION_MAJOR
 
 #Import mock module for Python2 and Python3
 try:
-    from unittest.mock import Mock, patch, MagicMock, DEFAULT
+    from unittest.mock import Mock, patch, MagicMock, DEFAULT, call
 except ImportError:
-    from mock import Mock, patch, MagicMock, DEFAULT
+    from mock import Mock, patch, MagicMock, DEFAULT, call
 
 test_dir = os.path.dirname(os.path.abspath(__file__))
 data_dir = os.path.join(test_dir, "data")


### PR DESCRIPTION
Move the DHCP / hostname monitoring and event collection threads into the child process.
Fix #297 
Signed-off-by: Brendan Dixon <brendand@microsoft.com>