### PR TITLE
Add support for Match blocks in sshd config

### DIFF
--- a/azurelinuxagent/common/utils/textutil.py
+++ b/azurelinuxagent/common/utils/textutil.py
@@ -229,8 +229,8 @@ def set_ssh_config(config, name, val):
         if config[i].startswith(name) and match_start == no_match:
             config[i] = "{0} {1}".format(name, val)
             found = True
-        elif config[i].startswith("Match"):
-            if config[i].startswith("Match all"):
+        elif config[i].lower().startswith("match"):
+            if config[i].lower().startswith("match all"):
                 # outside match block
                 match_start = no_match
             elif match_start == no_match:

--- a/azurelinuxagent/common/utils/textutil.py
+++ b/azurelinuxagent/common/utils/textutil.py
@@ -221,15 +221,24 @@ def hexstr_to_bytearray(a):
 
 
 def set_ssh_config(config, name, val):
-    notfound = True
+    found = False
+    no_match = -1
+
+    match_start = no_match
     for i in range(0, len(config)):
-        if config[i].startswith(name):
+        if config[i].startswith(name) and match_start == no_match:
             config[i] = "{0} {1}".format(name, val)
-            notfound = False
+            found = True
         elif config[i].startswith("Match"):
-            # Match block must be put in the end of sshd config
-            break
-    if notfound:
+            if config[i].startswith("Match all"):
+                # outside match block
+                match_start = no_match
+            elif match_start == no_match:
+                # inside match block
+                match_start = i
+    if not found:
+        if match_start != no_match:
+            i = match_start
         config.insert(i, "{0} {1}".format(name, val))
     return config
 

--- a/tests/common/osutil/test_default.py
+++ b/tests/common/osutil/test_default.py
@@ -21,6 +21,7 @@ import mock
 import azurelinuxagent.common.osutil.default as osutil
 import azurelinuxagent.common.utils.shellutil as shellutil
 from azurelinuxagent.common.osutil import get_osutil
+from azurelinuxagent.common.utils import fileutil
 from tests.tools import *
 
 
@@ -163,6 +164,51 @@ class TestOSUtil(AgentTestCase):
             self.assertEqual(int(ret[1]), get_osutil().get_processor_cores())
         else:
             self.fail("Cannot retrieve number of process cores using shell command.")
+
+    def test_conf_sshd(self):
+        new_file = "\
+Port 22\n\
+Protocol 2\n\
+ChallengeResponseAuthentication yes\n\
+#PasswordAuthentication yes\n\
+UsePAM yes\n\
+"
+        expected_output = "\
+Port 22\n\
+Protocol 2\n\
+ChallengeResponseAuthentication no\n\
+#PasswordAuthentication yes\n\
+UsePAM yes\n\
+PasswordAuthentication no\n\
+ClientAliveInterval 180\n\
+"
+
+        with patch.object(fileutil, 'write_file') as patch_write:
+            with patch.object(fileutil, 'read_file', return_value=new_file):
+                osutil.DefaultOSUtil().conf_sshd(disable_password=True)
+                patch_write.assert_called_once_with(conf.get_sshd_conf_file_path(),
+                                                    expected_output)
+    def test_conf_sshd_with_match(self):
+        new_file = "\
+Port 22\n\
+ChallengeResponseAuthentication yes\n\
+Match host 192.168.1.1\n\
+  ChallengeResponseAuthentication yes\n\
+"
+        expected_output = "\
+Port 22\n\
+ChallengeResponseAuthentication no\n\
+PasswordAuthentication no\n\
+ClientAliveInterval 180\n\
+Match host 192.168.1.1\n\
+  ChallengeResponseAuthentication yes\n\
+"
+
+        with patch.object(fileutil, 'write_file') as patch_write:
+            with patch.object(fileutil, 'read_file', return_value=new_file):
+                osutil.DefaultOSUtil().conf_sshd(disable_password=True)
+                patch_write.assert_called_once_with(conf.get_sshd_conf_file_path(),
+                                                    expected_output)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/common/osutil/test_default.py
+++ b/tests/common/osutil/test_default.py
@@ -238,16 +238,16 @@ Match host 192.168.1.1\n\
     def test_conf_sshd_with_match_middle(self):
         new_file = "\
 Port 22\n\
-Match host 192.168.1.1\n\
+match host 192.168.1.1\n\
   ChallengeResponseAuthentication yes\n\
-Match all\n\
+match all\n\
 #Other config\n\
 "
         expected_output = "\
 Port 22\n\
-Match host 192.168.1.1\n\
+match host 192.168.1.1\n\
   ChallengeResponseAuthentication yes\n\
-Match all\n\
+match all\n\
 #Other config\n\
 PasswordAuthentication no\n\
 ChallengeResponseAuthentication no\n\

--- a/tests/common/osutil/test_default.py
+++ b/tests/common/osutil/test_default.py
@@ -186,8 +186,10 @@ ClientAliveInterval 180\n\
         with patch.object(fileutil, 'write_file') as patch_write:
             with patch.object(fileutil, 'read_file', return_value=new_file):
                 osutil.DefaultOSUtil().conf_sshd(disable_password=True)
-                patch_write.assert_called_once_with(conf.get_sshd_conf_file_path(),
-                                                    expected_output)
+                patch_write.assert_called_once_with(
+                    conf.get_sshd_conf_file_path(),
+                    expected_output)
+
     def test_conf_sshd_with_match(self):
         new_file = "\
 Port 22\n\
@@ -207,8 +209,111 @@ Match host 192.168.1.1\n\
         with patch.object(fileutil, 'write_file') as patch_write:
             with patch.object(fileutil, 'read_file', return_value=new_file):
                 osutil.DefaultOSUtil().conf_sshd(disable_password=True)
-                patch_write.assert_called_once_with(conf.get_sshd_conf_file_path(),
-                                                    expected_output)
+                patch_write.assert_called_once_with(
+                    conf.get_sshd_conf_file_path(),
+                    expected_output)
+
+    def test_conf_sshd_with_match_last(self):
+        new_file = "\
+Port 22\n\
+Match host 192.168.1.1\n\
+  ChallengeResponseAuthentication yes\n\
+"
+        expected_output = "\
+Port 22\n\
+PasswordAuthentication no\n\
+ChallengeResponseAuthentication no\n\
+ClientAliveInterval 180\n\
+Match host 192.168.1.1\n\
+  ChallengeResponseAuthentication yes\n\
+"
+
+        with patch.object(fileutil, 'write_file') as patch_write:
+            with patch.object(fileutil, 'read_file', return_value=new_file):
+                osutil.DefaultOSUtil().conf_sshd(disable_password=True)
+                patch_write.assert_called_once_with(
+                    conf.get_sshd_conf_file_path(),
+                    expected_output)
+
+    def test_conf_sshd_with_match_middle(self):
+        new_file = "\
+Port 22\n\
+Match host 192.168.1.1\n\
+  ChallengeResponseAuthentication yes\n\
+Match all\n\
+#Other config\n\
+"
+        expected_output = "\
+Port 22\n\
+Match host 192.168.1.1\n\
+  ChallengeResponseAuthentication yes\n\
+Match all\n\
+#Other config\n\
+PasswordAuthentication no\n\
+ChallengeResponseAuthentication no\n\
+ClientAliveInterval 180\n\
+"
+
+        with patch.object(fileutil, 'write_file') as patch_write:
+            with patch.object(fileutil, 'read_file', return_value=new_file):
+                osutil.DefaultOSUtil().conf_sshd(disable_password=True)
+                patch_write.assert_called_once_with(
+                    conf.get_sshd_conf_file_path(),
+                    expected_output)
+
+    def test_conf_sshd_with_match_multiple(self):
+        new_file = "\
+Port 22\n\
+Match host 192.168.1.1\n\
+  ChallengeResponseAuthentication yes\n\
+Match host 192.168.1.2\n\
+  ChallengeResponseAuthentication yes\n\
+Match all\n\
+#Other config\n\
+"
+        expected_output = "\
+Port 22\n\
+Match host 192.168.1.1\n\
+  ChallengeResponseAuthentication yes\n\
+Match host 192.168.1.2\n\
+  ChallengeResponseAuthentication yes\n\
+Match all\n\
+#Other config\n\
+PasswordAuthentication no\n\
+ChallengeResponseAuthentication no\n\
+ClientAliveInterval 180\n\
+"
+
+        with patch.object(fileutil, 'write_file') as patch_write:
+            with patch.object(fileutil, 'read_file', return_value=new_file):
+                osutil.DefaultOSUtil().conf_sshd(disable_password=True)
+                patch_write.assert_called_once_with(
+                    conf.get_sshd_conf_file_path(),
+                    expected_output)
+
+    def test_conf_sshd_with_match_multiple_first_last(self):
+        new_file = "\
+Match host 192.168.1.1\n\
+  ChallengeResponseAuthentication yes\n\
+Match host 192.168.1.2\n\
+  ChallengeResponseAuthentication yes\n\
+"
+        expected_output = "\
+PasswordAuthentication no\n\
+ChallengeResponseAuthentication no\n\
+ClientAliveInterval 180\n\
+Match host 192.168.1.1\n\
+  ChallengeResponseAuthentication yes\n\
+Match host 192.168.1.2\n\
+  ChallengeResponseAuthentication yes\n\
+"
+
+        with patch.object(fileutil, 'write_file') as patch_write:
+            with patch.object(fileutil, 'read_file', return_value=new_file):
+                osutil.DefaultOSUtil().conf_sshd(disable_password=True)
+                patch_write.assert_called_once_with(
+                    conf.get_sshd_conf_file_path(),
+                    expected_output)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
We do not support `Match` blocks in sshd config, and if they occur anywhere but the end of the file, we can potentially break the config rules. In addition, we do not have unit tests for conf_sshd. These ensure the correct behavior.

- fixes #544 

/cc @jinhyunr @brendandixon 