### PR TITLE
rdma: reorder device processing steps back to v2.0

### DIFF
--- a/azurelinuxagent/common/rdma.py
+++ b/azurelinuxagent/common/rdma.py
@@ -198,12 +198,12 @@ class RDMADeviceHandler(object):
 
     def process(self):
         try:
-            RDMADeviceHandler.update_network_interface(self.mac_addr, self.ipv4_addr)
+            RDMADeviceHandler.update_dat_conf(dapl_config_paths, self.ipv4_addr)
             RDMADeviceHandler.wait_rdma_device(
                 self.rdma_dev, self.device_check_timeout_sec, self.device_check_interval_sec)
             RDMADeviceHandler.write_rdma_config_to_device(
                 self.rdma_dev, self.ipv4_addr, self.mac_addr)
-            RDMADeviceHandler.update_dat_conf(dapl_config_paths, self.ipv4_addr)
+            RDMADeviceHandler.update_network_interface(self.mac_addr, self.ipv4_addr)
         except Exception as e:
             logger.error("RDMA: device processing failed: {0}".format(e))
 


### PR DESCRIPTION
With this change, RDMA integration tests look as follows:

![image](https://cloud.githubusercontent.com/assets/159209/17563750/9c951168-5ee5-11e6-849d-a66e05da5c95.png)
 