### PR TITLE
Bug fix for upgrade GUID change

### DIFF
--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -330,6 +330,8 @@ class ExtHandlersHandler(object):
                     not self.is_new_guid(ext_handler):
                 ext_handler_i.ext_handler.properties.version = ext_handler_i.get_installed_version()
                 ext_handler_i.set_logger()
+                if self.last_etag != etag:
+                    self.set_log_guid(ext_handler, True)
 
                 if self.get_log_guid(ext_handler):
                     ext_handler_i.logger.info("New GUID is the same as the old GUID. Exiting without upgrading.")

--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -223,7 +223,15 @@ class ExtHandlersHandler(object):
         return
 
     def get_guid(self, name):
-        return self.last_guids.get(name, None)
+        return self.last_guids.get(name, (None, False))[0]
+
+    def get_log_guid(self, ext_handler):
+        return self.last_guids.get(ext_handler.name, (None, False))[1]
+
+    def set_log_guid(self, ext_handler, log_val):
+        guid = self.get_guid(ext_handler.name)
+        if guid is not None:
+            self.last_guids[ext_handler.name] = (guid, log_val)
 
     def is_new_guid(self, ext_handler):
         last_guid = self.get_guid(ext_handler.name)
@@ -320,9 +328,17 @@ class ExtHandlersHandler(object):
             if state == u"enabled" and \
                     ext_handler.properties.upgradeGuid is not None and \
                     not self.is_new_guid(ext_handler):
-                logger.info("New GUID is the same as the old GUID. Exiting without upgrading.")
+                ext_handler_i.ext_handler.properties.version = ext_handler_i.get_installed_version()
+                ext_handler_i.set_logger()
+
+                if self.get_log_guid(ext_handler):
+                    ext_handler_i.logger.info("New GUID is the same as the old GUID. Exiting without upgrading.")
+                    self.set_log_guid(ext_handler, False)
+                ext_handler_i.set_handler_state(ExtHandlerState.Enabled)
+                ext_handler_i.set_handler_status(status="Ready", message="No change")
                 return
 
+            self.set_log_guid(ext_handler, True)
             ext_handler_i.decide_version(target_state=state)
             if not ext_handler_i.is_upgrade and self.last_etag == etag:
                 if self.log_etag:
@@ -339,7 +355,7 @@ class ExtHandlersHandler(object):
                 self.handle_enable(ext_handler_i)
                 if ext_handler.properties.upgradeGuid is not None:
                     ext_handler_i.logger.info("New Upgrade GUID: {0}", ext_handler.properties.upgradeGuid)
-                    self.last_guids[ext_handler.name] = ext_handler.properties.upgradeGuid
+                    self.last_guids[ext_handler.name] = (ext_handler.properties.upgradeGuid, True)
             elif state == u"disabled":
                 self.handle_disable(ext_handler_i)
                 # Remove the GUID from the dictionary so that it is upgraded upon re-enable
@@ -462,9 +478,7 @@ class ExtHandlerInstance(object):
         self.pkg = None
         self.pkg_file = None
         self.is_upgrade = False
-
-        prefix = "[{0}]".format(self.get_full_name())
-        self.logger = logger.Logger(logger.DEFAULT_LOGGER, prefix)
+        self.set_logger()
         
         try:
             fileutil.mkdir(self.get_log_dir(), mode=0o755)
@@ -587,7 +601,12 @@ class ExtHandlerInstance(object):
             raise ExtensionError("Failed to find any valid extension package")
 
         self.logger.verbose("Use version: {0}", self.pkg.version)
+        self.set_logger()
         return
+
+    def set_logger(self):
+        prefix = "[{0}]".format(self.get_full_name())
+        self.logger = logger.Logger(logger.DEFAULT_LOGGER, prefix)
 
     def version_gt(self, other):
         self_version = self.ext_handler.properties.version

--- a/tests/ga/test_extension.py
+++ b/tests/ga/test_extension.py
@@ -414,7 +414,8 @@ class TestExtension(AgentTestCase):
                                                             "<Incarnation>4<")
         test_data.ext_conf = test_data.ext_conf.replace("1.0.0", "1.1.0")
         exthandlers_handler.run()
-        self._assert_no_handler_status(protocol.report_vm_status)
+        self._assert_handler_status(protocol.report_vm_status, "Ready", 1, "1.0.0")
+        self._assert_ext_status(protocol.report_ext_status, "success", 0)
 
         #Test GUID change with hotfix
         test_data.goal_state = test_data.goal_state.replace("<Incarnation>4<",
@@ -458,7 +459,8 @@ class TestExtension(AgentTestCase):
                                                             "<Incarnation>10<")
         test_data.ext_conf = test_data.ext_conf.replace("1.1.0", "1.2.0")
         exthandlers_handler.run()
-        self._assert_no_handler_status(protocol.report_vm_status)
+        self._assert_handler_status(protocol.report_vm_status, "Ready", 1, "1.1.1")
+        self._assert_ext_status(protocol.report_ext_status, "success", 0)
 
         #Test GUID change with upgrade available
         test_data.goal_state = test_data.goal_state.replace("<Incarnation>10<",


### PR DESCRIPTION
Reduce log spam from skipping an upgrade based on the GUID staying the same.

Ensure that the Agent reports the correct extension version and its state as enabled in cases where the GUID is the same.

Fix unit testing for the upgrade GUID feature
