### PR TITLE
- Obtain platform information in Python version dependent way

### DIFF
--- a/azurelinuxagent/common/future.py
+++ b/azurelinuxagent/common/future.py
@@ -2,7 +2,7 @@ import platform
 import sys
 
 # Note broken dependency handling to avoid potential backward
-# compantibility issues
+# compatibility issues on different distributions
 try:
     import distro
 except Exception:
@@ -46,15 +46,15 @@ def get_linux_distribution(get_full_name, supported_dists):
             )
         )
         if not osinfo or osinfo == ['','','']:
-            return get_linux_ditribution_from_distro(get_full_name)
-        full_name = platform_module.linux_distribution()[0].strip()
+            return get_linux_distribution_from_distro(get_full_name)
+        full_name = platform.linux_distribution()[0].strip()
         osinfo.append(full_name)
-    except Exception:
-        return get_linux_ditribution_from_distro(get_full_name)
+    except AttributeError:
+        return get_linux_distribution_from_distro(get_full_name)
 
     return osinfo
 
-def get_linux_ditribution_from_distro(get_full_name):
+def get_linux_distribution_from_distro(get_full_name):
     """Get the distribution information from the distro Python module."""
     # If we get here we have to have the distro module, thus we do
     # not wrap the call in a try-except block as it would mask the problem

--- a/azurelinuxagent/common/future.py
+++ b/azurelinuxagent/common/future.py
@@ -1,8 +1,12 @@
 import platform
 import sys
 
-if float(sys.version[:3]) >= 3.5:
+# Note broken dependency handling to avoid potential backward
+# compantibility issues
+try:
     import distro
+except Exception:
+    pass
     
 """
 Add alias for python2 and python3 libs and functions.
@@ -32,20 +36,39 @@ else:
 
 def get_linux_distribution(get_full_name, supported_dists):
     """Abstract platform.linux_distribution() call which is deprecated as of
-       Python 3.5"""
-    if float(sys.version[:3]) >= 3.5:
-        platform_module = distro
-        osinfo = list(distro.linux_distribution(
-            full_distribution_name=get_full_name
-        ))
-    else:
-        platform_module = platform
+       Python 3.5 and removed in Python 3.7"""
+    try:
         supported = platform._supported_dists + (supported_dists,)
-        osinfo = list(platform.linux_distribution(
-            full_distribution_name=get_full_name,
-            supported_dists=supported
-        ))
-    full_name = platform_module.linux_distribution()[0].strip()
-    osinfo.append(full_name)
+        osinfo = list(
+            platform.linux_distribution(
+                full_distribution_name=get_full_name,
+                supported_dists=supported
+            )
+        )
+        if not osinfo or osinfo == ['','','']:
+            return get_linux_ditribution_from_distro(get_full_name)
+        full_name = platform_module.linux_distribution()[0].strip()
+        osinfo.append(full_name)
+    except Exception:
+        return get_linux_ditribution_from_distro(get_full_name)
 
     return osinfo
+
+def get_linux_ditribution_from_distro(get_full_name):
+    """Get the distribution information from the distro Python module."""
+    # If we get here we have to have the distro module, thus we do
+    # not wrap the call in a try-except block as it would mask the problem
+    # and result in a broken agent installation
+    osinfo = list(
+        distro.linux_distribution(
+            full_distribution_name=get_full_name
+        )
+    )
+    full_name = distro.linux_distribution()[0].strip()
+    osinfo.append(full_name)
+    return osinfo
+
+
+
+
+    

--- a/azurelinuxagent/common/future.py
+++ b/azurelinuxagent/common/future.py
@@ -1,5 +1,9 @@
+import platform
 import sys
 
+if float(sys.version[:3]) >= 3.5:
+    import distro
+    
 """
 Add alias for python2 and python3 libs and functions.
 """
@@ -24,3 +28,24 @@ elif sys.version_info[0] == 2:
 
 else:
     raise ImportError("Unknown python version: {0}".format(sys.version_info))
+
+
+def get_linux_distribution(get_full_name, supported_dists):
+    """Abstract platform.linux_distribution() call which is deprecated as of
+       Python 3.5"""
+    if float(sys.version[:3]) >= 3.5:
+        platform_module = distro
+        osinfo = list(distro.linux_distribution(
+            full_distribution_name=get_full_name
+        ))
+    else:
+        platform_module = platform
+        supported = platform._supported_dists + (supported_dists,)
+        osinfo = list(platform.linux_distribution(
+            full_distribution_name=get_full_name,
+            supported_dists=supported
+        ))
+    full_name = platform_module.linux_distribution()[0].strip()
+    osinfo.append(full_name)
+
+    return osinfo

--- a/azurelinuxagent/common/version.py
+++ b/azurelinuxagent/common/version.py
@@ -20,13 +20,10 @@ import re
 import platform
 import sys
 
-if float(sys.version[:3]) >= 3.5:
-    import distro
-
 import azurelinuxagent.common.conf as conf
 import azurelinuxagent.common.utils.fileutil as fileutil
 from azurelinuxagent.common.utils.flexible_version import FlexibleVersion
-from azurelinuxagent.common.future import ustr
+from azurelinuxagent.common.future import ustr, get_linux_distribution
 
 
 def get_f5_platform():
@@ -84,20 +81,7 @@ def get_distro():
         release = re.sub('\-.*\Z', '', ustr(platform.release()))
         osinfo = ['openbsd', release, '', 'openbsd']
     elif 'Linux' in platform.system():
-        # platform.linux_distribution and platform.dist deprecated in
-        # Python 3.5 and removed in Python 3.7
-        if float(sys.version[:3]) >= 3.5:
-            platform_module = distro
-            osinfo = list(distro.linux_distribution(full_distribution_name=0))
-        else:
-            platform_module = platform
-            supported = platform._supported_dists + ('alpine',)
-            osinfo = list(platform.linux_distribution(
-                full_distribution_name=0,
-                supported_dists=supported
-            ))
-        full_name = platform_module.linux_distribution()[0].strip()
-        osinfo.append(full_name)
+        osinfo = get_linux_distribution(0, 'alpine')
     else:
         try:
             # dist() removed in Python 3.7

--- a/azurelinuxagent/common/version.py
+++ b/azurelinuxagent/common/version.py
@@ -20,6 +20,9 @@ import re
 import platform
 import sys
 
+if float(sys.version[:3]) >= 3.5:
+    import distro
+
 import azurelinuxagent.common.conf as conf
 import azurelinuxagent.common.utils.fileutil as fileutil
 from azurelinuxagent.common.utils.flexible_version import FlexibleVersion
@@ -80,14 +83,27 @@ def get_distro():
     elif 'OpenBSD' in platform.system():
         release = re.sub('\-.*\Z', '', ustr(platform.release()))
         osinfo = ['openbsd', release, '', 'openbsd']
-    elif 'linux_distribution' in dir(platform):
-        supported = platform._supported_dists + ('alpine',)
-        osinfo = list(platform.linux_distribution(full_distribution_name=0,
-                                                  supported_dists=supported))
-        full_name = platform.linux_distribution()[0].strip()
+    elif 'Linux' in platform.system():
+        # platform.linux_distribution and platform.dist deprecated in
+        # Python 3.5 and removed in Python 3.7
+        if float(sys.version[:3]) >= 3.5:
+            platform_module = distro
+            osinfo = list(distro.linux_distribution(full_distribution_name=0))
+        else:
+            platform_module = platform
+            supported = platform._supported_dists + ('alpine',)
+            osinfo = list(platform.linux_distribution(
+                full_distribution_name=0,
+                supported_dists=supported
+            ))
+        full_name = platform_module.linux_distribution()[0].strip()
         osinfo.append(full_name)
     else:
-        osinfo = platform.dist()
+        try:
+            # dist() removed in Python 3.7
+            osinfo = platform.dist()
+        except:
+            osinfo = ('UNKNOWN', 'FFFF', '')
 
     # The platform.py lib has issue with detecting oracle linux distribution.
     # Merge the following patch provided by oracle as a temporary fix.

--- a/setup.py
+++ b/setup.py
@@ -199,9 +199,14 @@ class install(_install):
             osutil.stop_agent_service()
             osutil.start_agent_service()
 
-requires = []
-if float(sys.version[:3]) >= 3.5:
-    requires = ['distro']
+# Note to packagers and users fromn source.
+# In version 3.5 of Python distribution information handling in the platform
+# module was deprecated. Depending on the Linux distribution the
+# implementation may be broken prior to Python 3.7 thus you may or may not
+# need to install the distro Python package. Due to concerns of breakage
+# the code cannot handle this automagically
+#if float(sys.version[:3]) >= 3.5:
+#    requires = ['distro']
 
 setuptools.setup(
     name=AGENT_NAME,
@@ -213,7 +218,6 @@ setuptools.setup(
     url='https://github.com/Azure/WALinuxAgent',
     license='Apache License Version 2.0',
     packages=find_packages(exclude=["tests"]),
-    install_requires=requires,
     py_modules=["__main__"],
     cmdclass={
         'install': install

--- a/setup.py
+++ b/setup.py
@@ -199,14 +199,14 @@ class install(_install):
             osutil.stop_agent_service()
             osutil.start_agent_service()
 
-# Note to packagers and users fromn source.
+# Note to packagers and users from source.
 # In version 3.5 of Python distribution information handling in the platform
 # module was deprecated. Depending on the Linux distribution the
-# implementation may be broken prior to Python 3.7 thus you may or may not
-# need to install the distro Python package. Due to concerns of breakage
-# the code cannot handle this automagically
-#if float(sys.version[:3]) >= 3.5:
-#    requires = ['distro']
+# implementation may be broken prior to Python 3.7 wher the functionality
+# will be removed from Python 3
+requires = []
+if float(sys.version[:3]) >= 3.7:
+    requires = ['distro']
 
 setuptools.setup(
     name=AGENT_NAME,
@@ -219,6 +219,7 @@ setuptools.setup(
     license='Apache License Version 2.0',
     packages=find_packages(exclude=["tests"]),
     py_modules=["__main__"],
+    install_requires=requires,
     cmdclass={
         'install': install
     }

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ from azurelinuxagent.common.osutil import get_osutil
 import setuptools
 from setuptools import find_packages
 from setuptools.command.install import install as  _install
+import sys
 
 root_dir = os.path.dirname(os.path.abspath(__file__))
 os.chdir(root_dir)
@@ -131,7 +132,7 @@ def get_data_files(name, version, fullname):
             # Ubuntu15.04+ uses systemd
             set_systemd_files(data_files,
                               src=["init/ubuntu/walinuxagent.service"])
-    elif name == 'suse':
+    elif name == 'suse' or name == 'opensuse':
         set_bin_files(data_files)
         set_conf_files(data_files, src=["config/suse/waagent.conf"])
         set_logrotate_files(data_files)
@@ -198,6 +199,9 @@ class install(_install):
             osutil.stop_agent_service()
             osutil.start_agent_service()
 
+requires = []
+if float(sys.version[:3]) >= 3.5:
+    requires = ['distro']
 
 setuptools.setup(
     name=AGENT_NAME,
@@ -209,6 +213,7 @@ setuptools.setup(
     url='https://github.com/Azure/WALinuxAgent',
     license='Apache License Version 2.0',
     packages=find_packages(exclude=["tests"]),
+    install_requires=requires,
     py_modules=["__main__"],
     cmdclass={
         'install': install


### PR DESCRIPTION
  + The platform module has deprecated functionality in Python 3.5 and
    the functionality will be removed in 3.7. For Python versions 3.5
    and greater depend on the distro module to obtain linux distribution
    information