### PR TITLE
route/dhcp logging cleanup

### DIFF
--- a/azurelinuxagent/common/dhcp.py
+++ b/azurelinuxagent/common/dhcp.py
@@ -84,7 +84,7 @@ class DhcpHandler(object):
         :return: True if a route to KNOWN_WIRESERVER_IP exists.
         """
         route_exists = False
-        logger.info("test for route to {0}".format(KNOWN_WIRESERVER_IP))
+        logger.info("Test for route to {0}".format(KNOWN_WIRESERVER_IP))
         try:
             route_file = '/proc/net/route'
             if os.path.exists(route_file) and \
@@ -95,13 +95,12 @@ class DhcpHandler(object):
                 self.gateway = None
                 self.routes = None
                 route_exists = True
-                logger.info("route to {0} exists".format(KNOWN_WIRESERVER_IP))
+                logger.info("Route to {0} exists".format(KNOWN_WIRESERVER_IP))
             else:
-                logger.warn(
-                    "no route exists to {0}".format(KNOWN_WIRESERVER_IP))
+                logger.warn("No route exists to {0}".format(KNOWN_WIRESERVER_IP))
         except Exception as e:
             logger.error(
-                "could not determine whether route exists to {0}: {1}".format(
+                "Could not determine whether route exists to {0}: {1}".format(
                     KNOWN_WIRESERVER_IP, e))
 
         return route_exists
@@ -118,12 +117,12 @@ class DhcpHandler(object):
 
         exists = False
 
-        logger.info("checking for dhcp lease cache")
+        logger.info("Checking for dhcp lease cache")
         cached_endpoint = self.osutil.get_dhcp_lease_endpoint()
         if cached_endpoint is not None:
             self.endpoint = cached_endpoint
             exists = True
-        logger.info("cache exists [{0}]".format(exists))
+        logger.info("Cache exists [{0}]".format(exists))
         return exists
 
     def conf_routes(self):

--- a/azurelinuxagent/common/osutil/default.py
+++ b/azurelinuxagent/common/osutil/default.py
@@ -446,11 +446,11 @@ class DefaultOSUtil(object):
             if len(iface) == 0 or self.is_loopback(iface) or iface != primary:
                 # test the next one
                 if len(iface) != 0 and not self.disable_route_warning:
-                    logger.info('interface [{0}] skipped'.format(iface))
+                    logger.info('Interface [{0}] skipped'.format(iface))
                 continue
             else:
                 # use this one
-                logger.info('interface [{0}] selected'.format(iface))
+                logger.info('Interface [{0}] selected'.format(iface))
                 break
 
         return iface.decode('latin-1'), socket.inet_ntoa(sock[i+20:i+24])
@@ -479,7 +479,7 @@ class DefaultOSUtil(object):
         primary_metric = None
 
         if not self.disable_route_warning:
-            logger.info("examine /proc/net/route for primary interface")
+            logger.info("Examine /proc/net/route for primary interface")
         with open('/proc/net/route') as routing_table:
             idx = 0
             for header in filter(lambda h: len(h) > 0, routing_table.readline().strip(" \n").split("\t")):
@@ -506,12 +506,13 @@ class DefaultOSUtil(object):
             if not self.disable_route_warning:
                 with open('/proc/net/route') as routing_table_fh:
                     routing_table_text = routing_table_fh.read()
-                    logger.error('could not determine primary interface, '
-                                 'please ensure /proc/net/route is correct:\n'
-                                 '{0}'.format(routing_table_text))
+                    logger.warn('Could not determine primary interface, '
+                                'please ensure /proc/net/route is correct')
+                    logger.warn('Contents of /proc/net/route:\n{0}'.format(routing_table_text))
+                    logger.warn('Primary interface examination will retry silently')
                     self.disable_route_warning = True
         else:
-            logger.info('primary interface is [{0}]'.format(primary))
+            logger.info('Primary interface is [{0}]'.format(primary))
             self.disable_route_warning = False
         return primary
 


### PR DESCRIPTION
- switch routing table error to a warning, since we are going to retry
- clean up logging to make casing consistent
