### PR TITLE
Report prolonged report status failures

### DIFF
--- a/azurelinuxagent/common/errorstate.py
+++ b/azurelinuxagent/common/errorstate.py
@@ -1,0 +1,30 @@
+from datetime import datetime, timedelta
+
+ERROR_STATE_DELTA = timedelta(minutes=15)
+
+class ErrorState(object):
+    def __init__(self, min_timedelta):
+        self.min_timedelta = min_timedelta
+
+        self.count = 0;
+        self.timestamp = None
+
+    def incr(self):
+        if self.count == 0:
+            self.timestamp = datetime.utcnow()
+
+        self.count += 1
+
+    def reset(self):
+        self.count = 0
+        self.timestamp = None
+
+    def is_triggered(self):
+        if self.timestamp is None:
+            return False
+
+        delta = datetime.utcnow() - self.timestamp
+        if delta >= self.min_timedelta:
+            return True
+
+        return False

--- a/azurelinuxagent/common/errorstate.py
+++ b/azurelinuxagent/common/errorstate.py
@@ -2,11 +2,12 @@ from datetime import datetime, timedelta
 
 ERROR_STATE_DELTA = timedelta(minutes=15)
 
+
 class ErrorState(object):
-    def __init__(self, min_timedelta):
+    def __init__(self, min_timedelta = ERROR_STATE_DELTA):
         self.min_timedelta = min_timedelta
 
-        self.count = 0;
+        self.count = 0
         self.timestamp = None
 
     def incr(self):

--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -182,8 +182,7 @@ class ExtHandlersHandler(object):
         self.log_report = False
         self.log_etag = True
 
-        delta = datetime.timedelta(minutes=15)
-        self.report_status_error_state = ErrorState(delta)
+        self.report_status_error_state = ErrorState()
 
     def run(self):
         self.ext_handlers, etag = None, None

--- a/tests/common/test_errorstate.py
+++ b/tests/common/test_errorstate.py
@@ -1,0 +1,69 @@
+from datetime import timedelta
+
+from azurelinuxagent.common.errorstate import *
+from tests.tools import *
+
+
+class TestErrorState(unittest.TestCase):
+    def test_errorstate00(self):
+        """
+        If ErrorState is never incremented, it will never trigger.
+        """
+        test_subject = ErrorState(timedelta(seconds=10000))
+        self.assertFalse(test_subject.is_triggered())
+        self.assertEqual(0, test_subject.count)
+
+    def test_errorstate01(self):
+        """
+        If ErrorState is never incremented, and the timedelta is zero it will
+        not trigger.
+        """
+        test_subject = ErrorState(timedelta(seconds=0))
+        self.assertFalse(test_subject.is_triggered())
+        self.assertEqual(0, test_subject.count)
+
+    def test_errorstate02(self):
+        """
+        If ErrorState is triggered, and the current time is within timedelta
+        of now it will trigger.
+        """
+        test_subject = ErrorState(timedelta(seconds=0))
+        test_subject.incr()
+
+
+        self.assertTrue(test_subject.is_triggered())
+        self.assertEqual(1, test_subject.count)
+
+    @patch('azurelinuxagent.common.errorstate.datetime')
+    def test_errorstate03(self, mock_time):
+        """
+        ErrorState will not trigger until
+         1. ErrorState has been incr() at least once.
+         2. The timedelta from the first incr() has elapsed.
+        """
+        test_subject = ErrorState(timedelta(minutes=15))
+
+        for x in range(1, 10):
+            mock_time.utcnow = Mock(return_value=datetime.utcnow() + timedelta(minutes=x))
+
+            test_subject.incr()
+            self.assertFalse(test_subject.is_triggered())
+
+        mock_time.utcnow = Mock(return_value=datetime.utcnow() + timedelta(minutes=30))
+        test_subject.incr()
+        self.assertTrue(test_subject.is_triggered())
+
+    def test_errorstate04(self, mock_time):
+        """
+        If ErrorState is reset the timestamp of the last incr() is reset to
+        None.
+        """
+
+        test_subject = ErrorState(timedelta(minutes=15))
+        self.assertTrue(test_subject.timestamp is not None)
+
+        test_subject.incr()
+        self.assertTrue(test_subject.timestamp is None)
+
+        test_subject.reset()
+        self.assertTrue(test_subject.timestamp is None)

--- a/tests/common/test_errorstate.py
+++ b/tests/common/test_errorstate.py
@@ -53,17 +53,17 @@ class TestErrorState(unittest.TestCase):
         test_subject.incr()
         self.assertTrue(test_subject.is_triggered())
 
-    def test_errorstate04(self, mock_time):
+    def test_errorstate04(self):
         """
         If ErrorState is reset the timestamp of the last incr() is reset to
         None.
         """
 
         test_subject = ErrorState(timedelta(minutes=15))
-        self.assertTrue(test_subject.timestamp is not None)
+        self.assertTrue(test_subject.timestamp is None)
 
         test_subject.incr()
-        self.assertTrue(test_subject.timestamp is None)
+        self.assertTrue(test_subject.timestamp is not None)
 
         test_subject.reset()
         self.assertTrue(test_subject.timestamp is None)


### PR DESCRIPTION
The agent report transient failures, but this is not very indicative of
customer failures.  The transient failures generally resolve themselves, so the
transients are not very useful for a dashboard.  This change tracks failures
that repeat for 15 minutes, and then report them.  If an operation fails and
succeeds within 15 minutes, the timer resets.  It must be a continual stream of
errors for 15 minutes for this telemetry event to trigger.

Closes #956 