### PR TITLE
Kali Linux 2016.2 Support

### DIFF
--- a/azurelinuxagent/common/osutil/factory.py
+++ b/azurelinuxagent/common/osutil/factory.py
@@ -45,6 +45,8 @@ def get_osutil(distro_name=DISTRO_NAME, distro_version=DISTRO_VERSION,
             return UbuntuOSUtil()
     if distro_name == "alpine":
         return AlpineOSUtil()
+    if distro_name == "kali":
+        return DebianOSUtil()    
     if distro_name == "coreos":
         return CoreOSUtil()
     if distro_name == "suse":
@@ -66,7 +68,7 @@ def get_osutil(distro_name=DISTRO_NAME, distro_version=DISTRO_VERSION,
     elif distro_name == "freebsd":
         return FreeBSDOSUtil()
     else:
-        logger.warn("Unable to load distro implemetation for {0}.", distro_name)
-        logger.warn("Use default distro implemetation instead.")
+        logger.warn("Unable to load distro implementation for {0}.", distro_name)
+        logger.warn("Use default distro implementation instead.")
         return DefaultOSUtil()
 


### PR DESCRIPTION
This change allows provisioning on Kali Linux 2016.2.

1. Edited factory.py - /usr/lib/python2.7/dist-packages/azurelinuxagent/common/osutil/factory.py
2. Rebuilt egg with makepkg.py, copied over existing egg in /var/lib/waagent/WALinuxAgent-2.1.6

**After Change:**
2016/09/06 13:53:48.603360 INFO Azure Linux Agent Version:2.1.6
2016/09/06 13:53:48.606832 INFO OS: kali kali-rolling
2016/09/06 13:53:48.608833 INFO Python: 2.7.12
2016/09/06 13:53:48.610525 INFO Run daemon
2016/09/06 13:53:48.612021 INFO No RDMA handler exists for distro='Kali' version='kali-rolling'
2016/09/06 13:53:48.613858 INFO Activate resource disk
2016/09/06 13:53:48.643262 INFO Detect GPT...
2016/09/06 13:53:48.655129 INFO GPT not detected
2016/09/06 13:53:48.658406 INFO Check fstype
2016/09/06 13:53:48.663811 INFO Mount resource disk
2016/09/06 13:53:48.695627 INFO Resource disk (/dev/sdb) is mounted at /mnt/resource with fstype ext4
2016/09/06 13:53:48.707695 INFO Clean protocol
2016/09/06 13:53:48.711049 INFO RDMA capabilities are not enabled, skipping
2016/09/06 13:53:48.716358 INFO Instantiating Agent WALinuxAgent-2.1.6 from disk
2016/09/06 13:53:48.717280 INFO Agent WALinuxAgent-2.1.6 error state: Last Failure: 0.0, Total Failures: 0, Fatal: False
2016/09/06 13:53:48.718841 INFO Ensuring Agent WALinuxAgent-2.1.6 is downloaded
2016/09/06 13:53:48.720442 INFO Agent WALinuxAgent-2.1.6 was previously downloaded - skipping download
2016/09/06 13:53:48.722107 INFO Agent WALinuxAgent-2.1.6 loaded manifest from /var/lib/waagent/WALinuxAgent-2.1.6/HandlerManifest.json
2016/09/06 13:53:48.723755 INFO Determined Agent WALinuxAgent-2.1.6 to be the latest agent
2016/09/06 13:53:48.782705 INFO Agent WALinuxAgent-2.1.6 launched with command 'python -u bin/WALinuxAgent-2.1.6-py2.7.egg -run-exthandlers'
2016/09/06 13:53:48.838224 INFO Agent WALinuxAgent-2.1.6 is running as the goal state agent
2016/09/06 13:53:48.855429 INFO Detect protocol endpoints
2016/09/06 13:53:48.862328 INFO Clean protocol
2016/09/06 13:53:48.868083 INFO WireServer endpoint is not found. Rerun dhcp handler
2016/09/06 13:53:48.878661 INFO test for route to 168.63.129.16
2016/09/06 13:53:48.886314 INFO route to 168.63.129.16 exists
2016/09/06 13:53:48.893663 INFO Wire server endpoint:168.63.129.16
2016/09/06 13:53:48.905079 INFO Fabric preferred wire protocol version:2015-04-05
2016/09/06 13:53:48.914871 INFO Wire protocol version:2012-11-30
2016/09/06 13:53:48.922746 WARNING Server prefered version:2015-04-05
2016/09/06 13:53:53.149946 INFO Start env monitor service.
2016/09/06 13:53:53.149644 INFO Event: name=WALinuxAgent-2.1.6, op=HeartBeat, message=
2016/09/06 13:53:53.157596 INFO Configure routes
2016/09/06 13:53:53.174214 INFO Gateway:None
2016/09/06 13:53:53.180500 INFO Routes:None
2016/09/06 13:53:53.191511 INFO WALinuxAgent-2.1.6 running as process 11850
2016/09/06 13:53:53.200585 INFO Checking for agent family Prod updates
2016/09/06 13:53:53.208966 INFO Wire server endpoint:168.63.129.16
2016/09/06 13:53:53.244475 INFO Instantiating Agent WALinuxAgent-2.1.6 from package
2016/09/06 13:53:53.254217 INFO Agent WALinuxAgent-2.1.6 error state: Last Failure: 0.0, Total Failures: 0, Fatal: False
2016/09/06 13:53:53.267632 INFO Ensuring Agent WALinuxAgent-2.1.6 is downloaded
2016/09/06 13:53:53.276607 INFO Agent WALinuxAgent-2.1.6 was previously downloaded - skipping download
2016/09/06 13:53:53.288425 INFO Agent WALinuxAgent-2.1.6 loaded manifest from /var/lib/waagent/WALinuxAgent-2.1.6/HandlerManifest.json
2016/09/06 13:53:53.303021 INFO Wire server endpoint:168.63.129.16
2016/09/06 13:53:53.314843 INFO Handle extensions updates for incarnation 2
2016/09/06 13:53:53.323273 INFO [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9007] Expected handler state: enabled
2016/09/06 13:53:53.335656 INFO [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9007] Decide which version to use
2016/09/06 13:53:53.369113 INFO [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9007] Use version: 2.3.9007
2016/09/06 13:53:53.380957 INFO [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9007] Current handler state is: Enabled
2016/09/06 13:53:53.393570 INFO [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9007] Update settings file: 0.settings
2016/09/06 13:53:53.406219 INFO [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9007] Enable extension.
2016/09/06 13:53:53.417874 INFO [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9007] Launch command:diagnostic.py -enable
2016/09/06 13:53:53 LinuxAzureDiagnostic started to handle.
2016/09/06 13:53:53 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9007] cwd is /var/lib/waagent/Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9007
2016/09/06 13:53:53 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9007] Change log file to /var/log/azure/Microsoft.OSTCExtensions.LinuxDiagnostic/2.3.9007/extension.log
2016/09/06 13:53:54.433825 INFO Event: name=Microsoft.OSTCExtensions.LinuxDiagnostic, op=Enable, message=Launch command succeeded: diagnostic.py -enable


**Before Change:**
2016/09/06 10:44:41.855714 INFO Azure Linux Agent Version:2.1.6
2016/09/06 10:44:41.867517 INFO OS: kali kali-rolling
2016/09/06 10:44:41.877287 INFO Python: 2.7.12
2016/09/06 10:44:41.885804 INFO Run daemon
_2016/09/06 10:44:41.894295 WARNING Unable to load distro implemetation for kali.
2016/09/06 10:44:41.906424 WARNING Use default distro implemetation instead.
2016/09/06 10:44:41.919327 WARNING Unable to load distro implemetation for kali.
2016/09/06 10:44:41.931697 WARNING Use default distro implemetation instead.
2016/09/06 10:44:41.943855 WARNING Unable to load distro implemetation for kali.
2016/09/06 10:44:41.956228 WARNING Use default distro implemetation instead.
2016/09/06 10:44:41.970985 WARNING Unable to load distro implemetation for kali.
2016/09/06 10:44:41.984514 WARNING Use default distro implemetation instead.
2016/09/06 10:44:41.996559 INFO No RDMA handler exists for distro='Kali' version='kali-rolling'
2016/09/06 10:44:42.011458 WARNING Unable to load distro implemetation for kali.
2016/09/06 10:44:42.028042 WARNING Use default distro implemetation instead.
2016/09/06 10:44:42.044458 WARNING Unable to load distro implemetation for kali.
2016/09/06 10:44:42.063754 WARNING Use default distro implemetation instead.
2016/09/06 10:44:42.075993 WARNING Unable to load distro implemetation for kali.
2016/09/06 10:44:42.091138 WARNING Use default distro implemetation instead.
2016/09/06 10:44:42.105039 WARNING Unable to load distro implemetation for kali.
[  316.734585] UDF-fs: INFO Mounting volume 'rd_rdfe_stable.160624-1024', timestamp 2016/09/06 14:38 (1000)
2016/09/06 10:44:42.121247 WARNING Use default distro implemetation instead.
2016/09/06 10:44:42.150037 WARNING Unable to load distro implemetation for kali.
2016/09/06 10:44:42.164192 WARNING Use default distro implemetion instead.
2016/09/06 10:44:42.177953 WARNING Unable to load distro implemetation for kali.
2016/09/06 10:44:42.191843 WARNING Use default distro implemetation instead._
2016/09/06 10:44:42.210529 INFO Activate resource disk
[  316.836568] cloud-init[984]: + i=eth0
[  316.848397] cloud-init[984]: + x=0
[  316.859765] cloud-init[984]: + ifdown eth0
2016/09/06 10:44:42.258307 INFO Detect GPT...
[  316.933627] cloud-init[984]: Killed old client process
2016/09/06 10:44:42.352719 INFO GPT not detected
2016/09/06 10:44:42.364534 INFO Check fstype
2016/09/06 10:44:42.424477 INFO Mount resource disk
[  317.089792] fuse init (API version 7.24)
2016/09/06 10:44:42.589868 INFO Resource disk (/dev/sdb) is mounted at /mnt/resource with fstype ext4
2016/09/06 10:44:42.608917 INFO Clean protocol
2016/09/06 10:44:42.618895 INFO Run provision handler.
2016/09/06 10:44:42.632946 INFO Copy ovf-env.xml.
2016/09/06 10:44:42.668090 INFO Successfully mounted dvd
2016/09/06 10:44:42.730551 INFO Detect protocol by file
2016/09/06 10:44:42.742705 INFO Clean protocol
2016/09/06 10:44:42.754078 INFO WireServer endpoint is not found. Rerun dhcp handler

**Before:**
![image](https://cloud.githubusercontent.com/assets/21345586/18285076/abd2aa0e-743a-11e6-8a2f-678ade442e1a.png)

**After:**
![image](https://cloud.githubusercontent.com/assets/21345586/18285114/db949432-743a-11e6-85d1-f3e45559697f.png)
