### PR TITLE
Cleanup SUSE config

### DIFF
--- a/config/suse/waagent.conf
+++ b/config/suse/waagent.conf
@@ -70,6 +70,21 @@ OS.OpensslPath=None
 # Detect Scvmm environment, default is n
 # DetectScvmmEnv=n
 
+#
+# Lib.Dir=/var/lib/waagent
+
+#
+# DVD.MountPoint=/mnt/cdrom/secure
+
+#
+# Pid.File=/var/run/waagent.pid
+
+#
+# Extension.LogDir=/var/log/azure
+
+#
+# Home.Dir=/home
+
 # Enable RDMA management and set up, should only be used in HPC images
 # OS.EnableRDMA=y
 

--- a/config/suse/waagent.conf
+++ b/config/suse/waagent.conf
@@ -37,7 +37,7 @@ ResourceDisk.Format=y
 
 # File system on the resource disk
 # Typically ext3 or ext4. FreeBSD images should use 'ufs2' here.
-ResourceDisk.Filesystem=ext3
+ResourceDisk.Filesystem=ext4
 
 # Mount point for the resource disk
 ResourceDisk.MountPoint=/mnt/resource


### PR DESCRIPTION
re: [BSC#997475 - waagent.conf in python-azure-agent package should use ext4 for ephemeral disk](https://bugzilla.suse.com/show_bug.cgi?id=997475) filed by @szarkos 

While correcting the SUSE config, a few other omissions were noted.

WRT to 1d4d383, this change is currently being made as part of image generation; moving to the config file reduces the number of times we need to touch `/etc/waagent.conf`.
