### PR TITLE
Don't write IP/MAC to device running newer driver version 4.1 or newer

### DIFF
--- a/azurelinuxagent/common/rdma.py
+++ b/azurelinuxagent/common/rdma.py
@@ -199,10 +199,24 @@ class RDMADeviceHandler(object):
     def process(self):
         try:
             RDMADeviceHandler.update_dat_conf(dapl_config_paths, self.ipv4_addr)
-            RDMADeviceHandler.wait_rdma_device(
-                self.rdma_dev, self.device_check_timeout_sec, self.device_check_interval_sec)
-            RDMADeviceHandler.write_rdma_config_to_device(
-                self.rdma_dev, self.ipv4_addr, self.mac_addr)
+
+            skip_rdma_device = False;
+            retcode,out = shellutil.run_get_output("modinfo hv_network_direct")
+            if retcode == 0 :
+                version = re.search("version:\s+(\d+)\.(\d+)\.(\d+)\D", out, re.IGNORECASE)
+                if version :
+                    v1 = version.groups(0)[0]
+                    v2 = version.groups(0)[1]
+                    if int(v1+v2)>40 :
+                        logger.info("Skip setting /dev/hvnd_rdma on 4.1 or later")
+                        skip_rdma_device = True;
+
+            if not skip_rdma_device :
+                RDMADeviceHandler.wait_rdma_device(
+                    self.rdma_dev, self.device_check_timeout_sec, self.device_check_interval_sec)
+                RDMADeviceHandler.write_rdma_config_to_device(
+                    self.rdma_dev, self.ipv4_addr, self.mac_addr)
+
             RDMADeviceHandler.update_network_interface(self.mac_addr, self.ipv4_addr)
         except Exception as e:
             logger.error("RDMA: device processing failed: {0}".format(e))

--- a/bin/waagent2.0
+++ b/bin/waagent2.0
@@ -3504,9 +3504,21 @@ class RdmaHandler(object):
         """
         Write config string to /dev/hvnd_rdma
         """
-        Log("Set /dev/hvnd_rdma")
-        self.wait_rdma_dev()
-        self.write_rdma_dev_conf()
+        skip_rdma_device = False;
+        retcode,out = RunGetOutput("modinfo hv_network_direct", True)
+        if retcode == 0 :
+            version = re.search("version:\s+(\d+)\.(\d+)\.(\d+)\D", out, re.IGNORECASE)
+                if version :
+                    v1 = version.groups(0)[0]
+                    v2 = version.groups(0)[1]
+                    if int(v1+v2)>40 :
+                        Log("Skip setting /dev/hvnd_rdma on 4.1 or later")
+                        skip_rdma_device = True;
+
+        if not skip_rdma_device :
+            Log("Set /dev/hvnd_rdma")
+            self.wait_rdma_dev()
+            self.write_rdma_dev_conf()
 
     def write_rdma_dev_conf(self):
         Log("Write rdma config to {0}: {1}".format(self.dev, self.data))


### PR DESCRIPTION
Since RDMA driver 4.1 we are moving to a different framework to probe ND device. The device for exposing MAC/IP is removed from kernel and no longer needed.