### PR TITLE
compress and base64 encode stdout/stderr

### DIFF
--- a/azurelinuxagent/common/event.py
+++ b/azurelinuxagent/common/event.py
@@ -35,6 +35,7 @@ from azurelinuxagent.common.future import ustr
 from azurelinuxagent.common.protocol.restapi import TelemetryEventParam, \
     TelemetryEvent, \
     get_properties
+from azurelinuxagent.common.utils import textutil
 from azurelinuxagent.common.version import CURRENT_VERSION
 
 _EVENT_MSG = "Event: name={0}, op={1}, message={2}, duration={3}"
@@ -166,9 +167,9 @@ def _encode_message(op, message):
         return message
 
     try:
-        return base64.b64encode(zlib.compress(message))
+        return textutil.b64encode(textutil.compress(message))
     except Exception:
-        # If the message could not be encoded and dummy message is returned.
+        # If the message could not be encoded a dummy message ('<>') is returned.
         # The original message was still sent via telemetry, so all is not lost.
         return "<>"
 

--- a/azurelinuxagent/common/event.py
+++ b/azurelinuxagent/common/event.py
@@ -16,12 +16,14 @@
 #
 
 import atexit
+import base64
 import datetime
 import json
 import os
 import sys
 import time
 import traceback
+import zlib
 
 from datetime import datetime
 
@@ -70,6 +72,14 @@ class WALAEventOperation:
     Upgrade = "Upgrade"
     Update = "Update"
 
+
+SHOULD_ENCODE_MESSAGE_LEN = 80
+SHOULD_ENCODE_MESSAGE_OP = [
+    WALAEventOperation.Disable,
+    WALAEventOperation.Enable,
+    WALAEventOperation.Install,
+    WALAEventOperation.UnInstall,
+]
 
 class EventStatus(object):
     EVENT_STATUS_FILE = "event_status.json"
@@ -128,9 +138,45 @@ __event_status_operations__ = [
     ]
 
 
+def _encode_message(op, message):
+    """
+    Gzip and base64 encode a message based on the operation.
+
+    The intent of this message is to make the logs human readable and include the
+    stdout/stderr from extension operations.  Extension operations tend to generate
+    a lot of noise, which makes it difficult to parse the line-oriented waagent.log.
+    The compromise is to encode the stdout/stderr so we preserve the data and do
+    not destroy the line oriented nature.
+
+    The data can be recovered using the following command:
+
+      $ echo '<encoded data>' | base64 -d | pigz -zd
+
+    You may need to install the pigz command.
+
+    :param op: Operation, e.g. Enable or Install
+    :param message: Message to encode
+    :return: gzip'ed and base64 encoded message, or the original message
+    """
+
+    if len(message) == 0:
+        return message
+
+    if op not in SHOULD_ENCODE_MESSAGE_OP:
+        return message
+
+    try:
+        return base64.b64encode(zlib.compress(message))
+    except Exception:
+        # If the message could not be encoded and dummy message is returned.
+        # The original message was still sent via telemetry, so all is not lost.
+        return "<>"
+
+
 def _log_event(name, op, message, duration, is_success=True):
     global _EVENT_MSG
 
+    message = _encode_message(op, message)
     if not is_success:
         logger.error(_EVENT_MSG, name, op, message, duration)
     else:

--- a/azurelinuxagent/common/utils/textutil.py
+++ b/azurelinuxagent/common/utils/textutil.py
@@ -23,6 +23,7 @@ import re
 import string
 import struct
 import sys
+import zlib
 import xml.dom.minidom as minidom
 
 from distutils.version import LooseVersion as Version
@@ -272,9 +273,9 @@ def replace_non_ascii(incoming, replace_char=''):
 
 
 def remove_bom(c):
-    '''
+    """
     bom is comprised of a sequence of three chars,0xef, 0xbb, 0xbf, in case of utf-8.
-    '''
+    """
     if not is_str_none_or_whitespace(c) and \
        len(c) > 2 and \
        str_to_ord(c[0]) > 128 and \
@@ -302,6 +303,13 @@ def get_bytes_from_pem(pem_str):
     return base64_bytes
 
 
+def compress(s):
+    from azurelinuxagent.common.version import PY_VERSION_MAJOR
+    if PY_VERSION_MAJOR > 2:
+        return zlib.compress(bytes(s, 'utf-8'))
+    return zlib.compress(s)
+
+
 def b64encode(s):
     from azurelinuxagent.common.version import PY_VERSION_MAJOR
     if PY_VERSION_MAJOR > 2:
@@ -323,6 +331,7 @@ def safe_shlex_split(s):
         return shlex.split(s.encode('utf-8'))
     return shlex.split(s)
 
+
 def swap_hexstring(s, width=2):
     r = len(s) % width
     if r != 0:
@@ -333,6 +342,7 @@ def swap_hexstring(s, width=2):
                                 r'[a-f0-9]{{{0}}}'.format(width),
                                 s,
                                 re.IGNORECASE)))
+
 
 def parse_json(json_str):
     """
@@ -345,6 +355,7 @@ def parse_json(json_str):
         result = json.loads(json_str.rstrip(' \t\r\n\0'))
 
     return result
+
 
 def is_str_none_or_whitespace(s):
     return s is None or len(s) == 0 or s.isspace()


### PR DESCRIPTION
The recent change to log stdout/stderr caused some other issues.  The output for most extenisons was never exposed before, and it is quite noisy.  There is some work that needs to be done on the part of extensions to cleanup this up.  The output contains (potentially) many newlines, which breaks the line oriented nature of waagent.log. These outputs are still useful for debugging, and we would like to preserve them.  The compromise is to keep the output, but encode it to keep the line oriented nature, and reduce the visual noise.  The data are compressed with zlib before encoding it to further reduce the base64 bloat.