### PR TITLE
Fix #297 and signal forwarding recursion

### DIFF
--- a/azurelinuxagent/common/version.py
+++ b/azurelinuxagent/common/version.py
@@ -66,6 +66,9 @@ AGENT_NAME_PATTERN = re.compile(AGENT_PATTERN)
 AGENT_DIR_PATTERN = re.compile(".*/{0}".format(AGENT_PATTERN))
 
 
+# Set the CURRENT_AGENT and CURRENT_VERSION to match the agent directory name
+# - This ensures the agent will "see itself" using the same name and version
+#   as the code that downloads agents.
 def set_current_agent():
     path = os.getcwd()
     lib_dir = conf.get_lib_dir()
@@ -79,6 +82,9 @@ def set_current_agent():
         version = AGENT_NAME_PATTERN.match(agent).group(1)
     return agent, FlexibleVersion(version)
 CURRENT_AGENT, CURRENT_VERSION = set_current_agent()
+
+def is_current_agent_installed():
+    return CURRENT_AGENT == AGENT_LONG_VERSION
 
 
 __distro__ = get_distro()

--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -230,7 +230,7 @@ class ExtHandlersHandler(object):
     def report_ext_handlers_status(self):
         """Go thru handler_state dir, collect and report status"""
         vm_status = VMStatus()
-        vm_status.vmAgent.version = AGENT_VERSION
+        vm_status.vmAgent.version = str(CURRENT_VERSION)
         vm_status.vmAgent.status = "Ready"
         vm_status.vmAgent.message = "Guest Agent is running"
 

--- a/azurelinuxagent/ga/monitor.py
+++ b/azurelinuxagent/ga/monitor.py
@@ -36,7 +36,8 @@ from azurelinuxagent.common.protocol.restapi import TelemetryEventParam, \
                                                     set_properties
 from azurelinuxagent.common.utils.textutil import parse_doc, findall, find, getattrib
 from azurelinuxagent.common.version import DISTRO_NAME, DISTRO_VERSION, \
-                                            DISTRO_CODE_NAME, AGENT_LONG_VERSION
+                                            DISTRO_CODE_NAME, AGENT_LONG_VERSION, \
+                                            CURRENT_AGENT, CURRENT_VERSION
 
 
 def parse_event(data_str):
@@ -106,7 +107,7 @@ class MonitorHandler(object):
                                                  platform.release())
         self.sysinfo.append(TelemetryEventParam("OSVersion", osversion))
         self.sysinfo.append(
-            TelemetryEventParam("GAVersion", AGENT_LONG_VERSION))
+            TelemetryEventParam("GAVersion", CURRENT_AGENT))
 
         try:
             ram = self.osutil.get_total_mem()


### PR DESCRIPTION
- Fix #297 
- Ensure self-update signal handler is created just once to prevent recursion.

Signed-off-by: Brendan Dixon <brendand@microsoft.com>