### PR TITLE
fix import of LooseVersion as Version

### DIFF
--- a/azurelinuxagent/common/osutil/factory.py
+++ b/azurelinuxagent/common/osutil/factory.py
@@ -15,8 +15,8 @@
 # Requires Python 2.6+ and Openssl 1.0+
 #
 
+
 import azurelinuxagent.common.logger as logger
-from azurelinuxagent.common.utils.textutil import Version
 from azurelinuxagent.common.version import *
 from .default import DefaultOSUtil
 from .arch import ArchUtil
@@ -32,6 +32,8 @@ from .ubuntu import UbuntuOSUtil, Ubuntu12OSUtil, Ubuntu14OSUtil, \
 from .alpine import AlpineOSUtil
 from .bigip import BigIpOSUtil
 from .gaia import GaiaOSUtil
+
+from distutils.version import LooseVersion as Version
 
 
 def get_osutil(distro_name=DISTRO_NAME,

--- a/azurelinuxagent/common/utils/textutil.py
+++ b/azurelinuxagent/common/utils/textutil.py
@@ -26,8 +26,6 @@ import sys
 import zlib
 import xml.dom.minidom as minidom
 
-from distutils.version import LooseVersion as Version
-
 
 def parse_doc(xml_text):
     """

--- a/azurelinuxagent/daemon/resourcedisk/factory.py
+++ b/azurelinuxagent/daemon/resourcedisk/factory.py
@@ -15,14 +15,15 @@
 # Requires Python 2.6+ and Openssl 1.0+
 #
 
-import azurelinuxagent.common.logger as logger
-from azurelinuxagent.common.utils.textutil import Version
 from azurelinuxagent.common.version import DISTRO_NAME, \
                                            DISTRO_VERSION, \
                                            DISTRO_FULL_NAME
 from .default import ResourceDiskHandler
 from .freebsd import FreeBSDResourceDiskHandler
 from .openbsd import OpenBSDResourceDiskHandler
+
+from distutils.version import LooseVersion as Version
+
 
 def get_resourcedisk_handler(distro_name=DISTRO_NAME, 
                              distro_version=DISTRO_VERSION,

--- a/azurelinuxagent/pa/deprovision/factory.py
+++ b/azurelinuxagent/pa/deprovision/factory.py
@@ -15,8 +15,6 @@
 # Requires Python 2.6+ and Openssl 1.0+
 #
 
-import azurelinuxagent.common.logger as logger
-from azurelinuxagent.common.utils.textutil import Version
 from azurelinuxagent.common.version import DISTRO_NAME, DISTRO_VERSION, \
                                      DISTRO_FULL_NAME
 
@@ -25,6 +23,9 @@ from .arch import ArchDeprovisionHandler
 from .clearlinux import ClearLinuxDeprovisionHandler
 from .coreos import CoreOSDeprovisionHandler
 from .ubuntu import UbuntuDeprovisionHandler
+
+from distutils.version import LooseVersion as Version
+
 
 def get_deprovision_handler(distro_name=DISTRO_NAME, 
                             distro_version=DISTRO_VERSION,

--- a/tests/pa/test_provision.py
+++ b/tests/pa/test_provision.py
@@ -15,7 +15,6 @@
 # Requires Python 2.6+ and Openssl 1.0+
 #
 
-from azurelinuxagent.common.event import WALAEventOperation
 from azurelinuxagent.common.exception import ProvisionError
 from azurelinuxagent.common.osutil.default import DefaultOSUtil
 from azurelinuxagent.common.protocol import OVF_FILE_NAME

--- a/tests/utils/test_text_util.py
+++ b/tests/utils/test_text_util.py
@@ -15,13 +15,12 @@
 # Requires Python 2.6+ and Openssl 1.0+
 #
 
+from distutils.version import LooseVersion as Version
 from tests.tools import *
-import uuid
-import unittest
-import os
-from azurelinuxagent.common.future import ustr
+
 import azurelinuxagent.common.utils.textutil as textutil
-from azurelinuxagent.common.utils.textutil import Version
+
+from azurelinuxagent.common.future import ustr
 
 
 class TestTextUtil(AgentTestCase):


### PR DESCRIPTION
The file texutil.py had an import of LooseVersion as Version, and then other
libraries where importing this version for their use. textutil.py never
referenced Version, so it seems like an error that just continued.  All imports
of textutil.Version now reference Version as expected.