### PR TITLE
RFE: add support for monitoring configure file changes

### DIFF
--- a/azurelinuxagent/common/conf.py
+++ b/azurelinuxagent/common/conf.py
@@ -200,6 +200,8 @@ def get_password_crypt_salt_len(conf=__conf__):
 def get_monitor_hostname(conf=__conf__):
     return conf.get_switch("Provisioning.MonitorHostName", False)
 
+def get_monitor_conf_file(conf=__conf__):
+    return conf.get_switch("Provisioning.MonitorConfFile", False)
 
 def get_httpproxy_host(conf=__conf__):
     return conf.get("HttpProxy.Host", None)

--- a/azurelinuxagent/common/osutil/default.py
+++ b/azurelinuxagent/common/osutil/default.py
@@ -722,10 +722,11 @@ class DefaultOSUtil(object):
                 continue
             if fileutil.findre_in_file(conf_file, autosend):
                 #Return if auto send host-name is configured
-                return
+                return False
             fileutil.update_conf_file(conf_file,
                                       'send host-name',
                                       'send host-name "{0}";'.format(hostname))
+        return True
 
     def restart_if(self, ifname, retries=3, wait=5):
         retry_limit=retries+1
@@ -741,10 +742,12 @@ class DefaultOSUtil(object):
                 logger.warn("exceeded restart retries")
 
     def publish_hostname(self, hostname):
-        self.set_dhcp_hostname(hostname)
+        changed = self.set_dhcp_hostname(hostname)
         self.set_hostname_record(hostname)
-        ifname = self.get_if_name()
-        self.restart_if(ifname)
+        # Configure changed, restart IF
+        if changed:
+            ifname = self.get_if_name()
+            self.restart_if(ifname)
 
     def set_scsi_disks_timeout(self, timeout):
         for dev in os.listdir("/sys/block"):

--- a/azurelinuxagent/ga/env.py
+++ b/azurelinuxagent/ga/env.py
@@ -27,7 +27,7 @@ import azurelinuxagent.common.logger as logger
 
 from azurelinuxagent.common.dhcp import get_dhcp_handler
 from azurelinuxagent.common.osutil import get_osutil
-from azurelinuxagetn.common.protocol import get_protocol_util
+from azurelinuxagent.common.protocol import get_protocol_util
 
 def get_env_handler():
     return EnvHandler()

--- a/config/waagent.conf
+++ b/config/waagent.conf
@@ -20,6 +20,9 @@ Provisioning.SshHostKeyPairType=rsa
 # Monitor host name changes and publish changes via DHCP requests.
 Provisioning.MonitorHostName=y
 
+# Monitor some important configure files
+Provisioning.MonitorConfFile=y
+
 # Decode CustomData from Base64.
 Provisioning.DecodeCustomData=n
 


### PR DESCRIPTION
In Azure, several configure files have some special settings, such as, sshd configure file(KeepAlive etc), dhcp client configure file(send hostname). But if we do system upgrade(such like with one rpm file), these special settings will be overwritten. This will have some impactions for use, such like,
if sshd keepalive option is lost, user 's current terminal will hang after a while idle.
if dhcp send hostname option is lost, hostname cannot be resolved after changing hostname.

so this PR adds support to monitor these files changes and make sure these setting will be there even after system upgrade. 