### PR TITLE
reset channel if host plugin put status fails

### DIFF
--- a/azurelinuxagent/common/protocol/hostplugin.py
+++ b/azurelinuxagent/common/protocol/hostplugin.py
@@ -183,6 +183,8 @@ class HostPluginProtocol(object):
             report_event(op=WALAEventOperation.ReportStatus,
                          is_success=False,
                          message=message)
+            logger.warn("HostGAPlugin: resetting default channel")
+            HostPluginProtocol.set_default_channel(False)
 
     def _put_block_blob_status(self, sas_url, status_blob):
         url = URI_FORMAT_PUT_VM_STATUS.format(self.endpoint, HOST_PLUGIN_PORT)


### PR DESCRIPTION
There are two known cases where using host plugin may fail today, but particularly in multi-nic vms we need to protect against the case where a transient issue leads to a non-nsg vm switching over to this channel permanently. I put this safety valve in the put vm status method only, because potentially valid failures in the download channel could regress the actual nsg scenarios. 