### PR TITLE
Add RDMA support for Ubuntu

### DIFF
--- a/azurelinuxagent/common/conf.py
+++ b/azurelinuxagent/common/conf.py
@@ -91,6 +91,8 @@ def enable_rdma(conf=__conf__):
            conf.get_switch("OS.UpdateRdmaDriver", False) or \
            conf.get_switch("OS.CheckRdmaDriver", False)
 
+def enable_rdma_update(conf=__conf__):
+    return conf.get_switch("OS.UpdateRdmaDriver", False)
 
 def get_logs_verbose(conf=__conf__):
     return conf.get_switch("Logs.Verbose", False)

--- a/azurelinuxagent/pa/rdma/factory.py
+++ b/azurelinuxagent/pa/rdma/factory.py
@@ -21,6 +21,7 @@ from azurelinuxagent.common.version import DISTRO_FULL_NAME, DISTRO_VERSION
 from azurelinuxagent.common.rdma import RDMAHandler
 from .suse import SUSERDMAHandler
 from .centos import CentOSRDMAHandler
+from .ubuntu import UbuntuRDMAHandler
 
 
 def get_rdma_handler(
@@ -36,6 +37,9 @@ def get_rdma_handler(
 
     if distro_full_name == 'CentOS Linux' or distro_full_name == 'CentOS':
         return CentOSRDMAHandler(distro_version)
+
+    if distro_full_name == 'Ubuntu':
+        return UbuntuRDMAHandler()
 
     logger.info("No RDMA handler exists for distro='{0}' version='{1}'", distro_full_name, distro_version)
     return RDMAHandler()

--- a/azurelinuxagent/pa/rdma/ubuntu.py
+++ b/azurelinuxagent/pa/rdma/ubuntu.py
@@ -21,6 +21,7 @@ import glob
 import os
 import re
 import time
+import azurelinuxagent.common.conf as conf
 import azurelinuxagent.common.logger as logger
 import azurelinuxagent.common.utils.shellutil as shellutil
 from azurelinuxagent.common.rdma import RDMAHandler
@@ -58,6 +59,10 @@ class UbuntuRDMAHandler(RDMAHandler):
             return
 
 	#Driver not found. We need to check to see if we need to update kernel
+        if not conf.enable_rdma_update():
+            logger.info("RDMA: driver update is disabled. Skip kernel update")
+            return
+
         status,output = shellutil.run_get_output('uname -r')
         if status != 0:
             return

--- a/azurelinuxagent/pa/rdma/ubuntu.py
+++ b/azurelinuxagent/pa/rdma/ubuntu.py
@@ -1,0 +1,116 @@
+# Microsoft Azure Linux Agent
+#
+# Copyright 2014 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Requires Python 2.4+ and Openssl 1.0+
+#
+
+import glob
+import os
+import re
+import time
+import azurelinuxagent.common.logger as logger
+import azurelinuxagent.common.utils.shellutil as shellutil
+from azurelinuxagent.common.rdma import RDMAHandler
+
+
+class UbuntuRDMAHandler(RDMAHandler):
+
+    def install_driver(self):
+        #Install the appropriate driver package for the RDMA firmware
+
+        nd_version = RDMAHandler.get_rdma_version()
+        if not nd_version:
+            logger.error("RDMA: Could not determine firmware version. No driver will be installed")
+            return
+        #strip the trailing .*, we are looking for number like 144
+        nd_version = re.sub('\..*', '', nd_version)
+
+        #Check to see if we need to reconfigure driver
+        status,module_name = shellutil.run_get_output('modprobe -R hv_network_direct')
+        if status != 0:
+            logger.info("RDMA: modprobe -R hv_network_direct failed. Use module name hv_network_direct")
+            module_name = "hv_network_direct"
+        else:
+            module_name = module_name.strip()
+        logger.info("RDMA: current RDMA driver %s nd_version %s" % (module_name, nd_version))
+        if module_name == 'hv_network_direct_%s' % nd_version:
+            logger.info("RDMA: driver is installed and ND version matched. Skip reconfiguring driver")
+            return
+
+        #Reconfigure driver if one is available
+        status,output = shellutil.run_get_output('modinfo hv_network_direct_%s' % nd_version);
+        if status == 0:
+            logger.info("RDMA: driver with ND version is installed. Link to module name")
+            self.update_modprobed_conf(nd_version)
+            return
+
+	#Driver not found. We need to check to see if we need to update kernel
+        status,output = shellutil.run_get_output('uname -r')
+        if status != 0:
+            return
+        if not re.search('-azure$', output):
+            logger.error("RDMA: skip driver update on non-Azure kernel")
+            return
+        kernel_version = re.sub('-azure$', '', output)
+        kernel_version = re.sub('-', '.', kernel_version)
+
+        #Find the new kernel package version
+        status,output = shellutil.run_get_output('apt-get update')
+        if status != 0:
+            return
+        status,output = shellutil.run_get_output('apt-cache show --no-all-versions linux-azure')
+        if status != 0:
+            return
+        r = re.search('Version: (\S+)', output)
+        if not r:
+            logger.error("RDMA: version not found in package linux-azure.")
+            return
+        package_version = r.groups()[0]
+        #Remove the ending .<upload number> after <ABI number>
+        package_version = re.sub("\.\d+$", "", package_version)
+
+        logger.info('RDMA: kernel_version=%s package_version=%s' % (kernel_version, package_version))
+        if kernel_version < package_version:
+            logger.info("RDMA: newer version available, update kernel and reboot")
+            status,output = shellutil.run_get_output('apt-get -y install linux-azure')
+            if status:
+                logger.error("RDMA: kernel update failed")
+                return
+            self.reboot_system()
+        else:
+            logger.error("RDMA: no kernel update is avaiable for ND version %s" % nd_version)
+
+    def update_modprobed_conf(self, nd_version):
+        #Update /etc/modprobe.d/vmbus-rdma.conf to point to the correct driver
+
+        modprobed_file = '/etc/modprobe.d/vmbus-rdma.conf'
+        if not os.path.isfile(modprobed_file):
+            logger.error("RDMA: % not found" % modprobed_file)
+            logger.error("RDMA: modprobed conf file is required for Ubuntu")
+            return
+
+        f = open(modprobed_file, 'r')
+        lines = f.read()
+        f.close()
+        r = re.search('alias hv_network_direct hv_network_direct_\S+', lines)
+        if r:
+            lines = re.sub('alias hv_network_direct hv_network_direct_\S+', 'alias hv_network_direct hv_network_direct_%s' % nd_version, lines)
+        else:
+            lines += '\nalias hv_network_direct hv_network_direct_%s\n' % nd_version
+        f = open('/etc/modprobe.d/vmbus-rdma.conf', 'w')
+        f.write(lines)
+        f.close()
+        logger.info("RDMA: hv_network_direct alias updated to ND %s" % nd_version)

--- a/config/ubuntu/waagent.conf
+++ b/config/ubuntu/waagent.conf
@@ -82,6 +82,9 @@ OS.SshDir=/etc/ssh
 # Enable RDMA management and set up, should only be used in HPC images
 # OS.EnableRDMA=y
 
+# Enable RDMA kernel update, should only be used with Ubuntu
+# OS.UpdateRdmaDriver=y
+
 # Enable or disable goal state processing auto-update, default is enabled
 # AutoUpdate.Enabled=y
 


### PR DESCRIPTION
Unlike CentOS and SUSE, Ubuntu uses a different method to package RDMA driver. It builds multiple versions of the driver in the same kernel. During boot process, WALA is responsible for locating the correct driver. Due to multiple versions of the same driver are present in the system, the hv_network_direct needs to be blacklisted in /etc/modprobe.d/vmbus-rdma.conf. WALA then probes the correct driver to load. If no suitable driver is found, WALA attempts to perform a kernel update.
