### PR TITLE
fix the issue of "dmidecode is not found" on FreeBSD

### DIFF
--- a/init/freebsd/waagent
+++ b/init/freebsd/waagent
@@ -6,7 +6,7 @@
 
 . /etc/rc.subr
 
-PATH=$PATH:/usr/local/bin
+PATH=$PATH:/usr/local/bin:/usr/local/sbin
 name="waagent"
 rcvar="waagent_enable"
 pidfile="/var/run/waagent.pid"


### PR DESCRIPTION
On FreeBSD, the ''dmidecode --string system-uuid" cannot execute correctly, because FreeBSD init rc script has to set PATH by itself. Currently PATH only contains "/usr/local/bin", unfortunately, dmidecode locates in "/usr/local/sbin".