### PR TITLE
Add goal state version info

### DIFF
--- a/azurelinuxagent/agent.py
+++ b/azurelinuxagent/agent.py
@@ -31,7 +31,7 @@ import azurelinuxagent.common.conf as conf
 from azurelinuxagent.common.version import AGENT_NAME, AGENT_LONG_VERSION, \
                                      DISTRO_NAME, DISTRO_VERSION, \
                                      PY_VERSION_MAJOR, PY_VERSION_MINOR, \
-                                     PY_VERSION_MICRO
+                                     PY_VERSION_MICRO, GOAL_STATE_AGENT_VERSION
 from azurelinuxagent.common.osutil import get_osutil
 
 class Agent(object):
@@ -173,10 +173,14 @@ def version():
     """
     Show agent version
     """
-    print(("{0} running on {1} {2}".format(AGENT_LONG_VERSION, DISTRO_NAME,
-                                          DISTRO_VERSION)))
-    print("Python: {0}.{1}.{2}".format(PY_VERSION_MAJOR, PY_VERSION_MINOR,
+    print(("{0} running on {1} {2}".format(AGENT_LONG_VERSION,
+                                           DISTRO_NAME,
+                                           DISTRO_VERSION)))
+    print("Python: {0}.{1}.{2}".format(PY_VERSION_MAJOR,
+                                       PY_VERSION_MINOR,
                                        PY_VERSION_MICRO))
+    print("Goal state agent: {0}".format(GOAL_STATE_AGENT_VERSION))
+
 def usage():
     """
     Show agent usage

--- a/azurelinuxagent/common/version.py
+++ b/azurelinuxagent/common/version.py
@@ -66,6 +66,8 @@ AGENT_PATTERN = "{0}-(.*)".format(AGENT_NAME)
 AGENT_NAME_PATTERN = re.compile(AGENT_PATTERN)
 AGENT_DIR_PATTERN = re.compile(".*/{0}".format(AGENT_PATTERN))
 
+EXT_HANDLER_PATTERN = ".*/WALinuxAgent-(\w.\w.\w[.\w]*)-.*-run-exthandlers"
+EXT_HANDLER_REGEX = re.compile(EXT_HANDLER_PATTERN)
 
 # Set the CURRENT_AGENT and CURRENT_VERSION to match the agent directory name
 # - This ensures the agent will "see itself" using the same name and version
@@ -83,6 +85,23 @@ def set_current_agent():
         version = AGENT_NAME_PATTERN.match(agent).group(1)
     return agent, FlexibleVersion(version)
 CURRENT_AGENT, CURRENT_VERSION = set_current_agent()
+
+def set_goal_state_agent():
+    agent = None
+    pids = [pid for pid in os.listdir('/proc') if pid.isdigit()]
+    for pid in pids:
+        try:
+            pname = open(os.path.join('/proc', pid, 'cmdline'), 'rb').read()
+            match = EXT_HANDLER_REGEX.match(pname)
+            if match:
+                agent = match.group(1)
+                break
+        except IOError:
+            continue
+    if agent is None:
+        agent = CURRENT_VERSION
+    return agent
+GOAL_STATE_AGENT_VERSION = set_goal_state_agent()
 
 def is_current_agent_installed():
     return CURRENT_AGENT == AGENT_LONG_VERSION

--- a/azurelinuxagent/common/version.py
+++ b/azurelinuxagent/common/version.py
@@ -66,7 +66,7 @@ AGENT_PATTERN = "{0}-(.*)".format(AGENT_NAME)
 AGENT_NAME_PATTERN = re.compile(AGENT_PATTERN)
 AGENT_DIR_PATTERN = re.compile(".*/{0}".format(AGENT_PATTERN))
 
-EXT_HANDLER_PATTERN = ".*/WALinuxAgent-(\w.\w.\w[.\w]*)-.*-run-exthandlers"
+EXT_HANDLER_PATTERN = b".*/WALinuxAgent-(\w.\w.\w[.\w]*)-.*-run-exthandlers"
 EXT_HANDLER_REGEX = re.compile(EXT_HANDLER_PATTERN)
 
 # Set the CURRENT_AGENT and CURRENT_VERSION to match the agent directory name

--- a/azurelinuxagent/common/version.py
+++ b/azurelinuxagent/common/version.py
@@ -51,7 +51,7 @@ def get_distro():
 
 AGENT_NAME = "WALinuxAgent"
 AGENT_LONG_NAME = "Azure Linux Agent"
-AGENT_VERSION = '2.1.6.1'
+AGENT_VERSION = '2.1.6.2'
 AGENT_LONG_VERSION = "{0}-{1}".format(AGENT_NAME, AGENT_VERSION)
 AGENT_DESCRIPTION = """\
 The Azure Linux Agent supports the provisioning and running of Linux


### PR DESCRIPTION
- examine `/proc` and extract the goal state agent version from `cmdline`
- add the goal state version to the output of `--version`
- fixes #418 
```
root@test1:~/WALinuxAgent# waagent --version
WALinuxAgent-2.1.5.3 running on ubuntu 14.04
Python: 2.7.6
Goal state agent: 2.1.6
```
/cc @brendandixon 