### PR TITLE
stop repeating logs for extension handling

### DIFF
--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -162,6 +162,7 @@ class ExtHandlersHandler(object):
         self.ext_handlers = None
         self.last_etag = None
         self.log_report = False
+        self.log_etag = True
 
     def run(self):
         self.ext_handlers, etag = None, None
@@ -203,8 +204,14 @@ class ExtHandlersHandler(object):
 
         ext_handler_i.decide_version()
         if not ext_handler_i.is_upgrade and self.last_etag == etag:
-            ext_handler_i.logger.verbose("No upgrade detected for etag {0}", etag)
+            if self.log_etag:
+                ext_handler_i.logger.info("Version {0} is current for etag {1}",
+                                          ext_handler_i.pkg.version,
+                                          etag)
+                self.log_etag = False
             return
+
+        self.log_etag = True
 
         try:
             state = ext_handler.properties.state

--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -203,7 +203,7 @@ class ExtHandlersHandler(object):
 
         ext_handler_i.decide_version()
         if not ext_handler_i.is_upgrade and self.last_etag == etag:
-            ext_handler_i.logger.info("No upgrade detected for etag {0}", etag)
+            ext_handler_i.logger.verbose("No upgrade detected for etag {0}", etag)
             return
 
         try:
@@ -342,7 +342,7 @@ class ExtHandlerInstance(object):
                                  logger.LogLevel.INFO, log_file)
 
     def decide_version(self):
-        self.logger.info("Decide which version to use")
+        self.logger.verbose("Decide which version to use")
         try:
             pkg_list = self.protocol.get_ext_handler_pkgs(self.ext_handler)
         except ProtocolError as e:
@@ -441,7 +441,7 @@ class ExtHandlerInstance(object):
         if self.pkg is None:
             raise ExtensionError("Failed to find any valid extension package")
 
-        self.logger.info("Use version: {0}", self.pkg.version)
+        self.logger.verbose("Use version: {0}", self.pkg.version)
         return
 
     def version_gt(self, other):


### PR DESCRIPTION
Now that we set the etag correctly, we have this logging behavior:
```
2016/09/26 18:56:29.489066 INFO [Microsoft.OSTCExtensions.VMAccessForLinux-1.4.6.0] Decide which version to use
2016/09/26 18:56:29.535969 INFO [Microsoft.OSTCExtensions.VMAccessForLinux-1.4.6.0] Use version: 1.4.6.0
2016/09/26 18:56:29.536328 INFO [Microsoft.OSTCExtensions.VMAccessForLinux-1.4.6.0] No upgrade detected for etag 2
2016/09/26 18:56:54.700577 INFO [Microsoft.OSTCExtensions.VMAccessForLinux-1.4.6.0] Decide which version to use
2016/09/26 18:56:54.767816 INFO [Microsoft.OSTCExtensions.VMAccessForLinux-1.4.6.0] Use version: 1.4.6.0
2016/09/26 18:56:54.781438 INFO [Microsoft.OSTCExtensions.VMAccessForLinux-1.4.6.0] No upgrade detected for etag 2
2016/09/26 18:57:21.002141 INFO [Microsoft.OSTCExtensions.VMAccessForLinux-1.4.6.0] Decide which version to use
2016/09/26 18:57:21.045476 INFO [Microsoft.OSTCExtensions.VMAccessForLinux-1.4.6.0] Use version: 1.4.6.0
2016/09/26 18:57:21.056896 INFO [Microsoft.OSTCExtensions.VMAccessForLinux-1.4.6.0] No upgrade detected for etag 2
```
For now we should move these log statements to the verbose level, and at a later stage improve the logging in this area.

/cc @brendandixon 