### PR TITLE
do not log a message for ignored commands

### DIFF
--- a/azurelinuxagent/common/osutil/default.py
+++ b/azurelinuxagent/common/osutil/default.py
@@ -96,7 +96,7 @@ class DefaultOSUtil(object):
         try:
             wait = self.get_firewall_will_wait()
 
-            rc, output = shellutil.run_get_output(FIREWALL_PACKETS.format(wait))
+            rc, output = shellutil.run_get_output(FIREWALL_PACKETS.format(wait), log_cmd=False)
             if rc == 3:
                 # Transient error  that we ignore.  This code fires every loop
                 # of the daemon (60m), so we will get the value eventually.


### PR DESCRIPTION
The previous commit in this area ignored an exit code of 3.  This is not sufficient because the tests still check for this string in the log messages. A better fix is to not log the error in the first place.