### PR TITLE
RHEL-7 hostname

### DIFF
--- a/azurelinuxagent/common/osutil/redhat.py
+++ b/azurelinuxagent/common/osutil/redhat.py
@@ -96,10 +96,9 @@ class RedhatOSUtil(Redhat6xOSUtil):
 
     def set_hostname(self, hostname):
         """
-        Set /etc/hostname
-        Unlike redhat 6.x, redhat 7.x will set hostname to /etc/hostname
+        Unlike redhat 6.x, redhat 7.x will set hostname via hostnamectl
         """
-        DefaultOSUtil.set_hostname(self, hostname)
+        shellutil.run("hostnamectl {0}".format(hostname))
 
     def publish_hostname(self, hostname):
         """

--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -807,6 +807,9 @@ class ExtHandlerInstance(object):
     def set_handler_state(self, handler_state):
         state_dir = self.get_conf_dir()
         try:
+            if not os.path.exists(state_dir):
+                fileutil.mkdir(state_dir, mode=0o700)
+
             state_file = os.path.join(state_dir, "HandlerState")
             fileutil.write_file(state_file, handler_state)
         except IOError as e:


### PR DESCRIPTION
- use `hostnamectl` to set the hostname in RHEL-7
- create the handler state directory if it is missing
- fixes #529, #530 

/cc @jinhyunr @brendandixon @yuxisun1217