### PR TITLE
Ensure all udev rules are copied in Ubuntu

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,7 @@ def get_data_files(name, version, fullname):
         set_bin_files(data_files)
         set_conf_files(data_files, src=["config/ubuntu/waagent.conf"])
         set_logrotate_files(data_files)
-        set_udev_files(data_files, src=["config/99-azure-product-uuid.rules"])
+        set_udev_files(data_files)
         if version.startswith("12") or version.startswith("14"):
             # Ubuntu12.04/14.04 - uses upstart
             set_files(data_files, dest="/etc/init",


### PR DESCRIPTION
The storage rules which were added recently are not copied during setup in Ubuntu. 