### PR TITLE
Decide version hotfix

### DIFF
--- a/azurelinuxagent/common/utils/textutil.py
+++ b/azurelinuxagent/common/utils/textutil.py
@@ -251,8 +251,10 @@ def set_ini_config(config, name, val):
 
 
 def remove_bom(c):
-    if str_to_ord(c[0]) > 128 and str_to_ord(c[1]) > 128 and \
-                    str_to_ord(c[2]) > 128:
+    if len(c) > 2 \
+            and str_to_ord(c[0]) > 128 \
+            and str_to_ord(c[1]) > 128 \
+            and str_to_ord(c[2]) > 128:
         c = c[3:]
     return c
 

--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -354,9 +354,10 @@ class ExtHandlerInstance(object):
 
         # Determine the desired and installed versions
         requested_version = FlexibleVersion(self.ext_handler.properties.version)
-        installed_version = FlexibleVersion(self.get_installed_version())
-        if installed_version is None:
-            installed_version = requested_version
+        installed_version_string = self.get_installed_version()
+        installed_version = requested_version \
+            if installed_version_string is None \
+            else FlexibleVersion(installed_version_string)
 
         # Divide packages
         # - Find the installed package (its version must exactly match)


### PR DESCRIPTION
When extensions have multiple major versions available, initial installation will fail due to the major version upgrade allowed check.

- correct the installed version check
- check the string length in `remove_bom`, I hit this in my repro testing

This PR is against the hotfix/2.2.0 branch.

/cc @brendandixon @jinhyunr 