### PR TITLE
compress works with strings

### DIFF
--- a/azurelinuxagent/common/event.py
+++ b/azurelinuxagent/common/event.py
@@ -16,14 +16,12 @@
 #
 
 import atexit
-import base64
 import datetime
 import json
 import os
 import sys
 import time
 import traceback
-import zlib
 
 from datetime import datetime
 
@@ -167,7 +165,7 @@ def _encode_message(op, message):
         return message
 
     try:
-        return textutil.b64encode(textutil.compress(message))
+        return textutil.compress(message)
     except Exception:
         # If the message could not be encoded a dummy message ('<>') is returned.
         # The original message was still sent via telemetry, so all is not lost.

--- a/azurelinuxagent/common/utils/textutil.py
+++ b/azurelinuxagent/common/utils/textutil.py
@@ -302,10 +302,18 @@ def get_bytes_from_pem(pem_str):
 
 
 def compress(s):
+    """
+    Compress a string, and return the base64 encoded result of the compression.
+
+    This method returns a string instead of a byte array.  It is expected
+    that this method is called to compress smallish strings, not to compress
+    the contents of a file. The output of this method is suitable for
+    embedding in log statements.
+    """
     from azurelinuxagent.common.version import PY_VERSION_MAJOR
     if PY_VERSION_MAJOR > 2:
-        return zlib.compress(bytes(s, 'utf-8'))
-    return zlib.compress(s)
+        return base64.b64encode(zlib.compress(bytes(s, 'utf-8'))).decode('utf-8')
+    return base64.b64encode(zlib.compress(s))
 
 
 def b64encode(s):

--- a/tests/utils/test_text_util.py
+++ b/tests/utils/test_text_util.py
@@ -137,6 +137,11 @@ class TestTextUtil(AgentTestCase):
 
         for t in data:
             self.assertEqual(t[2], textutil.swap_hexstring(t[0], width=t[1]))
-        
+
+    def test_compress(self):
+        result = textutil.compress('[stdout]\nHello World\n\n[stderr]\n\n')
+        self.assertEqual('eJyLLi5JyS8tieXySM3JyVcIzy/KSeHiigaKphYVxXJxAQDAYQr2', result)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The compress method failed on Python 3 because it did not properly handle the difference between a string and byte array.  The compress method is expected to only be called for strings, so I made that clearer in the code, and added a unit test.