### PR TITLE
Fix clearlinux distro_name (#792)

### DIFF
--- a/azurelinuxagent/common/osutil/factory.py
+++ b/azurelinuxagent/common/osutil/factory.py
@@ -41,7 +41,7 @@ def get_osutil(distro_name=DISTRO_NAME,
     if distro_name == "arch":
         return ArchUtil()
 
-    if distro_name == "clear linux software for intel architecture":
+    if distro_name == "clearlinux":
         return ClearLinuxUtil()
 
     if distro_name == "ubuntu":

--- a/azurelinuxagent/common/version.py
+++ b/azurelinuxagent/common/version.py
@@ -106,6 +106,9 @@ def get_distro():
     if os.path.exists("/etc/cp-release"):
         osinfo = get_checkpoint_platform()
 
+    if "Clear Linux" in osinfo[0]:
+        osinfo[0] = "clearlinux"
+
     # Remove trailing whitespace and quote in distro name
     osinfo[0] = osinfo[0].strip('"').strip(' ').lower()
     return osinfo


### PR DESCRIPTION
Updating distro_name condition to match /usr/lib/os-release for current 
clearlinux releases.

Signed-off-by: Ornelas Aguayo, Jesus <jesus.ornelas.aguayo@intel.com>