### PR TITLE
Fix for #667

### DIFF
--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -146,10 +146,19 @@ class UpdateHandler(object):
 
             logger.verbose(u"Agent {0} launched with command '{1}'", agent_name, agent_cmd)
 
+            # If the most current agent is the installed agent and update is enabled,
+            # assume updates are likely available and poll every second.
+            # This reduces the start-up impact of finding / launching agent updates on
+            # fresh VMs.
+            if latest_agent is None and conf.get_autoupdate_enabled():
+                poll_interval = 1
+            else:
+                poll_interval = CHILD_POLL_INTERVAL
+
             ret = None
             start_time = time.time()
             while (time.time() - start_time) < CHILD_HEALTH_INTERVAL:
-                time.sleep(CHILD_POLL_INTERVAL)
+                time.sleep(poll_interval)
                 ret = self.child_process.poll()
                 if ret is not None:
                     break


### PR DESCRIPTION
Change the poll interval used to monitor newly spawned goal state extensions. This change addresses
#667.

Signed-off-by: Brendan Dixon <brendandixon@me.com>