### PR TITLE
Add Support for Huawei EulerOS

### DIFF
--- a/azurelinuxagent/common/osutil/factory.py
+++ b/azurelinuxagent/common/osutil/factory.py
@@ -76,6 +76,9 @@ def get_osutil(distro_name=DISTRO_NAME,
         else:
             return RedhatOSUtil()
 
+    elif distro_name == "euleros":
+        return RedhatOSUtil()
+
     elif distro_name == "freebsd":
         return FreeBSDOSUtil()
 

--- a/azurelinuxagent/common/version.py
+++ b/azurelinuxagent/common/version.py
@@ -76,6 +76,9 @@ def get_distro():
         osinfo[2] = "oracle"
         osinfo[3] = "Oracle Linux"
 
+    if os.path.exists("/etc/euleros-release"):
+        osinfo[0] = "euleros"
+
     # The platform.py lib has issue with detecting BIG-IP linux distribution.
     # Merge the following patch provided by F5.
     if os.path.exists("/shared/vadc"):

--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -715,7 +715,7 @@ class ExtHandlerInstance(object):
  
     def is_responsive(self, heartbeat_file):
         last_update=int(time.time() - os.stat(heartbeat_file).st_mtime)
-        return  last_update > 600    # not updated for more than 10 min
+        return  last_update <= 600    # updated within the last 10 min
    
     def launch_command(self, cmd, timeout=300):
         self.logger.info("Launch command:{0}", cmd)

--- a/bin/waagent2.0
+++ b/bin/waagent2.0
@@ -1094,6 +1094,18 @@ class centosDistro(redhatDistro):
         super(centosDistro,self).__init__()
 
 ############################################################    
+#   eulerosDistro
+############################################################    
+
+class eulerosDistro(redhatDistro):
+    """
+    EulerOS Distro concrete class
+    Put EulerOS specific behavior here...
+    """
+    def __init__(self):
+        super(eulerosDistro,self).__init__()
+
+############################################################    
 #	oracleDistro
 ############################################################    
 
@@ -6016,6 +6028,8 @@ def DistInfo(fullname=0):
     if 'linux_distribution' in dir(platform):
         distinfo = list(platform.linux_distribution(full_distribution_name=fullname))
         distinfo[0] = distinfo[0].strip() # remove trailing whitespace in distro name
+        if os.path.exists("/etc/euleros-release"):
+            distinfo[0] = "euleros"
         return distinfo
     else:
         return platform.dist()


### PR DESCRIPTION
waagent doesn't work fine for Huawei EulerOS because it doesn't handle EulerOS distribution.
With this fix, waagent is able to get_osutil  and get instance of eulerosDistro. Please help to review and merge the request, thanks!
