### PR TITLE
Added safe deployment support and more

### DIFF
--- a/azurelinuxagent/common/event.py
+++ b/azurelinuxagent/common/event.py
@@ -44,7 +44,10 @@ _EVENT_MSG = "Event: name={0}, op={1}, message={2}, duration={3}"
 
 class WALAEventOperation:
     ActivateResourceDisk = "ActivateResourceDisk"
+    AgentBlacklisted = "AgentBlacklisted"
+    AgentEnabled = "AgentEnabled"
     AutoUpdate = "AutoUpdate"
+    Deploy = "Deploy"
     Disable = "Disable"
     Download = "Download"
     Enable = "Enable"
@@ -54,6 +57,7 @@ class WALAEventOperation:
     HostPlugin = "HostPlugin"
     Install = "Install"
     InitializeHostPlugin = "InitializeHostPlugin"
+    Partition = "Partition"
     ProcessGoalState = "ProcessGoalState"
     Provision = "Provision"
     ReportStatus = "ReportStatus"

--- a/azurelinuxagent/common/osutil/default.py
+++ b/azurelinuxagent/common/osutil/default.py
@@ -16,20 +16,21 @@
 # Requires Python 2.4+ and Openssl 1.0+
 #
 
+import array
+import base64
+import datetime
+import fcntl
+import glob
 import multiprocessing
 import os
 import platform
+import pwd
 import re
 import shutil
 import socket
-import array
 import struct
+import sys
 import time
-import pwd
-import fcntl
-import base64
-import glob
-import datetime
 
 import azurelinuxagent.common.logger as logger
 import azurelinuxagent.common.conf as conf
@@ -964,3 +965,7 @@ class DefaultOSUtil(object):
 
     def check_pid_alive(self, pid):
         return pid is not None and os.path.isdir(os.path.join('/proc', pid))
+
+    @property
+    def is_64bit(self):
+        return sys.maxsize > 2**32

--- a/azurelinuxagent/common/utils/deploy.py
+++ b/azurelinuxagent/common/utils/deploy.py
@@ -1,0 +1,134 @@
+# Windows Azure Linux Agent
+#
+# Copyright 2014 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Requires Python 2.4+ and Openssl 1.0+
+#
+
+import json
+import os
+import platform
+import re
+import sys
+
+import azurelinuxagent.common.conf as conf
+import azurelinuxagent.common.logger as logger
+import azurelinuxagent.common.utils.fileutil as fileutil
+
+from azurelinuxagent.common.osutil import get_osutil
+
+DEPLOY_FILE = "deploy.json"
+DEPLOYED_FILE = "deployed.json"
+
+
+class Deploy(object):
+    def __init__(self, dir=None):
+        if dir is not None and not os.path.isdir(dir):
+            raise Exception(u"Deploy requires a directory")
+
+        self.dir = dir
+        self._load()
+
+    @property
+    def blacklisted(self):
+        return self._blacklisted
+
+    @property
+    def family(self):
+        return None if self._family is None else self._family.name
+
+    def in_partition(self, partition):
+        return not self.in_safe_deployment_mode or \
+            (self._family is not None and self._family.in_partition(partition))
+
+    @property
+    def in_safe_deployment_mode(self):
+        return self._safe_deployment
+    
+    @property
+    def is_deployed(self):
+        return self._deployed
+
+    def mark_deployed(self):
+        before = os.path.join(self.dir, DEPLOY_FILE)
+        if os.path.exists(before):
+            after = os.path.join(self.dir, DEPLOYED_FILE)
+            try:
+                os.rename(before, after)
+                self._deployed = True
+            except Exception as e:
+                logger.warn("Failed to rename {0} to {1}".format(before, after))
+
+    def _load(self):
+        self._blacklisted = []
+        self._families = {}
+        self._family = None
+        self._deployed = False
+        self._safe_deployment = False
+
+        if self.dir is not None:
+            path = os.path.join(self.dir, DEPLOY_FILE)
+            if not os.path.isfile(path):
+                path = os.path.join(self.dir, DEPLOYED_FILE)
+                self._deployed = os.path.isfile(path)
+
+            if os.path.isfile(path):
+                self._safe_deployment = True
+                try:
+                    self._from_json(json.loads(fileutil.read_file(path)))
+                except Exception as e:
+                    logger.warn("Failed JSON parse of {0}: {1}".format(path, e))
+
+            for family in sorted(iter(self._families.keys())):
+                family = self._families[family]
+                if family._is_supported:
+                    self._family = family
+                    break
+    
+    def _from_json(self, data):
+        self._blacklisted = data.get('blacklisted', [])
+
+        if 'families' in data:
+            families = data['families']
+            for family in families:
+                self._families[family] = Family(family, families[family])
+
+class Family(object):
+    def __init__(self, name, data):
+        if name is None:
+            raise Exception(u"Family requires a name")
+        if data is None:
+            raise Exception(u"Family requires the family data")
+
+        self.name = name
+        self._from_json(data)
+        self._evaluate()
+
+    def in_partition(self, partition):
+        return self._is_supported and partition < self._partition
+
+    def _evaluate(self):
+        if not self._require_64bit or get_osutil().is_64bit:
+            d = ','.join(platform.linux_distribution())
+            for v in self._versions:
+                if re.match(v, d):
+                    self._is_supported = True
+                    break
+
+    def _from_json(self, data):
+        self._versions = data.get('versions', [])
+        self._require_64bit = data.get('require_64bit', True)
+        self._partition = data.get('partition', 0)
+        self._is_supported = False

--- a/tests/data/deploy.json
+++ b/tests/data/deploy.json
@@ -1,0 +1,20 @@
+{
+    "blacklisted" : ["1.2.3", "1.3.*"],
+
+    "families" : {
+        "ubuntu-x64": {
+            "versions": [
+                "^Ubuntu,(1[4-9]|2[0-9])\\.\\d+,.*$"
+            ],
+            "require_64bit": true,
+            "partition": 85
+        },
+        "fedora-x64": {
+            "versions": [
+                "^Oracle[^,]*,([7-9]|[1-9][0-9])\\.\\d+,.*$",
+                "^Red\\sHat[^,]*,([7-9]|[1-9][0-9])\\.\\d+,.*$"
+            ],
+            "partition": 20
+        }
+    }
+}

--- a/tests/data/ga/supported.json
+++ b/tests/data/ga/supported.json
@@ -1,8 +1,0 @@
-{
-    "ubuntu.16.10-x64": {
-        "versions": [
-            "^Ubuntu,16.10,yakkety$"
-        ],
-        "slice": 10
-    }
-}

--- a/tests/utils/test_deploy.py
+++ b/tests/utils/test_deploy.py
@@ -1,0 +1,194 @@
+# Copyright 2014 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Requires Python 2.4+ and Openssl 1.0+
+#
+
+from __future__ import print_function
+
+import json
+import os.path
+import shutil
+
+from azurelinuxagent.common.utils.deploy import *
+from azurelinuxagent.common.utils.fileutil import *
+from tests.tools import *
+
+
+UBUNTU_PLATFORMS = [
+    ["Ubuntu", "14.04", ""],
+    ["Ubuntu", "14.10", ""],
+    ["Ubuntu", "15.10", ""],
+    ["Ubuntu", "15.10", "Snappy Ubuntu Core"],
+    ["Ubuntu", "16.04", ""],
+    ["Ubuntu", "16.10", ""]
+]
+
+FEDORA_PLATFORMS = [
+    ["Oracle", "7.2", ""],
+    ["Oracle", "7.3", ""],
+
+    ["Red Hat", "7.0", ""],
+    ["Red Hat", "7.3", ""]
+]
+
+UNSUPPORTED_PLATFORMS = [
+    ["coreos", "", ""],
+
+    ["debian", "6.0", ""],
+
+    ["suse", "12", "SUSE Linux Enterprise Server"],
+    ["suse", "13.2", "openSUSE"],
+    ["suse", "11", "SUSE Linux Enterprise Server"],
+    ["suse", "13.1", "openSUSE"]
+]
+
+class TestFamily(AgentTestCase):
+
+    @patch('azurelinuxagent.common.utils.deploy.get_osutil', return_value=Mock(is_64bit=True))
+    @patch('platform.linux_distribution', return_value=('Ubuntu', '16.10', 'yakkety'))
+    def test_creation(self, mock_distribution, mock_osutil):
+        self.assertRaises(TypeError, Family)
+        self.assertRaises(Exception, Family, None, {})
+        self.assertRaises(Exception, Family, "name", None)
+
+        data = json.loads(load_data("deploy.json"))
+        family = Family("ubuntu-x64", data["families"]["ubuntu-x64"])
+
+        self.assertEqual(family.name, "ubuntu-x64")
+        self.assertTrue(family._is_supported)
+        self.assertEqual(family._partition, 85)
+        self.assertEqual(family._versions, ['^Ubuntu,(1[4-9]|2[0-9])\\.\\d+,.*$'])
+
+    @patch('azurelinuxagent.common.utils.deploy.get_osutil')
+    @patch('platform.linux_distribution', return_value=('Ubuntu', '16.10', 'yakkety'))
+    def test_architecture_matches(self, mock_distribution, mock_osutil):
+        data = json.loads(load_data("deploy.json"))
+
+        mock_osutil.is_64bit = True
+        family = Family("ubuntu-x64", data["families"]["ubuntu-x64"])
+        self.assertTrue(family._is_supported)
+
+        mock_osutil.is_64bit = False
+        family = Family("ubuntu-x64", data["families"]["ubuntu-x64"])
+        self.assertTrue(family._is_supported)
+
+    @patch('azurelinuxagent.common.utils.deploy.get_osutil', return_value=Mock(is_64bit=True))
+    @patch('platform.linux_distribution', return_value=('Ubuntu', '16.10', 'yakkety'))
+    def test_in_partition(self, mock_distribution, mock_osutil):
+        data = json.loads(load_data("deploy.json"))
+        family = Family("ubuntu-x64", data["families"]["ubuntu-x64"])
+
+        self.assertEqual(family._partition, 85)
+        for i in range(0, 100):
+            self.assertEqual(i < family._partition, family.in_partition(i))
+
+    @patch('azurelinuxagent.common.utils.deploy.get_osutil', return_value=Mock(is_64bit=True))
+    @patch('platform.linux_distribution')
+    def test_version_matches(self, mock_distribution, mock_osutil):
+        data = json.loads(load_data("deploy.json"))
+
+        for d in UBUNTU_PLATFORMS:
+            mock_distribution.return_value = d
+            family = Family("ubuntu-x64", data["families"]["ubuntu-x64"])
+            self.assertTrue(family._is_supported)
+
+        for d in FEDORA_PLATFORMS:
+            mock_distribution.return_value = d
+            family = Family("fedora-x64", data["families"]["fedora-x64"])
+            self.assertTrue(family._is_supported)
+
+        for d in UNSUPPORTED_PLATFORMS:
+            mock_distribution.return_value = d
+            family = Family("ubuntu-x64", data["families"]["ubuntu-x64"])
+            self.assertFalse(family._is_supported)
+            family = Family("fedora-x64", data["families"]["fedora-x64"])
+            self.assertFalse(family._is_supported)
+
+
+class TestDeploy(AgentTestCase):
+    def setUp(self):
+        AgentTestCase.setUp(self)
+        shutil.copy(os.path.join(data_dir, DEPLOY_FILE), self.tmp_dir)
+
+    @patch('azurelinuxagent.common.utils.deploy.get_osutil', return_value=Mock(is_64bit=True))
+    @patch('platform.linux_distribution', return_value=('Ubuntu', '16.10', 'yakkety'))
+    def test_creation(self, mock_distribution, mock_osutil):
+        self.assertRaises(Exception, Deploy, "foobarbaz")
+
+        deploy = Deploy()
+        self.assertEqual(0, len(deploy.blacklisted))
+        self.assertEqual(0, len(deploy._families))
+        self.assertEqual(None, deploy._family)
+        self.assertEqual(None, deploy.family)
+
+        deploy = Deploy(self.tmp_dir)
+        self.assertTrue(len(deploy.blacklisted) > 0)
+        self.assertTrue(len(deploy._families) > 0)
+        self.assertFalse(deploy._family is None)
+        self.assertTrue(len(deploy.family) > 0)
+
+        os.remove(os.path.join(self.tmp_dir, DEPLOY_FILE))
+        deploy = Deploy(self.tmp_dir)
+        self.assertEqual(0, len(deploy.blacklisted))
+        self.assertEqual(0, len(deploy._families))
+        self.assertEqual(None, deploy._family)
+        self.assertEqual(None, deploy.family)
+
+    @patch('azurelinuxagent.common.utils.deploy.get_osutil', return_value=Mock(is_64bit=True))
+    @patch('platform.linux_distribution', return_value=('Ubuntu', '16.10', 'yakkety'))
+    def test_in_safe_deployment_mode(self, mock_distribution, mock_osutil):
+        deploy = Deploy(self.tmp_dir)
+        self.assertTrue(deploy.in_safe_deployment_mode)
+
+        os.remove(os.path.join(self.tmp_dir, DEPLOY_FILE))
+        deploy = Deploy(self.tmp_dir)
+        self.assertFalse(deploy.in_safe_deployment_mode)
+
+    @patch('azurelinuxagent.common.utils.deploy.get_osutil', return_value=Mock(is_64bit=True))
+    @patch('platform.linux_distribution', return_value=('Ubuntu', '16.10', 'yakkety'))
+    def test_in_partition(self, mock_distribution, mock_osutil):
+        deploy = Deploy(self.tmp_dir)
+        self.assertTrue(deploy.in_partition(84))
+        self.assertFalse(deploy.in_partition(85))
+
+        os.remove(os.path.join(self.tmp_dir, DEPLOY_FILE))
+        deploy = Deploy(self.tmp_dir)
+        for i in range(0, 100):
+            self.assertTrue(deploy.in_partition(i))
+
+    @patch('azurelinuxagent.common.utils.deploy.get_osutil', return_value=Mock(is_64bit=True))
+    @patch('platform.linux_distribution', return_value=('Ubuntu', '16.10', 'yakkety'))
+    def test_mark_deployed(self, mock_distribution, mock_osutil):
+        deploy = Deploy(self.tmp_dir)
+
+        before = os.path.join(self.tmp_dir, DEPLOY_FILE)
+        after = os.path.join(self.tmp_dir, DEPLOYED_FILE)
+
+        self.assertTrue(os.path.isfile(before))
+        self.assertFalse(os.path.exists(after))
+        self.assertFalse(deploy.is_deployed)
+
+        deploy.mark_deployed()
+
+        self.assertFalse(os.path.exists(before))
+        self.assertTrue(os.path.isfile(after))
+        self.assertTrue(deploy.is_deployed)
+
+        deploy = Deploy(self.tmp_dir)
+        self.assertTrue(deploy.in_safe_deployment_mode)
+        self.assertTrue(deploy.is_deployed)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Added safe deployment support
[#875] -- The agent should include the incarnation number in ProcessGoalState events
[#874] -- The interval allowed before forcibly terminating the child process is too long

Signed-off-by: Brendan Dixon <brendandixon@me.com>