### PR TITLE
do not log keygen errors in ubuntu since we retry

### DIFF
--- a/azurelinuxagent/pa/provision/default.py
+++ b/azurelinuxagent/pa/provision/default.py
@@ -87,10 +87,9 @@ class ProvisionHandler(object):
         thumbprint = self.get_ssh_host_key_thumbprint(keypair_type)
         return thumbprint
 
-    def get_ssh_host_key_thumbprint(self, keypair_type):
-        cmd = "ssh-keygen -lf /etc/ssh/ssh_host_{0}_key.pub".format(
-            keypair_type)
-        ret = shellutil.run_get_output(cmd)
+    def get_ssh_host_key_thumbprint(self, keypair_type, chk_err=True):
+        cmd = "ssh-keygen -lf /etc/ssh/ssh_host_{0}_key.pub".format(keypair_type)
+        ret = shellutil.run_get_output(cmd, chk_err=chk_err)
         if ret[0] == 0:
             return ret[1].rstrip().split()[1].replace(':', '')
         else:

--- a/azurelinuxagent/pa/provision/ubuntu.py
+++ b/azurelinuxagent/pa/provision/ubuntu.py
@@ -91,7 +91,7 @@ class UbuntuProvisionHandler(ProvisionHandler):
             if os.path.isfile(path):
                 logger.info("ssh host key found at: {0}".format(path))
                 try:
-                    thumbprint = self.get_ssh_host_key_thumbprint(keypair_type)
+                    thumbprint = self.get_ssh_host_key_thumbprint(keypair_type, chk_err=False)
                     logger.info("Thumbprint obtained from : {0}".format(path))
                     return thumbprint
                 except ProvisionError:


### PR DESCRIPTION
To avoid confusion, skip the following logs in Ubuntu, since the provisioning agent will retry these steps:
```
2017/04/12 20:03:56.240034 ERROR run cmd 'ssh-keygen -lf /etc/ssh/ssh_host_rsa_key.pub' failed
2017/04/12 20:03:56.240277 ERROR Error Code:255
2017/04/12 20:03:56.240400 ERROR Result:ssh-keygen: /etc/ssh/ssh_host_rsa_key.pub: No such file or directory
```
