### PR TITLE
NSG improvements

### DIFF
--- a/azurelinuxagent/common/protocol/hostplugin.py
+++ b/azurelinuxagent/common/protocol/hostplugin.py
@@ -127,7 +127,10 @@ class HostPluginProtocol(object):
                                'content': status}, sort_keys=True)
             response = restutil.http_put(url, data=data, headers=headers)
             if response.status != httpclient.OK:
-                logger.error("PUT failed [{0}]", response.status)
+                logger.warn("PUT {0} [{1}: {2}]",
+                            url,
+                            response.status,
+                            response.reason)
             else:
                 logger.verbose("Successfully uploaded status to host plugin")
         except Exception as e:

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -702,7 +702,7 @@ class GuestAgent(object):
                 break
             else:
                 if self.host is not None:
-                    logger.info("Download unsuccessful, falling back to host plugin")
+                    logger.warn("Download unsuccessful, falling back to host plugin")
                     uri, headers = self.host.get_artifact_request(uri.uri, self.host.manifest_uri)
                     if self._fetch(uri, headers=headers):
                         break
@@ -730,9 +730,9 @@ class GuestAgent(object):
                 logger.info(u"Agent {0} downloaded from {1}", self.name, uri)
         except restutil.HttpError as http_error:
             logger.verbose(u"Agent {0} download from {1} failed [{2}]",
-                        self.name,
-                        uri,
-                        http_error)
+                           self.name,
+                           uri,
+                           http_error)
         return package is not None
 
     def _load_error(self):


### PR DESCRIPTION
When deploying extension updates under a NSG, the goal state on disk can diverge from that in memory. When this happens for certain host plugin APIs we receive a 400 and log an error, though this is a transient state and eventually succeeds the next time we instantiate the protocol. 

Instead, we can shorten time to success by refreshing the goal state, and logging a warning since this state is transient.

/cc @jinhyunr @brendandixon 