### PR TITLE
rm_files is unnecessary just unlink

### DIFF
--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -897,7 +897,7 @@ class WireClient(object):
         agent_manifest = os.path.join(conf.get_lib_dir(), fn)
 
         if os.path.exists(agent_manifest):
-            fileutil.rm_files([agent_manifest])
+            os.unlink(agent_manifest)
 
     def check_wire_protocol_version(self):
         uri = VERSION_INFO_URI.format(self.endpoint)


### PR DESCRIPTION
This change will get the BVTs back to green, and fixes the stale agentsManifest issue.  It is not the correct fix overall because it means the agent upgrades outside of goal state, which is the whole point of this work.  I am opening a new issue to cover that work.

Closes #1094 
Closes #1095 


