### PR TITLE
fix del_root_password on FreeBSD

### DIFF
--- a/azurelinuxagent/common/osutil/freebsd.py
+++ b/azurelinuxagent/common/osutil/freebsd.py
@@ -77,7 +77,7 @@ class FreeBSDOSUtil(DefaultOSUtil):
                                "").format(username, output))
 
     def del_root_password(self):
-        err = shellutil.run('pw mod user root -w no')
+        err = shellutil.run('pw usermod root -h -')
         if err:
             raise OSUtilError("Failed to delete root password: Failed to update password database.")
 


### PR DESCRIPTION
We are not correctly disabling the root login when config is provided or at de-provisioning. 

- fixes #575 

/cc @jinhyunr @brendandixon 