### PR TITLE
disable telemetry logging

### DIFF
--- a/azurelinuxagent/agent.py
+++ b/azurelinuxagent/agent.py
@@ -63,9 +63,10 @@ class Agent(object):
                                  path="/var/log/waagent.log")
         logger.add_logger_appender(logger.AppenderType.CONSOLE, level,
                                  path="/dev/console")
-        logger.add_logger_appender(logger.AppenderType.TELEMETRY,
-                                   logger.LogLevel.WARNING,
-                                   path=event.add_log_event)
+        # See issue #1035
+        # logger.add_logger_appender(logger.AppenderType.TELEMETRY,
+        #                            logger.LogLevel.WARNING,
+        #                            path=event.add_log_event)
 
         ext_log_dir = conf.get_ext_log_dir()
         try:


### PR DESCRIPTION
Closes #1035 

This pulls in the change from the hotfix/2.2.22 branch with a small change.