### PR TITLE
Extension name in status file set by a extension publisher is not honored

### DIFF
--- a/azurelinuxagent/common/protocol/restapi.py
+++ b/azurelinuxagent/common/protocol/restapi.py
@@ -226,12 +226,14 @@ class ExtensionSubStatus(DataContract):
 
 class ExtensionStatus(DataContract):
     def __init__(self,
+                 name=None,
                  configurationAppliedTime=None,
                  operation=None,
                  status=None,
                  seq_no=None,
                  code=None,
                  message=None):
+        self.name = name
         self.configurationAppliedTime = configurationAppliedTime
         self.operation = operation
         self.status = status

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -274,14 +274,16 @@ def ext_substatus_to_v1(sub_status_list):
     return status_list
 
 
-def ext_status_to_v1(ext_name, ext_status):
+def ext_status_to_v1(ext_handler_name, ext_status):
     if ext_status is None:
         return None
     timestamp = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
     v1_sub_status = ext_substatus_to_v1(ext_status.substatusList)
+    if not ext_status.name:
+        ext_status.name = ext_handler_name
     v1_ext_status = {
         "status": {
-            "name": ext_name,
+            "name": ext_status.name,
             "configurationAppliedTime": ext_status.configurationAppliedTime,
             "operation": ext_status.operation,
             "status": ext_status.status,
@@ -314,9 +316,9 @@ def ext_handler_status_to_v1(handler_status, ext_statuses, timestamp):
 
     if len(handler_status.extensions) > 0:
         # Currently, no more than one extension per handler
-        ext_name = handler_status.extensions[0]
-        ext_status = ext_statuses.get(ext_name)
-        v1_ext_status = ext_status_to_v1(ext_name, ext_status)
+        ext_handler_name = handler_status.extensions[0]
+        ext_status = ext_statuses.get(ext_handler_name)
+        v1_ext_status = ext_status_to_v1(ext_handler_name, ext_status)
         if ext_status is not None and v1_ext_status is not None:
             v1_handler_status["runtimeSettingsStatus"] = {
                 'settingsStatus': v1_ext_status,

--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -101,6 +101,7 @@ def parse_ext_status(ext_status, data):
     ext_status.operation = status_data.get('operation')
     ext_status.status = status_data.get('status')
     ext_status.code = status_data.get('code', 0)
+    ext_status.name = status_data.get('name', None)
     formatted_message = status_data.get('formattedMessage')
     ext_status.message = parse_formatted_message(formatted_message)
     substatus_list = status_data.get('substatus')


### PR DESCRIPTION
Check if status file contains extension name.
a. If it does, honor the name
b. If it does not, use extension handler name instead

- fixes #580 

Added UT.