### PR TITLE
Add Provisioning.SshHostKeyPairType=auto to support ssh-keygen -A

### DIFF
--- a/azurelinuxagent/common/conf.py
+++ b/azurelinuxagent/common/conf.py
@@ -151,6 +151,16 @@ def get_root_device_scsi_timeout(conf=__conf__):
     return conf.get("OS.RootDeviceScsiTimeout", None)
 
 def get_ssh_host_keypair_type(conf=__conf__):
+    keypair_type = conf.get("Provisioning.SshHostKeyPairType", "rsa")
+    if keypair_type == "auto":
+        '''
+        auto generates all supported key types and returns the
+        rsa thumbprint as the default.
+        '''
+        return "rsa"
+    return keypair_type
+
+def get_ssh_host_keypair_mode(conf=__conf__):
     return conf.get("Provisioning.SshHostKeyPairType", "rsa")
 
 def get_provision_enabled(conf=__conf__):

--- a/azurelinuxagent/pa/provision/default.py
+++ b/azurelinuxagent/pa/provision/default.py
@@ -128,9 +128,17 @@ class ProvisionHandler(object):
         keypair_type = conf.get_ssh_host_keypair_type()
         if conf.get_regenerate_ssh_host_key():
             fileutil.rm_files(conf.get_ssh_key_glob())
-            keygen_cmd = "ssh-keygen -N '' -t {0} -f {1}"
-            shellutil.run(keygen_cmd.format(keypair_type,
-                        conf.get_ssh_key_private_path()))
+            if conf.get_ssh_host_keypair_mode() == "auto":
+                '''
+                The -A option generates all supported key types.
+                This is supported since OpenSSH 5.9 (2011).
+                '''
+                shellutil.run("ssh-keygen -A")
+            else:
+                keygen_cmd = "ssh-keygen -N '' -t {0} -f {1}"
+                shellutil.run(keygen_cmd.
+                              format(keypair_type,
+                                     conf.get_ssh_key_private_path()))
         return self.get_ssh_host_key_thumbprint()
 
     def get_ssh_host_key_thumbprint(self, chk_err=True):

--- a/config/openbsd/waagent.conf
+++ b/config/openbsd/waagent.conf
@@ -14,8 +14,8 @@ Provisioning.DeleteRootPassword=y
 # Generate fresh host key pair.
 Provisioning.RegenerateSshHostKeyPair=y
 
-# Supported values are "rsa", "dsa", "ecdsa", and "ed25519".
-Provisioning.SshHostKeyPairType=ed25519
+# Supported values are "rsa", "dsa", "ecdsa", "ed25519", and "auto".
+Provisioning.SshHostKeyPairType=auto
 
 # Monitor host name changes and publish changes via DHCP requests.
 Provisioning.MonitorHostName=y

--- a/config/waagent.conf
+++ b/config/waagent.conf
@@ -14,7 +14,7 @@ Provisioning.DeleteRootPassword=y
 # Generate fresh host key pair.
 Provisioning.RegenerateSshHostKeyPair=y
 
-# Supported values are "rsa", "dsa" and "ecdsa".
+# Supported values are "rsa", "dsa", "ecdsa", "ed25519", and "auto".
 Provisioning.SshHostKeyPairType=rsa
 
 # Monitor host name changes and publish changes via DHCP requests.


### PR DESCRIPTION
The supported values are now `rsa`, `dsa`, `ecdsa`, `ed25519`, or **`auto`**.  **`auto`** generates all supported host key types in the correct directory by calling `ssh-keygen -A` (supported since ***Open*****SSH** 5.9 in 2011).  The code uses `rsa` for the thumbprint because only a single one is supported by the agent and the Azure protocol.