### PR TITLE
Sleep 1 second between polls for cloud-init created SSH keys

### DIFF
--- a/azurelinuxagent/pa/provision/cloudinit.py
+++ b/azurelinuxagent/pa/provision/cloudinit.py
@@ -103,7 +103,7 @@ class CloudInitProvisionHandler(ProvisionHandler):
                              "after {1}s".format(ovf_file_path,
                                                  max_retry * sleep_time))
 
-    def wait_for_ssh_host_key(self, max_retry=360, sleep_time=5):
+    def wait_for_ssh_host_key(self, max_retry=360, sleep_time=1):
         """
         Wait for cloud-init to generate ssh host key
         """

--- a/azurelinuxagent/pa/provision/cloudinit.py
+++ b/azurelinuxagent/pa/provision/cloudinit.py
@@ -103,7 +103,7 @@ class CloudInitProvisionHandler(ProvisionHandler):
                              "after {1}s".format(ovf_file_path,
                                                  max_retry * sleep_time))
 
-    def wait_for_ssh_host_key(self, max_retry=360, sleep_time=1):
+    def wait_for_ssh_host_key(self, max_retry=1800, sleep_time=1):
         """
         Wait for cloud-init to generate ssh host key
         """


### PR DESCRIPTION
We are not making any network calls, just simply querying for a file to exist. Personally I think this could be less than 1 second, maybe 0.1?