### PR TITLE
- Remove eject_dvd

### DIFF
--- a/azurelinuxagent/common/osutil/default.py
+++ b/azurelinuxagent/common/osutil/default.py
@@ -321,12 +321,6 @@ class DefaultOSUtil(object):
         if chk_err and retcode != 0:
             raise OSUtilError("Failed to umount dvd.")
 
-    def eject_dvd(self, chk_err=True):
-        dvd = self.get_dvd_device()
-        retcode = shellutil.run("eject {0}".format(dvd))
-        if chk_err and retcode != 0:
-            raise OSUtilError("Failed to eject dvd: ret={0}".format(retcode))
-
     def try_load_atapiix_mod(self):
         try:
             self.load_atapiix_mod()

--- a/azurelinuxagent/common/osutil/freebsd.py
+++ b/azurelinuxagent/common/osutil/freebsd.py
@@ -121,12 +121,6 @@ class FreeBSDOSUtil(DefaultOSUtil):
         ret = shellutil.run_get_output("pgrep -n dhclient")
         return ret[1] if ret[0] == 0 else None
 
-    def eject_dvd(self, chk_err=True):
-        dvd = self.get_dvd_device()
-        retcode = shellutil.run("cdcontrol -f {0} eject".format(dvd))
-        if chk_err and retcode != 0:
-            raise OSUtilError("Failed to eject dvd: ret={0}".format(retcode))
-
     def restart_if(self, ifname):
         # Restart dhclient only to publish hostname
         shellutil.run("/etc/rc.d/dhclient restart {0}".format(ifname), chk_err=False)

--- a/azurelinuxagent/common/protocol/util.py
+++ b/azurelinuxagent/common/protocol/util.py
@@ -89,7 +89,6 @@ class ProtocolUtil(object):
 
         try:
             self.osutil.umount_dvd()
-            self.osutil.eject_dvd()
         except OSUtilError as e:
             logger.warn(ustr(e))
 


### PR DESCRIPTION
  + The eject command is only useful for physical HW as the DVD/CDROM drive
    tray can be moved out via software control. In the cloud we have no
    physical drive thus issuing an eject command is superfluous. The DVD
    drive gets unmounted when no longer needed, this is sufficient to remove
    the device from the system. This also removes a packaging dependency for
    Linux systems.