### PR TITLE
replace incorrect call to low()

### DIFF
--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -933,4 +933,4 @@ class HandlerManifest(object):
         update_mode = self.data['handlerManifest'].get('updateMode')
         if update_mode is None:
             return True
-        return update_mode.low() == "updatewithinstall"
+        return update_mode.lower() == "updatewithinstall"


### PR DESCRIPTION
Seems this code was never invoked, as `low()` is not a valid method on `str`.

/cc @brendandixon 