### PR TITLE
Fix for the issue on recent FreeBSD 11 with the resource disc

### DIFF
--- a/azurelinuxagent/common/osutil/freebsd.py
+++ b/azurelinuxagent/common/osutil/freebsd.py
@@ -229,17 +229,21 @@ class FreeBSDOSUtil(DefaultOSUtil):
         err, output = shellutil.run_get_output(cmd_search_blkvsc)
         if err == 0:
             output = output.rstrip()
-            cmd_search_dev="camcontrol devlist | grep {0} | awk -F \( '{{print $2}}'|awk -F , '{{print $1}}'".format(output)
+            cmd_search_dev="camcontrol devlist | grep {0} | awk -F \( '{{print $2}}'|sed -e 's/.*(//'| sed -e 's/).*//'".format(output)
             err, output = shellutil.run_get_output(cmd_search_dev)
             if err == 0:
-                return output.rstrip()
+                for possible in output.rstrip().split(','):
+                    if not possible.startswith('pass'):
+                        return possible
 
         cmd_search_storvsc = "camcontrol devlist -b | grep storvsc{0} | awk '{{print $1}}'".format(output)
         err, output = shellutil.run_get_output(cmd_search_storvsc)
         if err == 0:
             output = output.rstrip()
-            cmd_search_dev="camcontrol devlist | grep {0} | awk -F \( '{{print $2}}'|awk -F , '{{print $1}}'".format(output)
+            cmd_search_dev="camcontrol devlist | grep {0} | awk -F \( '{{print $2}}'|sed -e 's/.*(//'| sed -e 's/).*//'".format(output)
             err, output = shellutil.run_get_output(cmd_search_dev)
             if err == 0:
-                return output.rstrip()
+                for possible in output.rstrip().split(','):
+                    if not possible.startswith('pass'):
+                        return possible
         return None

--- a/azurelinuxagent/daemon/resourcedisk/freebsd.py
+++ b/azurelinuxagent/daemon/resourcedisk/freebsd.py
@@ -59,7 +59,7 @@ class FreeBSDResourceDiskHandler(ResourceDiskHandler):
         disks = self.parse_gpart_list(output)
 
         device = self.osutil.device_for_ide_port(1)
-        if device is None:
+        if device is None or not device in disks:
         # fallback logic to find device
             err, output = shellutil.run_get_output('camcontrol periphlist 2:1:0')
             if err:


### PR DESCRIPTION
This is a fix for the resource disc issue. Instead of returning the first device it finds, it instead splits the list and skips any devices which begin 'pass'. This works for both the old and the new ordering.

In addition the returned device is checked to make sure it is in the 'disks' in the same way as the fallback code does, thus triggering the fallback path if a wrong device is somehow returned.