### PR TITLE
Fix #711, #714, #717, #720, and #724

### DIFF
--- a/azurelinuxagent/agent.py
+++ b/azurelinuxagent/agent.py
@@ -43,14 +43,17 @@ class Agent(object):
         """
         Initialize agent running environment.
         """
+        self.conf_file_path = conf_file_path
         self.osutil = get_osutil()
+
         #Init stdout log
         level = logger.LogLevel.VERBOSE if verbose else logger.LogLevel.INFO
         logger.add_logger_appender(logger.AppenderType.STDOUT, level)
 
         #Init config
-        if conf_file_path is None:
-            conf_file_path = self.osutil.get_agent_conf_file_path()
+        conf_file_path = self.conf_file_path \
+                if self.conf_file_path is not None \
+                    else self.osutil.get_agent_conf_file_path()
         conf.load_conf_from_file(conf_file_path)
 
         #Init log
@@ -70,9 +73,13 @@ class Agent(object):
         """
         Run agent daemon
         """
+        child_args = None \
+            if self.conf_file_path is None \
+                else "-configuration-path:{0}".format(self.conf_file_path)
+
         from azurelinuxagent.daemon import get_daemon_handler
         daemon_handler = get_daemon_handler()
-        daemon_handler.run()
+        daemon_handler.run(child_args=child_args)
 
     def provision(self):
         """

--- a/azurelinuxagent/common/conf.py
+++ b/azurelinuxagent/common/conf.py
@@ -40,12 +40,12 @@ class ConfigurationProvider(object):
             raise AgentConfigError("Can't not parse empty configuration")
         for line in content.split('\n'):
             if not line.startswith("#") and "=" in line:
-                parts = line.split()[0].split('=')
+                parts = line.split('=')
+                if len(parts) < 2:
+                    continue
+                key = parts[0].strip()
                 value = parts[1].strip("\" ")
-                if value != "None":
-                    self.values[parts[0]] = value
-                else:
-                    self.values[parts[0]] = None
+                self.values[key] = value if value != "None" else None
 
     def get(self, key, default_val):
         val = self.values.get(key)

--- a/azurelinuxagent/common/event.py
+++ b/azurelinuxagent/common/event.py
@@ -131,10 +131,11 @@ def report_event(op, is_success=True, message=''):
 
 
 def add_event(name, op="", is_success=True, duration=0, version=CURRENT_VERSION,
-              message="", evt_type="", is_internal=False,
+              message="", evt_type="", is_internal=False, log_event=True,
               reporter=__event_logger__):
-    log = logger.info if is_success else logger.error
-    log("Event: name={0}, op={1}, message={2}", name, op, message)
+    if log_event or not is_success:
+        log = logger.info if is_success else logger.error
+        log("Event: name={0}, op={1}, message={2}", name, op, message)
 
     if reporter.event_dir is None:
         logger.warn("Event reporter is not initialized.")

--- a/azurelinuxagent/ga/monitor.py
+++ b/azurelinuxagent/ga/monitor.py
@@ -178,11 +178,11 @@ class MonitorHandler(object):
             logger.error("{0}", e)
 
     def daemon(self):
-        last_heartbeat = datetime.datetime.min
         period = datetime.timedelta(minutes=30)
+        last_heartbeat = datetime.datetime.utcnow() - period
         while True:
-            if (datetime.datetime.now() - last_heartbeat) > period:
-                last_heartbeat = datetime.datetime.now()
+            if datetime.datetime.utcnow() >= (last_heartbeat + period):
+                last_heartbeat = datetime.datetime.utcnow()
                 add_event(
                     op=WALAEventOperation.HeartBeat,
                     name=CURRENT_AGENT,

--- a/azurelinuxagent/pa/deprovision/default.py
+++ b/azurelinuxagent/pa/deprovision/default.py
@@ -78,9 +78,13 @@ class DeprovisionHandler(object):
         warnings.append("WARNING! The waagent service will be stopped.")
         actions.append(DeprovisionAction(self.osutil.stop_agent_service))
 
+    def del_dirs(self, warnings, actions):
+        dirs = [conf.get_lib_dir(), conf.get_ext_log_dir()]
+        actions.append(DeprovisionAction(fileutil.rm_dirs, dirs))
+
     def del_files(self, warnings, actions):
-        files_to_del = ['/root/.bash_history', '/var/log/waagent.log']
-        actions.append(DeprovisionAction(fileutil.rm_files, files_to_del))
+        files = ['/root/.bash_history', '/var/log/waagent.log']
+        actions.append(DeprovisionAction(fileutil.rm_files, files))
 
     def del_resolv(self, warnings, actions):
         warnings.append("WARNING! /etc/resolv.conf will be deleted.")
@@ -96,9 +100,6 @@ class DeprovisionHandler(object):
         actions.append(DeprovisionAction(fileutil.rm_files, ["/var/db/dhclient.leases.hn0",
                                                              "/var/lib/NetworkManager/dhclient-*.lease"]))
 
-    def del_lib_dir(self, warnings, actions):
-        dirs_to_del = [conf.get_lib_dir()]
-        actions.append(DeprovisionAction(fileutil.rm_dirs, dirs_to_del))
 
     def del_lib_dir_files(self, warnings, actions):
         known_files = [
@@ -179,7 +180,7 @@ class DeprovisionHandler(object):
             self.del_root_password(warnings, actions)
 
         self.del_cloud_init(warnings, actions)
-        self.del_lib_dir(warnings, actions)
+        self.del_dirs(warnings, actions)
         self.del_files(warnings, actions)
         self.del_resolv(warnings, actions)
 

--- a/tests/common/test_conf.py
+++ b/tests/common/test_conf.py
@@ -31,6 +31,10 @@ class TestConf(AgentTestCase):
                 os.path.join(data_dir, "test_waagent.conf"),
                 self.conf)
 
+    def test_key_value_handling(self):
+        self.assertEqual("Value1", self.conf.get("FauxKey1", "Bad"))
+        self.assertEqual("Value2 Value2", self.conf.get("FauxKey2", "Bad"))
+
     def test_get_ssh_dir(self):
         self.assertTrue(get_ssh_dir(self.conf).startswith("/notareal/path"))
 

--- a/tests/data/test_waagent.conf
+++ b/tests/data/test_waagent.conf
@@ -2,6 +2,11 @@
 # Microsoft Azure Linux Agent Configuration
 #
 
+# Key / value handling test entries
+=Value0
+FauxKey1= Value1
+FauxKey2=Value2 Value2
+
 # Enable instance creation
 Provisioning.Enabled=y
 


### PR DESCRIPTION
[#711] -- There are too many log print to /var/log/waagent.log
[#714] -- Questionable split call in common/conf.py
[#717] -- Remove extension logs during deprovision
[#720] -- Reset of RDMA drivers not taking effect
[#724] -- Location of configuration file should be editable issue

Signed-off-by: Brendan Dixon <brendandixon@me.com>