### PR TITLE
Fix issues #727, #725, and #721

### DIFF
--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -830,10 +830,9 @@ class WireClient(object):
         if blob_uri is not None:
 
             if not blob_type in ["BlockBlob", "PageBlob"]:
-                self.report_status_event(
-                    "{0} is an unsupported blob type",
-                    blob_type)
-                return
+                blob_type = "BlockBlob"
+                logger.info("Status Blob type is unspecified "
+                    "-- assuming it is a BlockBlob")
 
             try:
                 self.status_blob.prepare(blob_type)

--- a/azurelinuxagent/pa/deprovision/default.py
+++ b/azurelinuxagent/pa/deprovision/default.py
@@ -17,6 +17,7 @@
 # Requires Python 2.4+ and Openssl 1.0+
 #
 
+import glob
 import os.path
 import signal
 import sys
@@ -99,20 +100,60 @@ class DeprovisionHandler(object):
         dirs_to_del = [conf.get_lib_dir()]
         actions.append(DeprovisionAction(fileutil.rm_dirs, dirs_to_del))
 
-    def cloud_init_directories(self):
-        return ["/var/lib/cloud/instance",
+    def del_lib_dir_files(self, warnings, actions):
+        known_files = [
+            'HostingEnvironmentConfig.xml',
+            'Incarnation',
+            'Protocol',
+            'SharedConfig.xml',
+            'WireServerEndpoint'
+        ]
+        known_files_glob = [
+            'Extensions.*.xml',
+            'ExtensionsConfig.*.xml',
+            'GoalState.*.xml'
+        ]
+
+        lib_dir = conf.get_lib_dir()
+        files = [f for f in \
+                    [os.path.join(lib_dir, kf) for kf in known_files] \
+                        if os.path.isfile(f)]
+        for p in known_files_glob:
+            files += glob.glob(os.path.join(lib_dir, p))
+
+        if len(files) > 0:
+            actions.append(DeprovisionAction(fileutil.rm_files, files))
+
+    def cloud_init_dirs(self, include_once=True):
+        dirs = [
+            "/var/lib/cloud/instance",
             "/var/lib/cloud/instances/",
-            "/var/lib/cloud/data"]
+            "/var/lib/cloud/data"
+        ]
+        if include_once:
+            dirs += [
+                "/var/lib/cloud/scripts/per-once"
+            ]
+        return dirs
+    
+    def cloud_init_files(self, include_once=True):
+        files = [
+            "/etc/sudoers.d/90-cloud-init-users"
+        ]
+        if include_once:
+            files += [
+                "/var/lib/cloud/sem/config_scripts_per_once.once"
+            ]
+        return files
 
-    def cloud_init_files(self):
-        return ["/etc/sudoers.d/90-cloud-init-users"]
-
-    def del_cloud_init(self, warnings, actions):
-        dirs = [d for d in self.cloud_init_directories() if os.path.isdir(d)]
+    def del_cloud_init(self, warnings, actions, include_once=True):
+        dirs = [d for d in self.cloud_init_dirs(include_once=include_once) \
+                    if os.path.isdir(d)]
         if len(dirs) > 0:
             actions.append(DeprovisionAction(fileutil.rm_dirs, dirs))
 
-        files = [f for f in self.cloud_init_files() if os.path.isfile(f)]
+        files = [f for f in self.cloud_init_files(include_once=include_once) \
+                    if os.path.isfile(f)]
         if len(files) > 0:
             actions.append(DeprovisionAction(fileutil.rm_files, files))
 
@@ -147,19 +188,55 @@ class DeprovisionHandler(object):
 
         return warnings, actions
 
+    def setup_changed_unique_id(self):
+        warnings = []
+        actions = []
+
+        self.del_cloud_init(warnings, actions, include_once=False)
+        self.del_dhcp_lease(warnings, actions)
+        self.del_lib_dir_files(warnings, actions)
+        self.del_resolv(warnings, actions)
+
+        return warnings, actions
+
     def run(self, force=False, deluser=False):
         warnings, actions = self.setup(deluser)
-        for warning in warnings:
-            print(warning)
 
-        if not force:
-            confirm = read_input("Do you want to proceed (y/n)")
-            if not confirm.lower().startswith('y'):
-                return
+        self.do_warnings(warnings)
+        self.do_confirmation(force=force)
+        self.do_actions(actions)
 
+    def run_changed_unique_id(self):
+        '''
+        Clean-up files and directories that may interfere when the VM unique
+        identifier has changed.
+
+        While users *should* manually deprovision a VM, the files removed by
+        this routine will help keep the agent from getting confused
+        (since incarnation and extension settings, among other items, will 
+        no longer be monotonically increasing).
+        '''
+        warnings, actions = self.setup_changed_unique_id()
+
+        self.do_warnings(warnings)
+        self.do_actions(actions)
+
+    def do_actions(self, actions):
         self.actions_running = True
         for action in actions:
             action.invoke()
+        self.actions_running = False
+
+    def do_confirmation(self, force=False):
+        if force:
+            return True
+
+        confirm = read_input("Do you want to proceed (y/n)")
+        return True if confirm.lower().startswith('y') else False
+    
+    def do_warnings(self, warnings):
+        for warning in warnings:
+            print(warning)
 
     def handle_interrupt_signal(self, signum, frame):
         if not self.actions_running:

--- a/tests/pa/test_deprovision.py
+++ b/tests/pa/test_deprovision.py
@@ -25,12 +25,28 @@ from tests.tools import *
 
 
 class TestDeprovision(AgentTestCase):
+    @patch("azurelinuxagent.pa.deprovision.default.DeprovisionHandler.cloud_init_dirs")
+    @patch("azurelinuxagent.pa.deprovision.default.DeprovisionHandler.cloud_init_files")
+    def test_del_cloud_init_without_once(self,
+                mock_files,
+                mock_dirs):
+        deprovision_handler = get_deprovision_handler("","","")
+        deprovision_handler.del_cloud_init([], [], include_once=False)
+
+        mock_dirs.assert_called_with(include_once=False)
+        mock_files.assert_called_with(include_once=False)
+
     @patch("signal.signal")
     @patch("azurelinuxagent.common.protocol.get_protocol_util")
     @patch("azurelinuxagent.common.osutil.get_osutil")
-    @patch("azurelinuxagent.pa.deprovision.default.DeprovisionHandler.cloud_init_directories")
+    @patch("azurelinuxagent.pa.deprovision.default.DeprovisionHandler.cloud_init_dirs")
     @patch("azurelinuxagent.pa.deprovision.default.DeprovisionHandler.cloud_init_files")
-    def test_del_cloud_init(self, mock_files, mock_dirs, mock_osutil, mock_util, mock_signal):
+    def test_del_cloud_init(self,
+                mock_files,
+                mock_dirs,
+                mock_osutil,
+                mock_util,
+                mock_signal):
         try:
             with tempfile.NamedTemporaryFile() as f:
                 warnings = []
@@ -44,6 +60,9 @@ class TestDeprovision(AgentTestCase):
 
                 deprovision_handler = get_deprovision_handler("","","")
                 deprovision_handler.del_cloud_init(warnings, actions)
+
+                mock_dirs.assert_called_with(include_once=True)
+                mock_files.assert_called_with(include_once=True)
 
                 self.assertEqual(len(warnings), 0)
                 self.assertEqual(len(actions), 2)
@@ -65,6 +84,47 @@ class TestDeprovision(AgentTestCase):
         except OSError:
             # Ignore the error caused by removing the file within the "with"
             pass
+    
+    @distros("ubuntu")
+    @patch('azurelinuxagent.common.conf.get_lib_dir')
+    def test_del_lib_dir_files(self,
+                        distro_name,
+                        distro_version,
+                        distro_full_name,
+                        mock_conf):
+        files = [
+            'HostingEnvironmentConfig.xml',
+            'Incarnation',
+            'Protocol',
+            'SharedConfig.xml',
+            'WireServerEndpoint',
+            'Extensions.1.xml',
+            'ExtensionsConfig.1.xml',
+            'GoalState.1.xml',
+            'Extensions.2.xml',
+            'ExtensionsConfig.2.xml',
+            'GoalState.2.xml'
+        ]
+
+        tmp = tempfile.mkdtemp()
+        mock_conf.return_value = tmp
+        for f in files:
+            fileutil.write_file(os.path.join(tmp, f), "Value")
+
+        deprovision_handler = get_deprovision_handler(distro_name,
+                                                      distro_version,
+                                                      distro_full_name)
+        warnings = []
+        actions = []
+        deprovision_handler.del_lib_dir_files(warnings, actions)
+
+        self.assertTrue(len(warnings) == 0)
+        self.assertTrue(len(actions) == 1)
+        self.assertEqual(fileutil.rm_files, actions[0].func)
+        self.assertTrue(len(actions[0].args) > 0)
+        for f in actions[0].args:
+            self.assertTrue(os.path.basename(f) in files)
+
 
     @distros("redhat")
     def test_deprovision(self,


### PR DESCRIPTION
[#727] -- v2.2.11 cannot update status for RDFE VMs
[#725] -- v2.2.11 can throw unexpected exceptions on provisioned VMs
[#721] -- WALA deprovision process not clean up all cloudinit files

Signed-off-by: Brendan Dixon <brendandixon@me.com>