### PR TITLE
Warn to Verbose

### DIFF
--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -160,7 +160,7 @@ class WireProtocol(Protocol):
         if package is not None:
             return package
         else:
-            logger.warn("Download did not succeed, falling back to host plugin")
+            logger.verbose("Download did not succeed, falling back to host plugin")
             host = self.client.get_host_plugin()
             uri, headers = host.get_artifact_request(uri, host.manifest_uri)
             package = super(WireProtocol, self).download_ext_handler_pkg(uri, headers=headers, use_proxy=False)


### PR DESCRIPTION
The log statement "Download did not succeed, falling back to host plugin" is not very useful, and is rather noisy.