### PR TITLE
Accommodate new Clear Linux distro string in os-release.

### DIFF
--- a/azurelinuxagent/common/osutil/factory.py
+++ b/azurelinuxagent/common/osutil/factory.py
@@ -41,7 +41,8 @@ def get_osutil(distro_name=DISTRO_NAME,
     if distro_name == "arch":
         return ArchUtil()
 
-    if distro_name == "clear linux software for intel architecture":
+    if distro_name == "clear linux os for intel architecture" \
+            or distro_name == "clear linux software for intel architecture": 
         return ClearLinuxUtil()
 
     if distro_name == "ubuntu":


### PR DESCRIPTION
Support both new and old text for Clear Linux in os-release. Verified this works in a live test in Azure.