### PR TITLE
Pass environment variables to subprocesses

### DIFF
--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -725,7 +725,8 @@ class ExtHandlerInstance(object):
             child = subprocess.Popen(base_dir + "/" + cmd,
                                      shell=True,
                                      cwd=base_dir,
-                                     stdout=devnull)
+                                     stdout=devnull,
+                                     env=os.environ)
         except Exception as e:
             #TODO do not catch all exception
             raise ExtensionError("Failed to launch: {0}, {1}".format(cmd, e))

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -140,7 +140,8 @@ class UpdateHandler(object):
                 cmds,
                 cwd=agent_dir,
                 stdout=sys.stdout,
-                stderr=sys.stderr)
+                stderr=sys.stderr,
+                env=os.environ)
 
             logger.info(u"Agent {0} launched with command '{1}'", agent_name, agent_cmd)
 


### PR DESCRIPTION
In cases where subprocesses are used to call python processes
it would be helpful to pass on the environment variables used for
the agent itself.  In particular, this is helpful for running
extensions from the agent in system containers.