### PR TITLE
Add initial support for the OpenBSD operating system

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 ### INTRODUCTION
 
-The Microsoft Azure Linux Agent (waagent) manages Linux & FreeBSD provisioning,
+The Microsoft Azure Linux Agent (waagent) manages Linux & BSD provisioning,
 and VM interaction with the Azure Fabric Controller. It provides the following
-functionality for Linux and FreeBSD IaaS deployments:
+functionality for Linux and BSD IaaS deployments:
 
   * Image Provisioning
     - Creation of a user account
@@ -70,6 +70,7 @@ Supported Linux Distributions:
 
 Other Supported Systems:
    * FreeBSD 10+ (Azure Linux Agent v2.0.10+)
+   * OpenBSD 6+ (Azure Linux Agent v2.2.11+)
 
 Waagent depends on some system packages in order to function properly:
 
@@ -303,8 +304,8 @@ _Default: ext4_
 
 This specifies the filesystem type for the resource disk. Supported values vary
 by Linux distribution. If the string is X, then mkfs.X should be present on the
-Linux image. SLES 11 images should typically use 'ext3'. FreeBSD images should
-use 'ufs2' here.
+Linux image. SLES 11 images should typically use 'ext3'. BSD images should use
+'ufs2' here.
 
 * __ResourceDisk.MountPoint__   
 _Type: String_   

--- a/azurelinuxagent/common/osutil/factory.py
+++ b/azurelinuxagent/common/osutil/factory.py
@@ -24,6 +24,7 @@ from .clearlinux import ClearLinuxUtil
 from .coreos import CoreOSUtil
 from .debian import DebianOSUtil
 from .freebsd import FreeBSDOSUtil
+from .openbsd import OpenBSDOSUtil
 from .redhat import RedhatOSUtil, Redhat6xOSUtil
 from .suse import SUSEOSUtil, SUSE11OSUtil
 from .ubuntu import UbuntuOSUtil, Ubuntu12OSUtil, Ubuntu14OSUtil, UbuntuSnappyOSUtil
@@ -86,6 +87,9 @@ def get_osutil(distro_name=DISTRO_NAME,
 
     elif distro_name == "freebsd":
         return FreeBSDOSUtil()
+
+    elif distro_name == "openbsd":
+        return OpenBSDOSUtil()
 
     elif distro_name == "bigip":
         return BigIpOSUtil()

--- a/azurelinuxagent/common/osutil/openbsd.py
+++ b/azurelinuxagent/common/osutil/openbsd.py
@@ -109,7 +109,7 @@ class OpenBSDOSUtil(DefaultOSUtil):
         if ret != 0:
             raise OSUtilError(("Failed to encrypt password for {0}: {1}"
                                "").format(username, output))
-        passwd_hash = output
+        passwd_hash = output.strip()
         cmd = "usermod -p '{0}' {1}".format(passwd_hash, username)
         ret, output = shellutil.run_get_output(cmd, log_cmd=False)
         if ret != 0:

--- a/azurelinuxagent/common/osutil/openbsd.py
+++ b/azurelinuxagent/common/osutil/openbsd.py
@@ -251,7 +251,6 @@ class OpenBSDOSUtil(DefaultOSUtil):
                 return
             if retry < max_retry - 1:
                 mountlist = shellutil.run_get_output("/sbin/mount")[1]
-                logger.info("mountlist: '{0}'", mountlist)
                 existing = self.get_mount_point(mountlist, dvd_device)
                 if existing is not None:
                     logger.info("{0} is mounted at {1}", dvd_device, existing)

--- a/azurelinuxagent/common/osutil/openbsd.py
+++ b/azurelinuxagent/common/osutil/openbsd.py
@@ -1,0 +1,342 @@
+# Microsoft Azure Linux Agent
+#
+# Copyright 2014 Microsoft Corporation
+# Copyright 2017 Reyk Floeter <reyk@openbsd.org>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Requires Python 2.4+ and OpenSSL 1.0+
+
+import os
+import re
+import time
+import glob
+import datetime
+
+import azurelinuxagent.common.utils.fileutil as fileutil
+import azurelinuxagent.common.utils.shellutil as shellutil
+import azurelinuxagent.common.utils.textutil as textutil
+import azurelinuxagent.common.logger as logger
+import azurelinuxagent.common.conf as conf
+
+from azurelinuxagent.common.exception import OSUtilError
+from azurelinuxagent.common.osutil.default import DefaultOSUtil
+from azurelinuxagent.common.future import ustr
+
+UUID_PATTERN = re.compile(
+    '^\s*[A-F0-9]{8}(?:\-[A-F0-9]{4}){3}\-[A-F0-9]{12}\s*$',
+    re.IGNORECASE)
+
+class OpenBSDOSUtil(DefaultOSUtil):
+    def __init__(self):
+        super(OpenBSDOSUtil, self).__init__()
+        self._scsi_disks_timeout_set = False
+
+    def get_instance_id(self):
+        ret, output = shellutil.run_get_output("sysctl -n hw.uuid")
+        if ret != 0 or UUID_PATTERN.match(output) is None:
+            return ""
+        return output.strip()
+
+    def set_hostname(self, hostname):
+        fileutil.write_file("/etc/myname", "{}\n".format(hostname))
+        shellutil.run("hostname {0}".format(hostname), chk_err=False)
+
+    def restart_ssh_service(self):
+        return shellutil.run('rcctl restart sshd', chk_err=False)
+
+    def start_agent_service(self):
+        return shellutil.run('rcctl start waagent', chk_err=False)
+
+    def stop_agent_service(self):
+        return shellutil.run('rcctl stop waagent', chk_err=False)
+
+    def register_agent_service(self):
+        shellutil.run('chmod 0555 /etc/rc.d/waagent', chk_err=False)
+        return shellutil.run('rcctl enable waagent', chk_err=False)
+
+    def unregister_agent_service(self):
+        return shellutil.run('rcctl disable waagent', chk_err=False)
+
+    def del_account(self, username):
+        if self.is_sys_user(username):
+            logger.error("{0} is a system user. Will not delete it.",
+                         username)
+        shellutil.run("> /var/run/utmp")
+        shellutil.run("userdel -r " + username)
+        self.conf_sudoer(username, remove=True)
+
+    def conf_sudoer(self, username, nopasswd=False, remove=False):
+        doas_conf = "/etc/doas.conf"
+        doas = None
+        if not remove:
+            if not os.path.isfile(doas_conf):
+                # always allow root to become root
+                doas = "permit keepenv nopass root\n"
+                fileutil.append_file(doas_conf, doas)
+            if nopasswd:
+                doas = "permit keepenv nopass {0}\n".format(username)
+            else:
+                doas = "permit keepenv persist {0}\n".format(username)
+            fileutil.append_file(doas_conf, doas)
+            fileutil.chmod(doas_conf, 0o644)
+        else:
+            # Remove user from doas.conf
+            if os.path.isfile(doas_conf):
+                try:
+                    content = fileutil.read_file(doas_conf)
+                    doas = content.split("\n")
+                    doas = [x for x in doas if username not in x]
+                    fileutil.write_file(doas_conf, "\n".join(doas))
+                except IOError as e:
+                    raise OSUtilError("Failed to remove sudoer: {0}".format(e))
+
+    def chpasswd(self, username, password, crypt_id=6, salt_len=10):
+        if self.is_sys_user(username):
+            raise OSUtilError(("User {0} is a system user. "
+                               "Will not set passwd.").format(username))
+        cmd = "echo -n {0}|encrypt".format(passwd_hash, username)
+        ret, output = shellutil.run_get_output(cmd, log_cmd=False)
+        if ret != 0:
+            raise OSUtilError(("Failed to encrypt password for {0}: {1}"
+                               "").format(username, output))
+        passwd_hash = output
+        cmd = "usermod -p '{0}' {1}".format(passwd_hash, username)
+        ret, output = shellutil.run_get_output(cmd, log_cmd=False)
+        if ret != 0:
+            raise OSUtilError(("Failed to set password for {0}: {1}"
+                               "").format(username, output))
+
+    def del_root_password(self):
+        ret, output = shellutil.run_get_output('usermod -p "*" root')
+        if ret:
+            raise OSUtilError(("Failed to delete root password: "
+                              "{0}".format(output)))
+
+    def get_if_mac(self, ifname):
+        data = self._get_net_info()
+        if data[0] == ifname:
+            return data[2].replace(':', '').upper()
+        return None
+
+    def get_first_if(self):
+        return self._get_net_info()[:2]
+
+    def route_add(self, net, mask, gateway):
+        cmd = 'route add {0} {1} {2}'.format(net, gateway, mask)
+        return shellutil.run(cmd, chk_err=False)
+
+    def is_missing_default_route(self):
+        ret = shellutil.run("route -n get default", chk_err=False)
+        if ret == 0:
+            return False
+        return True
+
+    def is_dhcp_enabled(self):
+        pass
+
+    def start_dhcp_service(self):
+        pass
+
+    def stop_dhcp_service(self):
+        pass
+
+    def get_dhcp_lease_endpoint(self):
+        """
+        OpenBSD has a sligthly different lease file format.
+        """
+        endpoint = None
+        pathglob = '/var/db/dhclient.leases.{}'.format(self.get_first_if()[0])
+
+        HEADER_LEASE = "lease"
+        HEADER_OPTION = "option option-245"
+        HEADER_EXPIRE = "expire"
+        FOOTER_LEASE = "}"
+        FORMAT_DATETIME = "%Y/%m/%d %H:%M:%S %Z"
+
+        logger.info("looking for leases in path [{0}]".format(pathglob))
+        for lease_file in glob.glob(pathglob):
+            leases = open(lease_file).read()
+            if HEADER_OPTION in leases:
+                cached_endpoint = None
+                has_option_245 = False
+                expired = True  # assume expired
+                for line in leases.splitlines():
+                    if line.startswith(HEADER_LEASE):
+                        cached_endpoint = None
+                        has_option_245 = False
+                        expired = True
+                    elif HEADER_OPTION in line:
+                        try:
+                            ip = line.split(" ")[-1].strip(";").split(":")
+                            cached_endpoint = ".".join(str(int(d, 16)) for d in ip)
+                            has_option_245 = True
+                        except:
+                            logger.error("could not parse '{0}'".format(line))
+                    elif HEADER_EXPIRE in line:
+                        if "never" in line:
+                            expired = False
+                        else:
+                            try:
+                                expire_string = line.split(
+                                    " ", 4)[-1].strip(";")
+                                expire_date = datetime.datetime.strptime(
+                                    expire_string, FORMAT_DATETIME)
+                                if expire_date > datetime.datetime.utcnow():
+                                    expired = False
+                            except:
+                                logger.error("could not parse expiry token "
+                                             "'{0}'".format(line))
+                    elif FOOTER_LEASE in line:
+                        logger.info("dhcp entry:{0}, 245:{1}, expired:"
+                                    "{2}".format(
+                                    cached_endpoint, has_option_245, expired))
+                        if not expired and cached_endpoint is not None and has_option_245:
+                            endpoint = cached_endpoint
+                            logger.info("found endpoint [{0}]".format(endpoint))
+                            # we want to return the last valid entry, so
+                            # keep searching
+        if endpoint is not None:
+            logger.info("cached endpoint found [{0}]".format(endpoint))
+        else:
+            logger.info("cached endpoint not found")
+        return endpoint
+
+    def allow_dhcp_broadcast(self):
+        pass
+
+    def set_route_for_dhcp_broadcast(self, ifname):
+        return shellutil.run("route add 255.255.255.255 -iface "
+                             "{0}".format(ifname), chk_err=False)
+
+    def remove_route_for_dhcp_broadcast(self, ifname):
+        shellutil.run("route delete 255.255.255.255 -iface "
+                      "{0}".format(ifname), chk_err=False)
+
+    def get_dhcp_pid(self):
+        ret, output = shellutil.run_get_output("pgrep -n dhclient",
+                                               chk_err=False)
+        return output if ret == 0 else None
+
+    def get_dvd_device(self, dev_dir='/dev'):
+        pattern=r'cd[0-9]c'
+        for dvd in [re.match(pattern, dev) for dev in os.listdir(dev_dir)]:
+            if dvd is not None:
+                return "/dev/{0}".format(dvd.group(0))
+        raise OSUtilError("Failed to get DVD device")
+
+    def mount_dvd(self, max_retry=6, chk_err=True, dvd_device=None, mount_point=None):
+        if dvd_device is None:
+            dvd_device = self.get_dvd_device()
+        if mount_point is None:
+            mount_point = conf.get_dvd_mount_point()
+        if not os.path.isdir(mount_point):
+            os.makedirs(mount_point)
+
+        for retry in range(0, max_retry):
+            retcode = self.mount(dvd_device, mount_point, option="-o ro -t udf",
+                                 chk_err=chk_err)
+            if retcode == 0:
+                logger.info("Successfully mounted DVD")
+                return
+            if retry < max_retry - 1:
+                mountlist = shellutil.run_get_output("/sbin/mount")[1]
+                logger.info("mountlist: '{0}'", mountlist)
+                existing = self.get_mount_point(mountlist, dvd_device)
+                if existing is not None:
+                    logger.info("{0} is mounted at {1}", dvd_device, existing)
+                    return
+                logger.warn("Mount DVD failed: retry={0}, ret={1}", retry,
+                            retcode)
+                time.sleep(5)
+        if chk_err:
+            raise OSUtilError("Failed to mount DVD.")
+
+    def eject_dvd(self, chk_err=True):
+        dvd = self.get_dvd_device()
+        retcode = shellutil.run("cdio eject {0}".format(dvd))
+        if chk_err and retcode != 0:
+            raise OSUtilError("Failed to eject DVD: ret={0}".format(retcode))
+
+    def restart_if(self, ifname):
+        # Restart dhclient only to publish hostname
+        shellutil.run("/sbin/dhclient {0}".format(ifname), chk_err=False)
+
+    def get_total_mem(self):
+        ret, output = shellutil.run_get_output("sysctl -n hw.physmem")
+        if ret:
+            raise OSUtilError("Failed to get total memory: {0}".format(output))
+        try:
+            return int(output)/1024/1024
+        except ValueError:
+            raise OSUtilError("Failed to get total memory: {0}".format(output))
+
+    def get_processor_cores(self):
+        ret, output = shellutil.run_get_output("sysctl -n hw.ncpu")
+        if ret:
+            raise OSUtilError("Failed to get processor cores.")
+
+        try:
+            return int(output)
+        except ValueError:
+            raise OSUtilError("Failed to get total memory: {0}".format(output))
+
+    def set_scsi_disks_timeout(self, timeout):
+        pass
+
+    def check_pid_alive(self, pid):
+        if not pid:
+            return
+        return shellutil.run('ps -p {0}'.format(pid), chk_err=False) == 0
+
+    @staticmethod
+    def _get_net_info():
+        """
+        There is no SIOCGIFCONF
+        on OpenBSD - just parse ifconfig.
+        Returns strings: iface, inet4_addr, and mac
+        or 'None,None,None' if unable to parse.
+        We will sleep and retry as the network must be up.
+        """
+        iface = ''
+        inet = ''
+        mac = ''
+
+        ret, output = shellutil.run_get_output(
+            'ifconfig hvn | grep -E "^hvn.:" | sed "s/:.*//g"', chk_err=False)
+        if ret:
+            raise OSUtilError("Can't find ether interface:{0}".format(output))
+        ifaces = output.split()
+        if not ifaces:
+            raise OSUtilError("Can't find ether interface.")
+        iface = ifaces[0]
+
+        ret, output = shellutil.run_get_output(
+            'ifconfig ' + iface, chk_err=False)
+        if ret:
+            raise OSUtilError("Can't get info for interface:{0}".format(iface))
+
+        for line in output.split('\n'):
+            if line.find('inet ') != -1:
+                inet = line.split()[1]
+            elif line.find('lladdr ') != -1:
+                mac = line.split()[1]
+        logger.verbose("Interface info: ({0},{1},{2})", iface, inet, mac)
+
+        return iface, inet, mac
+
+    def device_for_ide_port(self, port_id):
+        """
+        Return device name attached to ide port 'n'.
+        """
+        return "wd{0}".format(port_id)

--- a/azurelinuxagent/common/version.py
+++ b/azurelinuxagent/common/version.py
@@ -77,6 +77,9 @@ def get_distro():
     if 'FreeBSD' in platform.system():
         release = re.sub('\-.*\Z', '', ustr(platform.release()))
         osinfo = ['freebsd', release, '', 'freebsd']
+    elif 'OpenBSD' in platform.system():
+        release = re.sub('\-.*\Z', '', ustr(platform.release()))
+        osinfo = ['openbsd', release, '', 'openbsd']
     elif 'linux_distribution' in dir(platform):
         supported = platform._supported_dists + ('alpine',)
         osinfo = list(platform.linux_distribution(full_distribution_name=0,
@@ -160,7 +163,10 @@ CURRENT_AGENT, CURRENT_VERSION = set_current_agent()
 
 def set_goal_state_agent():
     agent = None
-    pids = [pid for pid in os.listdir('/proc') if pid.isdigit()]
+    if os.path.isdir("/proc"):
+        pids = [pid for pid in os.listdir('/proc') if pid.isdigit()]
+    else:
+        pids = []
     for pid in pids:
         try:
             pname = open(os.path.join('/proc', pid, 'cmdline'), 'rb').read()

--- a/azurelinuxagent/daemon/resourcedisk/factory.py
+++ b/azurelinuxagent/daemon/resourcedisk/factory.py
@@ -27,6 +27,9 @@ from .openbsd import OpenBSDResourceDiskHandler
 def get_resourcedisk_handler(distro_name=DISTRO_NAME, 
                              distro_version=DISTRO_VERSION,
                              distro_full_name=DISTRO_FULL_NAME):
+    if distro_name == "freebsd":
+        return FreeBSDResourceDiskHandler()
+
     if distro_name == "openbsd":
         return OpenBSDResourceDiskHandler()
 

--- a/azurelinuxagent/daemon/resourcedisk/factory.py
+++ b/azurelinuxagent/daemon/resourcedisk/factory.py
@@ -22,12 +22,13 @@ from azurelinuxagent.common.version import DISTRO_NAME, \
                                            DISTRO_FULL_NAME
 from .default import ResourceDiskHandler
 from .freebsd import FreeBSDResourceDiskHandler
+from .openbsd import OpenBSDResourceDiskHandler
 
 def get_resourcedisk_handler(distro_name=DISTRO_NAME, 
                              distro_version=DISTRO_VERSION,
                              distro_full_name=DISTRO_FULL_NAME):
-    if distro_name == "freebsd":
-        return FreeBSDResourceDiskHandler()
+    if distro_name == "openbsd":
+        return OpenBSDResourceDiskHandler()
 
     return ResourceDiskHandler()
 

--- a/azurelinuxagent/daemon/resourcedisk/openbsd.py
+++ b/azurelinuxagent/daemon/resourcedisk/openbsd.py
@@ -1,0 +1,113 @@
+# Microsoft Azure Linux Agent
+#
+# Copyright 2014 Microsoft Corporation
+# Copyright 2017 Reyk Floeter <reyk@openbsd.org>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Requires Python 2.4+ and OpenSSL 1.0+
+#
+import azurelinuxagent.common.logger as logger
+import azurelinuxagent.common.utils.fileutil as fileutil
+import azurelinuxagent.common.utils.shellutil as shellutil
+import azurelinuxagent.common.conf as conf
+from azurelinuxagent.common.exception import ResourceDiskError
+from azurelinuxagent.daemon.resourcedisk.default import ResourceDiskHandler
+
+class OpenBSDResourceDiskHandler(ResourceDiskHandler):
+    def __init__(self):
+        super(OpenBSDResourceDiskHandler, self).__init__()
+        # Fase File System (FFS) is UFS
+        if self.fs == 'ufs' or self.fs == 'ufs2':
+            self.fs = 'ffs'
+
+    def create_swap_space(self, mount_point, size_mb):
+        pass
+
+    def enable_swap(self, mount_point):
+        size_mb = conf.get_resourcedisk_swap_size_mb()
+        if size_mb:
+            logger.info("Enable swap")
+            device = self.osutil.device_for_ide_port(1)
+            err, output = shellutil.run_get_output("swapctl -a /dev/"
+                                                   "{0}b".format(device),
+                                                   chk_err=False)
+            if err:
+                logger.error("Failed to enable swap, error {0}", output)
+
+    def mount_resource_disk(self, mount_point):
+        fs = self.fs
+        if fs != 'ffs':
+            raise ResourceDiskError("Unsupported filesystem type: {0}, only "
+                                    "ufs/ffs is supported.".format(fs))
+
+        # 1. Get device
+        device = self.osutil.device_for_ide_port(1)
+
+        if not device:
+            raise ResourceDiskError("Unable to detect resource disk device.")
+        logger.info('Resource disk device {0} found.', device)
+
+        # 2. Get partitions
+        partition = "/dev/{0}a".format(device)
+        swappartition = "/dev/{0}b".format(device)
+
+        # 3. Mount partition
+        mount_list = shellutil.run_get_output("mount")[1]
+        existing = self.osutil.get_mount_point(mount_list, partition)
+
+        if existing:
+            logger.info("Resource disk {0} is already mounted", partition)
+            return existing
+
+        fileutil.mkdir(mount_point, mode=0o755)
+        mount_cmd = 'mount -t {0} {1} {2}'.format(fs, partition, mount_point)
+        err = shellutil.run(mount_cmd, chk_err=False)
+        if err:
+            logger.info('Creating {0} filesystem on {1}'.format(fs, device))
+
+            fdisk_cmd = "/sbin/fdisk -yi {0}".format(device)
+            err, output = shellutil.run_get_output(fdisk_cmd, chk_err=False)
+            if err:
+                raise ResourceDiskError("Failed to create new MBR on {0}, "
+                                        "error: {1}".format(device, output))
+
+            size_mb = conf.get_resourcedisk_swap_size_mb()
+            if size_mb:
+                if size_mb > 512 * 1024:
+                    size_mb = 512 * 1024
+                disklabel_cmd = ("echo -e '{0} 1G-* 50%\nswap 1-{1}M 50%' "
+                    "| disklabel -w -A -T /dev/stdin "
+                    "{2}").format(mount_point, size_mb, device)
+                ret, output = shellutil.run_get_output(
+                    disklabel_cmd, chk_err=False)
+                if ret:
+                    raise ResourceDiskError("Failed to create new disklabel "
+                                            "on {0}, error "
+                                            "{1}".format(device, output))
+
+            err, output = shellutil.run_get_output("newfs -O2 {0}a"
+                                                   "".format(device))
+            if err:
+                raise ResourceDiskError("Failed to create new filesystem on "
+                                        "partition {0}, error "
+                                        "{1}".format(partition, output))
+
+            err, output = shellutil.run_get_output(mount_cmd, chk_err=False)
+            if err:
+                raise ResourceDiskError("Failed to mount partition {0}, "
+                                        "error {1}".format(partition, output))
+
+        logger.info("Resource disk partition {0} is mounted at {1} with fstype "
+                    "{2}", partition, mount_point, fs)
+        return mount_point

--- a/azurelinuxagent/daemon/resourcedisk/openbsd.py
+++ b/azurelinuxagent/daemon/resourcedisk/openbsd.py
@@ -58,9 +58,8 @@ class OpenBSDResourceDiskHandler(ResourceDiskHandler):
             raise ResourceDiskError("Unable to detect resource disk device.")
         logger.info('Resource disk device {0} found.', device)
 
-        # 2. Get partitions
+        # 2. Get partition
         partition = "/dev/{0}a".format(device)
-        swappartition = "/dev/{0}b".format(device)
 
         # 3. Mount partition
         mount_list = shellutil.run_get_output("mount")[1]
@@ -71,7 +70,8 @@ class OpenBSDResourceDiskHandler(ResourceDiskHandler):
             return existing
 
         fileutil.mkdir(mount_point, mode=0o755)
-        mount_cmd = 'mount -t {0} {1} {2}'.format(fs, partition, mount_point)
+        mount_cmd = 'mount -t {0} {1} {2}'.format(self.fs,
+                                                  partition, mount_point)
         err = shellutil.run(mount_cmd, chk_err=False)
         if err:
             logger.info('Creating {0} filesystem on {1}'.format(fs, device))
@@ -87,8 +87,8 @@ class OpenBSDResourceDiskHandler(ResourceDiskHandler):
                 if size_mb > 512 * 1024:
                     size_mb = 512 * 1024
                 disklabel_cmd = ("echo -e '{0} 1G-* 50%\nswap 1-{1}M 50%' "
-                    "| disklabel -w -A -T /dev/stdin "
-                    "{2}").format(mount_point, size_mb, device)
+                                 "| disklabel -w -A -T /dev/stdin "
+                                 "{2}").format(mount_point, size_mb, device)
                 ret, output = shellutil.run_get_output(
                     disklabel_cmd, chk_err=False)
                 if ret:

--- a/azurelinuxagent/pa/deprovision/default.py
+++ b/azurelinuxagent/pa/deprovision/default.py
@@ -81,6 +81,15 @@ class DeprovisionHandler(object):
         files_to_del = ['/root/.bash_history', '/var/log/waagent.log']
         actions.append(DeprovisionAction(fileutil.rm_files, files_to_del))
 
+        # For OpenBSD
+        actions.append(DeprovisionAction(fileutil.rm_files,
+                                         ["/etc/random.seed",
+                                         "/var/db/host.random",
+                                         "/etc/isakmpd/local.pub",
+                                         "/etc/isakmpd/private/local.key",
+                                         "/etc/iked/private/local.key",
+                                         "/etc/iked/local.pub"]))
+
     def del_resolv(self, warnings, actions):
         warnings.append("WARNING! /etc/resolv.conf will be deleted.")
         files_to_del = ["/etc/resolv.conf"]
@@ -94,6 +103,9 @@ class DeprovisionHandler(object):
         # For Freebsd, NM controlled
         actions.append(DeprovisionAction(fileutil.rm_files, ["/var/db/dhclient.leases.hn0",
                                                              "/var/lib/NetworkManager/dhclient-*.lease"]))
+
+        # For OpenBSD
+        actions.append(DeprovisionAction(fileutil.rm_files, ["/var/db/dhclient.leases.hvn0"]))
 
     def del_lib_dir(self, warnings, actions):
         dirs_to_del = [conf.get_lib_dir()]

--- a/azurelinuxagent/pa/deprovision/default.py
+++ b/azurelinuxagent/pa/deprovision/default.py
@@ -84,11 +84,11 @@ class DeprovisionHandler(object):
         # For OpenBSD
         actions.append(DeprovisionAction(fileutil.rm_files,
                                          ["/etc/random.seed",
-                                         "/var/db/host.random",
-                                         "/etc/isakmpd/local.pub",
-                                         "/etc/isakmpd/private/local.key",
-                                         "/etc/iked/private/local.key",
-                                         "/etc/iked/local.pub"]))
+                                          "/var/db/host.random",
+                                          "/etc/isakmpd/local.pub",
+                                          "/etc/isakmpd/private/local.key",
+                                          "/etc/iked/private/local.key",
+                                          "/etc/iked/local.pub"]))
 
     def del_resolv(self, warnings, actions):
         warnings.append("WARNING! /etc/resolv.conf will be deleted.")
@@ -100,12 +100,13 @@ class DeprovisionHandler(object):
         dirs_to_del = ["/var/lib/dhclient", "/var/lib/dhcpcd", "/var/lib/dhcp"]
         actions.append(DeprovisionAction(fileutil.rm_dirs, dirs_to_del))
 
-        # For Freebsd, NM controlled
-        actions.append(DeprovisionAction(fileutil.rm_files, ["/var/db/dhclient.leases.hn0",
-                                                             "/var/lib/NetworkManager/dhclient-*.lease"]))
+        # For FreeBSD and OpenBSD
+        actions.append(DeprovisionAction(fileutil.rm_files,
+                                         ["/var/db/dhclient.leases.*"]))
 
-        # For OpenBSD
-        actions.append(DeprovisionAction(fileutil.rm_files, ["/var/db/dhclient.leases.hvn0"]))
+        # For FreeBSD, NM controlled
+        actions.append(DeprovisionAction(fileutil.rm_files,
+                                         ["/var/lib/NetworkManager/dhclient-*.lease"]))
 
     def del_lib_dir(self, warnings, actions):
         dirs_to_del = [conf.get_lib_dir()]

--- a/azurelinuxagent/pa/provision/default.py
+++ b/azurelinuxagent/pa/provision/default.py
@@ -103,8 +103,11 @@ class ProvisionHandler(object):
 
     @staticmethod
     def validate_cloud_init(is_expected=True):
-        pids = [pid for pid in os.listdir('/proc') if pid.isdigit()]
         is_running = False
+        if os.path.isdir("/proc"):
+            pids = [pid for pid in os.listdir('/proc') if pid.isdigit()]
+        else:
+            pids = []
         for pid in pids:
             try:
                 pname = open(os.path.join('/proc', pid, 'cmdline'), 'rb').read()

--- a/config/openbsd/waagent.conf
+++ b/config/openbsd/waagent.conf
@@ -1,0 +1,105 @@
+#
+# Microsoft Azure Linux Agent Configuration
+#
+
+# Enable instance creation
+Provisioning.Enabled=y
+
+# Rely on cloud-init to provision
+Provisioning.UseCloudInit=n
+
+# Password authentication for root account will be unavailable.
+Provisioning.DeleteRootPassword=y
+
+# Generate fresh host key pair.
+Provisioning.RegenerateSshHostKeyPair=y
+
+# Supported values are "rsa", "dsa", "ecdsa", and "ed25519".
+Provisioning.SshHostKeyPairType=ed25519
+
+# Monitor host name changes and publish changes via DHCP requests.
+Provisioning.MonitorHostName=y
+
+# Decode CustomData from Base64.
+Provisioning.DecodeCustomData=n
+
+# Execute CustomData after provisioning.
+Provisioning.ExecuteCustomData=n
+
+# Algorithm used by crypt when generating password hash.
+#Provisioning.PasswordCryptId=6
+
+# Length of random salt used when generating password hash.
+#Provisioning.PasswordCryptSaltLength=10
+
+# Format if unformatted. If 'n', resource disk will not be mounted.
+ResourceDisk.Format=y
+
+# File system on the resource disk
+# Typically ext3 or ext4. OpenBSD images should use 'ufs2' here.
+ResourceDisk.Filesystem=ufs2
+
+# Mount point for the resource disk
+ResourceDisk.MountPoint=/mnt/resource
+
+# Create and use swapfile on resource disk.
+ResourceDisk.EnableSwap=y
+
+# Max size of the swap partition in MB
+ResourceDisk.SwapSizeMB=65536
+
+# Comma-seperated list of mount options. See man(8) for valid options.
+ResourceDisk.MountOptions=None
+
+# Enable verbose logging (y|n)
+Logs.Verbose=n
+
+# Is FIPS enabled
+OS.EnableFIPS=n
+
+# Root device timeout in seconds.
+OS.RootDeviceScsiTimeout=300
+
+# If "None", the system default version is used.
+OS.OpensslPath=/usr/local/bin/eopenssl
+
+# Set the path to SSH keys and configuration files
+OS.SshDir=/etc/ssh
+
+OS.PasswordPath=/etc/master.passwd
+
+# If set, agent will use proxy server to access internet
+#HttpProxy.Host=None
+#HttpProxy.Port=None
+
+# Detect Scvmm environment, default is n
+# DetectScvmmEnv=n
+
+#
+# Lib.Dir=/var/lib/waagent
+
+#
+# DVD.MountPoint=/mnt/cdrom/secure
+
+#
+# Pid.File=/var/run/waagent.pid
+
+#
+# Extension.LogDir=/var/log/azure
+
+#
+# Home.Dir=/home
+
+# Enable RDMA management and set up, should only be used in HPC images
+# OS.EnableRDMA=y
+
+# Enable or disable goal state processing auto-update, default is enabled
+AutoUpdate.Enabled=n
+
+# Determine the update family, this should not be changed
+# AutoUpdate.GAFamily=Prod
+
+# Determine if the overprovisioning feature is enabled. If yes, hold extension
+# handling until inVMArtifactsProfile.OnHold is false.
+# Default is disabled
+# EnableOverProvisioning=n

--- a/config/openbsd/waagent.conf
+++ b/config/openbsd/waagent.conf
@@ -94,7 +94,7 @@ OS.PasswordPath=/etc/master.passwd
 # OS.EnableRDMA=y
 
 # Enable or disable goal state processing auto-update, default is enabled
-AutoUpdate.Enabled=n
+# AutoUpdate.Enabled=y
 
 # Determine the update family, this should not be changed
 # AutoUpdate.GAFamily=Prod

--- a/init/openbsd/waagent
+++ b/init/openbsd/waagent
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+daemon="python2.7 /usr/local/sbin/waagent -start"
+
+. /etc/rc.d/rc.subr
+
+pexp="python /usr/local/sbin/waagent -daemon"
+rc_reload=NO
+
+rc_cmd $1

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,11 @@ def set_systemd_files(data_files, dest="/lib/systemd/system",
     data_files.append((dest, src))
 
 
-def set_rc_files(data_files, dest="/etc/rc.d/", src=["init/freebsd/waagent"]):
+def set_freebsd_rc_files(data_files, dest="/etc/rc.d/", src=["init/freebsd/waagent"]):
+    data_files.append((dest, src))
+
+
+def set_openbsd_rc_files(data_files, dest="/etc/rc.d/", src=["init/openbsd/waagent"]):
     data_files.append((dest, src))
 
 
@@ -143,7 +147,11 @@ def get_data_files(name, version, fullname):
     elif name == 'freebsd':
         set_bin_files(data_files, dest="/usr/local/sbin")
         set_conf_files(data_files, src=["config/freebsd/waagent.conf"])
-        set_rc_files(data_files)
+        set_freebsd_rc_files(data_files)
+    elif name == 'openbsd':
+        set_bin_files(data_files, dest="/usr/local/sbin")
+        set_conf_files(data_files, src=["config/openbsd/waagent.conf"])
+        set_openbsd_rc_files(data_files)
     else:
         # Use default setting
         set_bin_files(data_files)


### PR DESCRIPTION
There are some differences between FreeBSD, OpenBSD, and Linux.

Notes:

- OpenBSD ships LibreSSL, but WALinuxAgent needs OpenSSL for CMS, so
use the openssl port and the "eopenssl" binary instead.

- Don't run the custom DHCP client but parse /var/db/dhclient.leases.hvn0.
OpenBSD's lease file uses a modified syntax.

- OpenBSD does not have /proc.  WALinuxAgent should never assume that
the /proc filesystem is available.

- OpenBSD does not have sudo, but its replacement doas.  The OpenBSD
class implements support for modifying the doas.conf file.

- Unlike FreeBSD, OpenBSD supports and mounts UDF DVDs just fine.

- Create a swap partition instead of a swap file on the resource disk.

- Many other minor changes for OpenBSD

TODO:

- The /proc checks needs to be replaced with pgrep/ps etc. checks for
OpenBSD.  For now it just checks if /proc is available or returns
without error.
Make sure to install waagent with --register-service as setuptools
will not set the permissions of /etc/rc.d/waagent correctly (the file
has to be executable to be used by OpenBSD's rc system).