### PR TITLE
Add telemetry event for host plugin usage

### DIFF
--- a/azurelinuxagent/common/event.py
+++ b/azurelinuxagent/common/event.py
@@ -44,6 +44,7 @@ class WALAEventOperation:
     HealthCheck = "HealthCheck"
     HeartBeat = "HeartBeat"
     Install = "Install"
+    InitializeHostPlugin = "InitializeHostPlugin"
     Provision = "Provision"
     Restart = "Restart"
     UnhandledError = "UnhandledError"

--- a/azurelinuxagent/common/event.py
+++ b/azurelinuxagent/common/event.py
@@ -28,28 +28,29 @@ import azurelinuxagent.common.logger as logger
 from azurelinuxagent.common.exception import EventError, ProtocolError
 from azurelinuxagent.common.future import ustr
 from azurelinuxagent.common.protocol.restapi import TelemetryEventParam, \
-                                             TelemetryEventList, \
-                                             TelemetryEvent, \
-                                             set_properties, get_properties
+    TelemetryEventList, \
+    TelemetryEvent, \
+    set_properties, get_properties
 from azurelinuxagent.common.version import DISTRO_NAME, DISTRO_VERSION, \
-                                     DISTRO_CODE_NAME, AGENT_VERSION, \
-                                     CURRENT_AGENT, CURRENT_VERSION
+    DISTRO_CODE_NAME, AGENT_VERSION, \
+    CURRENT_AGENT, CURRENT_VERSION
 
 
 class WALAEventOperation:
-    ActivateResourceDisk="ActivateResourceDisk"
+    ActivateResourceDisk = "ActivateResourceDisk"
     Disable = "Disable"
     Download = "Download"
     Enable = "Enable"
     HealthCheck = "HealthCheck"
-    HeartBeat="HeartBeat"
+    HeartBeat = "HeartBeat"
     Install = "Install"
     Provision = "Provision"
-    Restart="Restart"
-    UnhandledError="UnhandledError"
+    Restart = "Restart"
+    UnhandledError = "UnhandledError"
     UnInstall = "UnInstall"
     Upgrade = "Upgrade"
     Update = "Update"
+
 
 class EventLogger(object):
     def __init__(self):
@@ -66,22 +67,24 @@ class EventLogger(object):
         if len(os.listdir(self.event_dir)) > 1000:
             raise EventError("Too many files under: {0}".format(self.event_dir))
 
-        filename = os.path.join(self.event_dir, ustr(int(time.time()*1000000)))
+        filename = os.path.join(self.event_dir,
+                                ustr(int(time.time() * 1000000)))
         try:
-            with open(filename+".tmp",'wb+') as hfile:
+            with open(filename + ".tmp", 'wb+') as hfile:
                 hfile.write(data.encode("utf-8"))
-            os.rename(filename+".tmp", filename+".tld")
+            os.rename(filename + ".tmp", filename + ".tld")
         except IOError as e:
             raise EventError("Failed to write events to file:{0}", e)
 
-    def add_event(self, name, op="", is_success=True, duration=0, version=CURRENT_VERSION,
+    def add_event(self, name, op="", is_success=True, duration=0,
+                  version=CURRENT_VERSION,
                   message="", evt_type="", is_internal=False):
         event = TelemetryEvent(1, "69B669B9-4AF8-4C50-BDC4-6006FA76E975")
         event.parameters.append(TelemetryEventParam('Name', name))
         event.parameters.append(TelemetryEventParam('Version', str(version)))
         event.parameters.append(TelemetryEventParam('IsInternal', is_internal))
         event.parameters.append(TelemetryEventParam('Operation', op))
-        event.parameters.append(TelemetryEventParam('OperationSuccess', 
+        event.parameters.append(TelemetryEventParam('OperationSuccess',
                                                     is_success))
         event.parameters.append(TelemetryEventParam('Message', message))
         event.parameters.append(TelemetryEventParam('Duration', duration))
@@ -93,7 +96,9 @@ class EventLogger(object):
         except EventError as e:
             logger.error("{0}", e)
 
+
 __event_logger__ = EventLogger()
+
 
 def add_event(name, op="", is_success=True, duration=0, version=CURRENT_VERSION,
               message="", evt_type="", is_internal=False,
@@ -108,8 +113,10 @@ def add_event(name, op="", is_success=True, duration=0, version=CURRENT_VERSION,
                        version=str(version), message=message, evt_type=evt_type,
                        is_internal=is_internal)
 
+
 def init_event_logger(event_dir, reporter=__event_logger__):
     reporter.event_dir = event_dir
+
 
 def dump_unhandled_err(name):
     if hasattr(sys, 'last_type') and hasattr(sys, 'last_value') and \
@@ -119,9 +126,10 @@ def dump_unhandled_err(name):
         last_traceback = getattr(sys, 'last_traceback')
         error = traceback.format_exception(last_type, last_value,
                                            last_traceback)
-        message= "".join(error)
+        message = "".join(error)
         add_event(name, is_success=False, message=message,
                   op=WALAEventOperation.UnhandledError)
+
 
 def enable_unhandled_err_dump(name):
     atexit.register(dump_unhandled_err, name)

--- a/azurelinuxagent/common/protocol/hostplugin.py
+++ b/azurelinuxagent/common/protocol/hostplugin.py
@@ -16,7 +16,6 @@
 #
 # Requires Python 2.4+ and Openssl 1.0+
 #
-from azurelinuxagent.common.event import *
 from azurelinuxagent.common.protocol.wire import *
 from azurelinuxagent.common.utils import textutil
 
@@ -51,6 +50,8 @@ class HostPluginProtocol(object):
             self.api_versions = self.get_api_versions()
             self.is_available = API_VERSION in self.api_versions
             self.is_initialized = True
+
+            from azurelinuxagent.common.event import add_event, WALAEventOperation
             add_event(name="WALA",
                       op=WALAEventOperation.InitializeHostPlugin,
                       is_success=self.is_available)

--- a/azurelinuxagent/daemon/main.py
+++ b/azurelinuxagent/daemon/main.py
@@ -23,34 +23,32 @@ import time
 import traceback
 
 import azurelinuxagent.common.conf as conf
-import azurelinuxagent.common.event as event
-import azurelinuxagent.common.utils.fileutil as fileutil
 import azurelinuxagent.common.logger as logger
-
-from azurelinuxagent.common.future import ustr
+import azurelinuxagent.common.utils.fileutil as fileutil
 from azurelinuxagent.common.event import add_event, WALAEventOperation
-from azurelinuxagent.common.exception import ProtocolError
+from azurelinuxagent.common.future import ustr
 from azurelinuxagent.common.osutil import get_osutil
 from azurelinuxagent.common.protocol import get_protocol_util
-from azurelinuxagent.common.rdma import RDMADeviceHandler, setup_rdma_device
-from azurelinuxagent.common.utils.textutil import parse_doc, find, getattrib
+from azurelinuxagent.common.rdma import setup_rdma_device
 from azurelinuxagent.common.version import AGENT_LONG_NAME, AGENT_VERSION, \
-                                     DISTRO_NAME, DISTRO_VERSION, \
-                                     DISTRO_FULL_NAME, PY_VERSION_MAJOR, \
-                                     PY_VERSION_MINOR, PY_VERSION_MICRO
+    DISTRO_NAME, DISTRO_VERSION, PY_VERSION_MAJOR, PY_VERSION_MINOR, \
+    PY_VERSION_MICRO
 from azurelinuxagent.daemon.resourcedisk import get_resourcedisk_handler
 from azurelinuxagent.daemon.scvmm import get_scvmm_handler
+from azurelinuxagent.ga.update import get_update_handler
 from azurelinuxagent.pa.provision import get_provision_handler
 from azurelinuxagent.pa.rdma import get_rdma_handler
-from azurelinuxagent.ga.update import get_update_handler
+
 
 def get_daemon_handler():
     return DaemonHandler()
+
 
 class DaemonHandler(object):
     """
     Main thread of daemon. It will invoke other threads to do actual work
     """
+
     def __init__(self):
         self.running = True
         self.osutil = get_osutil()
@@ -59,7 +57,7 @@ class DaemonHandler(object):
         logger.info("{0} Version:{1}", AGENT_LONG_NAME, AGENT_VERSION)
         logger.info("OS: {0} {1}", DISTRO_NAME, DISTRO_VERSION)
         logger.info("Python: {0}.{1}.{2}", PY_VERSION_MAJOR, PY_VERSION_MINOR,
-            PY_VERSION_MICRO)
+                    PY_VERSION_MICRO)
 
         self.check_pid()
 
@@ -68,11 +66,10 @@ class DaemonHandler(object):
                 self.daemon()
             except Exception as e:
                 err_msg = traceback.format_exc()
-                add_event("WALA", is_success=False, message=ustr(err_msg), 
+                add_event("WALA", is_success=False, message=ustr(err_msg),
                           op=WALAEventOperation.UnhandledError)
                 logger.info("Sleep 15 seconds and restart daemon")
                 time.sleep(15)
-
 
     def check_pid(self):
         """Check whether daemon is already running"""
@@ -84,11 +81,11 @@ class DaemonHandler(object):
         if self.osutil.check_pid_alive(pid):
             logger.info("Daemon is already running: {0}", pid)
             sys.exit(0)
-            
+
         fileutil.write_file(pid_file, ustr(os.getpid()))
 
     def daemon(self):
-        logger.info("Run daemon") 
+        logger.info("Run daemon")
 
         self.protocol_util = get_protocol_util()
         self.scvmm_handler = get_scvmm_handler()
@@ -125,6 +122,6 @@ class DaemonHandler(object):
                 logger.error("Error setting up rdma device: %s" % e)
         else:
             logger.info("RDMA capabilities are not enabled, skipping")
-        
+
         while self.running:
             self.update_handler.run_latest()

--- a/azurelinuxagent/ga/monitor.py
+++ b/azurelinuxagent/ga/monitor.py
@@ -25,7 +25,7 @@ import threading
 import azurelinuxagent.common.conf as conf
 import azurelinuxagent.common.logger as logger
 
-from azurelinuxagent.common.event import WALAEventOperation, add_event
+from azurelinuxagent.common.event import add_event, WALAEventOperation
 from azurelinuxagent.common.exception import EventError, ProtocolError, OSUtilError
 from azurelinuxagent.common.future import ustr
 from azurelinuxagent.common.osutil import get_osutil

--- a/azurelinuxagent/ga/monitor.py
+++ b/azurelinuxagent/ga/monitor.py
@@ -198,6 +198,8 @@ class MonitorHandler(object):
         sysinfo_names = [v.name for v in self.sysinfo]
         for param in event.parameters:
             if param.name in sysinfo_names:
-                logger.verbose("Remove existing event parameter: [{0}:{1}]", param.name, param.value)
+                logger.verbose("Remove existing event parameter: [{0}:{1}]",
+                               param.name,
+                               param.value)
                 event.parameters.remove(param)
         event.parameters.extend(self.sysinfo)

--- a/azurelinuxagent/pa/provision/ubuntu.py
+++ b/azurelinuxagent/pa/provision/ubuntu.py
@@ -19,14 +19,12 @@
 
 import os
 import time
-import azurelinuxagent.common.logger as logger
-from azurelinuxagent.common.future import ustr
+
 import azurelinuxagent.common.conf as conf
-import azurelinuxagent.common.protocol.ovfenv as ovfenv
-from azurelinuxagent.common.event import add_event, WALAEventOperation
-from azurelinuxagent.common.exception import ProvisionError, ProtocolError
-import azurelinuxagent.common.utils.shellutil as shellutil
+import azurelinuxagent.common.logger as logger
 import azurelinuxagent.common.utils.fileutil as fileutil
+from azurelinuxagent.common.exception import ProvisionError, ProtocolError
+from azurelinuxagent.common.future import ustr
 from azurelinuxagent.pa.provision.default import ProvisionHandler
 
 """

--- a/tests/common/test_version.py
+++ b/tests/common/test_version.py
@@ -17,29 +17,13 @@
 
 from __future__ import print_function
 
-import copy
-import glob
-import json
-import mock
-import os
-import platform
-import random
-import subprocess
-import sys
-import tempfile
 import textwrap
-import zipfile
 
-from tests.protocol.mockwiredata import *
-from tests.tools import *
+import mock
 
-import azurelinuxagent.common.conf as conf
-import azurelinuxagent.common.logger as logger
-import azurelinuxagent.common.utils.fileutil as fileutil
 import azurelinuxagent.common.version as version
-
-from azurelinuxagent.common.utils.flexible_version import FlexibleVersion
 from azurelinuxagent.common.version import *
+from tests.tools import *
 
 
 class TestCurrentAgentName(AgentTestCase):

--- a/tests/daemon/test_daemon.py
+++ b/tests/daemon/test_daemon.py
@@ -15,9 +15,9 @@
 # Requires Python 2.4+ and Openssl 1.0+
 #
 
-from tests.tools import *
-from azurelinuxagent.common.exception import *
 from azurelinuxagent.daemon import *
+from tests.tools import *
+
 
 class MockDaemonCall(object):
     def __init__(self, daemon_handler, count):

--- a/tests/distro/test_resourceDisk.py
+++ b/tests/distro/test_resourceDisk.py
@@ -18,6 +18,7 @@
 # http://msdn.microsoft.com/en-us/library/cc227282%28PROT.10%29.aspx
 # http://msdn.microsoft.com/en-us/library/cc227259%28PROT.13%29.aspx
 
+import sys
 from azurelinuxagent.common.utils import shellutil
 from azurelinuxagent.daemon.resourcedisk import get_resourcedisk_handler
 from tests.tools import *

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -19,18 +19,14 @@
 Define util functions for unit test
 """
 
-import json
 import os
 import re
 import shutil
-import sys
 import tempfile
 import unittest
-
 from functools import wraps
 
 import azurelinuxagent.common.conf as conf
-import azurelinuxagent.common.event as event
 import azurelinuxagent.common.logger as logger
 from azurelinuxagent.common.version import PY_VERSION_MAJOR
 


### PR DESCRIPTION
We need some way of determining how frequently the host plugin is being used without sending telemetry on every request. This change adds a new event when we initialize the host plugin, which happens only on usage, and only once (until restart). We can fine tune as needed.

- add new telemetry event
- minor cleanup and reformatting
- fixes #557 

/cc @boumenot @brendandixon @jinhyunr 