### PR TITLE
add python-setuptools to deb build-depends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: python
 Priority: extra
 Maintainer: Ben Howard <ben.howard@ubuntu.com>
 XSBC-Original-Maintainer: Microsoft Corporation <walinuxagent@microsoft.com>
-Build-Depends: debhelper (>= 8), python-all
+Build-Depends: debhelper (>= 8), python-all, python-setuptools
 Standards-Version: 3.9.3
 XS-Python-Version: all
 Homepage: http://go.microsoft.com/fwlink/?LinkId=250998


### PR DESCRIPTION
This is intended to fix #380.