### PR TITLE
disable telemetry logging for now

### DIFF
--- a/azurelinuxagent/agent.py
+++ b/azurelinuxagent/agent.py
@@ -63,9 +63,9 @@ class Agent(object):
                                  path="/var/log/waagent.log")
         logger.add_logger_appender(logger.AppenderType.CONSOLE, level,
                                  path="/dev/console")
-        logger.add_logger_appender(logger.AppenderType.TELEMETRY,
-                                   logger.LogLevel.WARNING,
-                                   path=event.add_log_event)
+        # logger.add_logger_appender(logger.AppenderType.TELEMETRY,
+        #                            logger.LogLevel.WARNING,
+        #                            path=event.add_log_event)
 
         ext_log_dir = conf.get_ext_log_dir()
         try:

--- a/azurelinuxagent/common/version.py
+++ b/azurelinuxagent/common/version.py
@@ -113,7 +113,7 @@ def get_distro():
 
 AGENT_NAME = "WALinuxAgent"
 AGENT_LONG_NAME = "Azure Linux Agent"
-AGENT_VERSION = '2.2.21'
+AGENT_VERSION = '2.2.22'
 AGENT_LONG_VERSION = "{0}-{1}".format(AGENT_NAME, AGENT_VERSION)
 AGENT_DESCRIPTION = """
 The Azure Linux Agent supports the provisioning and running of Linux

--- a/tests/ga/test_update.py
+++ b/tests/ga/test_update.py
@@ -1018,8 +1018,8 @@ class TestUpdate(UpdateTestCase):
         self.assertTrue(2 < len(self.update_handler.agents))
 
         # Purge every other agent
-        purged_agents = self.update_handler.agents[1::2]
-        kept_agents = self.update_handler.agents[::2]
+        kept_agents = self.update_handler.agents[1::2]
+        purged_agents = self.update_handler.agents[::2]
 
         # Reload and assert only the kept agents remain on disk
         self.update_handler.agents = kept_agents


### PR DESCRIPTION
The chance of encountering #1035 is believed to be very low, but this type of issue means recovery is not possible.  We are hotfixing the agent, and disabling telemetry collection as a result.