### PR TITLE
Delete resolv.conf during deprovisioning

### DIFF
--- a/azurelinuxagent/pa/deprovision/default.py
+++ b/azurelinuxagent/pa/deprovision/default.py
@@ -74,6 +74,11 @@ class DeprovisionHandler(object):
         files_to_del = ['/root/.bash_history', '/var/log/waagent.log']
         actions.append(DeprovisionAction(fileutil.rm_files, files_to_del))
 
+    def del_resolv(self, warnings, actions):
+        warnings.append("WARNING! /etc/resolv.conf will be deleted.")
+        files_to_del = ["/etc/resolv.conf"]
+        actions.append(DeprovisionAction(fileutil.rm_files, files_to_del))
+
     def del_dhcp_lease(self, warnings, actions):
         warnings.append("WARNING! Cached DHCP leases will be deleted.")
         dirs_to_del = ["/var/lib/dhclient", "/var/lib/dhcpcd", "/var/lib/dhcp"]
@@ -109,6 +114,7 @@ class DeprovisionHandler(object):
 
         self.del_lib_dir(warnings, actions)
         self.del_files(warnings, actions)
+        self.del_resolv(warnings, actions)
 
         if deluser:
             self.del_user(warnings, actions)

--- a/tests/pa/test_deprovision.py
+++ b/tests/pa/test_deprovision.py
@@ -1,0 +1,48 @@
+# Copyright 2016 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Requires Python 2.4+ and Openssl 1.0+
+#
+
+from tests.tools import *
+from azurelinuxagent.pa.deprovision import get_deprovision_handler
+
+
+class TestDeprovision(AgentTestCase):
+    @distros("redhat")
+    def test_deprovision(self,
+                         distro_name,
+                         distro_version,
+                         distro_full_name):
+        deprovision_handler = get_deprovision_handler(distro_name,
+                                                      distro_version,
+                                                      distro_full_name)
+        warnings, actions = deprovision_handler.setup(deluser=False)
+        assert any("/etc/resolv.conf" in w for w in warnings)
+
+    @distros("ubuntu")
+    def test_deprovision_ubuntu(self,
+                                distro_name,
+                                distro_version,
+                                distro_full_name):
+        deprovision_handler = get_deprovision_handler(distro_name,
+                                                      distro_version,
+                                                      distro_full_name)
+
+        with patch("os.path.realpath", return_value="/run/resolvconf/resolv.conf"):
+            warnings, actions = deprovision_handler.setup(deluser=False)
+            assert any("/etc/resolvconf/resolv.conf.d/tail" in w for w in warnings)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This behavior is missing from 2.1.x but did exist in 2.0.x. We have special logic in place for Ubuntu, but we should always remove resolv.conf during deprovisioning.

- correctly delete /etc/resolv.conf during deprovisioning
- add unit tests
- fixes #351 

/cc @szarkos @yuxisun1217 @ahmetalpbalkan @brendandixon 