### PR TITLE
Report ProvisionGuestAgent value in telemetry

### DIFF
--- a/azurelinuxagent/common/event.py
+++ b/azurelinuxagent/common/event.py
@@ -62,6 +62,7 @@ class WALAEventOperation:
     Partition = "Partition"
     ProcessGoalState = "ProcessGoalState"
     Provision = "Provision"
+    ProvisionGuestAgent = "ProvisionGuestAgent"
     ReportStatus = "ReportStatus"
     Restart = "Restart"
     SkipUpdate = "SkipUpdate"

--- a/azurelinuxagent/common/protocol/ovfenv.py
+++ b/azurelinuxagent/common/protocol/ovfenv.py
@@ -113,10 +113,10 @@ class OvfEnv(object):
             self.ssh_keypairs.append((path, fingerprint))
 
         platform_settings_section = find(environment, "PlatformSettingsSection", namespace=wans)
-        _validate_ovf(platform_settings_section, "PlatformSettingsSection for found")
+        _validate_ovf(platform_settings_section, "PlatformSettingsSection not found")
 
         platform_settings = find(platform_settings_section, "PlatformSettings", namespace=wans)
-        _validate_ovf(platform_settings, "PlatformSettings for found")
+        _validate_ovf(platform_settings, "PlatformSettings not found")
 
         self.provision_guest_agent = findtext(platform_settings, "ProvisionGuestAgent", namespace=wans)
         _validate_ovf(self.provision_guest_agent, "ProvisionGuestAgent not found")

--- a/azurelinuxagent/common/protocol/ovfenv.py
+++ b/azurelinuxagent/common/protocol/ovfenv.py
@@ -52,7 +52,7 @@ class OvfEnv(object):
         self.disable_ssh_password_auth = True
         self.ssh_pubkeys = []
         self.ssh_keypairs = []
-        self.provision_guest_agent = False
+        self.provision_guest_agent = None
         self.parse(xml_text)
 
     def parse(self, xml_text):
@@ -118,7 +118,5 @@ class OvfEnv(object):
         platform_settings = find(platform_settings_section, "PlatformSettings", namespace=wans)
         _validate_ovf(platform_settings, "PlatformSettings for found")
 
-        provision_guest_agent_text = findtext(platform_settings, "ProvisionGuestAgent", namespace=wans)
-        _validate_ovf(provision_guest_agent_text, "ProvisionGuestAgent not found")
-
-        self.provision_guest_agent = bool(provision_guest_agent_text)
+        self.provision_guest_agent = findtext(platform_settings, "ProvisionGuestAgent", namespace=wans)
+        _validate_ovf(self.provision_guest_agent, "ProvisionGuestAgent not found")

--- a/azurelinuxagent/common/protocol/ovfenv.py
+++ b/azurelinuxagent/common/protocol/ovfenv.py
@@ -52,6 +52,7 @@ class OvfEnv(object):
         self.disable_ssh_password_auth = True
         self.ssh_pubkeys = []
         self.ssh_keypairs = []
+        self.provision_guest_agent = False
         self.parse(xml_text)
 
     def parse(self, xml_text):
@@ -111,3 +112,13 @@ class OvfEnv(object):
             fingerprint = findtext(keypair, "Fingerprint", namespace=wans)
             self.ssh_keypairs.append((path, fingerprint))
 
+        platform_settings_section = find(environment, "PlatformSettingsSection", namespace=wans)
+        _validate_ovf(platform_settings_section, "PlatformSettingsSection for found")
+
+        platform_settings = find(platform_settings_section, "PlatformSettings", namespace=wans)
+        _validate_ovf(platform_settings, "PlatformSettings for found")
+
+        provision_guest_agent_text = findtext(platform_settings, "ProvisionGuestAgent", namespace=wans)
+        _validate_ovf(provision_guest_agent_text, "ProvisionGuestAgent not found")
+
+        self.provision_guest_agent = bool(provision_guest_agent_text)

--- a/azurelinuxagent/pa/provision/cloudinit.py
+++ b/azurelinuxagent/pa/provision/cloudinit.py
@@ -83,7 +83,7 @@ class CloudInitProvisionHandler(ProvisionHandler):
             if os.path.isfile(ovf_file_path):
                 try:
                     ovf_env = OvfEnv(fileutil.read_file(ovf_file_path))
-                    self.report_event(message="{0}".format(ovf_env.provision_guest_agent),
+                    self.report_event(message=ovf_env.provision_guest_agent,
                                       is_success=True,
                                       duration=0,
                                       operation=WALAEventOperation.ProvisionGuestAgent)

--- a/azurelinuxagent/pa/provision/cloudinit.py
+++ b/azurelinuxagent/pa/provision/cloudinit.py
@@ -28,7 +28,7 @@ import azurelinuxagent.common.logger as logger
 import azurelinuxagent.common.utils.fileutil as fileutil
 import azurelinuxagent.common.utils.shellutil as shellutil
 
-from azurelinuxagent.common.event import elapsed_milliseconds
+from azurelinuxagent.common.event import elapsed_milliseconds, WALAEventOperation
 from azurelinuxagent.common.exception import ProvisionError, ProtocolError
 from azurelinuxagent.common.future import ustr
 from azurelinuxagent.common.protocol import OVF_FILE_NAME
@@ -82,7 +82,11 @@ class CloudInitProvisionHandler(ProvisionHandler):
         for retry in range(0, max_retry):
             if os.path.isfile(ovf_file_path):
                 try:
-                    OvfEnv(fileutil.read_file(ovf_file_path))
+                    ovf_env = OvfEnv(fileutil.read_file(ovf_file_path))
+                    self.report_event(message="{0}".format(ovf_env.provision_guest_agent),
+                                      is_success=True,
+                                      duration=0,
+                                      operation=WALAEventOperation.ProvisionGuestAgent)
                     return
                 except ProtocolError as pe:
                     raise ProvisionError("OVF xml could not be parsed "

--- a/azurelinuxagent/pa/provision/default.py
+++ b/azurelinuxagent/pa/provision/default.py
@@ -92,7 +92,7 @@ class ProvisionHandler(object):
                 is_success=True,
                 duration=elapsed_milliseconds(utc_start))
 
-            self.report_event(message="{0}".format(ovf_env.provision_guest_agent),
+            self.report_event(message=ovf_env.provision_guest_agent,
                               is_success=True,
                               duration=0,
                               operation=WALAEventOperation.ProvisionGuestAgent)

--- a/azurelinuxagent/pa/provision/default.py
+++ b/azurelinuxagent/pa/provision/default.py
@@ -92,6 +92,11 @@ class ProvisionHandler(object):
                 is_success=True,
                 duration=elapsed_milliseconds(utc_start))
 
+            self.report_event(message="{0}".format(ovf_env.provision_guest_agent),
+                              is_success=True,
+                              duration=0,
+                              operation=WALAEventOperation.ProvisionGuestAgent)
+
             self.report_ready(thumbprint)
             logger.info("Provisioning complete")
 

--- a/tests/data/ovf-env.xml
+++ b/tests/data/ovf-env.xml
@@ -26,4 +26,15 @@
         <CustomData>CustomData</CustomData>
       </LinuxProvisioningConfigurationSet>
     </wa:ProvisioningSection>
+    <wa:PlatformSettingsSection>
+		<wa:Version>1.0</wa:Version>
+		<wa:PlatformSettings>
+			<wa:KmsServerHostname>kms.core.windows.net</wa:KmsServerHostname>
+			<wa:ProvisionGuestAgent>false</wa:ProvisionGuestAgent>
+			<wa:GuestAgentPackageName xsi:nil="true"/>
+			<wa:RetainWindowsPEPassInUnattend>true</wa:RetainWindowsPEPassInUnattend>
+			<wa:RetainOfflineServicingPassInUnattend>true</wa:RetainOfflineServicingPassInUnattend>
+			<wa:PreprovisionedVm>false</wa:PreprovisionedVm>
+		</wa:PlatformSettings>
+	</wa:PlatformSettingsSection>
  </Environment>

--- a/tests/pa/test_provision.py
+++ b/tests/pa/test_provision.py
@@ -154,6 +154,7 @@ class TestProvision(AgentTestCase):
 
         positional_args, kw_args = ph.report_event.call_args_list[1]
         self.assertTrue(kw_args['operation'] == 'ProvisionGuestAgent')
+        self.assertTrue(kw_args['message'] == 'false')
         self.assertTrue(kw_args['is_success'])
 
     @distros()

--- a/tests/pa/test_provision.py
+++ b/tests/pa/test_provision.py
@@ -145,11 +145,15 @@ class TestProvision(AgentTestCase):
 
         ph.run()
 
-        self.assertEqual(1, ph.report_event.call_count)
-        positional_args, kw_args = ph.report_event.call_args
+        self.assertEqual(2, ph.report_event.call_count)
+        positional_args, kw_args = ph.report_event.call_args_list[0]
         # [call('Provisioning succeeded (146473.68s)', duration=65, is_success=True)]
         self.assertTrue(re.match(r'Provisioning succeeded \(\d+\.\d+s\)', positional_args[0]) is not None)
         self.assertTrue(isinstance(kw_args['duration'], int))
+        self.assertTrue(kw_args['is_success'])
+
+        positional_args, kw_args = ph.report_event.call_args_list[1]
+        self.assertTrue(kw_args['operation'] == 'ProvisionGuestAgent')
         self.assertTrue(kw_args['is_success'])
 
     @distros()


### PR DESCRIPTION
Today this defaults to `false` on Linux VMs. After the CRP agentless changes are released in the next couple weeks, this will change to `true` by default. Once that is completely rolled out, SDK changes will allow customers to change this to `false` and we can honor the flag via the agent (#838) and cloud-init. 

This telemetry is for tracking the rollover, so we know when it is safe to put in that code.