### PR TITLE
No need to set hostname again while hostname changes

### DIFF
--- a/azurelinuxagent/ga/env.py
+++ b/azurelinuxagent/ga/env.py
@@ -105,7 +105,6 @@ class EnvHandler(object):
             logger.info("EnvMonitor: Detected hostname change: {0} -> {1}",
                         self.hostname,
                         curr_hostname)
-            self.osutil.set_hostname(curr_hostname)
             self.osutil.publish_hostname(curr_hostname)
             self.hostname = curr_hostname
 


### PR DESCRIPTION
It is unnecessary to set hostname again while monitor detects hostname change.
Just publish it.