### PR TITLE
Set log event prefix for -daemon and -run-exthandler instances

### DIFF
--- a/azurelinuxagent/agent.py
+++ b/azurelinuxagent/agent.py
@@ -89,6 +89,7 @@ class Agent(object):
         """
         Run agent daemon
         """
+        logger.set_prefix("Daemon")
         child_args = None \
             if self.conf_file_path is None \
                 else "-configuration-path:{0}".format(self.conf_file_path)
@@ -128,6 +129,7 @@ class Agent(object):
         """
         Run the update and extension handler
         """
+        logger.set_prefix("Upd/Ext-Handler")
         from azurelinuxagent.ga.update import get_update_handler
         update_handler = get_update_handler()
         update_handler.run()

--- a/azurelinuxagent/common/logger.py
+++ b/azurelinuxagent/common/logger.py
@@ -42,6 +42,9 @@ class Logger(object):
     def reset_periodic(self):
         self.logger.periodic_messages = {}
 
+    def set_prefix(self, prefix):
+        self.prefix = prefix
+
     def is_period_elapsed(self, delta, h):
         return h not in self.logger.periodic_messages or \
             (self.logger.periodic_messages[h] + delta) <= datetime.now()
@@ -178,6 +181,8 @@ def add_logger_appender(appender_type, level=LogLevel.INFO, path=None):
 def reset_periodic():
     DEFAULT_LOGGER.reset_periodic()
 
+def set_prefix(prefix):
+    DEFAULT_LOGGER.set_prefix(prefix)
 
 def periodic(delta, msg_format, *args):
     DEFAULT_LOGGER.periodic(delta, msg_format, *args)


### PR DESCRIPTION
While the agent instance responsible for handling a particular operation on an extension sets a prefix on log events indicating which extension is being managed, the two long-running agent instances (-daemon, which watches the health of the update/extension handler, and -run-exthandlers, which checks for updates of the agent code itself and which processes goal-state changes) do not. This makes it hard to tell which agent instance is reporting what event.

This PR changes that. The -daemon and -run-exthandlers instances now flag their log entries (Daemon and Upd/Ext-Handlers, respectively).