### PR TITLE
overwrite if an archived file exists

### DIFF
--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -16,6 +16,8 @@
 #
 # Requires Python 2.6+ and Openssl 1.0+
 
+from datetime import datetime
+
 import json
 import os
 import random
@@ -719,7 +721,7 @@ class WireClient(object):
                             # Goalstate is not updated.
                             return
 
-                self.goal_state_flusher.flush()
+                self.goal_state_flusher.flush(datetime.utcnow())
 
                 self.goal_state = goal_state
                 file_name = GOAL_STATE_FILE_NAME.format(goal_state.incarnation)


### PR DESCRIPTION
There were two failures cases that need to be addressed.

 1. If purge() is called before archive() the history directory may not exist yet.  The first call should create the directory if it does not exist.
 1. If the same file is archived it should be overwritten.  The same file was being overwritten because the timestamp was defined at class instantiation time instead of at flush time.