### PR TITLE
ensure null bytes are not present in shlex input

### DIFF
--- a/azurelinuxagent/common/utils/textutil.py
+++ b/azurelinuxagent/common/utils/textutil.py
@@ -277,3 +277,11 @@ def b64encode(s):
     if PY_VERSION_MAJOR > 2:
         return base64.b64encode(bytes(s, 'utf-8')).decode('utf-8')
     return base64.b64encode(s)
+
+
+def safe_shlex_split(s):
+    import shlex
+    from azurelinuxagent.common.version import PY_VERSION
+    if PY_VERSION[:2] == (2, 6):
+        return shlex.split(s.encode('utf-8'))
+    return shlex.split(s)

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -16,12 +16,12 @@
 #
 # Requires Python 2.4+ and Openssl 1.0+
 #
+
 import glob
 import json
 import os
 import platform
 import re
-import shlex
 import shutil
 import signal
 import subprocess
@@ -130,7 +130,7 @@ class UpdateHandler(object):
         try:
 
             # Launch the correct Python version for python-based agents
-            cmds = shlex.split(agent_cmd)
+            cmds = textutil.safe_shlex_split(agent_cmd)
             if cmds[0].lower() == "python":
                 cmds[0] = get_python_cmd()
                 agent_cmd = " ".join(cmds)

--- a/tests/ga/test_update.py
+++ b/tests/ga/test_update.py
@@ -438,7 +438,8 @@ class TestGuestAgent(UpdateTestCase):
         agent = GuestAgent(path=self.agent_path)
         agent._unpack()
         agent._load_manifest()
-        self.assertEqual(agent.manifest.get_enable_command(), agent.get_agent_cmd())
+        self.assertEqual(agent.manifest.get_enable_command(),
+                         agent.get_agent_cmd())
         return
 
     @patch("azurelinuxagent.ga.update.GuestAgent._ensure_downloaded")
@@ -992,13 +993,14 @@ class TestUpdate(UpdateTestCase):
 
         agent = self.update_handler.get_latest_agent()
         args, kwargs = self._test_run_latest()
-        cmds = shlex.split(agent.get_agent_cmd())
+        cmds = textutil.safe_shlex_split(agent.get_agent_cmd())
         if cmds[0].lower() == "python":
             cmds[0] = get_python_cmd()
 
         self.assertEqual(args[0], cmds)
         self.assertEqual(True, 'cwd' in kwargs)
         self.assertEqual(agent.get_agent_dir(), kwargs['cwd'])
+        self.assertEqual(False, '\x00' in cmds[0])
         return
 
     def test_run_latest_polls_and_waits_for_success(self):


### PR DESCRIPTION
Python 2.6 contains a bug in `shlex_split` which can be avoided by encoding the input beforehand. This does not work for Python 3 however, so we need to have a selective function which only encodes when necessary. 

- adds `textutil.safe_shlex_split`
- fixes #389 

/cc @brendandixon 