### PR TITLE
Add Extension.Enabled to enable or disable extensions.

### DIFF
--- a/azurelinuxagent/common/conf.py
+++ b/azurelinuxagent/common/conf.py
@@ -112,6 +112,9 @@ def get_agent_pid_file_path(conf=__conf__):
     return conf.get("Pid.File", "/var/run/waagent.pid")
 
 
+def get_ext_enabled(conf=__conf__):
+    return conf.get_switch("Extension.Enabled", True)
+
 def get_ext_log_dir(conf=__conf__):
     return conf.get("Extension.LogDir", "/var/log/azure")
 

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -240,9 +240,10 @@ class UpdateHandler(object):
         from azurelinuxagent.ga.env import get_env_handler
         get_env_handler().run()
 
-        from azurelinuxagent.ga.exthandlers import get_exthandlers_handler, migrate_handler_state
-        exthandlers_handler = get_exthandlers_handler()
-        migrate_handler_state()
+        if conf.get_ext_enabled():
+            from azurelinuxagent.ga.exthandlers import get_exthandlers_handler, migrate_handler_state
+            exthandlers_handler = get_exthandlers_handler()
+            migrate_handler_state()
 
         try:
             send_event_time = datetime.utcnow()
@@ -265,17 +266,17 @@ class UpdateHandler(object):
 
                 utc_start = datetime.utcnow()
 
-                last_etag = exthandlers_handler.last_etag
-                exthandlers_handler.run()
-
-                if last_etag != exthandlers_handler.last_etag:
-                    add_event(
-                        AGENT_NAME,
-                        version=CURRENT_VERSION,
-                        op=WALAEventOperation.ProcessGoalState,
-                        is_success=True,
-                        duration=elapsed_milliseconds(utc_start),
-                        log_event=True)
+                if conf.get_ext_enabled():
+                    last_etag = exthandlers_handler.last_etag
+                    exthandlers_handler.run()
+                    if last_etag != exthandlers_handler.last_etag:
+                        add_event(
+                            AGENT_NAME,
+                            version=CURRENT_VERSION,
+                            op=WALAEventOperation.ProcessGoalState,
+                            is_success=True,
+                            duration=elapsed_milliseconds(utc_start),
+                            log_event=True)
 
                 test_agent = self.get_test_agent()
                 if test_agent is not None and test_agent.in_slice:

--- a/config/waagent.conf
+++ b/config/waagent.conf
@@ -85,6 +85,9 @@ OS.SshDir=/etc/ssh
 #
 # Pid.File=/var/run/waagent.pid
 
+# Enable or disable extensions, default is enabled
+# Extension.Enabled=y
+
 #
 # Extension.LogDir=/var/log/azure
 


### PR DESCRIPTION
Hi,

while extension might provide a useful feature, it is also very desirable for many users to disable them entirely. This is especially important for OpenBSD where we don't support most of the Linux-specific extensions. And it matches the our users' expectation to not run remotely-installed code.

This patch keeps extensions enabled by default, but they can be disabled in `/etc/waagent.conf`:

    # Enable or disable extensions, default is enabled
    Extension.Enabled=n

Reyk
