### PR TITLE
stop pidof from spamming the logs

### DIFF
--- a/azurelinuxagent/common/osutil/alpine.py
+++ b/azurelinuxagent/common/osutil/alpine.py
@@ -29,7 +29,7 @@ class AlpineOSUtil(DefaultOSUtil):
         return True
 
     def get_dhcp_pid(self):
-        ret = shellutil.run_get_output("pidof udhcpc")
+        ret = shellutil.run_get_output("pidof udhcpc", chk_err=False)
         return ret[1] if ret[0] == 0 else None
 
     def set_ssh_client_alive_interval(self):

--- a/azurelinuxagent/common/osutil/coreos.py
+++ b/azurelinuxagent/common/osutil/coreos.py
@@ -71,7 +71,8 @@ class CoreOSUtil(DefaultOSUtil):
         return shellutil.run("systemctl stop waagent", chk_err=False)
 
     def get_dhcp_pid(self):
-        ret = shellutil.run_get_output("systemctl show -p MainPID systemd-networkd")
+        ret = shellutil.run_get_output("systemctl show -p MainPID "
+                                       "systemd-networkd", chk_err=False)
         pid = ret[1].split('=', 1)[-1].strip() if ret[0] == 0 else None
         return pid if pid != '0' else None
 

--- a/azurelinuxagent/common/osutil/default.py
+++ b/azurelinuxagent/common/osutil/default.py
@@ -649,7 +649,7 @@ class DefaultOSUtil(object):
         return shellutil.run(cmd, chk_err=False)
 
     def get_dhcp_pid(self):
-        ret= shellutil.run_get_output("pidof dhclient")
+        ret = shellutil.run_get_output("pidof dhclient", chk_err=False)
         return ret[1] if ret[0] == 0 else None
 
     def set_hostname(self, hostname):

--- a/azurelinuxagent/common/osutil/freebsd.py
+++ b/azurelinuxagent/common/osutil/freebsd.py
@@ -118,7 +118,7 @@ class FreeBSDOSUtil(DefaultOSUtil):
         shellutil.run("route delete 255.255.255.255 -iface {0}".format(ifname), chk_err=False)
 
     def get_dhcp_pid(self):
-        ret = shellutil.run_get_output("pgrep -n dhclient")
+        ret = shellutil.run_get_output("pgrep -n dhclient", chk_err=False)
         return ret[1] if ret[0] == 0 else None
 
     def eject_dvd(self, chk_err=True):

--- a/azurelinuxagent/common/osutil/redhat.py
+++ b/azurelinuxagent/common/osutil/redhat.py
@@ -69,7 +69,7 @@ class Redhat6xOSUtil(DefaultOSUtil):
 
     #Override
     def get_dhcp_pid(self):
-        ret= shellutil.run_get_output("pidof dhclient")
+        ret = shellutil.run_get_output("pidof dhclient", chk_err=False)
         return ret[1] if ret[0] == 0 else None
 
     def set_hostname(self, hostname):

--- a/azurelinuxagent/common/osutil/suse.py
+++ b/azurelinuxagent/common/osutil/suse.py
@@ -42,7 +42,8 @@ class SUSE11OSUtil(DefaultOSUtil):
         shellutil.run("hostname {0}".format(hostname), chk_err=False)
 
     def get_dhcp_pid(self):
-        ret= shellutil.run_get_output("pidof {0}".format(self.dhclient_name))
+        ret = shellutil.run_get_output("pidof {0}".format(self.dhclient_name),
+                                       chk_err=False)
         return ret[1] if ret[0] == 0 else None
 
     def is_dhcp_enabled(self):

--- a/azurelinuxagent/common/osutil/ubuntu.py
+++ b/azurelinuxagent/common/osutil/ubuntu.py
@@ -45,9 +45,9 @@ class Ubuntu12OSUtil(Ubuntu14OSUtil):
     def __init__(self):
         super(Ubuntu12OSUtil, self).__init__()
 
-    #Override
+    # Override
     def get_dhcp_pid(self):
-        ret= shellutil.run_get_output("pidof dhclient3")
+        ret = shellutil.run_get_output("pidof dhclient3", chk_err=False)
         return ret[1] if ret[0] == 0 else None
 
 class UbuntuOSUtil(Ubuntu14OSUtil):

--- a/azurelinuxagent/ga/env.py
+++ b/azurelinuxagent/ga/env.py
@@ -45,7 +45,8 @@ class EnvHandler(object):
         self.stopped = True
         self.hostname = None
         self.dhcpid = None
-        self.server_thread=None
+        self.server_thread = None
+        self.dhcp_warning_enabled = True
 
     def run(self):
         if not self.stopped:
@@ -87,8 +88,11 @@ class EnvHandler(object):
 
     def handle_dhclient_restart(self):
         if self.dhcpid is None:
-            logger.warn("Dhcp client is not running. ")
+            if self.dhcp_warning_enabled:
+                logger.warn("Dhcp client is not running. ")
             self.dhcpid = self.osutil.get_dhcp_pid()
+            # disable subsequent error logging
+            self.dhcp_warning_enabled = self.dhcpid is not None
             return
 
         #The dhcp process hasn't changed since last check


### PR DESCRIPTION
We should support scenarios when dhcpd is not present, and not spam logs with the same warnings over and over. 

- set `chk_err=False` on all calls to `pidof`
- only allow one warning if dhcps is not running
- fixes #417 

/cc @brendandixon 