### PR TITLE
restart service on registration

### DIFF
--- a/azurelinuxagent/agent.py
+++ b/azurelinuxagent/agent.py
@@ -91,6 +91,8 @@ class Agent(object):
         """
         print("Register {0} service".format(AGENT_NAME))
         self.osutil.register_agent_service()
+        print("Stop {0} service".format(AGENT_NAME))
+        self.osutil.stop_agent_service()
         print("Start {0} service".format(AGENT_NAME))
         self.osutil.start_agent_service()
 

--- a/setup.py
+++ b/setup.py
@@ -174,6 +174,7 @@ class install(_install):
         if self.register_service:
             osutil = get_osutil()
             osutil.register_agent_service()
+            osutil.stop_agent_service()
             osutil.start_agent_service()
 
 


### PR DESCRIPTION
When calling `register_service` we should always stop any running instance before starting the service, to ensure there is only one agent process; fixes #404. 

/cc @brendandixon 