### PR TITLE
wire.py#decode_config needs to handle empty strings (#486)

### DIFF
--- a/azurelinuxagent/common/protocol/hostplugin.py
+++ b/azurelinuxagent/common/protocol/hostplugin.py
@@ -70,7 +70,7 @@ class HostPluginProtocol(object):
         if not self.ensure_initialized():
             logger.error("host plugin channel is not available")
             return
-        if artifact_url is None or artifact_url.isspace():
+        if textutil.is_str_none_or_whitespace(artifact_url):
             logger.error("no extension artifact url was provided")
             return
 

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -27,6 +27,7 @@ from azurelinuxagent.common.future import httpclient, bytebuffer
 from azurelinuxagent.common.utils.textutil import parse_doc, findall, find, \
     findtext, getattrib, gettext, remove_bom, get_bytes_from_pem, parse_json
 import azurelinuxagent.common.utils.fileutil as fileutil
+import azurelinuxagent.common.utils.textutil as textutil
 from azurelinuxagent.common.utils.cryptutil import CryptUtil
 from azurelinuxagent.common.protocol.restapi import *
 from azurelinuxagent.common.protocol.hostplugin import HostPluginProtocol
@@ -927,9 +928,7 @@ class WireClient(object):
 
     def get_in_vm_artifacts_profile(self):
         ext_conf = self.ext_conf
-        if ext_conf and \
-                ext_conf.in_vm_artifacts_profile_blob and not \
-                ext_conf.in_vm_artifacts_profile_blob.isspace():
+        if ext_conf and not textutil.is_str_none_or_whitespace(ext_conf.in_vm_artifacts_profile_blob):
             # try with the default protocol
             in_vm_artifacts_profile_byte_arr = \
                 self._get_in_vm_artifacts_profile(ext_conf.in_vm_artifacts_profile_blob)
@@ -943,7 +942,7 @@ class WireClient(object):
                 in_vm_artifacts_profile_byte_arr = self._get_in_vm_artifacts_profile(host_plugin_endpoint, headers)
 
             in_vm_artifacts_profile_json = self.decode_config(in_vm_artifacts_profile_byte_arr)
-            if in_vm_artifacts_profile_json and not in_vm_artifacts_profile_json.isspace():
+            if not textutil.is_str_none_or_whitespace(in_vm_artifacts_profile_json):
                 return InVMArtifactsProfile(in_vm_artifacts_profile_json)
 
     def _get_in_vm_artifacts_profile(self, blob_url, headers=None):
@@ -953,7 +952,7 @@ class WireClient(object):
             response_body = resp.read()
             if resp.status < 400:
                 decoded = self.decode_config(response_body)
-                if decoded and not decoded.isspace():
+                if not textutil.is_str_none_or_whitespace(decoded):
                     result = InVMArtifactsProfile(decoded)
             else:
                 logger.warn("Unexpected http status '{0}' is returned with the message '{1}'",
@@ -1353,7 +1352,7 @@ class InVMArtifactsProfile(object):
     '''
 
     def __init__(self, in_vm_artifacts_profile_json):
-        if in_vm_artifacts_profile_json and not in_vm_artifacts_profile_json.isspace():
+        if not textutil.is_str_none_or_whitespace(in_vm_artifacts_profile_json):
             self.__dict__.update(parse_json(in_vm_artifacts_profile_json))
 
     def is_extension_handlers_handling_on_hold(self):

--- a/azurelinuxagent/common/utils/textutil.py
+++ b/azurelinuxagent/common/utils/textutil.py
@@ -251,10 +251,14 @@ def set_ini_config(config, name, val):
 
 
 def remove_bom(c):
-    if len(c) > 2 \
-            and str_to_ord(c[0]) > 128 \
-            and str_to_ord(c[1]) > 128 \
-            and str_to_ord(c[2]) > 128:
+    '''
+    bom is comprised of a sequence of three chars,0xef, 0xbb, 0xbf, in case of utf-8.
+    '''
+    if not is_str_none_or_whitespace(c) and \
+       len(c) > 2 and \
+       str_to_ord(c[0]) > 128 and \
+       str_to_ord(c[1]) > 128 and \
+       str_to_ord(c[2]) > 128:
         c = c[3:]
     return c
 
@@ -302,8 +306,11 @@ def parse_json(json_str):
     """
     # trim null and whitespaces
     result = None
-    if json_str and not json_str.isspace():
+    if not is_str_none_or_whitespace(json_str):
         import json
         result = json.loads(json_str.rstrip(' \t\r\n\0'))
 
     return result
+
+def is_str_none_or_whitespace(s):
+    return s is None or len(s) == 0 or s.isspace()

--- a/tests/utils/test_text_util.py
+++ b/tests/utils/test_text_util.py
@@ -35,11 +35,30 @@ class TestTextUtil(AgentTestCase):
         data = ustr(b'\xef\xbb\xbfhehe', encoding='utf-8')
         data = textutil.remove_bom(data)
         self.assertNotEquals(0xbb, data[0])
-        
+
+        #bom is comprised of a sequence of three bytes and ff length of the input is shorter
+        # than three bytes, remove_bom should not do anything
+        data = u"\xa7"
+        data = textutil.remove_bom(data)
+        self.assertEquals(data, data[0])
+
+        data = u"\xa7\xef"
+        data = textutil.remove_bom(data)
+        self.assertEquals(u"\xa7", data[0])
+        self.assertEquals(u"\xef", data[1])
+
         #Test string without BOM is not affected
         data = u"hehe"
         data = textutil.remove_bom(data)
         self.assertEquals(u"h", data[0])
+
+        data = u""
+        data = textutil.remove_bom(data)
+        self.assertEquals(u"", data)
+
+        data = u"  "
+        data = textutil.remove_bom(data)
+        self.assertEquals(u"  ", data)
 
     def test_version_compare(self):
         self.assertTrue(Version("1.0") < Version("1.1"))


### PR DESCRIPTION
1. Add is_str_none_or_whitespace to textutil for string emptiness check
2. Update remove_bom to properly handle empty/none/whitespace string
