### PR TITLE
[#801] -- Agent fails to clean-up PID files

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,10 @@ script.
 ### CONFIGURATION
 
 A configuration file (/etc/waagent.conf) controls the actions of
-waagent. A sample configuration file is shown below:
+waagent. Blank lines and lines whose first character is a `#` are
+ignored (end-of-line comments are *not* supported).
+
+A sample configuration file is shown below:
 
 ```
 Provisioning.Enabled=y

--- a/azurelinuxagent/agent.py
+++ b/azurelinuxagent/agent.py
@@ -64,7 +64,19 @@ class Agent(object):
         logger.add_logger_appender(logger.AppenderType.CONSOLE, level,
                                  path="/dev/console")
 
+        ext_log_dir = conf.get_ext_log_dir()
+        try:
+            if os.path.isfile(ext_log_dir):
+                raise Exception("{0} is a file".format(ext_log_dir))
+            if not os.path.isdir(ext_log_dir):
+                os.makedirs(ext_log_dir)
+        except Exception as e:
+            logger.error(
+                "Exception occurred while creating extension "
+                "log directory {0}: {1}".format(ext_log_dir, e))
+
         #Init event reporter
+        event.init_event_status(conf.get_lib_dir())
         event_dir = os.path.join(conf.get_lib_dir(), "events")
         event.init_event_logger(event_dir)
         event.enable_unhandled_err_dump("WALA")

--- a/azurelinuxagent/common/event.py
+++ b/azurelinuxagent/common/event.py
@@ -67,25 +67,29 @@ class EventStatus(object):
     EVENT_STATUS_FILE = "event_status.json"
 
     def __init__(self, status_dir=conf.get_lib_dir()):
-        self._path = os.path.join(status_dir, EventStatus.EVENT_STATUS_FILE)
-        self._load()
+        self._path = None
+        self._status = {}
 
     def clear(self):
-        self.status = {}
+        self._status = {}
         self._save()
 
     def event_marked(self, name, version, op):
-        return self._event_name(name, version, op) in self.status
+        return self._event_name(name, version, op) in self._status
 
     def event_succeeded(self, name, version, op):
         event = self._event_name(name, version, op)
-        if event not in self.status:
+        if event not in self._status:
             return True
-        return self.status[event] == True
+        return self._status[event] == True
+
+    def initialize(self, status_dir=conf.get_lib_dir()):
+        self._path = os.path.join(status_dir, EventStatus.EVENT_STATUS_FILE)
+        self._load()
 
     def mark_event_status(self, name, version, op, status):
         event = self._event_name(name, version, op)
-        self.status[event] = (status == True)
+        self._status[event] = (status == True)
         self._save()
 
     def _event_name(self, name, version, op):
@@ -93,18 +97,18 @@ class EventStatus(object):
 
     def _load(self):
         try:
-            self.status = {}
+            self._status = {}
             if os.path.isfile(self._path):
                 with open(self._path, 'r') as f:
-                    self.status = json.load(f)
+                    self._status = json.load(f)
         except Exception as e:
             logger.warn("Exception occurred loading event status: {0}".format(e))
-            self.status = {}
+            self._status = {}
 
     def _save(self):
         try:
             with open(self._path, 'w') as f:
-                json.dump(self.status, f)
+                json.dump(self._status, f)
         except Exception as e:
             logger.warn("Exception occurred saving event status: {0}".format(e))
 
@@ -130,7 +134,7 @@ class EventLogger(object):
 
     def save_event(self, data):
         if self.event_dir is None:
-            logger.warn("Event reporter is not initialized.")
+            logger.warn("Cannot save event -- Event reporter is not initialized.")
             return
 
         if not os.path.exists(self.event_dir):
@@ -230,7 +234,7 @@ def add_event(name, op="", is_success=True, duration=0, version=CURRENT_VERSION,
               message="", evt_type="", is_internal=False, log_event=True,
               reporter=__event_logger__):
     if reporter.event_dir is None:
-        logger.warn("Event reporter is not initialized.")
+        logger.warn("Cannot add event -- Event reporter is not initialized.")
         _log_event(name, op, message, is_success=is_success)
         return
 
@@ -246,7 +250,7 @@ def add_periodic(
     message="", evt_type="", is_internal=False, log_event=True, force=False,
     reporter=__event_logger__):
     if reporter.event_dir is None:
-        logger.warn("Event reporter is not initialized.")
+        logger.warn("Cannot add periodic event -- Event reporter is not initialized.")
         _log_event(name, op, message, is_success=is_success)
         return
 
@@ -266,9 +270,11 @@ def should_emit_event(name, version, op, status):
         not __event_status__.event_marked(name, version, op) or \
         __event_status__.event_succeeded(name, version, op) != status
 
-def init_event_logger(event_dir, reporter=__event_logger__):
-    reporter.event_dir = event_dir
+def init_event_logger(event_dir):
+    __event_logger__.event_dir = event_dir
 
+def init_event_status(status_dir):
+    __event_status__.initialize(status_dir)
 
 def dump_unhandled_err(name):
     if hasattr(sys, 'last_type') and hasattr(sys, 'last_value') and \

--- a/azurelinuxagent/ga/monitor.py
+++ b/azurelinuxagent/ga/monitor.py
@@ -36,8 +36,8 @@ from azurelinuxagent.common.protocol.restapi import TelemetryEventParam, \
                                                     set_properties
 from azurelinuxagent.common.utils.textutil import parse_doc, findall, find, getattrib
 from azurelinuxagent.common.version import DISTRO_NAME, DISTRO_VERSION, \
-                                            DISTRO_CODE_NAME, AGENT_LONG_VERSION, \
-                                            AGENT_NAME, CURRENT_VERSION
+            DISTRO_CODE_NAME, AGENT_LONG_VERSION, \
+            AGENT_NAME, CURRENT_AGENT, CURRENT_VERSION
 
 
 def parse_event(data_str):

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -26,8 +26,10 @@ import tempfile
 import unittest
 from functools import wraps
 
+import azurelinuxagent.common.event as event
 import azurelinuxagent.common.conf as conf
 import azurelinuxagent.common.logger as logger
+
 from azurelinuxagent.common.version import PY_VERSION_MAJOR
 
 #Import mock module for Python2 and Python3
@@ -51,13 +53,20 @@ if debug:
 class AgentTestCase(unittest.TestCase):
     def setUp(self):
         prefix = "{0}_".format(self.__class__.__name__)
+
         self.tmp_dir = tempfile.mkdtemp(prefix=prefix)
         self.test_file = 'test_file'
+
         conf.get_autoupdate_enabled = Mock(return_value=True)
         conf.get_lib_dir = Mock(return_value=self.tmp_dir)
+
         ext_log_dir = os.path.join(self.tmp_dir, "azure")
         conf.get_ext_log_dir = Mock(return_value=ext_log_dir)
+
         conf.get_agent_pid_file_path = Mock(return_value=os.path.join(self.tmp_dir, "waagent.pid"))
+
+        event.init_event_status(self.tmp_dir)
+        event.init_event_logger(self.tmp_dir)
 
     def tearDown(self):
         if not debug and self.tmp_dir is not None:


### PR DESCRIPTION
[#801] -- Agent fails to clean-up PID files
[#811] -- Comments inline in /etc/waagent.conf cause config to not be read
[#812] -- Agent fails and isn't recoverable if an extension's log directory is not present anymore

Signed-off-by: Brendan Dixon <brendandixon@me.com>