### PR TITLE
correct logic for dd fallback

### DIFF
--- a/azurelinuxagent/daemon/resourcedisk/default.py
+++ b/azurelinuxagent/daemon/resourcedisk/default.py
@@ -201,7 +201,7 @@ class ResourceDiskHandler(object):
         # fallocate command
         fn_sh = shellutil.quote((filename,))
         ret = shellutil.run(u"umask 0077 && fallocate -l {0} {1}".format(nbytes, fn_sh))
-        if ret != 127:  # 127 = command not found
+        if ret == 0:
             return ret
 
         # dd fallback


### PR DESCRIPTION
when fallocate fails for any reason we should fall back to dd, not just when fallocate is not found. also adds unit test. fix for #347 