### PR TITLE
Fix cache-incarnation sync

### DIFF
--- a/azurelinuxagent/common/osutil/default.py
+++ b/azurelinuxagent/common/osutil/default.py
@@ -749,9 +749,16 @@ class DefaultOSUtil(object):
         fileutil.write_file(conf.get_published_hostname(), contents=hostname)
 
     def get_hostname_record(self):
-        record = None
-        if os.path.exists(conf.get_published_hostname()):
-            record = fileutil.read_file(conf.get_published_hostname())
+        hostname_record = conf.get_published_hostname()
+        if not os.path.exists(hostname_record):
+            # this file is created at provisioning time with agents >= 2.2.3
+            hostname = socket.gethostname()
+            logger.warn('Hostname record does not exist, '
+                        'creating [{0}] with hostname [{1}]',
+                        hostname_record,
+                        hostname)
+            self.set_hostname_record(hostname)
+        record = fileutil.read_file(hostname_record)
         return record
 
     def del_account(self, username):
@@ -765,7 +772,7 @@ class DefaultOSUtil(object):
         return base64.b64decode(data).decode('utf-8')
 
     def get_total_mem(self):
-        # Get total memory in bytes and divide by 1024**2 to get the valu in MB.
+        # Get total memory in bytes and divide by 1024**2 to get the value in MB.
         return os.sysconf('SC_PAGE_SIZE') * os.sysconf('SC_PHYS_PAGES') / (1024**2)
 
     def get_processor_cores(self):

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -736,11 +736,11 @@ class WireClient(object):
                 file_name = GOAL_STATE_FILE_NAME.format(goal_state.incarnation)
                 goal_state_file = os.path.join(conf.get_lib_dir(), file_name)
                 self.save_cache(goal_state_file, xml_text)
-                self.save_cache(incarnation_file, goal_state.incarnation)
                 self.update_hosting_env(goal_state)
                 self.update_shared_conf(goal_state)
                 self.update_certs(goal_state)
                 self.update_ext_conf(goal_state)
+                self.save_cache(incarnation_file, goal_state.incarnation)
                 if self.host_plugin is not None:
                     self.host_plugin.container_id = goal_state.container_id
                     self.host_plugin.role_config_name = goal_state.role_config_name

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -721,7 +721,7 @@ class WireClient(object):
 
         if not forced:
             last_incarnation = None
-            if (os.path.isfile(incarnation_file)):
+            if os.path.isfile(incarnation_file):
                 last_incarnation = fileutil.read_file(incarnation_file)
             new_incarnation = goal_state.incarnation
             if last_incarnation is not None and \

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -992,6 +992,7 @@ class WireClient(object):
             if force_update:
                 logger.warn("Forcing update of goal state")
                 self.goal_state = None
+                self.update_goal_state(forced=True)
             goal_state = self.get_goal_state()
             self.host_plugin = HostPluginProtocol(self.endpoint,
                                                   goal_state.container_id,

--- a/azurelinuxagent/common/utils/restutil.py
+++ b/azurelinuxagent/common/utils/restutil.py
@@ -86,7 +86,7 @@ def _http_request(method, host, rel_uri, port=None, data=None, secure=False,
                                              timeout=10)
             url = rel_uri
 
-    logger.verbose("HTTPConnection [{0}] [{1}] [{2}] [{3}]",
+    logger.verbose("HTTP connection [{0}] [{1}] [{2}] [{3}]",
                    method,
                    url,
                    data,
@@ -128,13 +128,6 @@ def http_request(method, url, data, headers=None, max_retry=3,
                         "(new in python 2.7)")
             secure_warning = False
 
-    logger.verbose("HTTP method: [{0}]", method)
-    logger.verbose("HTTP host: [{0}]", host)
-    logger.verbose("HTTP uri: [{0}]", rel_uri)
-    logger.verbose("HTTP port: [{0}]", port)
-    logger.verbose("HTTP data: [{0}]", data)
-    logger.verbose("HTTP secure: [{0}]", secure)
-    logger.verbose("HTTP headers: [{0}]", headers)
     logger.verbose("HTTP proxy: [{0}:{1}]", proxy_host, proxy_port)
 
     retry_msg = ''

--- a/azurelinuxagent/common/utils/restutil.py
+++ b/azurelinuxagent/common/utils/restutil.py
@@ -128,7 +128,8 @@ def http_request(method, url, data, headers=None, max_retry=3,
                         "(new in python 2.7)")
             secure_warning = False
 
-    logger.verbose("HTTP proxy: [{0}:{1}]", proxy_host, proxy_port)
+    if proxy_host or proxy_port:
+        logger.verbose("HTTP proxy: [{0}:{1}]", proxy_host, proxy_port)
 
     retry_msg = ''
     log_msg = "HTTP {0}".format(method)

--- a/azurelinuxagent/common/version.py
+++ b/azurelinuxagent/common/version.py
@@ -88,7 +88,7 @@ def get_distro():
 
 AGENT_NAME = "WALinuxAgent"
 AGENT_LONG_NAME = "Azure Linux Agent"
-AGENT_VERSION = '2.2.4'
+AGENT_VERSION = '2.2.4.1'
 AGENT_LONG_VERSION = "{0}-{1}".format(AGENT_NAME, AGENT_VERSION)
 AGENT_DESCRIPTION = """\
 The Azure Linux Agent supports the provisioning and running of Linux

--- a/azurelinuxagent/common/version.py
+++ b/azurelinuxagent/common/version.py
@@ -88,7 +88,7 @@ def get_distro():
 
 AGENT_NAME = "WALinuxAgent"
 AGENT_LONG_NAME = "Azure Linux Agent"
-AGENT_VERSION = '2.2.4.1'
+AGENT_VERSION = '2.2.5'
 AGENT_LONG_VERSION = "{0}-{1}".format(AGENT_NAME, AGENT_VERSION)
 AGENT_DESCRIPTION = """\
 The Azure Linux Agent supports the provisioning and running of Linux


### PR DESCRIPTION
Recently we added code to store the published hostname on disk, in order to detect a hostname change when the agent is not running. When the agent upgrades at runtime across this boundary, we can initiate a hostname change immediately after provisioning. This resets the network adapter, which can cause the manifest or goalstate download to fail. 

In some cases, particularly when installing an extension at provision time, this leads to a state where the agent has recorded the `Incarnation` as `n`, but `ExtensionsConfig.{n}.xml` does not yet exist. 

This PR contains several updates:

- prevent the network adapter from resetting, and causing the initial failure
- make sure the incarnation is only updated after the cache is stored, in case networking fails for another reason
- reduce the http verbose logging, so debugging is a little easier
- in the case of NSG, ensure we force update the goal state
- update the version to 2.2.5 for publishing
- fixes #585 

/cc @brendandixon @jinhyunr 