### PR TITLE
Add restart_if function for Alpine

### DIFF
--- a/azurelinuxagent/common/osutil/alpine.py
+++ b/azurelinuxagent/common/osutil/alpine.py
@@ -17,6 +17,7 @@
 # Requires Python 2.4+ and Openssl 1.0+
 #
 
+import azurelinuxagent.common.logger as logger
 import azurelinuxagent.common.utils.shellutil as shellutil
 from azurelinuxagent.common.osutil.default import DefaultOSUtil
 
@@ -30,7 +31,16 @@ class AlpineOSUtil(DefaultOSUtil):
 
     def get_dhcp_pid(self):
         ret = shellutil.run_get_output('pidof dhcpcd', chk_err=False)
-        return ret[1] if ret[0] == 0 else None
+        if ret[0] == 0:
+            logger.info('dhcpcd is pid {}'.format(ret[1]))
+            return ret[1].strip()
+        return None
+
+    def restart_if(self, ifname):
+        logger.info('restarting {} (sort of, actually SIGHUPing dhcpcd)'.format(ifname))
+        pid = self.get_dhcp_pid()
+        if pid != None:
+            ret = shellutil.run_get_output('kill -HUP {}'.format(pid))
 
     def set_ssh_client_alive_interval(self):
         # Alpine will handle this.


### PR DESCRIPTION
We need this for Azure-provided DNS to work on our instances.

It attempts to call `ifdown eth0 && ifup eth0` by default, this does not work for us because they expect the interfaces to be configured statically in `/etc/network/interfaces`.  We configure them dynamically using `dhcpcd`, so a simple SIGHUP to that daemon will suffice to renew the DHCP lease after the agent has set hostname.

@ahmetalpbalkan @hglkrijger @brendandixon PTAL

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>