### PR TITLE
use call_count instead of assert_called_once

### DIFF
--- a/tests/common/test_event.py
+++ b/tests/common/test_event.py
@@ -108,7 +108,7 @@ class TestEvent(AgentTestCase):
         event.__event_logger__.reset_periodic()
 
         event.add_periodic(logger.EVERY_DAY, "FauxEvent")
-        mock_event.assert_called_once()
+        self.assertEqual(1, mock_event.call_count)
 
     @patch('azurelinuxagent.common.event.EventLogger.add_event')
     def test_periodic_does_not_emit_if_previously_sent(self, mock_event):

--- a/tests/common/test_logger.py
+++ b/tests/common/test_logger.py
@@ -34,7 +34,7 @@ class TestLogger(AgentTestCase):
         logger.reset_periodic()
 
         logger.periodic(logger.EVERY_DAY, _MSG, *_DATA)
-        mock_info.assert_called_once()
+        self.assertEqual(1, mock_info.call_count)
 
     @patch('azurelinuxagent.common.logger.Logger.info')
     def test_periodic_does_not_emit_if_previously_sent(self, mock_info):

--- a/tests/distro/test_resourceDisk.py
+++ b/tests/distro/test_resourceDisk.py
@@ -78,7 +78,7 @@ class TestResourceDisk(AgentTestCase):
             # assert
             if sys.version_info >= (3,3):
                 with patch("os.posix_fallocate") as posix_fallocate:
-                    assert posix_fallocate.assert_not_called()
+                    self.assertEqual(0, posix_fallocate.call_count)
 
             assert run_patch.call_count == 1
             assert "dd if" in run_patch.call_args_list[0][0][0]

--- a/tests/ga/test_extension.py
+++ b/tests/ga/test_extension.py
@@ -571,13 +571,13 @@ class TestExtension(AgentTestCase):
         conf.get_enable_overprovisioning = Mock(return_value=False)
         with patch.object(ExtHandlersHandler, 'handle_ext_handler') as patch_handle_ext_handler:
             exthandlers_handler.handle_ext_handlers()
-            patch_handle_ext_handler.assert_called()
+            self.assertEqual(1, patch_handle_ext_handler.call_count)
 
         # enable extension handling blocking
         conf.get_enable_overprovisioning = Mock(return_value=True)
         with patch.object(ExtHandlersHandler, 'handle_ext_handler') as patch_handle_ext_handler:
             exthandlers_handler.handle_ext_handlers()
-            patch_handle_ext_handler.assert_not_called()
+            self.assertEqual(0, patch_handle_ext_handler.call_count)
 
 
     def test_handle_ext_handlers_on_hold_false(self, *args):
@@ -596,13 +596,13 @@ class TestExtension(AgentTestCase):
         protocol.get_artifacts_profile = Mock(return_value=mock_in_vm_artifacts_profile)
         with patch.object(ExtHandlersHandler, 'handle_ext_handler') as patch_handle_ext_handler:
             exthandlers_handler.handle_ext_handlers()
-            patch_handle_ext_handler.assert_called_once()
+            self.assertEqual(1, patch_handle_ext_handler.call_count)
 
         #Test when in_vm_artifacts_profile is not available
         protocol.get_artifacts_profile = Mock(return_value=None)
         with patch.object(ExtHandlersHandler, 'handle_ext_handler') as patch_handle_ext_handler:
             exthandlers_handler.handle_ext_handlers()
-            patch_handle_ext_handler.assert_called_once()
+            self.assertEqual(1, patch_handle_ext_handler.call_count)
 
     def _assert_ext_status(self, report_ext_status, expected_status,
                            expected_seq_no):

--- a/tests/ga/test_update.py
+++ b/tests/ga/test_update.py
@@ -884,7 +884,7 @@ class TestUpdate(UpdateTestCase):
         mock_get_host.return_value = "faux host"
         host = self.update_handler._get_host_plugin(protocol=protocol)
         print("mock_get_host call cound={0}".format(mock_get_host.call_count))
-        mock_get_host.assert_called_once()
+        self.assertEqual(1, mock_get_host.call_count)
         self.assertEqual("faux host", host)
 
     @patch('azurelinuxagent.common.protocol.wire.WireClient.get_host_plugin')

--- a/tests/pa/test_provision.py
+++ b/tests/pa/test_provision.py
@@ -65,9 +65,9 @@ class TestProvision(AgentTestCase):
 
         ph.run()
 
-        ph.is_provisioned.assert_not_called()
-        ph.report_ready.assert_called_once()
-        ph.write_provisioned.assert_called_once()
+        self.assertEqual(0, ph.is_provisioned.call_count)
+        self.assertEqual(1, ph.report_ready.call_count)
+        self.assertEqual(1, ph.write_provisioned.call_count)
 
     @patch('os.path.isfile', return_value=False)
     def test_is_provisioned_not_provisioned(self, mock_isfile):
@@ -90,8 +90,8 @@ class TestProvision(AgentTestCase):
         mock_deprovision.return_value = deprovision_handler
 
         self.assertTrue(ph.is_provisioned())
-        ph.osutil.is_current_instance_id.assert_called_once()
-        deprovision_handler.run_changed_unique_id.assert_not_called()
+        self.assertEqual(1, ph.osutil.is_current_instance_id.call_count)
+        self.assertEqual(0, deprovision_handler.run_changed_unique_id.call_count)
 
     @patch('os.path.isfile', return_value=True)
     @patch('azurelinuxagent.common.utils.fileutil.read_file',
@@ -110,8 +110,8 @@ class TestProvision(AgentTestCase):
         mock_deprovision.return_value = deprovision_handler
 
         self.assertTrue(ph.is_provisioned())
-        ph.osutil.is_current_instance_id.assert_called_once()
-        deprovision_handler.run_changed_unique_id.assert_called_once()
+        self.assertEqual(1, ph.osutil.is_current_instance_id.call_count)
+        self.assertEqual(1, deprovision_handler.run_changed_unique_id.call_count)
 
     @distros()
     @patch('azurelinuxagent.common.osutil.default.DefaultOSUtil.get_instance_id',

--- a/tests/protocol/test_wire.py
+++ b/tests/protocol/test_wire.py
@@ -153,7 +153,7 @@ class TestWireProtocol(AgentTestCase):
             host_plugin = wire_protocol_client.get_host_plugin()
             self.assertEqual(goal_state.container_id, host_plugin.container_id)
             self.assertEqual(goal_state.role_config_name, host_plugin.role_config_name)
-            patch_get_goal_state.assert_called_once()
+            self.assertEqual(1, patch_get_goal_state.call_count)
 
     def test_download_ext_handler_pkg_fallback(self, *args):
         ext_uri = 'extension_uri'
@@ -218,7 +218,7 @@ class TestWireProtocol(AgentTestCase):
                     wire_protocol_client.get_goal_state = Mock(return_value=goal_state)
                     wire_protocol_client.upload_status_blob()
                     patch_default_upload.assert_called_once_with(testurl)
-                    wire_protocol_client.get_goal_state.assert_called_once()
+                    self.assertEqual(1, wire_protocol_client.get_goal_state.call_count)
                     patch_http.assert_called_once_with(testurl, wire_protocol_client.status_blob)
                     self.assertTrue(HostPluginProtocol.is_default_channel())
                     HostPluginProtocol.set_default_channel(False)
@@ -255,8 +255,8 @@ class TestWireProtocol(AgentTestCase):
             with patch.object(WireClient, "report_status_event") as mock_event:
                 wire_protocol_client.upload_status_blob()
 
-                mock_prepare.assert_called_once()
-                mock_event.assert_called_once()
+                self.assertEqual(1, mock_prepare.call_count)
+                self.assertEqual(1, mock_event.call_count)
 
     def test_get_in_vm_artifacts_profile_blob_not_available(self, *args):
         wire_protocol_client = WireProtocol(wireserver_url).client

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -117,7 +117,7 @@ class TestAgent(AgentTestCase):
         agent.daemon()
 
         mock_daemon.run.assert_called_once_with(child_args=None)
-        mock_load.assert_called_once()
+        self.assertEqual(1, mock_load.call_count)
 
     @patch("azurelinuxagent.daemon.get_daemon_handler")
     @patch("azurelinuxagent.common.conf.load_conf_from_file")
@@ -131,7 +131,7 @@ class TestAgent(AgentTestCase):
         agent.daemon()
 
         mock_daemon.run.assert_called_once_with(child_args="-configuration-path:/foo/bar.conf")
-        mock_load.assert_called_once()
+        self.assertEqual(1, mock_load.call_count)
 
     @patch("azurelinuxagent.common.conf.get_ext_log_dir")
     def test_agent_ensures_extension_log_directory(self, mock_dir):
@@ -156,7 +156,7 @@ class TestAgent(AgentTestCase):
                     conf_file_path=os.path.join(data_dir, "test_waagent.conf"))
         self.assertTrue(os.path.isfile(ext_log_dir))
         self.assertFalse(os.path.isdir(ext_log_dir))
-        mock_log.assert_called_once()
+        self.assertEqual(1, mock_log.call_count)
 
     def test_agent_get_configuration(self):
         Agent(False, conf_file_path=os.path.join(data_dir, "test_waagent.conf"))

--- a/tests/utils/test_rest_util.py
+++ b/tests/utils/test_rest_util.py
@@ -132,8 +132,8 @@ class TestHttpOperations(AgentTestCase):
         h, p = restutil._get_http_proxy()
         self.assertEqual("host", h)
         self.assertEqual(None, p)
-        mock_host.assert_called_once()
-        mock_port.assert_called_once()
+        self.assertEqual(1, mock_host.call_count)
+        self.assertEqual(1, mock_port.call_count)
 
     @patch('azurelinuxagent.common.conf.get_httpproxy_port')
     @patch('azurelinuxagent.common.conf.get_httpproxy_host')
@@ -143,8 +143,8 @@ class TestHttpOperations(AgentTestCase):
         h, p = restutil._get_http_proxy()
         self.assertEqual(None, h)
         self.assertEqual(None, p)
-        mock_host.assert_called_once()
-        mock_port.assert_not_called()
+        self.assertEqual(1, mock_host.call_count)
+        self.assertEqual(0, mock_port.call_count)
 
     @patch('azurelinuxagent.common.conf.get_httpproxy_host')
     def test_get_http_proxy_http_uses_httpproxy(self, mock_host):
@@ -197,7 +197,7 @@ class TestHttpOperations(AgentTestCase):
         mock_conn.request.assert_has_calls([
             call(method="GET", url="/bar", body=None, headers={'User-Agent': HTTP_USER_AGENT})
         ])
-        mock_conn.getresponse.assert_called_once()
+        self.assertEqual(1, mock_conn.getresponse.call_count)
         self.assertNotEquals(None, resp)
         self.assertEquals("TheResults", resp.read())
 
@@ -220,7 +220,7 @@ class TestHttpOperations(AgentTestCase):
         mock_conn.request.assert_has_calls([
             call(method="GET", url="/bar", body=None, headers={'User-Agent': HTTP_USER_AGENT})
         ])
-        mock_conn.getresponse.assert_called_once()
+        self.assertEqual(1, mock_conn.getresponse.call_count)
         self.assertNotEquals(None, resp)
         self.assertEquals("TheResults", resp.read())
 
@@ -244,7 +244,7 @@ class TestHttpOperations(AgentTestCase):
         mock_conn.request.assert_has_calls([
             call(method="GET", url="http://foo:80/bar", body=None, headers={'User-Agent': HTTP_USER_AGENT})
         ])
-        mock_conn.getresponse.assert_called_once()
+        self.assertEqual(1, mock_conn.getresponse.call_count)
         self.assertNotEquals(None, resp)
         self.assertEquals("TheResults", resp.read())
 
@@ -269,7 +269,7 @@ class TestHttpOperations(AgentTestCase):
         mock_conn.request.assert_has_calls([
             call(method="GET", url="https://foo:443/bar", body=None, headers={'User-Agent': HTTP_USER_AGENT})
         ])
-        mock_conn.getresponse.assert_called_once()
+        self.assertEqual(1, mock_conn.getresponse.call_count)
         self.assertNotEquals(None, resp)
         self.assertEquals("TheResults", resp.read())
 


### PR DESCRIPTION
I don't know what's going on.  When I run the tests on my machine under 2.7 they work just fine.  When I run them under 3.5 they fail with AttributeError because of assert_called_once.  According to the docs assert_called_once was introduced in 3.6, so I have no idea how or why this works.

I dropped all usage of assert_called_once to be consistent with the docs, and to get these tests working on my machine.