### PR TITLE
Fix issues with resource disk mount (#600)

### DIFF
--- a/azurelinuxagent/daemon/resourcedisk/default.py
+++ b/azurelinuxagent/daemon/resourcedisk/default.py
@@ -85,6 +85,11 @@ class ResourceDiskHandler(object):
         except ResourceDiskError as e:
             logger.error("Failed to enable swap {0}", e)
 
+    def reread_partition_table(self, device):
+        if shellutil.run("sfdisk -R {0}".format(device), chk_err=False):
+            shellutil.run("blockdev --rereadpt {0}".format(device),
+                          chk_err=False)
+
     def mount_resource_disk(self, mount_point):
         device = self.osutil.device_for_ide_port(1)
         if device is None:
@@ -144,6 +149,7 @@ class ResourceDiskHandler(object):
                 logger.info("The partition is formatted with ntfs, updating "
                             "partition type to 83")
                 self.change_partition_type(suppress_message=False, option_str="{0} 1 83".format(device))
+                self.reread_partition_table(device)
                 logger.info("Format partition [{0}]", mkfs_string)
                 shellutil.run(mkfs_string)
             else:
@@ -178,9 +184,7 @@ class ResourceDiskHandler(object):
             logger.warn("Failed to mount resource disk. "
                         "Retry mounting after re-reading partition info.")
 
-            if shellutil.run("sfdisk -R {0}".format(device), chk_err=False):
-                shellutil.run("blockdev --rereadpt {0}".format(device),
-                              chk_err=False)
+            self.reread_partition_table(device)
 
             ret, output = shellutil.run_get_output(mount_string)
             if ret:

--- a/azurelinuxagent/daemon/resourcedisk/default.py
+++ b/azurelinuxagent/daemon/resourcedisk/default.py
@@ -166,8 +166,8 @@ class ResourceDiskHandler(object):
 
         logger.info("Mount resource disk [{0}]", mount_string)
         ret, output = shellutil.run_get_output(mount_string, chk_err=False)
-        # if the exit code is 32, then the resource disk is already mounted
-        if ret == 32:
+        # if the exit code is 32, then the resource disk can be already mounted
+        if ret == 32 and output.find("is already mounted") != -1:
             logger.warn("Could not mount resource disk: {0}", output)
         elif ret != 0:
             # Some kernels seem to issue an async partition re-read after a

--- a/azurelinuxagent/daemon/resourcedisk/default.py
+++ b/azurelinuxagent/daemon/resourcedisk/default.py
@@ -138,7 +138,7 @@ class ResourceDiskHandler(object):
                 shellutil.run(mkfs_string)
         else:
             logger.info("GPT not detected, determining filesystem")
-            ret = self.change_partition_type(suppress_message=True, option_str="{0} 1".format(device))
+            ret = self.change_partition_type(suppress_message=True, option_str="{0} 1 -n".format(device))
             ptype = ret[1].strip()
             if ptype == "7" and self.fs != "ntfs":
                 logger.info("The partition is formatted with ntfs, updating "


### PR DESCRIPTION
Some old sfdisk(8) versions (e.g. v2.23.2 from RHEL7) require additional workarounds to make resource
disk mount smooth.