### PR TITLE
Fix write_file swapped parameters bug

### DIFF
--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -773,7 +773,7 @@ class ExtHandlerInstance(object):
                         "code" : 0
                     }
                 }
-                fileutil.write_file(json.dumps(status), status_path)
+                fileutil.write_file(status_path, json.dumps(status))
 
             conf_dir = self.get_conf_dir()
             fileutil.mkdir(conf_dir, mode=0o700)


### PR DESCRIPTION
`fileutil.write_file` is path, contents rather than contents, path.

Ran into this when I noticed strange files cluttering up my copy of the repo after doing unit test runs.
