### PR TITLE
retry once when network unreachable

### DIFF
--- a/azurelinuxagent/common/utils/restutil.py
+++ b/azurelinuxagent/common/utils/restutil.py
@@ -152,8 +152,14 @@ def http_request(method, url, data, headers=None, max_retry=3,
             retry_interval = 5
         except IOError as e:
             retry_msg = 'IO error: {0} {1}'.format(log_msg, e)
-            retry_interval = 0
-            max_retry = 0
+            # error 101: network unreachable; when the adapter resets we may
+            # see this transient error for a short time, retry once.
+            if e.errno == 101:
+                retry_interval = RETRY_WAITING_INTERVAL
+                max_retry = 1
+            else:
+                retry_interval = 0
+                max_retry = 0
 
         if retry < max_retry:
             logger.info("Retry [{0}/{1} - {3}]",


### PR DESCRIPTION
When the network adapter resets, we should retry the HTTP request. This is beneficial because we do not send a telemetry error event, and also prevents an error from appearing in the log.

The new log is as follows:

```
2017/03/06 17:29:41.954307 INFO EnvMonitor: Detected hostname change: walacheck32 -> walacheck1
2017/03/06 17:29:41.977586 INFO examine /proc/net/route for primary interface
2017/03/06 17:29:41.978245 INFO primary interface is [eth0]
2017/03/06 17:29:41.984112 INFO interface [lo] has flags [73], is loopback [True]
2017/03/06 17:29:41.984255 INFO interface [lo] skipped
2017/03/06 17:29:41.984513 INFO interface [eth0] has flags [4163], is loopback [False]
2017/03/06 17:29:41.987336 INFO interface [eth0] selected
2017/03/06 17:29:41.998687 INFO examine /proc/net/route for primary interface
2017/03/06 17:29:42.005914 INFO primary interface is [eth0]
2017/03/06 17:29:42.009490 INFO interface [lo] has flags [73], is loopback [True]
2017/03/06 17:29:42.017444 INFO interface [lo] skipped
2017/03/06 17:29:42.020978 INFO interface [eth0] has flags [4163], is loopback [False]
2017/03/06 17:29:42.023703 INFO interface [eth0] selected
2017/03/06 17:29:42.452327 INFO Retry [1/1 - IO error: HTTP GET [Errno 101] Network is unreachable]
2017/03/06 17:29:44.823581 INFO EnvMonitor: Detected dhcp client restart. Restoring routing table.
2017/03/06 17:29:44.824115 INFO Configure routes
2017/03/06 17:29:44.826926 INFO Gateway:None
2017/03/06 17:29:44.827055 INFO Routes:None
```

- fixes #601 

/cc @brendandixon @jinhyunr 