### PR TITLE
Instead of adding values in sysinfo directly to event, if a value

### DIFF
--- a/azurelinuxagent/ga/monitor.py
+++ b/azurelinuxagent/ga/monitor.py
@@ -162,7 +162,7 @@ class MonitorHandler(object):
 
             try:
                 event = parse_event(data_str)
-                event.parameters.extend(self.sysinfo)
+                self.add_sysinfo(event)
                 event_list.events.append(event)
             except (ValueError, ProtocolError) as e:
                 logger.warn("Failed to decode event file: {0}", e)
@@ -193,3 +193,13 @@ class MonitorHandler(object):
             except Exception as e:
                 logger.warn("Failed to send events: {0}", e)
             time.sleep(60)
+
+    def add_sysinfo(self, event):
+        event_param_dict = {}  # key: TelemetryEventParam.name, val: idx of the EventParam in event.parameters
+        for i in range(len(event.parameters)):
+            event_param_dict[event.parameters[i].name] = i
+        for e in self.sysinfo:
+            if e.name in event_param_dict:
+                event.parameters[event_param_dict[e.name]] = e
+            else:
+                event.parameters.append(e)

--- a/azurelinuxagent/ga/monitor.py
+++ b/azurelinuxagent/ga/monitor.py
@@ -195,11 +195,9 @@ class MonitorHandler(object):
             time.sleep(60)
 
     def add_sysinfo(self, event):
-        event_param_dict = {}  # key: TelemetryEventParam.name, val: idx of the EventParam in event.parameters
-        for i in range(len(event.parameters)):
-            event_param_dict[event.parameters[i].name] = i
-        for e in self.sysinfo:
-            if e.name in event_param_dict:
-                event.parameters[event_param_dict[e.name]] = e
-            else:
-                event.parameters.append(e)
+        sysinfo_names = [v.name for v in self.sysinfo]
+        for param in event.parameters:
+            if param.name in sysinfo_names:
+                logger.verbose("Remove existing event parameter: [{0}:{1}]", param.name, param.value)
+                event.parameters.remove(param)
+        event.parameters.extend(self.sysinfo)

--- a/tests/ga/test_monitor.py
+++ b/tests/ga/test_monitor.py
@@ -16,7 +16,6 @@
 #
 
 from tests.tools import *
-from azurelinuxagent.common.exception import *
 from azurelinuxagent.ga.monitor import *
 
 class TestMonitor(AgentTestCase):
@@ -27,3 +26,52 @@ class TestMonitor(AgentTestCase):
         self.assertNotEquals(0, event.parameters)
         self.assertNotEquals(None, event.parameters[0])
 
+    @patch('azurelinuxagent.common.osutil.get_osutil')
+    @patch('azurelinuxagent.common.protocol.get_protocol_util')
+    def test_add_sysinfo(self, _, __):
+        data_str = load_data('ext/event.xml')
+        event = parse_xml_event(data_str)
+        monitor_handler = get_monitor_handler()
+
+        vm_name = 'dummy_vm'
+        tenant_name = 'dummy_tenant'
+        role_name = 'dummy_role'
+        role_instance_name = 'dummy_role_instance'
+        container_id = 'dummy_container_id'
+
+        vm_name_param = "VMName"
+        tenant_name_param = "TenantName"
+        role_name_param = "RoleName"
+        role_instance_name_param = "RoleInstanceName"
+        container_id_param = "ContainerId"
+
+        sysinfo = [TelemetryEventParam(vm_name_param, vm_name),
+                   TelemetryEventParam(tenant_name_param, tenant_name),
+                   TelemetryEventParam(role_name_param, role_name),
+                   TelemetryEventParam(role_instance_name_param, role_instance_name),
+                   TelemetryEventParam(container_id_param, container_id)]
+        monitor_handler.sysinfo = sysinfo
+        monitor_handler.add_sysinfo(event)
+
+        self.assertNotEquals(None, event)
+        self.assertNotEquals(0, event.parameters)
+        self.assertNotEquals(None, event.parameters[0])
+        counter = 0
+        for p in event.parameters:
+            if p.name == vm_name_param:
+                self.assertEquals(vm_name, p.value)
+                counter += 1
+            elif p.name == tenant_name_param:
+                self.assertEquals(tenant_name, p.value)
+                counter += 1
+            elif p.name == role_name_param:
+                self.assertEquals(role_name, p.value)
+                counter += 1
+            elif p.name == role_instance_name_param:
+                self.assertEquals(role_instance_name, p.value)
+                counter += 1
+            elif p.name == container_id_param:
+                self.assertEquals(container_id, p.value)
+                counter += 1
+
+        self.assertEquals(5, counter)


### PR DESCRIPTION
already exist in the event, overwrite it to prevent duplicates.

This fixes #520.