### PR TITLE
Add supported_dists kwarg to distro detection

### DIFF
--- a/azurelinuxagent/common/version.py
+++ b/azurelinuxagent/common/version.py
@@ -31,7 +31,8 @@ def get_distro():
         release = re.sub('\-.*\Z', '', ustr(platform.release()))
         osinfo = ['freebsd', release, '', 'freebsd']
     elif 'linux_distribution' in dir(platform):
-        osinfo = list(platform.linux_distribution(full_distribution_name=0))
+        osinfo = list(platform.linux_distribution(full_distribution_name=0,
+            supported_dists=platform._supported_dists+('alpine',)))
         full_name = platform.linux_distribution()[0].strip()
         osinfo.append(full_name)
     else:


### PR DESCRIPTION
cc @ahmetalpbalkan 

Distro detection won't work in some cases without it.  Even though there's a valid `/etc/os-release` file in Alpine the Python code checks to see if the distro is in `supported_dists` kwarg before returning the information.

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>