### PR TITLE
Prevent cycling agent

### DIFF
--- a/azurelinuxagent/common/utils/flexible_version.py
+++ b/azurelinuxagent/common/utils/flexible_version.py
@@ -133,6 +133,9 @@ class FlexibleVersion(version.Version):
 
         return this_index < that_index
 
+    def __ne__(self, that):
+        return not self.__eq__(that)
+
     def __eq__(self, that):
         this_version, that_version = self._ensure_compatible(that)
 

--- a/tests/utils/test_flexible_version.py
+++ b/tests/utils/test_flexible_version.py
@@ -467,6 +467,9 @@ class TestFlexibleVersion(unittest.TestCase):
         self.assertTrue(FlexibleVersion("1.0") == FlexibleVersion("1.0"))
         self.assertTrue(FlexibleVersion("1.0") >= FlexibleVersion("1.0"))
         self.assertTrue(FlexibleVersion("1.0") <= FlexibleVersion("1.0"))
+
+        self.assertFalse(FlexibleVersion("1.0") != FlexibleVersion("1.0"))
+        self.assertTrue(FlexibleVersion("1.1") != FlexibleVersion("1.0"))
         return
 
 


### PR DESCRIPTION
This change blacklists an agent the restarts too often in a five minute window.
Signed-off-by: Brendan Dixon <brendand@microsoft.com>