### PR TITLE
walinuxagent.service: drop cloud-final from Wants, After on Ubuntu (#425)

### DIFF
--- a/init/ubuntu/walinuxagent.service
+++ b/init/ubuntu/walinuxagent.service
@@ -7,8 +7,8 @@
 [Unit]
 Description=Azure Linux Agent
 
-After=network-online.target cloud-final.service
-Wants=network-online.target sshd.service sshd-keygen.service cloud-final.service
+After=network-online.target cloud-init.service
+Wants=network-online.target sshd.service sshd-keygen.service
 
 ConditionFileIsExecutable=/usr/sbin/waagent
 ConditionPathExists=/etc/waagent.conf


### PR DESCRIPTION
There is no reason for walinuxagent.service to attempt to start up
cloud-final.service if it is running, so remove it from Wants.

There is also no reason for it to need to run After cloud-final, so
remove that also.   The need for this is because cloud-init was starting
walinux.service during cloud-init.service, which would cause unresolvable
cyclic dependencies.