### PR TITLE
improve test_get_first_if for other systems

### DIFF
--- a/azurelinuxagent/common/osutil/default.py
+++ b/azurelinuxagent/common/osutil/default.py
@@ -674,6 +674,7 @@ class DefaultOSUtil(object):
                              socket.IPPROTO_UDP)
         param = struct.pack('256s', (ifname[:15]+('\0'*241)).encode('latin-1'))
         info = fcntl.ioctl(sock.fileno(), IOCTL_SIOCGIFHWADDR, param)
+        sock.close()
         return ''.join(['%02X' % textutil.str_to_ord(char) for char in info[18:24]])
 
     @staticmethod
@@ -698,13 +699,16 @@ class DefaultOSUtil(object):
 
         buff = array.array('B', b'\0' * array_size)
         param = struct.pack('iL', array_size, buff.buffer_info()[0])
+
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
         ret = fcntl.ioctl(sock.fileno(), IOCTL_SIOCGIFCONF, param)
         retsize = (struct.unpack('iL', ret)[0])
+        sock.close()
+
         if retsize == array_size:
             logger.warn(('SIOCGIFCONF returned more than {0} up '
                          'network interfaces.'), expected)
-        sock = None
+
         ifconf_buff = buff.tostring()
 
         ifaces = {}
@@ -820,6 +824,7 @@ class DefaultOSUtil(object):
         if not self.disable_route_warning:
             logger.info('interface [{0}] has flags [{1}], '
                         'is loopback [{2}]'.format(ifname, flags, isloopback))
+        s.close()
         return isloopback
 
     def get_dhcp_lease_endpoint(self):

--- a/tests/common/osutil/test_default.py
+++ b/tests/common/osutil/test_default.py
@@ -18,15 +18,18 @@
 import socket
 import glob
 import mock
+import traceback
 
 import azurelinuxagent.common.osutil.default as osutil
 import azurelinuxagent.common.utils.shellutil as shellutil
 from azurelinuxagent.common.exception import OSUtilError
 from azurelinuxagent.common.future import ustr
 from azurelinuxagent.common.osutil import get_osutil
-from azurelinuxagent.common.utils import fileutil
-from azurelinuxagent.common.utils.flexible_version import FlexibleVersion
 from tests.tools import *
+
+
+def fake_is_loopback(_, iface):
+    return iface.startswith('lo')
 
 
 class TestOSUtil(AgentTestCase):
@@ -88,7 +91,27 @@ class TestOSUtil(AgentTestCase):
                         self.assertTrue(msg in ustr(ose))
                         self.assertTrue(patch_run.call_count == 6)
 
-    def test_get_first_if(self):
+
+    @patch('azurelinuxagent.common.osutil.default.DefaultOSUtil.get_primary_interface', return_value='eth0')
+    @patch('azurelinuxagent.common.osutil.default.DefaultOSUtil._get_all_interfaces', return_value={'eth0':'10.0.0.1'})
+    @patch('azurelinuxagent.common.osutil.default.DefaultOSUtil.is_loopback', fake_is_loopback)
+    def test_get_first_if(self, get_all_interfaces_mock, get_primary_interface_mock):
+        """
+        Validate that the agent can find the first active non-loopback
+        interface.
+
+        This test case used to run live, but not all developers have an eth*
+        interface. It is perfectly valid to have a br*, but this test does not
+        account for that.
+        """
+        ifname, ipaddr = osutil.DefaultOSUtil().get_first_if()
+        self.assertEqual(ifname, 'eth0')
+        self.assertEqual(ipaddr, '10.0.0.1')
+
+    @patch('azurelinuxagent.common.osutil.default.DefaultOSUtil.get_primary_interface', return_value='bogus0')
+    @patch('azurelinuxagent.common.osutil.default.DefaultOSUtil._get_all_interfaces', return_value={'eth0':'10.0.0.1', 'lo': '127.0.0.1'})
+    @patch('azurelinuxagent.common.osutil.default.DefaultOSUtil.is_loopback', fake_is_loopback)
+    def test_get_first_if_nosuchprimary(self, get_all_interfaces_mock, get_primary_interface_mock):
         ifname, ipaddr = osutil.DefaultOSUtil().get_first_if()
         self.assertTrue(ifname.startswith('eth'))
         self.assertTrue(ipaddr is not None)
@@ -96,18 +119,6 @@ class TestOSUtil(AgentTestCase):
             socket.inet_aton(ipaddr)
         except socket.error:
             self.fail("not a valid ip address")
-
-    def test_get_first_if_nosuchprimary(self):
-        fake_ifaces = {'eth0':'192.0.2.100','lo':'127.0.0.1'}
-        with patch.object(osutil.DefaultOSUtil, 'get_primary_interface', return_value='bogus0'):
-            with patch.object(osutil.DefaultOSUtil, '_get_all_interfaces', return_value=fake_ifaces):
-                ifname, ipaddr = osutil.DefaultOSUtil().get_first_if()
-                self.assertTrue(ifname.startswith('eth'))
-                self.assertTrue(ipaddr is not None)
-                try:
-                    socket.inet_aton(ipaddr)
-                except socket.error:
-                    self.fail("not a valid ip address")
 
     def test_get_first_if_all_loopback(self):
         fake_ifaces = {'lo':'127.0.0.1'}
@@ -196,6 +207,7 @@ class TestOSUtil(AgentTestCase):
             try:
                 osutil.DefaultOSUtil().get_first_if()[0]
             except Exception as e:
+                print(traceback.format_exc())
                 exception = True
             self.assertFalse(exception)
 


### PR DESCRIPTION
The test case makes an assumption about the user's network configuration that
is not always valid.  Rather than assume, the code has been changed to mock out
these dependencies.

Closes #1046