### PR TITLE
CoreOS fix

### DIFF
--- a/azurelinuxagent/common/osutil/factory.py
+++ b/azurelinuxagent/common/osutil/factory.py
@@ -17,9 +17,7 @@
 
 import azurelinuxagent.common.logger as logger
 from azurelinuxagent.common.utils.textutil import Version
-from azurelinuxagent.common.version import DISTRO_NAME, DISTRO_VERSION, \
-                                     DISTRO_FULL_NAME
-
+from azurelinuxagent.common.version import *
 from .default import DefaultOSUtil
 from .clearlinux import ClearLinuxUtil
 from .coreos import CoreOSUtil
@@ -27,54 +25,65 @@ from .debian import DebianOSUtil
 from .freebsd import FreeBSDOSUtil
 from .redhat import RedhatOSUtil, Redhat6xOSUtil
 from .suse import SUSEOSUtil, SUSE11OSUtil
-from .ubuntu import UbuntuOSUtil, Ubuntu12OSUtil, Ubuntu14OSUtil, \
-                    UbuntuSnappyOSUtil
+from .ubuntu import UbuntuOSUtil, Ubuntu12OSUtil, Ubuntu14OSUtil, UbuntuSnappyOSUtil
 from .alpine import AlpineOSUtil
 from .bigip import BigIpOSUtil
 
-def get_osutil(distro_name=DISTRO_NAME, distro_version=DISTRO_VERSION,
+
+def get_osutil(distro_name=DISTRO_NAME,
+               distro_code_name=DISTRO_CODE_NAME,
+               distro_version=DISTRO_VERSION,
                distro_full_name=DISTRO_FULL_NAME):
+
     if distro_name == "clear linux software for intel architecture":
         return ClearLinuxUtil()
+
     if distro_name == "ubuntu":
-        if Version(distro_version) == Version("12.04") or \
-           Version(distro_version) == Version("12.10"):
+        if Version(distro_version) == Version("12.04") or Version(distro_version) == Version("12.10"):
             return Ubuntu12OSUtil()
-        elif Version(distro_version) == Version("14.04") or \
-             Version(distro_version) == Version("14.10"):
+        elif Version(distro_version) == Version("14.04") or Version(distro_version) == Version("14.10"):
             return Ubuntu14OSUtil()
         elif distro_full_name == "Snappy Ubuntu Core":
             return UbuntuSnappyOSUtil()
         else:
             return UbuntuOSUtil()
+
     if distro_name == "alpine":
         return AlpineOSUtil()
+
     if distro_name == "kali":
-        return DebianOSUtil()    
-    if distro_name == "coreos":
+        return DebianOSUtil()
+
+    if distro_name == "coreos" or distro_code_name == "coreos":
         return CoreOSUtil()
+
     if distro_name == "suse":
-        if distro_full_name=='SUSE Linux Enterprise Server' and \
-           Version(distro_version) < Version('12') or \
-           distro_full_name == 'openSUSE' and \
-           Version(distro_version) < Version('13.2'):
+        if distro_full_name == 'SUSE Linux Enterprise Server' \
+                and Version(distro_version) < Version('12') \
+                or distro_full_name == 'openSUSE' and Version(distro_version) < Version('13.2'):
             return SUSE11OSUtil()
         else:
             return SUSEOSUtil()
+
     elif distro_name == "debian":
         return DebianOSUtil()
-    elif distro_name == "redhat" or distro_name == "centos" or \
-            distro_name == "oracle":
+
+    elif distro_name == "redhat" \
+            or distro_name == "centos" \
+            or distro_name == "oracle":
         if Version(distro_version) < Version("7"):
             return Redhat6xOSUtil()
         else:
             return RedhatOSUtil()
+
     elif distro_name == "freebsd":
         return FreeBSDOSUtil()
+
     elif distro_name == "bigip":
         return BigIpOSUtil()
-    else:
-        logger.warn("Unable to load distro implementation for {0}.", distro_name)
-        logger.warn("Use default distro implementation instead.")
-        return DefaultOSUtil()
 
+    else:
+        logger.warn("Unable to load distro implementation for {0}. Using "
+                    "default distro implementation instead.",
+                    distro_name)
+        return DefaultOSUtil()

--- a/azurelinuxagent/common/version.py
+++ b/azurelinuxagent/common/version.py
@@ -26,13 +26,13 @@ from azurelinuxagent.common.utils.flexible_version import FlexibleVersion
 from azurelinuxagent.common.future import ustr
 
 
-"""
-Add this workaround for detecting F5 products because BIG-IP/IQ/etc do not show
-their version info in the /etc/product-version location. Instead, the version
-and product information is contained in the /VERSION file.
-"""
 def get_f5_platform():
-    result = [None,None,None,None]
+    """
+    Add this workaround for detecting F5 products because BIG-IP/IQ/etc do
+    not show their version info in the /etc/product-version location. Instead,
+    the version and product information is contained in the /VERSION file.
+    """
+    result = [None, None, None, None]
     f5_version = re.compile("^Version: (\d+\.\d+\.\d+)")
     f5_product = re.compile("^Product: ([\w-]+)")
 
@@ -56,13 +56,15 @@ def get_f5_platform():
                     result[2] = "iworkflow"
     return result
 
+
 def get_distro():
     if 'FreeBSD' in platform.system():
         release = re.sub('\-.*\Z', '', ustr(platform.release()))
         osinfo = ['freebsd', release, '', 'freebsd']
     elif 'linux_distribution' in dir(platform):
+        supported = platform._supported_dists + ('alpine',)
         osinfo = list(platform.linux_distribution(full_distribution_name=0,
-            supported_dists=platform._supported_dists+('alpine',)))
+                                                  supported_dists=supported))
         full_name = platform.linux_distribution()[0].strip()
         osinfo.append(full_name)
     else:
@@ -104,6 +106,7 @@ AGENT_DIR_PATTERN = re.compile(".*/{0}".format(AGENT_PATTERN))
 EXT_HANDLER_PATTERN = b".*/WALinuxAgent-(\w.\w.\w[.\w]*)-.*-run-exthandlers"
 EXT_HANDLER_REGEX = re.compile(EXT_HANDLER_PATTERN)
 
+
 # Set the CURRENT_AGENT and CURRENT_VERSION to match the agent directory name
 # - This ensures the agent will "see itself" using the same name and version
 #   as the code that downloads agents.
@@ -120,7 +123,10 @@ def set_current_agent():
         agent = AGENT_LONG_VERSION
         version = AGENT_VERSION
     return agent, FlexibleVersion(version)
+
+
 CURRENT_AGENT, CURRENT_VERSION = set_current_agent()
+
 
 def set_goal_state_agent():
     agent = None
@@ -137,7 +143,10 @@ def set_goal_state_agent():
     if agent is None:
         agent = CURRENT_VERSION
     return agent
+
+
 GOAL_STATE_AGENT_VERSION = set_goal_state_agent()
+
 
 def is_current_agent_installed():
     return CURRENT_AGENT == AGENT_LONG_VERSION
@@ -154,13 +163,12 @@ PY_VERSION_MAJOR = sys.version_info[0]
 PY_VERSION_MINOR = sys.version_info[1]
 PY_VERSION_MICRO = sys.version_info[2]
 
-"""
-Add this workaround for detecting Snappy Ubuntu Core temporarily, until ubuntu
-fixed this bug: https://bugs.launchpad.net/snappy/+bug/1481086
-"""
-
 
 def is_snappy():
+    """
+    Add this workaround for detecting Snappy Ubuntu Core temporarily,
+    until ubuntu fixed this bug: https://bugs.launchpad.net/snappy/+bug/1481086
+    """
     if os.path.exists("/etc/motd"):
         motd = fileutil.read_file("/etc/motd")
         if "snappy" in motd:
@@ -170,4 +178,3 @@ def is_snappy():
 
 if is_snappy():
     DISTRO_FULL_NAME = "Snappy Ubuntu Core"
-


### PR DESCRIPTION
- minor cleanup
- add `distro_code_name` which is populated from the `ID` field
- detect CoreOS via `distro_code_name`
- fixes #532 

/cc @jinhyunr @brendandixon @crawford 