### PR TITLE
Address issues

### DIFF
--- a/azurelinuxagent/common/conf.py
+++ b/azurelinuxagent/common/conf.py
@@ -44,7 +44,7 @@ class ConfigurationProvider(object):
                 if len(parts) < 2:
                     continue
                 key = parts[0].strip()
-                value = parts[1].strip("\" ")
+                value = parts[1].split('#')[0].strip("\" ")
                 self.values[key] = value if value != "None" else None
 
     def get(self, key, default_val):

--- a/azurelinuxagent/common/event.py
+++ b/azurelinuxagent/common/event.py
@@ -47,6 +47,7 @@ class WALAEventOperation:
     AgentBlacklisted = "AgentBlacklisted"
     AgentEnabled = "AgentEnabled"
     AutoUpdate = "AutoUpdate"
+    CustomData = "CustomData"
     Deploy = "Deploy"
     Disable = "Disable"
     Download = "Download"

--- a/azurelinuxagent/common/utils/fileutil.py
+++ b/azurelinuxagent/common/utils/fileutil.py
@@ -42,7 +42,7 @@ KNOWN_IOERRORS = [
     errno.ENOSPC,       # Out of space
     errno.ENAMETOOLONG, # Name too long
     errno.ELOOP,        # Too many symbolic links encountered
-    errno.EREMOTEIO     # Remote I/O error
+    121                 # Remote I/O error (errno.EREMOTEIO -- not present in all Python 2.7+)
 ]
 
 

--- a/azurelinuxagent/common/utils/restutil.py
+++ b/azurelinuxagent/common/utils/restutil.py
@@ -32,10 +32,11 @@ from azurelinuxagent.common.version import PY_VERSION_MAJOR
 
 SECURE_WARNING_EMITTED = False
 
-DEFAULT_RETRIES = 3
+DEFAULT_RETRIES = 4
 
-SHORT_DELAY_IN_SECONDS = 5
-LONG_DELAY_IN_SECONDS = 15
+DELAY_IN_SECONDS = 1
+THROTTLE_DELAY_IN_SECONDS = 1
+MINIMUM_THROTTLE_RETRY = 15
 
 RETRY_CODES = [
     httpclient.RESET_CONTENT,
@@ -63,7 +64,8 @@ OK_CODES = [
 
 THROTTLE_CODES = [
     httpclient.FORBIDDEN,
-    httpclient.SERVICE_UNAVAILABLE
+    httpclient.SERVICE_UNAVAILABLE,
+    429, # Request Rate Limit Exceeded
 ]
 
 RETRY_EXCEPTIONS = [
@@ -76,6 +78,12 @@ RETRY_EXCEPTIONS = [
 HTTP_PROXY_ENV = "http_proxy"
 HTTPS_PROXY_ENV = "https_proxy"
 
+
+def _compute_delay(retry_attempt=1, delay=DELAY_IN_SECONDS):
+    fib = (1, 1)
+    for n in range(retry_attempt):
+        fib = (fib[1], fib[0]+fib[1])
+    return delay*fib[1]
 
 def _is_retry_status(status, retry_codes=RETRY_CODES):
     return status in retry_codes
@@ -166,7 +174,7 @@ def http_request(method,
                 use_proxy=False,
                 max_retry=DEFAULT_RETRIES,
                 retry_codes=RETRY_CODES,
-                retry_delay=SHORT_DELAY_IN_SECONDS):
+                retry_delay=DELAY_IN_SECONDS):
 
     global SECURE_WARNING_EMITTED
 
@@ -219,7 +227,7 @@ def http_request(method,
             time.sleep(delay)
 
         attempt += 1
-        delay = retry_delay
+        delay = _compute_delay(retry_attempt=attempt, delay=retry_delay)
 
         try:
             resp = _http_request(method,
@@ -237,8 +245,17 @@ def http_request(method,
                 if _is_retry_status(resp.status, retry_codes=retry_codes):
                     msg = '[HTTP Retry] HTTP {0} Status Code {1}'.format(
                         method, resp.status)
+
+                    # Always delay a short, constant time for throttling
+                    # -- Most (all?) throttling comes from wireserver or
+                    #    the HostPlugin; both throttle when receiving more than
+                    #    1 message per second; longer delays impact deployment
+                    #    peformance
+                    # -- Since the delay for throttled requests is constant,
+                    #    ensure a safe, minimum number of retries is performed
                     if _is_throttle_status(resp.status):
-                        delay = LONG_DELAY_IN_SECONDS
+                        delay = THROTTLE_DELAY_IN_SECONDS
+                        max_retry = max(max_retry, MINIMUM_THROTTLE_RETRY)
                         logger.info("[HTTP Delay] Delay {0} seconds for " \
                                     "Status Code {1}".format(
                                         delay, resp.status))
@@ -265,7 +282,7 @@ def http_request(method,
 def http_get(url, headers=None, use_proxy=False,
                 max_retry=DEFAULT_RETRIES,
                 retry_codes=RETRY_CODES,
-                retry_delay=SHORT_DELAY_IN_SECONDS):
+                retry_delay=DELAY_IN_SECONDS):
     return http_request("GET",
                         url, None, headers=headers,
                         use_proxy=use_proxy,
@@ -277,7 +294,7 @@ def http_get(url, headers=None, use_proxy=False,
 def http_head(url, headers=None, use_proxy=False,
                 max_retry=DEFAULT_RETRIES,
                 retry_codes=RETRY_CODES,
-                retry_delay=SHORT_DELAY_IN_SECONDS):
+                retry_delay=DELAY_IN_SECONDS):
     return http_request("HEAD",
                         url, None, headers=headers,
                         use_proxy=use_proxy,
@@ -289,7 +306,7 @@ def http_head(url, headers=None, use_proxy=False,
 def http_post(url, data, headers=None, use_proxy=False,
                 max_retry=DEFAULT_RETRIES,
                 retry_codes=RETRY_CODES,
-                retry_delay=SHORT_DELAY_IN_SECONDS):
+                retry_delay=DELAY_IN_SECONDS):
     return http_request("POST",
                         url, data, headers=headers,
                         use_proxy=use_proxy,
@@ -301,7 +318,7 @@ def http_post(url, data, headers=None, use_proxy=False,
 def http_put(url, data, headers=None, use_proxy=False,
                 max_retry=DEFAULT_RETRIES,
                 retry_codes=RETRY_CODES,
-                retry_delay=SHORT_DELAY_IN_SECONDS):
+                retry_delay=DELAY_IN_SECONDS):
     return http_request("PUT",
                         url, data, headers=headers,
                         use_proxy=use_proxy,
@@ -313,7 +330,7 @@ def http_put(url, data, headers=None, use_proxy=False,
 def http_delete(url, headers=None, use_proxy=False,
                 max_retry=DEFAULT_RETRIES,
                 retry_codes=RETRY_CODES,
-                retry_delay=SHORT_DELAY_IN_SECONDS):
+                retry_delay=DELAY_IN_SECONDS):
     return http_request("DELETE",
                         url, None, headers=headers,
                         use_proxy=use_proxy,

--- a/azurelinuxagent/common/version.py
+++ b/azurelinuxagent/common/version.py
@@ -113,7 +113,7 @@ def get_distro():
 
 AGENT_NAME = "WALinuxAgent"
 AGENT_LONG_NAME = "Azure Linux Agent"
-AGENT_VERSION = '2.2.18'
+AGENT_VERSION = '2.2.18.1'
 AGENT_LONG_VERSION = "{0}-{1}".format(AGENT_NAME, AGENT_VERSION)
 AGENT_DESCRIPTION = """
 The Azure Linux Agent supports the provisioning and running of Linux

--- a/azurelinuxagent/pa/provision/default.py
+++ b/azurelinuxagent/pa/provision/default.py
@@ -22,6 +22,7 @@ Provision handler
 import os
 import os.path
 import re
+import time
 
 from datetime import datetime
 
@@ -244,9 +245,14 @@ class ProvisionHandler(object):
         fileutil.write_file(customdata_file, customdata)
 
         if conf.get_execute_customdata():
+            start = time.time()
             logger.info("Execute custom data")
             os.chmod(customdata_file, 0o700)
             shellutil.run(customdata_file)
+            add_event(name=AGENT_NAME,
+                        duration=int(time.time() - start),
+                        is_success=True,
+                        op=WALAEventOperation.CustomData)
 
     def deploy_ssh_pubkeys(self, ovfenv):
         for pubkey in ovfenv.ssh_pubkeys:

--- a/tests/data/test_waagent.conf
+++ b/tests/data/test_waagent.conf
@@ -20,13 +20,13 @@ Provisioning.DeleteRootPassword=y
 Provisioning.RegenerateSshHostKeyPair=y
 
 # Supported values are "rsa", "dsa" and "ecdsa".
-Provisioning.SshHostKeyPairType=rsa
+Provisioning.SshHostKeyPairType=rsa # An EOL comment that should be ignored
 
 # Monitor host name changes and publish changes via DHCP requests.
 Provisioning.MonitorHostName=y
 
 # Decode CustomData from Base64.
-Provisioning.DecodeCustomData=n
+Provisioning.DecodeCustomData=n#Another EOL comment that should be ignored
 
 # Execute CustomData after provisioning.
 Provisioning.ExecuteCustomData=n
@@ -63,7 +63,7 @@ ResourceDisk.MountOptions=None
 Logs.Verbose=n
 
 # Is FIPS enabled
-OS.EnableFIPS=y
+OS.EnableFIPS=y#Another EOL comment that should be ignored
 
 # Root device timeout in seconds.
 OS.RootDeviceScsiTimeout=300
@@ -72,7 +72,7 @@ OS.RootDeviceScsiTimeout=300
 OS.OpensslPath=None
 
 # Set the SSH ClientAliveInterval
-OS.SshClientAliveInterval=42
+OS.SshClientAliveInterval=42#Yet another EOL comment with a '#' that should be ignored
 
 # Set the path to SSH keys and configuration files
 OS.SshDir=/notareal/path

--- a/tests/utils/test_rest_util.py
+++ b/tests/utils/test_rest_util.py
@@ -268,6 +268,68 @@ class TestHttpOperations(AgentTestCase):
 
     @patch("time.sleep")
     @patch("azurelinuxagent.common.utils.restutil._http_request")
+    def test_http_request_retries_with_fibonacci_delay(self, _http_request, _sleep):
+        # Ensure the code is not a throttle code
+        self.assertFalse(httpclient.BAD_GATEWAY in restutil.THROTTLE_CODES)
+
+        _http_request.side_effect = [
+                Mock(status=httpclient.BAD_GATEWAY)
+                    for i in range(restutil.DEFAULT_RETRIES)
+            ] + [Mock(status=httpclient.OK)]
+
+        restutil.http_get("https://foo.bar",
+                            max_retry=restutil.DEFAULT_RETRIES+1)
+
+        self.assertEqual(restutil.DEFAULT_RETRIES+1, _http_request.call_count)
+        self.assertEqual(restutil.DEFAULT_RETRIES, _sleep.call_count)
+        self.assertEqual(
+            [
+                call(restutil._compute_delay(i+1, restutil.DELAY_IN_SECONDS))
+                    for i in range(restutil.DEFAULT_RETRIES)],
+            _sleep.call_args_list)
+
+    @patch("time.sleep")
+    @patch("azurelinuxagent.common.utils.restutil._http_request")
+    def test_http_request_retries_with_constant_delay_when_throttled(self, _http_request, _sleep):
+        # Ensure the code is a throttle code
+        self.assertTrue(httpclient.SERVICE_UNAVAILABLE in restutil.THROTTLE_CODES)
+
+        _http_request.side_effect = [
+                Mock(status=httpclient.SERVICE_UNAVAILABLE)
+                    for i in range(restutil.DEFAULT_RETRIES)
+            ] + [Mock(status=httpclient.OK)]
+
+        restutil.http_get("https://foo.bar",
+                            max_retry=restutil.DEFAULT_RETRIES+1)
+
+        self.assertEqual(restutil.DEFAULT_RETRIES+1, _http_request.call_count)
+        self.assertEqual(restutil.DEFAULT_RETRIES, _sleep.call_count)
+        self.assertEqual(
+            [call(1) for i in range(restutil.DEFAULT_RETRIES)],
+            _sleep.call_args_list)
+
+    @patch("time.sleep")
+    @patch("azurelinuxagent.common.utils.restutil._http_request")
+    def test_http_request_retries_for_safe_minimum_number_when_throttled(self, _http_request, _sleep):
+        # Ensure the code is a throttle code
+        self.assertTrue(httpclient.SERVICE_UNAVAILABLE in restutil.THROTTLE_CODES)
+
+        _http_request.side_effect = [
+                Mock(status=httpclient.SERVICE_UNAVAILABLE)
+                    for i in range(restutil.MINIMUM_THROTTLE_RETRY-1)
+            ] + [Mock(status=httpclient.OK)]
+
+        restutil.http_get("https://foo.bar",
+                            max_retry=1)
+
+        self.assertEqual(restutil.MINIMUM_THROTTLE_RETRY, _http_request.call_count)
+        self.assertEqual(restutil.MINIMUM_THROTTLE_RETRY-1, _sleep.call_count)
+        self.assertEqual(
+            [call(1) for i in range(restutil.MINIMUM_THROTTLE_RETRY-1)],
+            _sleep.call_args_list)
+
+    @patch("time.sleep")
+    @patch("azurelinuxagent.common.utils.restutil._http_request")
     def test_http_request_raises_for_bad_request(self, _http_request, _sleep):
         _http_request.side_effect = [
             Mock(status=httpclient.BAD_REQUEST)


### PR DESCRIPTION
[#897] -- 'Target handler state' wall of errors
[#896] -- End of Line Comments are Not Supported nor Handled
[#891] -- Create a Telemetry Event to Track Custom Data Execution
[#884] -- Cleanup Old Goal State and Extension Cache
[#876] -- The agent should use a scaling back-off when retrying HTTP requests
[#869] -- The agent should report OS information in the correct JSON format.

Updated version to 2.2.18.1
Replaced errno.EREMOTEIO with fixed value (since the constant is not present in all Python 2.7 versions)

Signed-off-by: Brendan Dixon <brendandixon@me.com>