### PR TITLE
Add support for splitting configurations into separate files

### DIFF
--- a/azurelinuxagent/common/conf.py
+++ b/azurelinuxagent/common/conf.py
@@ -49,7 +49,7 @@ class ConfigurationProvider(object):
                 if not os.path.exists(path):
                     raise AgentConfigError(
                         "Included configuration path does "
-                        "not exist: {}".format(path))
+                        "not exist: {0}".format(path))
                 elif os.path.isdir(path):
                     for file in os.listdir(path):
                         conf_path = os.path.join(path, file)

--- a/azurelinuxagent/common/conf.py
+++ b/azurelinuxagent/common/conf.py
@@ -44,6 +44,21 @@ class ConfigurationProvider(object):
                     self.values[parts[0]] = value
                 else:
                     self.values[parts[0]] = None
+            elif line.startswith("include "):
+                path = line[8:]
+                if not os.path.exists(path):
+                    raise AgentConfigError(
+                        "Included configuration path does "
+                        "not exist: {}".format(path))
+                elif os.path.isdir(path):
+                    for file in os.listdir(path):
+                        conf_path = os.path.join(path, file)
+                        if os.path.isfile(conf_path):
+                            include_content = fileutil.read_file(conf_path)
+                            self.load(include_content)
+                else:
+                    include_content = fileutil.read_file(path)
+                    self.load(include_content)
 
     def get(self, key, default_val):
         val = self.values.get(key)

--- a/tests/common/test_conf.py
+++ b/tests/common/test_conf.py
@@ -61,7 +61,7 @@ Integer=123
             conf_file.write(b"Two=Bar\n")
             conf_file.flush()
             content = """One=Foo
-include {}
+include {0}
 Three=Baz
 """.format(conf_file.name)
             conf = ConfigurationProvider()
@@ -77,7 +77,7 @@ Three=Baz
         with open(os.path.join(self.temp_dir, "two.conf"), "w") as f:
             f.write("Three=Baz\n")   
         content = """One=Foo
-include {}
+include {0}
 Four=Qux
 """.format(self.temp_dir)
         conf = ConfigurationProvider()
@@ -89,7 +89,7 @@ Four=Qux
         return
 
     def test_load_include_invalid(self):
-        content = "include {}/missing.conf\n".format(self.temp_dir)
+        content = "include {0}/missing.conf\n".format(self.temp_dir)
         conf = ConfigurationProvider()
         with self.assertRaises(AgentConfigError):
             conf.load(content)

--- a/tests/common/test_conf.py
+++ b/tests/common/test_conf.py
@@ -91,6 +91,5 @@ Four=Qux
     def test_load_include_invalid(self):
         content = "include {0}/missing.conf\n".format(self.temp_dir)
         conf = ConfigurationProvider()
-        with self.assertRaises(AgentConfigError):
-            conf.load(content)
+        self.assertRaises(AgentConfigError, conf.load, content)
         return

--- a/tests/common/test_conf.py
+++ b/tests/common/test_conf.py
@@ -1,0 +1,87 @@
+# Copyright 2017 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Requires Python 2.4+ and Openssl 1.0+
+#
+
+from tempfile import NamedTemporaryFile, TemporaryDirectory
+
+from azurelinuxagent.common.conf import *
+from tests.tools import *
+
+
+class TestConfigurationProvider(AgentTestCase):
+    def setUp(self):
+        AgentTestCase.setUp(self)
+        return
+
+    def test_load(self):
+        content = """# Some comment line
+#Commented=With Value
+Key=Value
+Quoted="Value"
+None=None
+Switch=y
+Integer=123
+"""
+        conf = ConfigurationProvider()
+        conf.load(content)
+        self.assertEqual(conf.get("Commented", None), None)
+        self.assertEqual(conf.get("Key", None), "Value")
+        self.assertEqual(conf.get("Quoted", None), "Value")
+        self.assertEqual(conf.get("None", None), None)
+        self.assertEqual(conf.get_switch("Switch", False), True)
+        self.assertEqual(conf.get_int("Integer", None), 123)
+        return
+
+    def test_load_include(self):
+        with NamedTemporaryFile() as conf_file:
+            conf_file.write(b"Two=Bar\n")
+            conf_file.flush()
+            content = """One=Foo
+include {}
+Three=Baz
+""".format(conf_file.name)
+            conf = ConfigurationProvider()
+            conf.load(content)
+        self.assertEqual(conf.get("One", None), "Foo")
+        self.assertEqual(conf.get("Two", None), "Bar")
+        self.assertEqual(conf.get("Three", None), "Baz")
+        return
+
+    def test_load_include_directory(self):
+        with TemporaryDirectory() as conf_dir:
+            with open(os.path.join(conf_dir, "one.conf"), "w") as f:
+                f.write("Two=Bar\n")
+            with open(os.path.join(conf_dir, "two.conf"), "w") as f:
+                f.write("Three=Baz\n")   
+            content = """One=Foo
+include {}
+Four=Qux
+""".format(conf_dir)
+            conf = ConfigurationProvider()
+            conf.load(content)
+        self.assertEqual(conf.get("One", None), "Foo")
+        self.assertEqual(conf.get("Two", None), "Bar")
+        self.assertEqual(conf.get("Three", None), "Baz")
+        self.assertEqual(conf.get("Four", None), "Qux")
+        return
+
+    def test_load_include_invalid(self):
+        with TemporaryDirectory() as conf_dir:
+            content = "include {}/missing.conf\n".format(conf_dir)
+            conf = ConfigurationProvider()
+            with self.assertRaises(AgentConfigError):
+                conf.load(content)
+        return


### PR DESCRIPTION
Add a new config option 'include' that allows to include config options from a separate file or directory. Add a test suite for the conf part. Issue: #586 .