### PR TITLE
Handle ExtensionErrors from decide_version

### DIFF
--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -209,18 +209,18 @@ class ExtHandlersHandler(object):
     def handle_ext_handler(self, ext_handler, etag):
         ext_handler_i = ExtHandlerInstance(ext_handler, self.protocol)
 
-        ext_handler_i.decide_version()
-        if not ext_handler_i.is_upgrade and self.last_etag == etag:
-            if self.log_etag:
-                ext_handler_i.logger.verbose("Version {0} is current for etag {1}",
-                                             ext_handler_i.pkg.version,
-                                             etag)
-                self.log_etag = False
-            return
-
-        self.log_etag = True
-
         try:
+            ext_handler_i.decide_version()
+            if not ext_handler_i.is_upgrade and self.last_etag == etag:
+                if self.log_etag:
+                    ext_handler_i.logger.verbose("Version {0} is current for etag {1}",
+                                                 ext_handler_i.pkg.version,
+                                                 etag)
+                    self.log_etag = False
+                return
+
+            self.log_etag = True
+
             state = ext_handler.properties.state
             ext_handler_i.logger.info("Expected handler state: {0}", state)
             if state == "enabled":


### PR DESCRIPTION
When all downloads fail, `decide_version` will raise an `ExtensionError` which is currently uncaught:
```
2017/01/19 23:11:14.503656 ERROR Event: name=WALinuxAgent, op=Download, message=Unable to download Agent WALinuxAgent-2.2.2 from any URI
2017/01/19 23:15:40.048827 ERROR Event: name=WALinuxAgent, op=Enable, message=Agent WALinuxAgent-2.2.2 launched with command 'python3 -u /usr/sbin/waagent -run-exthandlers' failed with return code: 1
2017/01/19 23:15:40.543697 ERROR Event: name=WALinuxAgent, op=Restart, message=WALinuxAgent-2.2.2 did not terminate cleanly
```
We should be handling this so the process does not terminate.

/cc @brendandixon @jinhyunr 