### PR TITLE
- Detect openSUSE and SLES

### DIFF
--- a/azurelinuxagent/common/osutil/factory.py
+++ b/azurelinuxagent/common/osutil/factory.py
@@ -69,7 +69,7 @@ def get_osutil(distro_name=DISTRO_NAME,
     if distro_name == "coreos" or distro_code_name == "coreos":
         return CoreOSUtil()
 
-    if distro_name == "suse":
+    if distro_name in ("suse", "sles", "opensuse"):
         if distro_full_name == 'SUSE Linux Enterprise Server' \
                 and Version(distro_version) < Version('12') \
                 or distro_full_name == 'openSUSE' and Version(distro_version) < Version('13.2'):


### PR DESCRIPTION
  + For openSUSE Leap and SLES >= 15 Python 3 is used and the distro
    is identified as "opensuse" and "sles" while in Python 2 both
    were lumped together as "suse"
  + Closes #1089