### PR TITLE
retry get thumbprint if key is deleted

### DIFF
--- a/azurelinuxagent/pa/provision/ubuntu.py
+++ b/azurelinuxagent/pa/provision/ubuntu.py
@@ -89,8 +89,14 @@ class UbuntuProvisionHandler(ProvisionHandler):
         path = '/etc/ssh/ssh_host_{0}_key.pub'.format(keypair_type)
         for retry in range(0, max_retry):
             if os.path.isfile(path):
-                return self.get_ssh_host_key_thumbprint(keypair_type)
+                logger.info("ssh host key found at: {0}".format(path))
+                try:
+                    thumbprint = self.get_ssh_host_key_thumbprint(keypair_type)
+                    logger.info("Thumbprint obtained from : {0}".format(path))
+                    return thumbprint
+                except ProvisionError:
+                    logger.warn("Could not get thumbprint from {0}".format(path))
             if retry < max_retry - 1:
-                logger.info("Wait for ssh host key be generated: {0}", path)
+                logger.info("Wait for ssh host key be generated: {0}".format(path))
                 time.sleep(5)
         raise ProvisionError("ssh host key is not generated.")


### PR DESCRIPTION
When cloud-init provisions the vm in Ubuntu, we wait for the ssh key to be present on disk. It is possible to hit a race condition where we fail to get the thumbprint before the key is regenerated. If this happens we should retry.

- fixes #591 

/cc @brendandixon @jinhyunr 