### PR TITLE
ensure config file is updated correctly

### DIFF
--- a/azurelinuxagent/common/osutil/redhat.py
+++ b/azurelinuxagent/common/osutil/redhat.py
@@ -84,7 +84,8 @@ class Redhat6xOSUtil(DefaultOSUtil):
     def set_dhcp_hostname(self, hostname):
         ifname = self.get_if_name()
         filepath = "/etc/sysconfig/network-scripts/ifcfg-{0}".format(ifname)
-        fileutil.update_conf_file(filepath, 'DHCP_HOSTNAME',
+        fileutil.update_conf_file(filepath,
+                                  'DHCP_HOSTNAME',
                                   'DHCP_HOSTNAME={0}'.format(hostname))
 
     def get_dhcp_lease_endpoint(self):

--- a/azurelinuxagent/common/utils/fileutil.py
+++ b/azurelinuxagent/common/utils/fileutil.py
@@ -140,7 +140,7 @@ def update_conf_file(path, line_start, val, chk_err=False):
     if not os.path.isfile(path) and chk_err:
         raise IOError("Can't find config file:{0}".format(path))
     conf = read_file(path).split('\n')
-    conf = [x for x in conf if not x.startswith(line_start) and x is not None and len(x) > 0]
+    conf = [x for x in conf if x is not None and len(x) > 0 and not x.startswith(line_start)]
     conf.append(val)
     write_file(path, '\n'.join(conf) + '\n')
 

--- a/azurelinuxagent/common/utils/fileutil.py
+++ b/azurelinuxagent/common/utils/fileutil.py
@@ -140,9 +140,9 @@ def update_conf_file(path, line_start, val, chk_err=False):
     if not os.path.isfile(path) and chk_err:
         raise IOError("Can't find config file:{0}".format(path))
     conf = read_file(path).split('\n')
-    conf = [x for x in conf if not x.startswith(line_start)]
+    conf = [x for x in conf if not x.startswith(line_start) and x is not None and len(x) > 0]
     conf.append(val)
-    write_file(path, '\n'.join(conf))
+    write_file(path, '\n'.join(conf) + '\n')
 
 def search_file(target_dir_name, target_file_name):
     for root, dirs, files in os.walk(target_dir_name):

--- a/tests/utils/test_file_util.py
+++ b/tests/utils/test_file_util.py
@@ -15,13 +15,12 @@
 # Requires Python 2.4+ and Openssl 1.0+
 #
 
-from tests.tools import *
 import uuid
-import unittest
-import os
-import sys
-from azurelinuxagent.common.future import ustr
+
 import azurelinuxagent.common.utils.fileutil as fileutil
+from azurelinuxagent.common.future import ustr
+from tests.tools import *
+
 
 class TestFileOperations(AgentTestCase):
 
@@ -116,6 +115,64 @@ class TestFileOperations(AgentTestCase):
         actual_files = fileutil.get_all_files(self.tmp_dir)
 
         self.assertEqual(set(expected_files), set(actual_files))
+
+    @patch('os.path.isfile')
+    def test_update_conf_file(self, _):
+        new_file = "\
+DEVICE=eth0\n\
+ONBOOT=yes\n\
+BOOTPROTO=dhcp\n\
+TYPE=Ethernet\n\
+USERCTL=no\n\
+PEERDNS=yes\n\
+IPV6INIT=no\n\
+NM_CONTROLLED=yes\n"
+
+        existing_file = "\
+DEVICE=eth0\n\
+ONBOOT=yes\n\
+BOOTPROTO=dhcp\n\
+TYPE=Ethernet\n\
+DHCP_HOSTNAME=existing\n\
+USERCTL=no\n\
+PEERDNS=yes\n\
+IPV6INIT=no\n\
+NM_CONTROLLED=yes\n"
+
+        bad_file = "\
+DEVICE=eth0\n\
+ONBOOT=yes\n\
+BOOTPROTO=dhcp\n\
+TYPE=Ethernet\n\
+USERCTL=no\n\
+PEERDNS=yes\n\
+IPV6INIT=no\n\
+NM_CONTROLLED=yes\n\
+DHCP_HOSTNAME=no_new_line"
+
+        updated_file = "\
+DEVICE=eth0\n\
+ONBOOT=yes\n\
+BOOTPROTO=dhcp\n\
+TYPE=Ethernet\n\
+USERCTL=no\n\
+PEERDNS=yes\n\
+IPV6INIT=no\n\
+NM_CONTROLLED=yes\n\
+DHCP_HOSTNAME=test\n"
+
+        path = 'path'
+        with patch.object(fileutil, 'write_file') as patch_write, patch.object(fileutil, 'read_file', return_value=new_file):
+                fileutil.update_conf_file(path, 'DHCP_HOSTNAME', 'DHCP_HOSTNAME=test')
+                patch_write.assert_called_once_with(path, updated_file)
+
+        with patch.object(fileutil, 'write_file') as patch_write, patch.object(fileutil, 'read_file', return_value=existing_file):
+                fileutil.update_conf_file(path, 'DHCP_HOSTNAME', 'DHCP_HOSTNAME=test')
+                patch_write.assert_called_once_with(path, updated_file)
+
+        with patch.object(fileutil, 'write_file') as patch_write, patch.object(fileutil, 'read_file', return_value=bad_file):
+                fileutil.update_conf_file(path, 'DHCP_HOSTNAME', 'DHCP_HOSTNAME=test')
+                patch_write.assert_called_once_with(path, updated_file)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/utils/test_file_util.py
+++ b/tests/utils/test_file_util.py
@@ -162,15 +162,18 @@ NM_CONTROLLED=yes\n\
 DHCP_HOSTNAME=test\n"
 
         path = 'path'
-        with patch.object(fileutil, 'write_file') as patch_write, patch.object(fileutil, 'read_file', return_value=new_file):
+        with patch.object(fileutil, 'write_file') as patch_write:
+            with patch.object(fileutil, 'read_file', return_value=new_file):
                 fileutil.update_conf_file(path, 'DHCP_HOSTNAME', 'DHCP_HOSTNAME=test')
                 patch_write.assert_called_once_with(path, updated_file)
 
-        with patch.object(fileutil, 'write_file') as patch_write, patch.object(fileutil, 'read_file', return_value=existing_file):
+        with patch.object(fileutil, 'write_file') as patch_write:
+            with patch.object(fileutil, 'read_file', return_value=existing_file):
                 fileutil.update_conf_file(path, 'DHCP_HOSTNAME', 'DHCP_HOSTNAME=test')
                 patch_write.assert_called_once_with(path, updated_file)
 
-        with patch.object(fileutil, 'write_file') as patch_write, patch.object(fileutil, 'read_file', return_value=bad_file):
+        with patch.object(fileutil, 'write_file') as patch_write:
+            with patch.object(fileutil, 'read_file', return_value=bad_file):
                 fileutil.update_conf_file(path, 'DHCP_HOSTNAME', 'DHCP_HOSTNAME=test')
                 patch_write.assert_called_once_with(path, updated_file)
 


### PR DESCRIPTION
In `fileutil.update_conf_file` we do not append a final newline, which can cause values to become unreadable. Also, when updating a value, we can potentially add multiple newline characters. This change addresses both cases.

- fixes #538 

/cc @brendandixon @jinhyunr 