### PR TITLE
Host plugin updates

### DIFF
--- a/azurelinuxagent/common/event.py
+++ b/azurelinuxagent/common/event.py
@@ -41,6 +41,7 @@ class WALAEventOperation:
     Disable = "Disable"
     Download = "Download"
     Enable = "Enable"
+    HealthCheck = "HealthCheck"
     HeartBeat="HeartBeat"
     Install = "Install"
     Provision = "Provision"

--- a/azurelinuxagent/common/protocol/hostplugin.py
+++ b/azurelinuxagent/common/protocol/hostplugin.py
@@ -29,7 +29,8 @@ API_VERSION = "2015-09-01"
 HEADER_CONTAINER_ID = "x-ms-containerid"
 HEADER_VERSION = "x-ms-version"
 HEADER_HOST_CONFIG_NAME = "x-ms-host-config-name"
-
+HEADER_ARTIFACT_LOCATION = "x-ms-artifact-location"
+HEADER_ARTIFACT_MANIFEST_LOCATION = "x-ms-artifact-manifest-location"
 
 class HostPluginProtocol(object):
     def __init__(self, endpoint, container_id, role_config_name):
@@ -41,6 +42,7 @@ class HostPluginProtocol(object):
         self.endpoint = endpoint
         self.container_id = container_id
         self.role_config_name = role_config_name
+        self.manifest_uri = None
 
     def ensure_initialized(self):
         if not self.is_initialized:
@@ -52,21 +54,24 @@ class HostPluginProtocol(object):
     def get_api_versions(self):
         url = URI_FORMAT_GET_API_VERSIONS.format(self.endpoint,
                                                  HOST_PLUGIN_PORT)
-        logger.info("getting API versions at [{0}]".format(url))
+        logger.verbose("getting API versions at [{0}]".format(url))
+        return_val = []
         try:
-            headers = { HEADER_CONTAINER_ID: self.container_id }
+            headers = {HEADER_CONTAINER_ID: self.container_id}
             response = restutil.http_get(url, headers)
             if response.status != httpclient.OK:
                 logger.error(
                     "get API versions returned status code [{0}]".format(
                         response.status))
-                return []
-            return response.read()
+            else:
+                return_val = ustr(remove_bom(response.read()), encoding='utf-8')
+
         except HttpError as e:
             logger.error("get API versions failed with [{0}]".format(e))
-            return []
 
-    def get_extension_artifact_url_and_headers(self, artifact_url, artifact_manifest_url = None):
+        return return_val
+
+    def get_artifact_request(self, artifact_url, artifact_manifest_url=None):
         if not self.ensure_initialized():
             logger.error("host plugin channel is not available")
             return
@@ -74,20 +79,23 @@ class HostPluginProtocol(object):
             logger.error("no extension artifact url was provided")
             return
 
-        url = URI_FORMAT_GET_EXTENSION_ARTIFACT.format(self.endpoint, HOST_PLUGIN_PORT)
+        url = URI_FORMAT_GET_EXTENSION_ARTIFACT.format(self.endpoint,
+                                                       HOST_PLUGIN_PORT)
         headers = {HEADER_VERSION: API_VERSION,
                    HEADER_CONTAINER_ID: self.container_id,
                    HEADER_HOST_CONFIG_NAME: self.role_config_name,
-                   "x-ms-artifact-location": artifact_url}
+                   HEADER_ARTIFACT_LOCATION: artifact_url}
+
         if artifact_manifest_url is not None:
-            headers["x-ms-artifact-manifest-location"] = artifact_manifest_url
+            headers[HEADER_ARTIFACT_MANIFEST_LOCATION] = artifact_manifest_url
 
         return url, headers
 
-    def put_vm_status(self, status_blob, sas_url):
+    def put_vm_status(self, status_blob, sas_url, config_blob_type=None):
         """
         Try to upload the VM status via the host plugin /status channel
         :param sas_url: the blob SAS url to pass to the host plugin
+        :param config_blob_type: the blob type from the extension config
         :type status_blob: StatusBlob
         """
         if not self.ensure_initialized():
@@ -96,26 +104,28 @@ class HostPluginProtocol(object):
         if status_blob is None or status_blob.vm_status is None:
             logger.error("no status data was provided")
             return
-        url = URI_FORMAT_PUT_VM_STATUS.format(self.endpoint, HOST_PLUGIN_PORT)
-        logger.verbose("Posting VM status to host channel [{0}]".format(url))
-        status = textutil.b64encode(status_blob.data)
-        headers = {HEADER_VERSION: API_VERSION,
-                   "Content-type": "application/json",
-                   HEADER_CONTAINER_ID: self.container_id,
-                   HEADER_HOST_CONFIG_NAME: self.role_config_name}
-        blob_headers = [{'headerName': 'x-ms-version',
-                         'headerValue': status_blob.__storage_version__},
-                        {'headerName': 'x-ms-blob-type',
-                         'headerValue': status_blob.type}]
-        data = json.dumps({'requestUri': sas_url, 'headers': blob_headers,
-                           'content': status}, sort_keys=True)
         try:
-            response = restutil.http_put(url, data, headers)
+            url = URI_FORMAT_PUT_VM_STATUS.format(self.endpoint, HOST_PLUGIN_PORT)
+            logger.verbose("Posting VM status to host plugin")
+            status = textutil.b64encode(status_blob.data)
+            blob_type = status_blob.type if status_blob.type else config_blob_type
+            headers = {HEADER_VERSION: API_VERSION,
+                       "Content-type": "application/json",
+                       HEADER_CONTAINER_ID: self.container_id,
+                       HEADER_HOST_CONFIG_NAME: self.role_config_name}
+            blob_headers = [{'headerName': 'x-ms-version',
+                             'headerValue': status_blob.__storage_version__},
+                            {'headerName': 'x-ms-blob-type',
+                             'headerValue': blob_type}]
+            data = json.dumps({'requestUri': sas_url, 'headers': blob_headers,
+                               'content': status}, sort_keys=True)
+            response = restutil.http_put(url, data=data, headers=headers)
             if response.status != httpclient.OK:
-                logger.error("put VM status returned status code [{0}]".format(
-                    response.status))
-        except HttpError as e:
-            logger.error("put VM status failed with [{0}]".format(e))
+                logger.error("PUT failed [{0}]", response.status)
+            else:
+                logger.verbose("Successfully uploaded status to host plugin")
+        except Exception as e:
+            logger.error("Put VM status failed [{0}]", e)
 
     def put_vm_log(self, content):
         """

--- a/azurelinuxagent/common/protocol/restapi.py
+++ b/azurelinuxagent/common/protocol/restapi.py
@@ -282,16 +282,16 @@ class Protocol(DataContract):
     def get_ext_handler_pkgs(self, extension):
         raise NotImplementedError()
 
-    def get_in_vm_artifacts_profile(self):
+    def get_artifacts_profile(self):
         raise NotImplementedError()
 
-    def download_ext_handler_pkg(self, uri):
+    def download_ext_handler_pkg(self, uri, headers=None):
         try:
-            resp = restutil.http_get(uri, chk_proxy=True)
+            resp = restutil.http_get(uri, chk_proxy=True, headers=headers)
             if resp.status == restutil.httpclient.OK:
                 return resp.read()
-        except HttpError as e:
-            raise ProtocolError("Failed to download from: {0}".format(uri), e)
+        except Exception as e:
+            logger.warn("Failed to download from: {0}".format(uri), e)
 
     def report_provision_status(self, provision_status):
         raise NotImplementedError()

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -526,6 +526,7 @@ class WireClient(object):
         self.req_count = 0
         self.host_plugin = None
         self.status_blob = StatusBlob(self)
+        self.status_blob_type_reported = False
 
     def prevent_throttling(self):
         """
@@ -703,6 +704,7 @@ class WireClient(object):
         xml_text = self.fetch_config(goal_state.ext_uri, self.get_header())
         self.save_cache(local_file, xml_text)
         self.ext_conf = ExtensionsConfig(xml_text)
+        self.status_blob_type_reported = False
 
     def update_goal_state(self, forced=False, max_retry=3):
         uri = GOAL_STATE_URI.format(self.endpoint)
@@ -746,7 +748,7 @@ class WireClient(object):
         raise ProtocolError("Exceeded max retry updating goal state")
 
     def get_goal_state(self):
-        if (self.goal_state is None):
+        if self.goal_state is None:
             incarnation_file = os.path.join(conf.get_lib_dir(),
                                             INCARNATION_FILE_NAME)
             incarnation = self.fetch_cache(incarnation_file)
@@ -783,7 +785,7 @@ class WireClient(object):
         return self.certs
 
     def get_ext_conf(self):
-        if (self.ext_conf is None):
+        if self.ext_conf is None:
             goal_state = self.get_goal_state()
             if goal_state.ext_uri is None:
                 self.ext_conf = ExtensionsConfig(None)
@@ -792,6 +794,7 @@ class WireClient(object):
                 local_file = os.path.join(conf.get_lib_dir(), local_file)
                 xml_text = self.fetch_cache(local_file)
                 self.ext_conf = ExtensionsConfig(xml_text)
+                self.status_blob_type_reported = False
         return self.ext_conf
 
     def get_ext_manifest(self, ext_handler, goal_state):
@@ -832,6 +835,8 @@ class WireClient(object):
             uploaded = False
             try:
                 uploaded = self.status_blob.upload(ext_conf.status_upload_blob)
+                self.report_blob_type(self.status_blob.type,
+                                      ext_conf.status_upload_blob_type)
             except (HttpError, ProtocolError) as e:
                 # errors have already been logged
                 pass
@@ -840,6 +845,29 @@ class WireClient(object):
                 host.put_vm_status(self.status_blob,
                                    ext_conf.status_upload_blob,
                                    ext_conf.status_upload_blob_type)
+
+    """
+    Emit an event to determine if the type in the extension config
+    matches the actual type from the HTTP HEAD request.
+    """
+    def report_blob_type(self, head_type, config_type):
+        if head_type and config_type:
+            is_match = head_type == config_type
+            if self.status_blob_type_reported is False:
+                message = \
+                    'Blob type match [{0}]'.format(head_type) if is_match else \
+                    'Blob type mismatch [HEAD {0}], [CONFIG {1}]'.format(
+                        head_type,
+                        config_type)
+
+                from azurelinuxagent.common.event import add_event, WALAEventOperation
+                from azurelinuxagent.common.version import AGENT_NAME, CURRENT_VERSION
+                add_event(AGENT_NAME,
+                          version=CURRENT_VERSION,
+                          is_success=is_match,
+                          message=message,
+                          op=WALAEventOperation.HealthCheck)
+                self.status_blob_type_reported = True
 
     def report_role_prop(self, thumbprint):
         goal_state = self.get_goal_state()

--- a/azurelinuxagent/common/utils/restutil.py
+++ b/azurelinuxagent/common/utils/restutil.py
@@ -131,7 +131,10 @@ def http_request(method, url, data, headers=None, max_retry=3,
     logger.verbose("HTTP headers: [{0}]", headers)
     logger.verbose("HTTP proxy: [{0}:{1}]", proxy_host, proxy_port)
 
+    retry_msg = ''
+    log_msg = "HTTP {0}".format(method)
     for retry in range(0, max_retry):
+        retry_interval = RETRY_WAITING_INTERVAL
         try:
             resp = _http_request(method,
                                  host,
@@ -145,21 +148,22 @@ def http_request(method, url, data, headers=None, max_retry=3,
             logger.verbose("HTTP response status: [{0}]", resp.status)
             return resp
         except httpclient.HTTPException as e:
-            logger.warn('HTTPException: [{0}]', e)
+            retry_msg = 'HTTP exception: {0} {1}'.format(log_msg, e)
+            retry_interval = 5
         except IOError as e:
-            logger.warn('IOError: [{0}]', e)
+            retry_msg = 'IO error: {0} {1}'.format(log_msg, e)
+            retry_interval = 0
+            max_retry = 0
 
-        if retry < max_retry - 1:
-            logger.info("Retry {0}", retry)
-            time.sleep(RETRY_WAITING_INTERVAL)
-        else:
-            logger.error("All retries failed")
+        if retry < max_retry:
+            logger.info("Retry [{0}/{1} - {3}]",
+                        retry+1,
+                        max_retry,
+                        retry_interval,
+                        retry_msg)
+            time.sleep(retry_interval)
 
-    if url is not None and len(url) > 100:
-        url_log = url[0: 100]  # In case the url is too long
-    else:
-        url_log = url
-    raise HttpError("HTTPError: {0} {1}".format(method, url_log))
+    raise HttpError("{0} failed".format(log_msg))
 
 
 def http_get(url, headers=None, max_retry=3, chk_proxy=False):

--- a/tests/data/wire/ext_conf.xml
+++ b/tests/data/wire/ext_conf.xml
@@ -22,5 +22,5 @@
     <RuntimeSettings seqNo="0">{"runtimeSettings":[{"handlerSettings":{"protectedSettingsCertThumbprint":"4037FBF5F1F3014F99B5D6C7799E9B20E6871CB3","protectedSettings":"MIICWgYJK","publicSettings":{"foo":"bar"}}}]}</RuntimeSettings>
   </Plugin>
 </PluginSettings>
-<StatusUploadBlob>https://yuezhatest.blob.core.windows.net/vhds/test-cs12.test-cs12.test-cs12.status?sr=b&amp;sp=rw&amp;se=9999-01-01&amp;sk=key1&amp;sv=2014-02-14&amp;sig=hfRh7gzUE7sUtYwke78IOlZOrTRCYvkec4hGZ9zZzXo%3D</StatusUploadBlob></Extensions>
+<StatusUploadBlob statusBlobType="BlockBlob">https://yuezhatest.blob.core.windows.net/vhds/test-cs12.test-cs12.test-cs12.status?sr=b&amp;sp=rw&amp;se=9999-01-01&amp;sk=key1&amp;sv=2014-02-14&amp;sig=hfRh7gzUE7sUtYwke78IOlZOrTRCYvkec4hGZ9zZzXo%3D</StatusUploadBlob></Extensions>
 

--- a/tests/ga/test_extension.py
+++ b/tests/ga/test_extension.py
@@ -290,7 +290,7 @@ class TestExtension(AgentTestCase):
         test_data = WireProtocolData(DATA_FILE)
         exthandlers_handler, protocol = self._create_mock(test_data, *args)
         exthandlers_handler.ext_handlers, exthandlers_handler.last_etag = protocol.get_ext_handlers()
-        protocol.get_in_vm_artifacts_profile = MagicMock()
+        protocol.get_artifacts_profile = MagicMock()
         exthandlers_handler.protocol = protocol
 
         # Disable extension handling blocking
@@ -315,17 +315,17 @@ class TestExtension(AgentTestCase):
         # enable extension handling blocking
         conf.get_enable_overprovisioning = Mock(return_value=True)
 
-        #Test when is_extension_handlers_handling_on_hold returns False
+        #Test when is_on_hold returns False
         from azurelinuxagent.common.protocol.wire import InVMArtifactsProfile
         mock_in_vm_artifacts_profile = InVMArtifactsProfile(MagicMock())
-        mock_in_vm_artifacts_profile.is_extension_handlers_handling_on_hold = Mock(return_value=False)
-        protocol.get_in_vm_artifacts_profile = Mock(return_value=mock_in_vm_artifacts_profile)
+        mock_in_vm_artifacts_profile.is_on_hold = Mock(return_value=False)
+        protocol.get_artifacts_profile = Mock(return_value=mock_in_vm_artifacts_profile)
         with patch.object(ExtHandlersHandler, 'handle_ext_handler') as patch_handle_ext_handler:
             exthandlers_handler.handle_ext_handlers()
             patch_handle_ext_handler.assert_called_once()
 
         #Test when in_vm_artifacts_profile is not available
-        protocol.get_in_vm_artifacts_profile = Mock(return_value=None)
+        protocol.get_artifacts_profile = Mock(return_value=None)
         with patch.object(ExtHandlersHandler, 'handle_ext_handler') as patch_handle_ext_handler:
             exthandlers_handler.handle_ext_handlers()
             patch_handle_ext_handler.assert_called_once()

--- a/tests/protocol/test_wire.py
+++ b/tests/protocol/test_wire.py
@@ -20,6 +20,7 @@ from tests.protocol.mockwiredata import *
 
 data_with_bom = b'\xef\xbb\xbfhehe'
 testurl = 'http://foo'
+testtype = 'BlockBlob'
 wireserver_url = '168.63.129.16'
 
 @patch("time.sleep")
@@ -100,6 +101,18 @@ class TestWireProtocolGetters(AgentTestCase):
             for c in http_patch.call_args_list:
                 self.assertTrue(c[-1]['chk_proxy'] == True)
 
+    def test_status_blob_parsing(self, *args):
+        wire_protocol_client = WireProtocol(wireserver_url).client
+        wire_protocol_client.ext_conf = ExtensionsConfig(WireProtocolData(DATA_FILE).ext_conf)
+        self.assertEqual(wire_protocol_client.ext_conf.status_upload_blob,
+                         u'https://yuezhatest.blob.core.windows.net/vhds/test'
+                         u'-cs12.test-cs12.test-cs12.status?sr=b&sp=rw&se'
+                         u'=9999-01-01&sk=key1&sv=2014-02-14&sig'
+                         u'=hfRh7gzUE7sUtYwke78IOlZOrTRCYvkec4hGZ9zZzXo%3D')
+        self.assertEqual(wire_protocol_client.ext_conf.status_upload_blob_type,
+                         u'BlockBlob')
+        pass
+
     def test_get_host_ga_plugin(self, *args):
         wire_protocol_client = WireProtocol(wireserver_url).client
         goal_state = GoalState(WireProtocolData(DATA_FILE).goal_state)
@@ -107,8 +120,32 @@ class TestWireProtocolGetters(AgentTestCase):
         with patch.object(WireClient, "get_goal_state", return_value = goal_state) as patch_get_goal_state:
             host_plugin = wire_protocol_client.get_host_plugin()
             self.assertEqual(goal_state.container_id, host_plugin.container_id)
-            self.assertEqual(goal_state.role_instance_config_name, host_plugin.role_config_name)
+            self.assertEqual(goal_state.role_config_name, host_plugin.role_config_name)
             patch_get_goal_state.assert_called_once()
+
+    def test_download_ext_handler_pkg_fallback(self, *args):
+        ext_uri = 'extension_uri'
+        host_uri = 'host_uri'
+        mock_host = HostPluginProtocol(host_uri, 'container_id', 'role_config')
+        with patch.object(restutil,
+                          "http_request",
+                          side_effect=IOError) as patch_http:
+            with patch.object(WireClient,
+                              "get_host_plugin",
+                              return_value=mock_host):
+                with patch.object(HostPluginProtocol,
+                                  "get_artifact_request",
+                                  return_value=[host_uri, {}]) as patch_request:
+
+                    WireProtocol(wireserver_url).download_ext_handler_pkg(ext_uri)
+
+                    self.assertEqual(patch_http.call_count, 2)
+                    self.assertEqual(patch_request.call_count, 1)
+
+                    self.assertEqual(patch_http.call_args_list[0][0][1],
+                                     ext_uri)
+                    self.assertEqual(patch_http.call_args_list[1][0][1],
+                                     host_uri)
 
     def test_upload_status_blob_default(self, *args):
         wire_protocol_client = WireProtocol(wireserver_url).client
@@ -128,6 +165,7 @@ class TestWireProtocolGetters(AgentTestCase):
         wire_protocol_client = WireProtocol(wireserver_url).client
         wire_protocol_client.ext_conf = ExtensionsConfig(None)
         wire_protocol_client.ext_conf.status_upload_blob = testurl
+        wire_protocol_client.ext_conf.status_upload_blob_type = testtype
         goal_state = GoalState(WireProtocolData(DATA_FILE).goal_state)
 
         with patch.object(HostPluginProtocol, "put_vm_status") as patch_host_ga_plugin_upload:
@@ -137,43 +175,43 @@ class TestWireProtocolGetters(AgentTestCase):
 
                 patch_default_upload.assert_called_once_with(testurl)
                 wire_protocol_client.get_goal_state.assert_called_once()
-                patch_host_ga_plugin_upload.assert_called_once_with(wire_protocol_client.status_blob, testurl)
+                patch_host_ga_plugin_upload.assert_called_once_with(wire_protocol_client.status_blob, testurl, testtype)
 
     def test_get_in_vm_artifacts_profile_blob_not_available(self, *args):
         wire_protocol_client = WireProtocol(wireserver_url).client
         wire_protocol_client.ext_conf = ExtensionsConfig(None)
 
-        # Test when in_vm_artifacts_profile_blob is null/None
-        self.assertEqual(None, wire_protocol_client.get_in_vm_artifacts_profile())
+        # Test when artifacts_profile_blob is null/None
+        self.assertEqual(None, wire_protocol_client.get_artifacts_profile())
 
-        #Test when in_vm_artifacts_profile_blob is whitespace
-        wire_protocol_client.ext_conf.in_vm_artifacts_profile_blob = "  "
-        self.assertEqual(None, wire_protocol_client.get_in_vm_artifacts_profile())
+        #Test when artifacts_profile_blob is whitespace
+        wire_protocol_client.ext_conf.artifacts_profile_blob = "  "
+        self.assertEqual(None, wire_protocol_client.get_artifacts_profile())
 
     def test_get_in_vm_artifacts_profile_response_body_not_valid(self, *args):
         wire_protocol_client = WireProtocol(wireserver_url).client
         wire_protocol_client.ext_conf = ExtensionsConfig(None)
-        wire_protocol_client.ext_conf.in_vm_artifacts_profile_blob = testurl
+        wire_protocol_client.ext_conf.artifacts_profile_blob = testurl
         goal_state = GoalState(WireProtocolData(DATA_FILE).goal_state)
         wire_protocol_client.get_goal_state = Mock(return_value=goal_state)
 
-        with patch.object(HostPluginProtocol, "get_extension_artifact_url_and_headers",
+        with patch.object(HostPluginProtocol, "get_artifact_request",
                           return_value = ['dummy_url', {}]) as host_plugin_get_artifact_url_and_headers:
             #Test when response body is None
             wire_protocol_client.call_storage_service = Mock(return_value=MockResponse(None, 200))
-            in_vm_artifacts_profile = wire_protocol_client.get_in_vm_artifacts_profile()
+            in_vm_artifacts_profile = wire_protocol_client.get_artifacts_profile()
             self.assertTrue(in_vm_artifacts_profile is None)
 
             #Test when response body is None
             wire_protocol_client.call_storage_service = Mock(return_value=MockResponse('   '.encode('utf-8'), 200))
-            in_vm_artifacts_profile = wire_protocol_client.get_in_vm_artifacts_profile()
+            in_vm_artifacts_profile = wire_protocol_client.get_artifacts_profile()
             self.assertTrue(in_vm_artifacts_profile is None)
 
             #Test when response body is None
             wire_protocol_client.call_storage_service = Mock(return_value=MockResponse('{ }'.encode('utf-8'), 200))
-            in_vm_artifacts_profile = wire_protocol_client.get_in_vm_artifacts_profile()
+            in_vm_artifacts_profile = wire_protocol_client.get_artifacts_profile()
             self.assertEqual(dict(), in_vm_artifacts_profile.__dict__,
-                             'If in_vm_artifacts_profile_blob has empty json dictionary, in_vm_artifacts_profile '
+                             'If artifacts_profile_blob has empty json dictionary, in_vm_artifacts_profile '
                              'should contain nothing')
 
             host_plugin_get_artifact_url_and_headers.assert_called_with(testurl)
@@ -182,30 +220,55 @@ class TestWireProtocolGetters(AgentTestCase):
     def test_get_in_vm_artifacts_profile_default(self, *args):
         wire_protocol_client = WireProtocol(wireserver_url).client
         wire_protocol_client.ext_conf = ExtensionsConfig(None)
-        wire_protocol_client.ext_conf.in_vm_artifacts_profile_blob = testurl
+        wire_protocol_client.ext_conf.artifacts_profile_blob = testurl
         goal_state = GoalState(WireProtocolData(DATA_FILE).goal_state)
         wire_protocol_client.get_goal_state = Mock(return_value=goal_state)
 
         wire_protocol_client.call_storage_service = Mock(return_value=MockResponse('{"onHold": "true"}'.encode('utf-8'), 200))
-        in_vm_artifacts_profile = wire_protocol_client.get_in_vm_artifacts_profile()
+        in_vm_artifacts_profile = wire_protocol_client.get_artifacts_profile()
         self.assertEqual(dict(onHold='true'), in_vm_artifacts_profile.__dict__)
-        self.assertTrue(in_vm_artifacts_profile.is_extension_handlers_handling_on_hold())
+        self.assertTrue(in_vm_artifacts_profile.is_on_hold())
+
+    @patch("time.sleep")
+    def test_fetch_manifest_fallback(self, patch_sleep,  *args):
+        uri1 = ExtHandlerVersionUri()
+        uri1.uri = 'ext_uri'
+        uris = DataContractList(ExtHandlerVersionUri)
+        uris.append(uri1)
+        host_uri = 'host_uri'
+        mock_host = HostPluginProtocol(host_uri,
+                                       'container_id',
+                                       'role_config')
+        client = WireProtocol(wireserver_url).client
+        with patch.object(WireClient,
+                          "fetch",
+                          return_value=None) as patch_fetch:
+            with patch.object(WireClient,
+                              "get_host_plugin",
+                              return_value=mock_host):
+                with patch.object(HostPluginProtocol,
+                                  "get_artifact_request",
+                                  return_value=[host_uri, {}]):
+                    self.assertRaises(ProtocolError, client.fetch_manifest, uris)
+                    self.assertEqual(patch_fetch.call_count, 2)
+                    self.assertEqual(patch_fetch.call_args_list[0][0][0], uri1.uri)
+                    self.assertEqual(patch_fetch.call_args_list[1][0][0], host_uri)
 
     def test_get_in_vm_artifacts_profile_host_ga_plugin(self, *args):
         wire_protocol_client = WireProtocol(wireserver_url).client
         wire_protocol_client.ext_conf = ExtensionsConfig(None)
-        wire_protocol_client.ext_conf.in_vm_artifacts_profile_blob = testurl
+        wire_protocol_client.ext_conf.artifacts_profile_blob = testurl
         goal_state = GoalState(WireProtocolData(DATA_FILE).goal_state)
         wire_protocol_client.get_goal_state = Mock(return_value=goal_state)
-
-        wire_protocol_client._get_in_vm_artifacts_profile = Mock(side_effect=[None, '{"onHold": "true"}'.encode('utf-8')])
-
-        with patch.object(HostPluginProtocol, "get_extension_artifact_url_and_headers",
-                          return_value = ['dummy_url', {}]) as host_plugin_get_artifact_url_and_headers:
-            in_vm_artifacts_profile = wire_protocol_client.get_in_vm_artifacts_profile()
+        wire_protocol_client.fetch = Mock(side_effect=[None, '{"onHold": "true"}'.encode('utf-8')])
+        with patch.object(HostPluginProtocol,
+                          "get_artifact_request",
+                          return_value=['dummy_url', {}]) as artifact_request:
+            in_vm_artifacts_profile = wire_protocol_client.get_artifacts_profile()
+            self.assertTrue(in_vm_artifacts_profile is not None)
             self.assertEqual(dict(onHold='true'), in_vm_artifacts_profile.__dict__)
-            self.assertTrue(in_vm_artifacts_profile.is_extension_handlers_handling_on_hold())
-            host_plugin_get_artifact_url_and_headers.assert_called_once_with(testurl)
+            self.assertTrue(in_vm_artifacts_profile.is_on_hold())
+            artifact_request.assert_called_once_with(testurl)
 
 
 class MockResponse:


### PR DESCRIPTION
These changes allow the agent to function normally even while outbound connectivity to the public internet is blocked, via NSG for example. 

- enables host plugin downloads for extension and agent manifests and packages
- fixes an issue uploading the extension health via the host plugin
- fixes issues whereby the agent manifest and package are downloaded multiple times
- refactor and cleanup 
- adds unit tests

/cc @jinhyunr @brendandixon 