### PR TITLE
Emit log message when work is done

### DIFF
--- a/azurelinuxagent/common/osutil/ubuntu.py
+++ b/azurelinuxagent/common/osutil/ubuntu.py
@@ -62,7 +62,7 @@ class Ubuntu16OSUtil(Ubuntu14OSUtil):
     Ubuntu 16.04, 16.10, and 17.04.
     """
     def __init__(self):
-        super(UbuntuOSUtil, self).__init__()
+        super(Ubuntu16OSUtil, self).__init__()
 
     def register_agent_service(self):
         return shellutil.run("systemctl unmask walinuxagent", chk_err=False)
@@ -91,7 +91,6 @@ class UbuntuOSUtil(Ubuntu16OSUtil):
                 time.sleep(wait)
             else:
                 logger.warn("exceeded restart retries")
-
 
 
 class UbuntuSnappyOSUtil(Ubuntu14OSUtil):

--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -181,6 +181,7 @@ class ExtHandlersHandler(object):
         self.last_upgrade_guids = {}
         self.log_report = False
         self.log_etag = True
+        self.log_process = False
 
         self.report_status_error_state = ErrorState()
 
@@ -380,6 +381,7 @@ class ExtHandlersHandler(object):
             ext_handler_i.report_event(message=ustr(e), is_success=False)
     
     def handle_enable(self, ext_handler_i):
+        self.log_process = True
         old_ext_handler_i = ext_handler_i.get_installed_ext_handler()
         if old_ext_handler_i is not None and \
            old_ext_handler_i.version_gt(ext_handler_i):
@@ -406,6 +408,7 @@ class ExtHandlersHandler(object):
         ext_handler_i.enable() 
 
     def handle_disable(self, ext_handler_i):
+        self.log_process = True
         handler_state = ext_handler_i.get_handler_state()
         ext_handler_i.logger.info("[Disable] current handler state is: {0}",
                                   handler_state.lower())
@@ -413,6 +416,7 @@ class ExtHandlersHandler(object):
             ext_handler_i.disable()
 
     def handle_uninstall(self, ext_handler_i):
+        self.log_process = True
         handler_state = ext_handler_i.get_handler_state()
         ext_handler_i.logger.info("[Uninstall] current handler state is: {0}",
                                   handler_state.lower())

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -295,7 +295,7 @@ class UpdateHandler(object):
                         duration=elapsed_milliseconds(utc_start),
                         message="Incarnation {0}".format(
                                             exthandlers_handler.last_etag),
-                        log_event=False)
+                        log_event=exthandlers_handler.log_process)
 
                 time.sleep(GOAL_STATE_INTERVAL)
 


### PR DESCRIPTION
Only emit log messages for `ProcessGoalState` when install, enable, uninstall or disable runs.