### PR TITLE
Health store integration

### DIFF
--- a/azurelinuxagent/agent.py
+++ b/azurelinuxagent/agent.py
@@ -129,7 +129,7 @@ class Agent(object):
         """
         Run the update and extension handler
         """
-        logger.set_prefix("Upd/Ext-Handler")
+        logger.set_prefix("ExtHandler")
         from azurelinuxagent.ga.update import get_update_handler
         update_handler = get_update_handler()
         update_handler.run()

--- a/azurelinuxagent/common/errorstate.py
+++ b/azurelinuxagent/common/errorstate.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta
 
 ERROR_STATE_DELTA_DEFAULT = timedelta(minutes=15)
 ERROR_STATE_DELTA_INSTALL = timedelta(minutes=5)
+ERROR_STATE_HOST_PLUGIN_FAILURE = timedelta(minutes=5)
 
 class ErrorState(object):
     def __init__(self, min_timedelta=ERROR_STATE_DELTA_DEFAULT):

--- a/azurelinuxagent/common/errorstate.py
+++ b/azurelinuxagent/common/errorstate.py
@@ -4,6 +4,7 @@ ERROR_STATE_DELTA_DEFAULT = timedelta(minutes=15)
 ERROR_STATE_DELTA_INSTALL = timedelta(minutes=5)
 ERROR_STATE_HOST_PLUGIN_FAILURE = timedelta(minutes=5)
 
+
 class ErrorState(object):
     def __init__(self, min_timedelta=ERROR_STATE_DELTA_DEFAULT):
         self.min_timedelta = min_timedelta

--- a/azurelinuxagent/common/event.py
+++ b/azurelinuxagent/common/event.py
@@ -56,6 +56,7 @@ class WALAEventOperation:
     HealthCheck = "HealthCheck"
     HeartBeat = "HeartBeat"
     HostPlugin = "HostPlugin"
+    HostPluginHeartbeat = "HostPluginHeartbeat"
     HttpErrors = "HttpErrors"
     Install = "Install"
     InitializeHostPlugin = "InitializeHostPlugin"

--- a/azurelinuxagent/common/protocol/healthservice.py
+++ b/azurelinuxagent/common/protocol/healthservice.py
@@ -48,7 +48,7 @@ class HealthService(object):
     API = 'reporttargethealth'
     VERSION = "1.0"
     OBSERVER_NAME = 'WALinuxAgent'
-    HOST_PLUGIN_HEARTBEAT_OBSERVATION_NAME = 'HostPluginHeartbeat'
+    HOST_PLUGIN_HEARTBEAT_OBSERVATION_NAME = 'GuestAgentPluginHeartbeat'
 
     def __init__(self, endpoint):
         self.endpoint = HealthService.ENDPOINT.format(endpoint)

--- a/azurelinuxagent/common/protocol/healthservice.py
+++ b/azurelinuxagent/common/protocol/healthservice.py
@@ -20,6 +20,7 @@
 import json
 
 from azurelinuxagent.common import logger
+from azurelinuxagent.common.dhcp import KNOWN_WIRESERVER_IP
 from azurelinuxagent.common.exception import HttpError
 from azurelinuxagent.common.future import ustr
 from azurelinuxagent.common.utils import restutil
@@ -44,6 +45,7 @@ class Observation(object):
 
 class HealthService(object):
 
+    VNET_ENDPOINT = '169.254.169.254'
     ENDPOINT = 'http://{0}:80/HealthService'
     API = 'reporttargethealth'
     OBSERVER_NAME = 'WALinuxAgent'
@@ -51,7 +53,8 @@ class HealthService(object):
     HOST_PLUGIN_HEARTBEAT_OBSERVATION_NAME = 'HostPluginHeartbeat'
 
     def __init__(self, endpoint):
-        self.endpoint = HealthService.ENDPOINT.format(endpoint)
+        self.endpoint = HealthService.ENDPOINT.format(endpoint if endpoint != KNOWN_WIRESERVER_IP
+                                                      else HealthService.VNET_ENDPOINT)
         self.api = HealthService.API
         self.version = HealthService.VERSION
         self.source = HealthService.OBSERVER_NAME

--- a/azurelinuxagent/common/protocol/healthservice.py
+++ b/azurelinuxagent/common/protocol/healthservice.py
@@ -79,7 +79,7 @@ class HealthService(object):
             # TODO: remove
             logger.info('Report observation to {0}: {1}', self.endpoint, self.as_json)
 
-            restutil.http_post(self.endpoint, self.as_json)
+            restutil.http_post(self.endpoint, self.as_json, headers={'Content-Type': 'application/json'})
             del self.observations[:]
         except HttpError as e:
             logger.warn("HealthService could not report observations: {0}", ustr(e))

--- a/azurelinuxagent/common/protocol/healthservice.py
+++ b/azurelinuxagent/common/protocol/healthservice.py
@@ -27,6 +27,18 @@ from azurelinuxagent.common.utils import restutil
 
 class Observation(object):
     def __init__(self, name, is_healthy, description='', value=''):
+        if name is None:
+            raise ValueError("Observation name must be provided")
+
+        if is_healthy is None:
+            raise ValueError("Observation health must be provided")
+
+        if value is None:
+            value = ''
+
+        if description is None:
+            description = ''
+
         self.name = name
         self.is_healthy = is_healthy
         self.description = description
@@ -35,10 +47,10 @@ class Observation(object):
     @property
     def as_obj(self):
         return {
-            "ObservationName": self.name,
+            "ObservationName": self.name[:64],
             "IsHealthy": self.is_healthy,
-            "Description": self.description,
-            "Value": self.value
+            "Description": self.description[:128],
+            "Value": self.value[:128]
         }
 
 

--- a/azurelinuxagent/common/protocol/healthservice.py
+++ b/azurelinuxagent/common/protocol/healthservice.py
@@ -89,7 +89,7 @@ class HealthService(object):
         """
         self.observations.append(Observation(name=HealthService.HOST_PLUGIN_HEARTBEAT_OBSERVATION_NAME,
                                              is_healthy=is_healthy))
-        self.report()
+        self._report()
 
     def report_host_plugin_versions(self, is_healthy, response):
         """
@@ -100,7 +100,7 @@ class HealthService(object):
         self.observations.append(Observation(name=HealthService.HOST_PLUGIN_VERSIONS_OBSERVATION_NAME,
                                              is_healthy=is_healthy,
                                              value=response))
-        self.report()
+        self._report()
 
     def report_host_plugin_extension_artifact(self, is_healthy, source, response):
         """
@@ -114,7 +114,7 @@ class HealthService(object):
                                              is_healthy=is_healthy,
                                              description=source,
                                              value=response))
-        self.report()
+        self._report()
 
     def report_host_plugin_status(self, is_healthy, response):
         """
@@ -126,15 +126,16 @@ class HealthService(object):
         self.observations.append(Observation(name=HealthService.HOST_PLUGIN_STATUS_OBSERVATION_NAME,
                                              is_healthy=is_healthy,
                                              value=response))
-        self.report()
+        self._report()
 
-    def report(self):
+    def _report(self):
         logger.verbose('HealthService: report observations')
         try:
             restutil.http_post(self.endpoint, self.as_json, headers={'Content-Type': 'application/json'})
             logger.verbose('HealthService: Reported observations to {0}: {1}', self.endpoint, self.as_json)
         except HttpError as e:
             logger.warn("HealthService: could not report observations: {0}", ustr(e))
-
-        # these signals are not timestamped, so there is no value in persisting data
-        del self.observations[:]
+        finally:
+            # TODO: add safety boundaries
+            # these signals are not timestamped, so there is no value in persisting data
+            del self.observations[:]

--- a/azurelinuxagent/common/protocol/healthservice.py
+++ b/azurelinuxagent/common/protocol/healthservice.py
@@ -104,6 +104,18 @@ class HealthService(object):
                                              value=response))
         self.report()
 
+    def report_host_plugin_status(self, is_healthy, response):
+        """
+        Reports a signal for /status
+        :param is_healthy: whether the api call succeeded
+        :param response: debugging information for failures
+        :return:
+        """
+        self.observations.append(Observation(name=HealthService.HOST_PLUGIN_STATUS_OBSERVATION_NAME,
+                                             is_healthy=is_healthy,
+                                             value=response))
+        self.report()
+
     def report(self):
         logger.verbose('HealthService: report observations')
         try:

--- a/azurelinuxagent/common/protocol/healthservice.py
+++ b/azurelinuxagent/common/protocol/healthservice.py
@@ -18,7 +18,6 @@
 #
 
 import json
-from datetime import datetime
 
 from azurelinuxagent.common import logger
 from azurelinuxagent.common.exception import HttpError
@@ -71,8 +70,8 @@ class HealthService(object):
     def observe_host_plugin_heartbeat(self, is_healthy):
         self.observations.append(Observation(name=HealthService.HOST_PLUGIN_HEARTBEAT_OBSERVATION_NAME,
                                              is_healthy=is_healthy,
-                                             description=datetime.utcnow(),
-                                             value=is_healthy))
+                                             description='',
+                                             value=''))
 
     def report(self):
         logger.verbose('HealthService: report observations')

--- a/azurelinuxagent/common/protocol/healthservice.py
+++ b/azurelinuxagent/common/protocol/healthservice.py
@@ -90,15 +90,17 @@ class HealthService(object):
                                              value=response))
         self.report()
 
-    def report_host_plugin_extension_artifact(self, is_healthy, response):
+    def report_host_plugin_extension_artifact(self, is_healthy, source, response):
         """
         Reports a signal for /extensionArtifact
         :param is_healthy: whether the api call succeeded
+        :param source: specifies the api caller for debugging failures
         :param response: debugging information for failures
         :return:
         """
         self.observations.append(Observation(name=HealthService.HOST_PLUGIN_ARTIFACT_OBSERVATION_NAME,
                                              is_healthy=is_healthy,
+                                             description=source,
                                              value=response))
         self.report()
 

--- a/azurelinuxagent/common/protocol/healthservice.py
+++ b/azurelinuxagent/common/protocol/healthservice.py
@@ -1,0 +1,85 @@
+# Microsoft Azure Linux Agent
+#
+# Copyright 2018 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Requires Python 2.6+ and Openssl 1.0+
+#
+
+import json
+
+from azurelinuxagent.common import logger
+from azurelinuxagent.common.exception import HttpError
+from azurelinuxagent.common.future import ustr
+from azurelinuxagent.common.utils import restutil
+
+
+class Observation(object):
+    def __init__(self, name, is_healthy, description, value):
+        self.name = name
+        self.is_healthy = is_healthy
+        self.description = description
+        self.value = value
+
+    @property
+    def as_obj(self):
+        return {
+            "ObservationName": self.name,
+            "IsHealthy": self.is_healthy,
+            "Description": self.description,
+            "Value": self.value
+        }
+
+
+class HealthService(object):
+
+    ENDPOINT = 'http://{0}:80/HealthService'
+    API = 'reporttargethealth'
+    OBSERVER_NAME = 'WALinuxAgent'
+    VERSION = 1
+    HOST_PLUGIN_HEARTBEAT_OBSERVATION_NAME = 'HostPluginHeartbeat'
+
+    def __init__(self, endpoint):
+        self.endpoint = HealthService.ENDPOINT.format(endpoint)
+        self.api = HealthService.API
+        self.version = HealthService.VERSION
+        self.source = HealthService.OBSERVER_NAME
+        self.observations = list()
+
+    @property
+    def as_json(self):
+        data = {
+            "Api": self.api,
+            "Version": self.version,
+            "Source": self.source,
+            "Observations": [o.as_obj for o in self.observations]
+        }
+        return json.dumps(data)
+
+    def observe_host_plugin_heartbeat(self, is_healthy):
+        self.observations.append(Observation(name=HealthService.HOST_PLUGIN_HEARTBEAT_OBSERVATION_NAME,
+                                             is_healthy=is_healthy,
+                                             description='',
+                                             value=''))
+
+    def report(self):
+        logger.verbose('HealthService: report observations')
+        try:
+            # TODO: remove
+            logger.info('Report observation to {0}: {1}', self.endpoint, self.as_json)
+
+            restutil.http_post(self.endpoint, self.as_json)
+            del self.observations[:]
+        except HttpError as e:
+            logger.warn("HealthService could not report observations: {0}", ustr(e))

--- a/azurelinuxagent/common/protocol/healthservice.py
+++ b/azurelinuxagent/common/protocol/healthservice.py
@@ -96,6 +96,9 @@ class HealthService(object):
     def report(self):
         logger.verbose('HealthService: report observations')
         try:
+            # TODO: debugging
+            logger.info("{0}", self.as_json)
+
             restutil.http_post(self.endpoint, self.as_json, headers={'Content-Type': 'application/json'})
             logger.verbose('HealthService: Reported observations to {0}: {1}', self.endpoint, self.as_json)
         except HttpError as e:

--- a/azurelinuxagent/common/protocol/healthservice.py
+++ b/azurelinuxagent/common/protocol/healthservice.py
@@ -76,10 +76,8 @@ class HealthService(object):
     def report(self):
         logger.verbose('HealthService: report observations')
         try:
-            # TODO: remove
-            logger.info('Report observation to {0}: {1}', self.endpoint, self.as_json)
-
             restutil.http_post(self.endpoint, self.as_json, headers={'Content-Type': 'application/json'})
             del self.observations[:]
+            logger.verbose('HealthService: Reported observations to {0}: {1}', self.endpoint, self.as_json)
         except HttpError as e:
-            logger.warn("HealthService could not report observations: {0}", ustr(e))
+            logger.warn("HealthService: could not report observations: {0}", ustr(e))

--- a/azurelinuxagent/common/protocol/healthservice.py
+++ b/azurelinuxagent/common/protocol/healthservice.py
@@ -26,7 +26,7 @@ from azurelinuxagent.common.utils import restutil
 
 
 class Observation(object):
-    def __init__(self, name, is_healthy, description, value):
+    def __init__(self, name, is_healthy, description='', value=''):
         self.name = name
         self.is_healthy = is_healthy
         self.description = description
@@ -73,12 +73,10 @@ class HealthService(object):
     def report_host_plugin_heartbeat(self, is_healthy):
         """
         Reports a signal for /health
-        :param is_healthy: whether the call suceeded
+        :param is_healthy: whether the call succeeded
         """
         self.observations.append(Observation(name=HealthService.HOST_PLUGIN_HEARTBEAT_OBSERVATION_NAME,
-                                             is_healthy=is_healthy,
-                                             description='',
-                                             value=''))
+                                             is_healthy=is_healthy))
         self.report()
 
     def report_host_plugin_versions(self, is_healthy, response):
@@ -89,7 +87,18 @@ class HealthService(object):
         """
         self.observations.append(Observation(name=HealthService.HOST_PLUGIN_VERSIONS_OBSERVATION_NAME,
                                              is_healthy=is_healthy,
-                                             description='',
+                                             value=response))
+        self.report()
+
+    def report_host_plugin_extension_artifact(self, is_healthy, response):
+        """
+        Reports a signal for /extensionArtifact
+        :param is_healthy: whether the api call succeeded
+        :param response: debugging information for failures
+        :return:
+        """
+        self.observations.append(Observation(name=HealthService.HOST_PLUGIN_ARTIFACT_OBSERVATION_NAME,
+                                             is_healthy=is_healthy,
                                              value=response))
         self.report()
 

--- a/azurelinuxagent/common/protocol/healthservice.py
+++ b/azurelinuxagent/common/protocol/healthservice.py
@@ -18,9 +18,9 @@
 #
 
 import json
+from datetime import datetime
 
 from azurelinuxagent.common import logger
-from azurelinuxagent.common.dhcp import KNOWN_WIRESERVER_IP
 from azurelinuxagent.common.exception import HttpError
 from azurelinuxagent.common.future import ustr
 from azurelinuxagent.common.utils import restutil
@@ -45,16 +45,14 @@ class Observation(object):
 
 class HealthService(object):
 
-    VNET_ENDPOINT = '169.254.169.254'
     ENDPOINT = 'http://{0}:80/HealthService'
     API = 'reporttargethealth'
+    VERSION = "1.0"
     OBSERVER_NAME = 'WALinuxAgent'
-    VERSION = 1
     HOST_PLUGIN_HEARTBEAT_OBSERVATION_NAME = 'HostPluginHeartbeat'
 
     def __init__(self, endpoint):
-        self.endpoint = HealthService.ENDPOINT.format(endpoint if endpoint != KNOWN_WIRESERVER_IP
-                                                      else HealthService.VNET_ENDPOINT)
+        self.endpoint = HealthService.ENDPOINT.format(endpoint)
         self.api = HealthService.API
         self.version = HealthService.VERSION
         self.source = HealthService.OBSERVER_NAME
@@ -73,8 +71,8 @@ class HealthService(object):
     def observe_host_plugin_heartbeat(self, is_healthy):
         self.observations.append(Observation(name=HealthService.HOST_PLUGIN_HEARTBEAT_OBSERVATION_NAME,
                                              is_healthy=is_healthy,
-                                             description='',
-                                             value=''))
+                                             description=datetime.utcnow(),
+                                             value=is_healthy))
 
     def report(self):
         logger.verbose('HealthService: report observations')

--- a/azurelinuxagent/common/protocol/healthservice.py
+++ b/azurelinuxagent/common/protocol/healthservice.py
@@ -119,9 +119,6 @@ class HealthService(object):
     def report(self):
         logger.verbose('HealthService: report observations')
         try:
-            # TODO: debugging
-            logger.info("{0}", self.as_json)
-
             restutil.http_post(self.endpoint, self.as_json, headers={'Content-Type': 'application/json'})
             logger.verbose('HealthService: Reported observations to {0}: {1}', self.endpoint, self.as_json)
         except HttpError as e:

--- a/azurelinuxagent/common/protocol/hostplugin.py
+++ b/azurelinuxagent/common/protocol/hostplugin.py
@@ -48,8 +48,7 @@ MAXIMUM_PAGEBLOB_PAGE_SIZE = 4 * 1024 * 1024  # Max page size: 4MB
 
 
 class HostPluginProtocol(object):
-    # TODO: debugging
-    _is_default_channel = True
+    _is_default_channel = False
 
     FETCH_REPORTING_PERIOD = datetime.timedelta(minutes=1)
     STATUS_REPORTING_PERIOD = datetime.timedelta(minutes=1)

--- a/azurelinuxagent/common/protocol/hostplugin.py
+++ b/azurelinuxagent/common/protocol/hostplugin.py
@@ -97,8 +97,8 @@ class HostPluginProtocol(object):
     def get_api_versions(self):
         url = URI_FORMAT_GET_API_VERSIONS.format(self.endpoint,
                                                  HOST_PLUGIN_PORT)
-        logger.verbose("HostGAPlugin: Getting API versions at [{0}]".format(
-            url))
+        logger.verbose("HostGAPlugin: Getting API versions at [{0}]"
+                       .format(url))
         return_val = []
         try:
             headers = {HEADER_CONTAINER_ID: self.container_id}

--- a/azurelinuxagent/common/protocol/hostplugin.py
+++ b/azurelinuxagent/common/protocol/hostplugin.py
@@ -145,7 +145,7 @@ class HostPluginProtocol(object):
 
         return url, headers
 
-    def report_fetch(self, uri, is_healthy=True, source='WireClient', response=''):
+    def report_fetch(self, uri, is_healthy=True, source='', response=''):
 
         if uri != URI_FORMAT_GET_EXTENSION_ARTIFACT.format(self.endpoint, HOST_PLUGIN_PORT):
             return

--- a/azurelinuxagent/common/protocol/hostplugin.py
+++ b/azurelinuxagent/common/protocol/hostplugin.py
@@ -35,6 +35,7 @@ URI_FORMAT_GET_API_VERSIONS = "http://{0}:{1}/versions"
 URI_FORMAT_GET_EXTENSION_ARTIFACT = "http://{0}:{1}/extensionArtifact"
 URI_FORMAT_PUT_VM_STATUS = "http://{0}:{1}/status"
 URI_FORMAT_PUT_LOG = "http://{0}:{1}/vmAgentLog"
+URI_FORMAT_HEALTH = "http://{0}:{1}/health"
 API_VERSION = "2015-09-01"
 HEADER_CONTAINER_ID = "x-ms-containerid"
 HEADER_VERSION = "x-ms-version"
@@ -76,6 +77,22 @@ class HostPluginProtocol(object):
             report_event(WALAEventOperation.InitializeHostPlugin,
                          is_success=self.is_available)
         return self.is_available
+
+    def get_health(self):
+        """
+        Call the /health endpoint
+        :return: True if 200 received, False otherwise
+        """
+        url = URI_FORMAT_HEALTH.format(self.endpoint,
+                                       HOST_PLUGIN_PORT)
+        logger.verbose("HostGAPlugin: Getting health from [{0}]", url)
+        status_ok = False
+        try:
+            response = restutil.http_get(url, max_retry=1)
+            status_ok = restutil.request_succeeded(response)
+        except HttpError as e:
+            logger.verbose("HostGAPlugin: Exception getting health", ustr(e))
+        return status_ok
 
     def get_api_versions(self):
         url = URI_FORMAT_GET_API_VERSIONS.format(self.endpoint,

--- a/azurelinuxagent/common/protocol/hostplugin.py
+++ b/azurelinuxagent/common/protocol/hostplugin.py
@@ -174,8 +174,19 @@ class HostPluginProtocol(object):
 
     @staticmethod
     def should_report(is_healthy, error_state, last_timestamp, period):
+        """
+        Determine whether a health signal should be reported
+        :param is_healthy: whether the current measurement is healthy
+        :param error_state: the error state which is tracking time since failure
+        :param last_timestamp: the last measurement time stamp
+        :param period: the reporting period
+        :return: True if the signal should be reported, False otherwise
+        """
 
         if is_healthy:
+            # we only reset the error state upon success, since we want to keep
+            # reporting the failure; this is different to other uses of error states
+            # which do not have a separate periodicity
             error_state.reset()
         else:
             error_state.incr()

--- a/azurelinuxagent/common/protocol/hostplugin.py
+++ b/azurelinuxagent/common/protocol/hostplugin.py
@@ -47,7 +47,8 @@ MAXIMUM_PAGEBLOB_PAGE_SIZE = 4 * 1024 * 1024  # Max page size: 4MB
 
 
 class HostPluginProtocol(object):
-    _is_default_channel = False
+    # TODO: debugging
+    _is_default_channel = True
 
     def __init__(self, endpoint, container_id, role_config_name):
         if endpoint is None:

--- a/azurelinuxagent/common/protocol/hostplugin.py
+++ b/azurelinuxagent/common/protocol/hostplugin.py
@@ -232,7 +232,7 @@ class HostPluginProtocol(object):
 
         if restutil.request_failed(response):
             error_response = restutil.read_response_error(response)
-            is_healthy = restutil.request_failed_at_hostplugin(response)
+            is_healthy = not restutil.request_failed_at_hostplugin(response)
             self.report_status_health(is_healthy=is_healthy, response=error_response)
             raise HttpError("HostGAPlugin: Put BlockBlob failed: {0}"
                             .format(error_response))
@@ -257,7 +257,7 @@ class HostPluginProtocol(object):
 
         if restutil.request_failed(response):
             error_response = restutil.read_response_error(response)
-            is_healthy = restutil.request_failed_at_hostplugin(response)
+            is_healthy = not restutil.request_failed_at_hostplugin(response)
             self.report_status_health(is_healthy=is_healthy, response=error_response)
             raise HttpError("HostGAPlugin: Failed PageBlob clean-up: {0}"
                             .format(error_response))
@@ -290,7 +290,7 @@ class HostPluginProtocol(object):
 
             if restutil.request_failed(response):
                 error_response = restutil.read_response_error(response)
-                is_healthy = restutil.request_failed_at_hostplugin(response)
+                is_healthy = not restutil.request_failed_at_hostplugin(response)
                 self.report_status_health(is_healthy=is_healthy, response=error_response)
                 raise HttpError(
                     "HostGAPlugin Error: Put PageBlob bytes "

--- a/azurelinuxagent/common/protocol/hostplugin.py
+++ b/azurelinuxagent/common/protocol/hostplugin.py
@@ -282,17 +282,19 @@ class HostPluginProtocol(object):
 
             # Send the page
             response = restutil.http_put(url,
-                            data=self._build_status_data(
-                                        sas_url,
-                                        status_blob.get_page_blob_page_headers(start, end),
-                                        buf),
-                            headers=self._build_status_headers())
+                                         data=self._build_status_data(
+                                             sas_url,
+                                             status_blob.get_page_blob_page_headers(start, end),
+                                             buf),
+                                         headers=self._build_status_headers())
 
             if restutil.request_failed(response):
+                error_response = restutil.read_response_error(response)
+                is_healthy = restutil.request_failed_at_hostplugin(response)
+                self.report_status_health(is_healthy=is_healthy, response=error_response)
                 raise HttpError(
-                    "HostGAPlugin Error: Put PageBlob bytes [{0},{1}]: " \
-                    "{2}".format(
-                        start, end, restutil.read_response_error(response)))
+                    "HostGAPlugin Error: Put PageBlob bytes "
+                    "[{0},{1}]: {2}".format(start, end, error_response))
 
             # Advance to the next page (if any)
             start = end

--- a/azurelinuxagent/common/protocol/restapi.py
+++ b/azurelinuxagent/common/protocol/restapi.py
@@ -333,12 +333,14 @@ class Protocol(DataContract):
         raise NotImplementedError()
 
     def download_ext_handler_pkg(self, uri, headers=None, use_proxy=True):
+        pkg = None
         try:
             resp = restutil.http_get(uri, headers=headers, use_proxy=use_proxy)
             if restutil.request_succeeded(resp):
-                return resp.read()
+                pkg = resp.read()
         except Exception as e:
             logger.warn("Failed to download from: {0}".format(uri), e)
+        return pkg
 
     def report_provision_status(self, provision_status):
         raise NotImplementedError()

--- a/azurelinuxagent/common/protocol/util.py
+++ b/azurelinuxagent/common/protocol/util.py
@@ -54,6 +54,7 @@ def get_protocol_util():
 
 
 class ProtocolUtil(object):
+
     """
     ProtocolUtil handles initialization for protocol instance. 2 protocol types 
     are invoked, wire protocol and metadata protocols.

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -158,16 +158,15 @@ class WireProtocol(Protocol):
         logger.verbose("Get In-VM Artifacts Profile")
         return self.client.get_artifacts_profile()
 
-    def download_ext_handler_pkg(self, uri, headers=None):
-        package = super(WireProtocol, self).download_ext_handler_pkg(uri)
+    def download_ext_handler_pkg(self, uri, headers=None, use_proxy=True):
+        package = super(WireProtocol, self).download_ext_handler_pkg(uri, use_proxy=use_proxy)
 
-        if package is not None:
-            return package
-        else:
+        if package is None:
             logger.verbose("Download did not succeed, falling back to host plugin")
             host = self.client.get_host_plugin()
             uri, headers = host.get_artifact_request(uri, host.manifest_uri)
             package = super(WireProtocol, self).download_ext_handler_pkg(uri, headers=headers, use_proxy=False)
+
         return package
 
     def report_provision_status(self, provision_status):

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -614,7 +614,7 @@ class WireClient(object):
                     logger.verbose("Using host plugin as default channel")
                 else:
                     logger.verbose("Failed to download manifest, "
-                                        "switching to host plugin")
+                                   "switching to host plugin")
 
                 try:
                     host = self.get_host_plugin()
@@ -1132,7 +1132,7 @@ class WireClient(object):
                             logger.verbose("Using host plugin as default channel")
                         else:
                             logger.verbose("Failed to download artifacts profile, "
-                                                "switching to host plugin")
+                                           "switching to host plugin")
 
                         host = self.get_host_plugin()
                         uri, headers = host.get_artifact_request(blob)

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -251,12 +251,10 @@ def _build_health_report(incarnation, container_id, role_instance_id,
     return xml
 
 
-"""
-Convert VMStatus object to status blob format
-"""
-
-
 def ga_status_to_guest_info(ga_status):
+    """
+    Convert VMStatus object to status blob format
+    """
     v1_ga_guest_info = {
         "computerName" : ga_status.hostname,
         "osName" : ga_status.osname,
@@ -277,6 +275,7 @@ def ga_status_to_v1(ga_status):
         "formattedMessage" : formatted_msg
     }
     return v1_ga_status
+
 
 def ext_substatus_to_v1(sub_status_list):
     status_list = []
@@ -1155,6 +1154,7 @@ class WireClient(object):
                         ustr(e)))
 
         return None
+
 
 class VersionInfo(object):
     def __init__(self, xml_text):

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -652,15 +652,15 @@ class WireClient(object):
                 error_response = restutil.read_response_error(resp)
                 msg = "Fetch failed from [{0}]: {1}".format(uri, error_response)
                 logger.warn(msg)
-                self.host_plugin.report_fetch(uri,
-                                              is_healthy=restutil.request_failed_at_hostplugin(resp),
-                                              source='WireClient',
-                                              response=error_response)
+                self.host_plugin.report_fetch_health(uri,
+                                                     is_healthy=restutil.request_failed_at_hostplugin(resp),
+                                                     source='WireClient',
+                                                     response=error_response)
                 raise ProtocolError(msg)
             else:
                 response_content = resp.read()
                 content = self.decode_config(response_content) if decode else response_content
-                self.host_plugin.report_fetch(uri, source='WireClient')
+                self.host_plugin.report_fetch_health(uri, source='WireClient')
 
         except (HttpError, ProtocolError, IOError) as e:
             logger.verbose("Fetch failed from [{0}]: {1}", uri, e)

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -654,12 +654,13 @@ class WireClient(object):
                 logger.warn(msg)
                 self.host_plugin.report_fetch(uri,
                                               is_healthy=restutil.request_failed_at_hostplugin(resp),
+                                              source='WireClient',
                                               response=error_response)
                 raise ProtocolError(msg)
             else:
                 response_content = resp.read()
                 content = self.decode_config(response_content) if decode else response_content
-                self.host_plugin.report_fetch(uri)
+                self.host_plugin.report_fetch(uri, source='WireClient')
 
         except (HttpError, ProtocolError, IOError) as e:
             logger.verbose("Fetch failed from [{0}]: {1}", uri, e)

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -652,15 +652,17 @@ class WireClient(object):
                 error_response = restutil.read_response_error(resp)
                 msg = "Fetch failed from [{0}]: {1}".format(uri, error_response)
                 logger.warn(msg)
-                self.host_plugin.report_fetch_health(uri,
-                                                     is_healthy=restutil.request_failed_at_hostplugin(resp),
-                                                     source='WireClient',
-                                                     response=error_response)
+                if self.host_plugin is not None:
+                    self.host_plugin.report_fetch_health(uri,
+                                                         is_healthy=restutil.request_failed_at_hostplugin(resp),
+                                                         source='WireClient',
+                                                         response=error_response)
                 raise ProtocolError(msg)
             else:
                 response_content = resp.read()
                 content = self.decode_config(response_content) if decode else response_content
-                self.host_plugin.report_fetch_health(uri, source='WireClient')
+                if self.host_plugin is not None:
+                    self.host_plugin.report_fetch_health(uri, source='WireClient')
 
         except (HttpError, ProtocolError, IOError) as e:
             logger.verbose("Fetch failed from [{0}]: {1}", uri, e)

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -652,15 +652,14 @@ class WireClient(object):
                 error_response = restutil.read_response_error(resp)
                 msg = "Fetch failed from [{0}]: {1}".format(uri, error_response)
                 logger.warn(msg)
-                self.report_fetch(uri,
-                                  is_healthy=restutil.request_failed_at_hostplugin(resp),
-                                  response=error_response)
+                self.host_plugin.report_fetch(uri,
+                                              is_healthy=restutil.request_failed_at_hostplugin(resp),
+                                              response=error_response)
                 raise ProtocolError(msg)
             else:
                 response_content = resp.read()
                 content = self.decode_config(response_content) if decode else response_content
-
-                self.report_fetch(uri)
+                self.host_plugin.report_fetch(uri)
 
         except (HttpError, ProtocolError, IOError) as e:
             logger.verbose("Fetch failed from [{0}]: {1}", uri, e)
@@ -668,14 +667,6 @@ class WireClient(object):
                 raise
 
         return content
-
-    def report_fetch(self, uri, is_healthy=True, source='WireClient', response=''):
-        if uri == URI_FORMAT_GET_EXTENSION_ARTIFACT.format(self.endpoint, HOST_PLUGIN_PORT) \
-                and self.host_plugin is not None \
-                and self.host_plugin.health_service is not None:
-            self.host_plugin.health_service.report_host_plugin_extension_artifact(is_healthy=is_healthy,
-                                                                                  source=source,
-                                                                                  response=response)
 
     def update_hosting_env(self, goal_state):
         if goal_state.hosting_env_uri is None:

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -659,7 +659,9 @@ class WireClient(object):
             else:
                 response_content = resp.read()
                 content = self.decode_config(response_content) if decode else response_content
-                self.report_fetch(uri)
+
+               # TODO: debugging
+                self.report_fetch(uri, source=headers['x-ms-artifact-location'])
 
         except (HttpError, ProtocolError, IOError) as e:
             logger.verbose("Fetch failed from [{0}]: {1}", uri, e)
@@ -672,6 +674,8 @@ class WireClient(object):
         if uri == URI_FORMAT_GET_EXTENSION_ARTIFACT.format(self.endpoint, HOST_PLUGIN_PORT) \
                 and self.host_plugin is not None \
                 and self.host_plugin.health_service is not None:
+            # TODO: debugging
+            logger.info("report_fetch: {0}", source)
             self.host_plugin.health_service.report_host_plugin_extension_artifact(is_healthy=is_healthy,
                                                                                   source=source,
                                                                                   response=response)

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -660,8 +660,7 @@ class WireClient(object):
                 response_content = resp.read()
                 content = self.decode_config(response_content) if decode else response_content
 
-               # TODO: debugging
-                self.report_fetch(uri, source=headers['x-ms-artifact-location'])
+                self.report_fetch(uri)
 
         except (HttpError, ProtocolError, IOError) as e:
             logger.verbose("Fetch failed from [{0}]: {1}", uri, e)
@@ -674,8 +673,6 @@ class WireClient(object):
         if uri == URI_FORMAT_GET_EXTENSION_ARTIFACT.format(self.endpoint, HOST_PLUGIN_PORT) \
                 and self.host_plugin is not None \
                 and self.host_plugin.health_service is not None:
-            # TODO: debugging
-            logger.info("report_fetch: {0}", source)
             self.host_plugin.health_service.report_host_plugin_extension_artifact(is_healthy=is_healthy,
                                                                                   source=source,
                                                                                   response=response)

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -654,7 +654,7 @@ class WireClient(object):
                 logger.warn(msg)
                 if self.host_plugin is not None:
                     self.host_plugin.report_fetch_health(uri,
-                                                         is_healthy=restutil.request_failed_at_hostplugin(resp),
+                                                         is_healthy=not restutil.request_failed_at_hostplugin(resp),
                                                          source='WireClient',
                                                          response=error_response)
                 raise ProtocolError(msg)

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -660,7 +660,7 @@ class WireClient(object):
                 response_content = resp.read()
                 content = self.decode_config(response_content) if decode else response_content
                 self.report_fetch(uri)
-                
+
         except (HttpError, ProtocolError, IOError) as e:
             logger.verbose("Fetch failed from [{0}]: {1}", uri, e)
             if isinstance(e, ResourceGoneError):

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -652,21 +652,17 @@ class WireClient(object):
                 error_response = restutil.read_response_error(resp)
                 msg = "Fetch failed from [{0}]: {1}".format(uri, error_response)
                 logger.warn(msg)
-
                 self.report_fetch(uri,
                                   is_healthy=restutil.request_failed_at_hostplugin(resp),
                                   response=error_response)
-
                 raise ProtocolError(msg)
-
-            response_content = resp.read()
-            content = self.decode_config(response_content) if decode else response_content
-
-            self.report_fetch(uri)
-
+            else:
+                response_content = resp.read()
+                content = self.decode_config(response_content) if decode else response_content
+                self.report_fetch(uri)
+                
         except (HttpError, ProtocolError, IOError) as e:
             logger.verbose("Fetch failed from [{0}]: {1}", uri, e)
-
             if isinstance(e, ResourceGoneError):
                 raise
 

--- a/azurelinuxagent/common/utils/restutil.py
+++ b/azurelinuxagent/common/utils/restutil.py
@@ -52,7 +52,6 @@ RETRY_CODES = [
 ]
 
 RESOURCE_GONE_CODES = [
-    httpclient.BAD_REQUEST,
     httpclient.GONE
 ]
 

--- a/azurelinuxagent/common/utils/restutil.py
+++ b/azurelinuxagent/common/utils/restutil.py
@@ -62,6 +62,12 @@ OK_CODES = [
     httpclient.ACCEPTED
 ]
 
+HOSTPLUGIN_FAILURE_CODES = [
+    500,
+    502,
+    503
+]
+
 THROTTLE_CODES = [
     httpclient.FORBIDDEN,
     httpclient.SERVICE_UNAVAILABLE,
@@ -392,6 +398,10 @@ def request_failed(resp, ok_codes=OK_CODES):
 
 def request_succeeded(resp, ok_codes=OK_CODES):
     return resp is not None and resp.status in ok_codes
+
+
+def request_failed_at_hostplugin(resp, failure_codes=HOSTPLUGIN_FAILURE_CODES):
+    return resp is not None and resp.status in failure_codes
 
 
 def read_response_error(resp):

--- a/azurelinuxagent/common/utils/restutil.py
+++ b/azurelinuxagent/common/utils/restutil.py
@@ -385,11 +385,14 @@ def http_delete(url, headers=None, use_proxy=False,
                         retry_codes=retry_codes,
                         retry_delay=retry_delay)
 
+
 def request_failed(resp, ok_codes=OK_CODES):
     return not request_succeeded(resp, ok_codes=ok_codes)
 
+
 def request_succeeded(resp, ok_codes=OK_CODES):
     return resp is not None and resp.status in ok_codes
+
 
 def read_response_error(resp):
     result = ''

--- a/azurelinuxagent/common/utils/restutil.py
+++ b/azurelinuxagent/common/utils/restutil.py
@@ -61,10 +61,8 @@ OK_CODES = [
     httpclient.ACCEPTED
 ]
 
-HOSTPLUGIN_FAILURE_CODES = [
-    500,
-    502,
-    503
+UPSTREAM_FAILURE_CODES = [
+    502
 ]
 
 THROTTLE_CODES = [
@@ -399,8 +397,11 @@ def request_succeeded(resp, ok_codes=OK_CODES):
     return resp is not None and resp.status in ok_codes
 
 
-def request_failed_at_hostplugin(resp, failure_codes=HOSTPLUGIN_FAILURE_CODES):
-    return resp is not None and resp.status in failure_codes
+def request_failed_at_hostplugin(resp, upstream_failure_codes=UPSTREAM_FAILURE_CODES):
+    """
+    Host plugin will return 502 for any upstream issue, so a failure is any 5xx except 502
+    """
+    return resp is not None and resp.status >= 500 and resp.status not in upstream_failure_codes
 
 
 def read_response_error(resp):

--- a/azurelinuxagent/common/utils/restutil.py
+++ b/azurelinuxagent/common/utils/restutil.py
@@ -61,7 +61,7 @@ OK_CODES = [
     httpclient.ACCEPTED
 ]
 
-UPSTREAM_FAILURE_CODES = [
+HOSTPLUGIN_UPSTREAM_FAILURE_CODES = [
     502
 ]
 
@@ -397,7 +397,7 @@ def request_succeeded(resp, ok_codes=OK_CODES):
     return resp is not None and resp.status in ok_codes
 
 
-def request_failed_at_hostplugin(resp, upstream_failure_codes=UPSTREAM_FAILURE_CODES):
+def request_failed_at_hostplugin(resp, upstream_failure_codes=HOSTPLUGIN_UPSTREAM_FAILURE_CODES):
     """
     Host plugin will return 502 for any upstream issue, so a failure is any 5xx except 502
     """

--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -717,10 +717,10 @@ class ExtHandlerInstance(object):
     def set_operation(self, op):
         self.operation = op
 
-    def report_event(self, message="", is_success=True, duration=0):
+    def report_event(self, message="", is_success=True, duration=0, log_event=True):
         ext_handler_version = self.ext_handler.properties.version
         add_event(name=self.ext_handler.name, version=ext_handler_version, message=message,
-                  op=self.operation, is_success=is_success, duration=duration)
+                  op=self.operation, is_success=is_success, duration=duration, log_event=log_event)
 
     def download(self):
         begin_utc = datetime.datetime.utcnow()
@@ -1004,7 +1004,7 @@ class ExtHandlerInstance(object):
             raise ExtensionError("Non-zero exit code: {0}, {1}\n{2}".format(ret, cmd, msg))
 
         duration = elapsed_milliseconds(begin_utc)
-        self.report_event(message="{0}\n{1}".format(cmd, msg), duration=duration)
+        self.report_event(message="{0}\n{1}".format(cmd, msg), duration=duration, log_event=False)
 
     def load_manifest(self):
         man_file = self.get_manifest_file()

--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -1111,9 +1111,8 @@ class ExtHandlerInstance(object):
                     self.ext_handler.name,
                     self.ext_handler.properties.version))
         except (IOError, ValueError, ProtocolError) as e:
-            fileutil.clean_ioerror(e,
-                paths=[status_file])
-            self.logger.error("Failed to save handler status: {0}", ustr(e))
+            fileutil.clean_ioerror(e, paths=[status_file])
+            self.logger.error("Failed to save handler status: {0}, {1}", ustr(e), traceback.format_exc())
         
     def get_handler_status(self):
         state_dir = self.get_conf_dir()

--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -236,10 +236,6 @@ class ExtHandlersHandler(object):
                       message=msg)
             return
 
-    def run_status(self):
-        self.report_ext_handlers_status()
-        return
-
     def get_upgrade_guid(self, name):
         return self.last_upgrade_guids.get(name, (None, False))[0]
 

--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -1113,7 +1113,7 @@ class ExtHandlerInstance(object):
         except (IOError, ValueError, ProtocolError) as e:
             fileutil.clean_ioerror(e,
                 paths=[status_file])
-            self.logger.error("Failed to save handler status: {0}", traceback.format_exc())
+            self.logger.error("Failed to save handler status: {0}", ustr(e))
         
     def get_handler_status(self):
         state_dir = self.get_conf_dir()

--- a/azurelinuxagent/ga/monitor.py
+++ b/azurelinuxagent/ga/monitor.py
@@ -241,7 +241,8 @@ class MonitorHandler(object):
             last_host_plugin_heartbeat = self.send_host_plugin_heartbeat(protocol,
                                                                          last_host_plugin_heartbeat,
                                                                          host_plugin_errorstate)
-            time.sleep(5)
+            # currently the smallest delta is 1 minute
+            time.sleep(60)
 
     def add_sysinfo(self, event):
         sysinfo_names = [v.name for v in self.sysinfo]

--- a/azurelinuxagent/ga/monitor.py
+++ b/azurelinuxagent/ga/monitor.py
@@ -122,6 +122,11 @@ class MonitorHandler(object):
         self.init_protocols()
         self.start()
 
+    def stop(self):
+        self.should_run = False
+        if self.is_alive():
+            self.event_thread.join()
+
     def init_protocols(self):
         self.protocol = self.protocol_util.get_protocol()
         self.health_service = HealthService(self.protocol.endpoint)

--- a/azurelinuxagent/ga/monitor.py
+++ b/azurelinuxagent/ga/monitor.py
@@ -132,7 +132,7 @@ class MonitorHandler(object):
         self.health_service = HealthService(self.protocol.endpoint)
 
     def is_alive(self):
-        return self.event_thread.is_alive()
+        return self.event_thread is not None and self.event_thread.is_alive()
 
     def start(self):
         self.event_thread = threading.Thread(target=self.daemon)

--- a/azurelinuxagent/ga/monitor.py
+++ b/azurelinuxagent/ga/monitor.py
@@ -281,7 +281,7 @@ class MonitorHandler(object):
                 host_plugin_errorstate.incr()
 
             is_healthy = host_plugin_errorstate.is_triggered() is False
-            logger.verbose("HostGAPlugin health: {0}", is_healthy)
+            logger.info("HostGAPlugin health: {0}", is_healthy)
 
             health_service.report_host_plugin_heartbeat(is_healthy)
 
@@ -293,7 +293,7 @@ class MonitorHandler(object):
                 op=WALAEventOperation.HostPluginHeartbeat,
                 is_success=False,
                 message=msg,
-                log_event=False)
+                log_event=True)
 
         return datetime.datetime.utcnow()
 

--- a/azurelinuxagent/ga/monitor.py
+++ b/azurelinuxagent/ga/monitor.py
@@ -231,7 +231,7 @@ class MonitorHandler(object):
         heartbeat_id = str(uuid.uuid4()).upper()
         protocol = self.protocol_util.get_protocol()
         host_plugin_errorstate = ErrorState(min_timedelta=MonitorHandler.HOST_PLUGIN_HEALTH_PERIOD)
-        health_service = HealthService()
+        health_service = HealthService(protocol.endpoint)
 
         while True:
             last_telemetry_heartbeat = self.send_telemetry_heartbeat(protocol,

--- a/azurelinuxagent/ga/monitor.py
+++ b/azurelinuxagent/ga/monitor.py
@@ -113,6 +113,7 @@ class MonitorHandler(object):
 
         self.counter = 0
         self.sysinfo = []
+        self.should_run = True
         self.heartbeat_id = str(uuid.uuid4()).upper()
         self.host_plugin_errorstate = ErrorState(min_timedelta=MonitorHandler.HOST_PLUGIN_HEALTH_PERIOD)
 
@@ -237,7 +238,7 @@ class MonitorHandler(object):
         min_delta = min(MonitorHandler.TELEMETRY_HEARTBEAT_PERIOD,
                         MonitorHandler.EVENT_COLLECTION_PERIOD,
                         MonitorHandler.HOST_PLUGIN_HEARTBEAT_PERIOD).seconds
-        while True:
+        while self.should_run:
             self.send_telemetry_heartbeat()
             self.collect_and_send_events()
             self.send_host_plugin_heartbeat()

--- a/azurelinuxagent/ga/monitor.py
+++ b/azurelinuxagent/ga/monitor.py
@@ -282,7 +282,14 @@ class MonitorHandler(object):
             logger.info("HostGAPlugin health: {0}", is_healthy)
 
         except Exception as e:
-            logger.error("Could not send host plugin heartbeat: {0}", ustr(e))
+            msg = "Exception sending host plugin heartbeat: {0}".format(ustr(e))
+            add_event(
+                name=AGENT_NAME,
+                version=CURRENT_VERSION,
+                op=WALAEventOperation.HostPluginHeartbeat,
+                is_success=False,
+                message=msg,
+                log_event=False)
 
         return datetime.datetime.utcnow()
 

--- a/azurelinuxagent/ga/monitor.py
+++ b/azurelinuxagent/ga/monitor.py
@@ -118,8 +118,8 @@ class MonitorHandler(object):
         self.host_plugin_errorstate = ErrorState(min_timedelta=MonitorHandler.HOST_PLUGIN_HEALTH_PERIOD)
 
     def run(self):
-        self.init_sysinfo()
         self.init_protocols()
+        self.init_sysinfo()
         self.start()
 
     def stop(self):

--- a/azurelinuxagent/ga/monitor.py
+++ b/azurelinuxagent/ga/monitor.py
@@ -281,7 +281,7 @@ class MonitorHandler(object):
                 host_plugin_errorstate.incr()
 
             is_healthy = host_plugin_errorstate.is_triggered() is False
-            logger.info("HostGAPlugin health: {0}", is_healthy)
+            logger.verbose("HostGAPlugin health: {0}", is_healthy)
 
             health_service.report_host_plugin_heartbeat(is_healthy)
 
@@ -293,7 +293,7 @@ class MonitorHandler(object):
                 op=WALAEventOperation.HostPluginHeartbeat,
                 is_success=False,
                 message=msg,
-                log_event=True)
+                log_event=False)
 
         return datetime.datetime.utcnow()
 

--- a/azurelinuxagent/ga/monitor.py
+++ b/azurelinuxagent/ga/monitor.py
@@ -231,7 +231,7 @@ class MonitorHandler(object):
         heartbeat_id = str(uuid.uuid4()).upper()
         protocol = self.protocol_util.get_protocol()
         host_plugin_errorstate = ErrorState(min_timedelta=MonitorHandler.HOST_PLUGIN_HEALTH_PERIOD)
-        health_service = HealthService(protocol.endpoint)
+        health_service = HealthService()
 
         while True:
             last_telemetry_heartbeat = self.send_telemetry_heartbeat(protocol,
@@ -283,8 +283,7 @@ class MonitorHandler(object):
             is_healthy = host_plugin_errorstate.is_triggered() is False
             logger.verbose("HostGAPlugin health: {0}", is_healthy)
 
-            health_service.observe_host_plugin_heartbeat(is_healthy)
-            health_service.report()
+            health_service.report_host_plugin_heartbeat(is_healthy)
 
         except Exception as e:
             msg = "Exception sending host plugin heartbeat: {0}".format(ustr(e))

--- a/azurelinuxagent/ga/monitor.py
+++ b/azurelinuxagent/ga/monitor.py
@@ -101,23 +101,29 @@ class MonitorHandler(object):
 
     def __init__(self):
         self.osutil = get_osutil()
-        self.protocol = get_protocol_util().get_protocol()
+        self.protocol_util = get_protocol_util()
         self.imds_client = get_imds_client()
-        self.sysinfo = []
+
         self.event_thread = None
         self.last_event_collection = None
         self.last_telemetry_heartbeat = None
         self.last_host_plugin_heartbeat = None
-        self.counter = 0
-        self.heartbeat_id = str(uuid.uuid4()).upper()
-        self.host_plugin_errorstate = None
+        self.protocol = None
         self.health_service = None
-        self.health_service = HealthService(self.protocol.endpoint)
+
+        self.counter = 0
+        self.sysinfo = []
+        self.heartbeat_id = str(uuid.uuid4()).upper()
         self.host_plugin_errorstate = ErrorState(min_timedelta=MonitorHandler.HOST_PLUGIN_HEALTH_PERIOD)
 
     def run(self):
         self.init_sysinfo()
+        self.init_protocols()
         self.start()
+
+    def init_protocols(self):
+        self.protocol = self.protocol_util.get_protocol()
+        self.health_service = HealthService(self.protocol.endpoint)
 
     def is_alive(self):
         return self.event_thread.is_alive()

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -890,7 +890,7 @@ class GuestAgent(object):
                 is_healthy = restutil.request_failed_at_hostplugin(resp)
 
             if self.host is not None:
-                self.host.report_fetch(uri, is_healthy, source='GuestAgent', response=error_response)
+                self.host.report_fetch_health(uri, is_healthy, source='GuestAgent', response=error_response)
 
         except restutil.HttpError as http_error:
             if isinstance(http_error, ResourceGoneError):

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -541,7 +541,7 @@ class UpdateHandler(object):
 
         known_versions = [agent.version for agent in self.agents]
         if CURRENT_VERSION not in known_versions:
-            logger.info(
+            logger.verbose(
                 u"Running Agent {0} was not found in the agent manifest - adding to list",
                 CURRENT_VERSION)
             known_versions.append(CURRENT_VERSION)

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -888,7 +888,7 @@ class GuestAgent(object):
             else:
                 error_response = restutil.read_response_error(resp)
                 logger.verbose("Fetch was unsuccessful [{0}]", error_response)
-                is_healthy = restutil.request_failed_at_hostplugin(resp)
+                is_healthy = not restutil.request_failed_at_hostplugin(resp)
 
             if self.host is not None:
                 self.host.report_fetch_health(uri, is_healthy, source='GuestAgent', response=error_response)

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -191,7 +191,8 @@ class UpdateHandler(object):
                     version=agent_version,
                     op=WALAEventOperation.Enable,
                     is_success=True,
-                    message=msg)
+                    message=msg,
+                    log_event=False)
 
                 if ret is None:
                     ret = self.child_process.wait()

--- a/tests/ga/test_monitor.py
+++ b/tests/ga/test_monitor.py
@@ -158,6 +158,7 @@ class TestMonitor(AgentTestCase):
     @patch("azurelinuxagent.common.protocol.healthservice.HealthService.report_host_plugin_heartbeat")
     def test_heartbeat_creates_signal(self, patch_report_heartbeat, *args):
         monitor_handler = get_monitor_handler()
+        monitor_handler.init_protocols()
         monitor_handler.last_host_plugin_heartbeat = datetime.datetime.utcnow() - timedelta(hours=1)
         monitor_handler.send_host_plugin_heartbeat()
         self.assertEqual(1, patch_report_heartbeat.call_count)

--- a/tests/ga/test_monitor.py
+++ b/tests/ga/test_monitor.py
@@ -97,6 +97,8 @@ class TestMonitor(AgentTestCase):
         self.assertNotEqual(0, patch_send_events.call_count)
         self.assertNotEqual(0, patch_telemetry_heartbeat.call_count)
 
+        monitor_handler.should_run = False
+
     def test_heartbeat_timings_updates_after_window(self, *args):
         monitor_handler = get_monitor_handler()
 
@@ -125,6 +127,8 @@ class TestMonitor(AgentTestCase):
         self.assertNotEqual(heartbeat_hostplugin, monitor_handler.last_host_plugin_heartbeat)
         self.assertNotEqual(events_collection, monitor_handler.last_event_collection)
         self.assertNotEqual(heartbeat_telemetry, monitor_handler.last_telemetry_heartbeat)
+
+        monitor_handler.should_run = False
 
     def test_heartbeat_timings_no_updates_within_window(self, *args):
         monitor_handler = get_monitor_handler()
@@ -155,6 +159,8 @@ class TestMonitor(AgentTestCase):
         self.assertEqual(events_collection, monitor_handler.last_event_collection)
         self.assertEqual(heartbeat_telemetry, monitor_handler.last_telemetry_heartbeat)
 
+        monitor_handler.should_run = False
+
     @patch("azurelinuxagent.common.protocol.healthservice.HealthService.report_host_plugin_heartbeat")
     def test_heartbeat_creates_signal(self, patch_report_heartbeat, *args):
         monitor_handler = get_monitor_handler()
@@ -162,3 +168,5 @@ class TestMonitor(AgentTestCase):
         monitor_handler.last_host_plugin_heartbeat = datetime.datetime.utcnow() - timedelta(hours=1)
         monitor_handler.send_host_plugin_heartbeat()
         self.assertEqual(1, patch_report_heartbeat.call_count)
+        monitor_handler.should_run = False
+

--- a/tests/ga/test_monitor.py
+++ b/tests/ga/test_monitor.py
@@ -14,22 +14,26 @@
 #
 # Requires Python 2.6+ and Openssl 1.0+
 #
+from datetime import timedelta
 
+from azurelinuxagent.common.protocol.wire import WireProtocol
 from tests.tools import *
 from azurelinuxagent.ga.monitor import *
 
 
+@patch('azurelinuxagent.common.osutil.get_osutil')
+@patch('azurelinuxagent.common.protocol.get_protocol_util')
+@patch('azurelinuxagent.common.protocol.util.ProtocolUtil.get_protocol')
+@patch("azurelinuxagent.common.protocol.healthservice.HealthService.report")
 class TestMonitor(AgentTestCase):
-    def test_parse_xml_event(self):
+    def test_parse_xml_event(self, *args):
         data_str = load_data('ext/event.xml')
         event = parse_xml_event(data_str)
         self.assertNotEquals(None, event)
         self.assertNotEquals(0, event.parameters)
         self.assertNotEquals(None, event.parameters[0])
 
-    @patch('azurelinuxagent.common.osutil.get_osutil')
-    @patch('azurelinuxagent.common.protocol.get_protocol_util')
-    def test_add_sysinfo(self, _, __):
+    def test_add_sysinfo(self, *args):
         data_str = load_data('ext/event.xml')
         event = parse_xml_event(data_str)
         monitor_handler = get_monitor_handler()
@@ -76,3 +80,84 @@ class TestMonitor(AgentTestCase):
                 counter += 1
 
         self.assertEquals(5, counter)
+
+    @patch("azurelinuxagent.ga.monitor.MonitorHandler.send_telemetry_heartbeat")
+    @patch("azurelinuxagent.ga.monitor.MonitorHandler.collect_and_send_events")
+    @patch("azurelinuxagent.ga.monitor.MonitorHandler.send_host_plugin_heartbeat")
+    def test_heartbeats(self, patch_hostplugin_heartbeat, patch_send_events, patch_telemetry_heartbeat, *args):
+        monitor_handler = get_monitor_handler()
+
+        self.assertEqual(0, patch_hostplugin_heartbeat.call_count)
+        self.assertEqual(0, patch_send_events.call_count)
+        self.assertEqual(0, patch_telemetry_heartbeat.call_count)
+        monitor_handler.start()
+        time.sleep(1)
+        self.assertTrue(monitor_handler.is_alive())
+        self.assertNotEqual(0, patch_hostplugin_heartbeat.call_count)
+        self.assertNotEqual(0, patch_send_events.call_count)
+        self.assertNotEqual(0, patch_telemetry_heartbeat.call_count)
+
+    def test_heartbeat_timings_updates_after_window(self, *args):
+        monitor_handler = get_monitor_handler()
+
+        MonitorHandler.TELEMETRY_HEARTBEAT_PERIOD = timedelta(seconds=1)
+        MonitorHandler.EVENT_COLLECTION_PERIOD = timedelta(seconds=1)
+        MonitorHandler.HOST_PLUGIN_HEARTBEAT_PERIOD = timedelta(seconds=1)
+
+        self.assertEqual(None, monitor_handler.last_host_plugin_heartbeat)
+        self.assertEqual(None, monitor_handler.last_event_collection)
+        self.assertEqual(None, monitor_handler.last_telemetry_heartbeat)
+
+        monitor_handler.start()
+        time.sleep(1)
+        self.assertTrue(monitor_handler.is_alive())
+
+        self.assertNotEqual(None, monitor_handler.last_host_plugin_heartbeat)
+        self.assertNotEqual(None, monitor_handler.last_event_collection)
+        self.assertNotEqual(None, monitor_handler.last_telemetry_heartbeat)
+
+        heartbeat_hostplugin = monitor_handler.last_host_plugin_heartbeat
+        heartbeat_telemetry = monitor_handler.last_telemetry_heartbeat
+        events_collection = monitor_handler.last_event_collection
+
+        time.sleep(2)
+
+        self.assertNotEqual(heartbeat_hostplugin, monitor_handler.last_host_plugin_heartbeat)
+        self.assertNotEqual(events_collection, monitor_handler.last_event_collection)
+        self.assertNotEqual(heartbeat_telemetry, monitor_handler.last_telemetry_heartbeat)
+
+    def test_heartbeat_timings_no_updates_within_window(self, *args):
+        monitor_handler = get_monitor_handler()
+
+        MonitorHandler.TELEMETRY_HEARTBEAT_PERIOD = timedelta(seconds=100)
+        MonitorHandler.EVENT_COLLECTION_PERIOD = timedelta(seconds=100)
+        MonitorHandler.HOST_PLUGIN_HEARTBEAT_PERIOD = timedelta(seconds=100)
+
+        self.assertEqual(None, monitor_handler.last_host_plugin_heartbeat)
+        self.assertEqual(None, monitor_handler.last_event_collection)
+        self.assertEqual(None, monitor_handler.last_telemetry_heartbeat)
+
+        monitor_handler.start()
+        time.sleep(1)
+        self.assertTrue(monitor_handler.is_alive())
+
+        self.assertNotEqual(None, monitor_handler.last_host_plugin_heartbeat)
+        self.assertNotEqual(None, monitor_handler.last_event_collection)
+        self.assertNotEqual(None, monitor_handler.last_telemetry_heartbeat)
+
+        heartbeat_hostplugin = monitor_handler.last_host_plugin_heartbeat
+        heartbeat_telemetry = monitor_handler.last_telemetry_heartbeat
+        events_collection = monitor_handler.last_event_collection
+
+        time.sleep(2)
+
+        self.assertEqual(heartbeat_hostplugin, monitor_handler.last_host_plugin_heartbeat)
+        self.assertEqual(events_collection, monitor_handler.last_event_collection)
+        self.assertEqual(heartbeat_telemetry, monitor_handler.last_telemetry_heartbeat)
+
+    @patch("azurelinuxagent.common.protocol.healthservice.HealthService.report_host_plugin_heartbeat")
+    def test_heartbeat_creates_signal(self, patch_report_heartbeat, *args):
+        monitor_handler = get_monitor_handler()
+        monitor_handler.last_host_plugin_heartbeat = datetime.datetime.utcnow() - timedelta(hours=1)
+        monitor_handler.send_host_plugin_heartbeat()
+        self.assertEqual(1, patch_report_heartbeat.call_count)

--- a/tests/ga/test_monitor.py
+++ b/tests/ga/test_monitor.py
@@ -16,11 +16,11 @@
 #
 from datetime import timedelta
 
-from azurelinuxagent.common.protocol.wire import WireProtocol
 from tests.tools import *
 from azurelinuxagent.ga.monitor import *
 
 
+@patch('azurelinuxagent.common.event.EventLogger.add_event')
 @patch('azurelinuxagent.common.osutil.get_osutil')
 @patch('azurelinuxagent.common.protocol.get_protocol_util')
 @patch('azurelinuxagent.common.protocol.util.ProtocolUtil.get_protocol')

--- a/tests/ga/test_monitor.py
+++ b/tests/ga/test_monitor.py
@@ -90,14 +90,16 @@ class TestMonitor(AgentTestCase):
         self.assertEqual(0, patch_hostplugin_heartbeat.call_count)
         self.assertEqual(0, patch_send_events.call_count)
         self.assertEqual(0, patch_telemetry_heartbeat.call_count)
+
         monitor_handler.start()
         time.sleep(1)
         self.assertTrue(monitor_handler.is_alive())
+
         self.assertNotEqual(0, patch_hostplugin_heartbeat.call_count)
         self.assertNotEqual(0, patch_send_events.call_count)
         self.assertNotEqual(0, patch_telemetry_heartbeat.call_count)
 
-        monitor_handler.should_run = False
+        monitor_handler.stop()
 
     def test_heartbeat_timings_updates_after_window(self, *args):
         monitor_handler = get_monitor_handler()
@@ -128,7 +130,7 @@ class TestMonitor(AgentTestCase):
         self.assertNotEqual(events_collection, monitor_handler.last_event_collection)
         self.assertNotEqual(heartbeat_telemetry, monitor_handler.last_telemetry_heartbeat)
 
-        monitor_handler.should_run = False
+        monitor_handler.stop()
 
     def test_heartbeat_timings_no_updates_within_window(self, *args):
         monitor_handler = get_monitor_handler()
@@ -159,7 +161,7 @@ class TestMonitor(AgentTestCase):
         self.assertEqual(events_collection, monitor_handler.last_event_collection)
         self.assertEqual(heartbeat_telemetry, monitor_handler.last_telemetry_heartbeat)
 
-        monitor_handler.should_run = False
+        monitor_handler.stop()
 
     @patch("azurelinuxagent.common.protocol.healthservice.HealthService.report_host_plugin_heartbeat")
     def test_heartbeat_creates_signal(self, patch_report_heartbeat, *args):
@@ -168,5 +170,4 @@ class TestMonitor(AgentTestCase):
         monitor_handler.last_host_plugin_heartbeat = datetime.datetime.utcnow() - timedelta(hours=1)
         monitor_handler.send_host_plugin_heartbeat()
         self.assertEqual(1, patch_report_heartbeat.call_count)
-        monitor_handler.should_run = False
-
+        monitor_handler.stop()

--- a/tests/ga/test_monitor.py
+++ b/tests/ga/test_monitor.py
@@ -24,7 +24,7 @@ from azurelinuxagent.ga.monitor import *
 @patch('azurelinuxagent.common.osutil.get_osutil')
 @patch('azurelinuxagent.common.protocol.get_protocol_util')
 @patch('azurelinuxagent.common.protocol.util.ProtocolUtil.get_protocol')
-@patch("azurelinuxagent.common.protocol.healthservice.HealthService.report")
+@patch("azurelinuxagent.common.protocol.healthservice.HealthService._report")
 class TestMonitor(AgentTestCase):
     def test_parse_xml_event(self, *args):
         data_str = load_data('ext/event.xml')
@@ -104,16 +104,16 @@ class TestMonitor(AgentTestCase):
     def test_heartbeat_timings_updates_after_window(self, *args):
         monitor_handler = get_monitor_handler()
 
-        MonitorHandler.TELEMETRY_HEARTBEAT_PERIOD = timedelta(seconds=1)
-        MonitorHandler.EVENT_COLLECTION_PERIOD = timedelta(seconds=1)
-        MonitorHandler.HOST_PLUGIN_HEARTBEAT_PERIOD = timedelta(seconds=1)
+        MonitorHandler.TELEMETRY_HEARTBEAT_PERIOD = timedelta(milliseconds=100)
+        MonitorHandler.EVENT_COLLECTION_PERIOD = timedelta(milliseconds=100)
+        MonitorHandler.HOST_PLUGIN_HEARTBEAT_PERIOD = timedelta(milliseconds=100)
 
         self.assertEqual(None, monitor_handler.last_host_plugin_heartbeat)
         self.assertEqual(None, monitor_handler.last_event_collection)
         self.assertEqual(None, monitor_handler.last_telemetry_heartbeat)
 
         monitor_handler.start()
-        time.sleep(1)
+        time.sleep(0.2)
         self.assertTrue(monitor_handler.is_alive())
 
         self.assertNotEqual(None, monitor_handler.last_host_plugin_heartbeat)
@@ -124,7 +124,7 @@ class TestMonitor(AgentTestCase):
         heartbeat_telemetry = monitor_handler.last_telemetry_heartbeat
         events_collection = monitor_handler.last_event_collection
 
-        time.sleep(2)
+        time.sleep(0.5)
 
         self.assertNotEqual(heartbeat_hostplugin, monitor_handler.last_host_plugin_heartbeat)
         self.assertNotEqual(events_collection, monitor_handler.last_event_collection)
@@ -135,16 +135,16 @@ class TestMonitor(AgentTestCase):
     def test_heartbeat_timings_no_updates_within_window(self, *args):
         monitor_handler = get_monitor_handler()
 
-        MonitorHandler.TELEMETRY_HEARTBEAT_PERIOD = timedelta(seconds=100)
-        MonitorHandler.EVENT_COLLECTION_PERIOD = timedelta(seconds=100)
-        MonitorHandler.HOST_PLUGIN_HEARTBEAT_PERIOD = timedelta(seconds=100)
+        MonitorHandler.TELEMETRY_HEARTBEAT_PERIOD = timedelta(seconds=1)
+        MonitorHandler.EVENT_COLLECTION_PERIOD = timedelta(seconds=1)
+        MonitorHandler.HOST_PLUGIN_HEARTBEAT_PERIOD = timedelta(seconds=1)
 
         self.assertEqual(None, monitor_handler.last_host_plugin_heartbeat)
         self.assertEqual(None, monitor_handler.last_event_collection)
         self.assertEqual(None, monitor_handler.last_telemetry_heartbeat)
 
         monitor_handler.start()
-        time.sleep(1)
+        time.sleep(0.2)
         self.assertTrue(monitor_handler.is_alive())
 
         self.assertNotEqual(None, monitor_handler.last_host_plugin_heartbeat)
@@ -155,7 +155,7 @@ class TestMonitor(AgentTestCase):
         heartbeat_telemetry = monitor_handler.last_telemetry_heartbeat
         events_collection = monitor_handler.last_event_collection
 
-        time.sleep(2)
+        time.sleep(0.5)
 
         self.assertEqual(heartbeat_hostplugin, monitor_handler.last_host_plugin_heartbeat)
         self.assertEqual(events_collection, monitor_handler.last_event_collection)

--- a/tests/ga/test_update.py
+++ b/tests/ga/test_update.py
@@ -514,7 +514,8 @@ class TestGuestAgent(UpdateTestCase):
     @patch("azurelinuxagent.ga.update.GuestAgent._ensure_downloaded")
     @patch("azurelinuxagent.ga.update.GuestAgent._ensure_loaded")
     @patch("azurelinuxagent.ga.update.restutil.http_get")
-    def test_download_fallback(self, mock_http_get, mock_loaded, mock_downloaded):
+    @patch("azurelinuxagent.ga.update.restutil.http_post")
+    def test_download_fallback(self, mock_http_post, mock_http_get, mock_loaded, mock_downloaded):
         self.remove_agents()
         self.assertFalse(os.path.isdir(self.agent_path))
 

--- a/tests/protocol/test_healthservice.py
+++ b/tests/protocol/test_healthservice.py
@@ -15,6 +15,7 @@
 # Requires Python 2.6+ and Openssl 1.0+
 import json
 
+from azurelinuxagent.common.exception import HttpError
 from azurelinuxagent.common.protocol.healthservice import Observation, HealthService
 from tests.tools import *
 
@@ -164,4 +165,10 @@ class TestHealthService(AgentTestCase):
                                 is_healthy=False,
                                 value='response',
                                 description='')
+        self.assertEqual(0, len(health_service.observations))
+
+        patch_post.side_effect = HttpError()
+        health_service.report_host_plugin_versions(is_healthy=True, response='')
+
+        self.assertEqual(9, patch_post.call_count)
         self.assertEqual(0, len(health_service.observations))

--- a/tests/protocol/test_healthservice.py
+++ b/tests/protocol/test_healthservice.py
@@ -1,0 +1,159 @@
+# Copyright 2018 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Requires Python 2.6+ and Openssl 1.0+
+import json
+
+from azurelinuxagent.common.protocol.healthservice import Observation, HealthService
+from tests.tools import *
+
+
+class TestHealthService(AgentTestCase):
+
+    def assert_observation(self, call_args, name, is_healthy, value, description):
+        endpoint = call_args[0][0]
+        content = call_args[0][1]
+
+        jo = json.loads(content)
+        api = jo['Api']
+        source = jo['Source']
+        version = jo['Version']
+        obs = jo['Observations']
+        fo = obs[0]
+        obs_name = fo['ObservationName']
+        obs_healthy = fo['IsHealthy']
+        obs_value = fo['Value']
+        obs_description = fo['Description']
+
+        self.assertEqual('application/json', call_args[1]['headers']['Content-Type'])
+        self.assertEqual('http://endpoint:80/HealthService', endpoint)
+        self.assertEqual('reporttargethealth', api)
+        self.assertEqual('WALinuxAgent', source)
+        self.assertEqual('1.0', version)
+
+        self.assertEqual(name, obs_name)
+        self.assertEqual(value, obs_value)
+        self.assertEqual(is_healthy, obs_healthy)
+        self.assertEqual(description, obs_description)
+
+    def test_observation_validity(self):
+        try:
+            Observation(name=None, is_healthy=True)
+            self.fail('Empty observation name should raise ValueError')
+        except ValueError:
+            pass
+
+        try:
+            Observation(name='Name', is_healthy=None)
+            self.fail('Empty measurement should raise ValueError')
+        except ValueError:
+            pass
+
+        o = Observation(name='Name', is_healthy=True, value=None, description=None)
+        self.assertEqual('', o.value)
+        self.assertEqual('', o.description)
+
+        long_str = 's' * 200
+        o = Observation(name=long_str, is_healthy=True, value=long_str, description=long_str)
+        self.assertEqual(200, len(o.name))
+        self.assertEqual(200, len(o.value))
+        self.assertEqual(200, len(o.description))
+
+        self.assertEqual(64, len(o.as_obj['ObservationName']))
+        self.assertEqual(128, len(o.as_obj['Value']))
+        self.assertEqual(128, len(o.as_obj['Description']))
+
+    def test_observation_json(self):
+        health_service = HealthService('endpoint')
+        health_service.observations.append(Observation(name='name',
+                                                       is_healthy=True,
+                                                       value='value',
+                                                       description='description'))
+        expected_json = '{"Source": "WALinuxAgent", ' \
+                         '"Api": "reporttargethealth", ' \
+                         '"Version": "1.0", ' \
+                         '"Observations": [{' \
+                            '"Value": "value", ' \
+                            '"ObservationName": "name", ' \
+                            '"Description": "description", ' \
+                            '"IsHealthy": true' \
+                        '}]}'
+        self.assertEqual(expected_json, health_service.as_json)
+
+    @patch("azurelinuxagent.common.utils.restutil.http_post")
+    def test_reporting(self, patch_post):
+        health_service = HealthService('endpoint')
+        health_service.report_host_plugin_status(is_healthy=True, response='response')
+        self.assertEqual(1, patch_post.call_count)
+        self.assert_observation(call_args=patch_post.call_args,
+                                name=HealthService.HOST_PLUGIN_STATUS_OBSERVATION_NAME,
+                                is_healthy=True,
+                                value='response',
+                                description='')
+
+        health_service.report_host_plugin_status(is_healthy=False, response='error')
+        self.assertEqual(2, patch_post.call_count)
+        self.assert_observation(call_args=patch_post.call_args,
+                                name=HealthService.HOST_PLUGIN_STATUS_OBSERVATION_NAME,
+                                is_healthy=False,
+                                value='error',
+                                description='')
+
+        health_service.report_host_plugin_extension_artifact(is_healthy=True, source='source', response='response')
+        self.assertEqual(3, patch_post.call_count)
+        self.assert_observation(call_args=patch_post.call_args,
+                                name=HealthService.HOST_PLUGIN_ARTIFACT_OBSERVATION_NAME,
+                                is_healthy=True,
+                                value='response',
+                                description='source')
+
+        health_service.report_host_plugin_extension_artifact(is_healthy=False, source='source', response='response')
+        self.assertEqual(4, patch_post.call_count)
+        self.assert_observation(call_args=patch_post.call_args,
+                                name=HealthService.HOST_PLUGIN_ARTIFACT_OBSERVATION_NAME,
+                                is_healthy=False,
+                                value='response',
+                                description='source')
+
+        health_service.report_host_plugin_heartbeat(is_healthy=True)
+        self.assertEqual(5, patch_post.call_count)
+        self.assert_observation(call_args=patch_post.call_args,
+                                name=HealthService.HOST_PLUGIN_HEARTBEAT_OBSERVATION_NAME,
+                                is_healthy=True,
+                                value='',
+                                description='')
+
+        health_service.report_host_plugin_heartbeat(is_healthy=False)
+        self.assertEqual(6, patch_post.call_count)
+        self.assert_observation(call_args=patch_post.call_args,
+                                name=HealthService.HOST_PLUGIN_HEARTBEAT_OBSERVATION_NAME,
+                                is_healthy=False,
+                                value='',
+                                description='')
+
+        health_service.report_host_plugin_versions(is_healthy=True, response='response')
+        self.assertEqual(7, patch_post.call_count)
+        self.assert_observation(call_args=patch_post.call_args,
+                                name=HealthService.HOST_PLUGIN_VERSIONS_OBSERVATION_NAME,
+                                is_healthy=True,
+                                value='response',
+                                description='')
+
+        health_service.report_host_plugin_versions(is_healthy=False, response='response')
+        self.assertEqual(8, patch_post.call_count)
+        self.assert_observation(call_args=patch_post.call_args,
+                                name=HealthService.HOST_PLUGIN_VERSIONS_OBSERVATION_NAME,
+                                is_healthy=False,
+                                value='response',
+                                description='')

--- a/tests/protocol/test_healthservice.py
+++ b/tests/protocol/test_healthservice.py
@@ -101,6 +101,7 @@ class TestHealthService(AgentTestCase):
                                 is_healthy=True,
                                 value='response',
                                 description='')
+        self.assertEqual(0, len(health_service.observations))
 
         health_service.report_host_plugin_status(is_healthy=False, response='error')
         self.assertEqual(2, patch_post.call_count)
@@ -109,6 +110,7 @@ class TestHealthService(AgentTestCase):
                                 is_healthy=False,
                                 value='error',
                                 description='')
+        self.assertEqual(0, len(health_service.observations))
 
         health_service.report_host_plugin_extension_artifact(is_healthy=True, source='source', response='response')
         self.assertEqual(3, patch_post.call_count)
@@ -117,6 +119,7 @@ class TestHealthService(AgentTestCase):
                                 is_healthy=True,
                                 value='response',
                                 description='source')
+        self.assertEqual(0, len(health_service.observations))
 
         health_service.report_host_plugin_extension_artifact(is_healthy=False, source='source', response='response')
         self.assertEqual(4, patch_post.call_count)
@@ -125,6 +128,7 @@ class TestHealthService(AgentTestCase):
                                 is_healthy=False,
                                 value='response',
                                 description='source')
+        self.assertEqual(0, len(health_service.observations))
 
         health_service.report_host_plugin_heartbeat(is_healthy=True)
         self.assertEqual(5, patch_post.call_count)
@@ -133,6 +137,7 @@ class TestHealthService(AgentTestCase):
                                 is_healthy=True,
                                 value='',
                                 description='')
+        self.assertEqual(0, len(health_service.observations))
 
         health_service.report_host_plugin_heartbeat(is_healthy=False)
         self.assertEqual(6, patch_post.call_count)
@@ -141,6 +146,7 @@ class TestHealthService(AgentTestCase):
                                 is_healthy=False,
                                 value='',
                                 description='')
+        self.assertEqual(0, len(health_service.observations))
 
         health_service.report_host_plugin_versions(is_healthy=True, response='response')
         self.assertEqual(7, patch_post.call_count)
@@ -149,6 +155,7 @@ class TestHealthService(AgentTestCase):
                                 is_healthy=True,
                                 value='response',
                                 description='')
+        self.assertEqual(0, len(health_service.observations))
 
         health_service.report_host_plugin_versions(is_healthy=False, response='response')
         self.assertEqual(8, patch_post.call_count)
@@ -157,3 +164,4 @@ class TestHealthService(AgentTestCase):
                                 is_healthy=False,
                                 value='response',
                                 description='')
+        self.assertEqual(0, len(health_service.observations))

--- a/tests/protocol/test_healthservice.py
+++ b/tests/protocol/test_healthservice.py
@@ -182,6 +182,20 @@ class TestHealthService(AgentTestCase):
         self.assertEqual(9, patch_post.call_count)
         self.assertEqual(0, len(health_service.observations))
 
+    def test_observation_length(self):
+        health_service = HealthService('endpoint')
+
+        # make 100 observations
+        for i in range(0, 100):
+            health_service._observe(is_healthy=True, name='{0}'.format(i))
+
+        # ensure we keep only 10
+        self.assertEqual(10, len(health_service.observations))
+
+        # ensure we keep the most recent 10
+        self.assertEqual('90', health_service.observations[0].name)
+        self.assertEqual('99', health_service.observations[9].name)
+
     def test_status_codes(self):
         # healthy
         self.assert_status_code(status_code=200, expected_healthy=True)

--- a/tests/protocol/test_healthservice.py
+++ b/tests/protocol/test_healthservice.py
@@ -97,7 +97,9 @@ class TestHealthService(AgentTestCase):
                             '"Description": "description", ' \
                             '"IsHealthy": true' \
                         '}]}'
-        self.assertEqual(expected_json, health_service.as_json)
+        expected = sorted(json.loads(expected_json).items())
+        actual = sorted(json.loads(health_service.as_json).items())
+        self.assertEqual(expected, actual)
 
     @patch("azurelinuxagent.common.utils.restutil.http_post")
     def test_reporting(self, patch_post):

--- a/tests/protocol/test_hostplugin.py
+++ b/tests/protocol/test_hostplugin.py
@@ -22,8 +22,9 @@ import sys
 import azurelinuxagent.common.protocol.restapi as restapi
 import azurelinuxagent.common.protocol.wire as wire
 import azurelinuxagent.common.protocol.hostplugin as hostplugin
-from azurelinuxagent.common.exception import HttpError
 
+from azurelinuxagent.common import event
+from azurelinuxagent.common.exception import HttpError
 from azurelinuxagent.common.protocol.hostplugin import API_VERSION
 from azurelinuxagent.common.utils import restutil
 from tests.protocol.mockwiredata import WireProtocolData, DATA_FILE

--- a/tests/protocol/test_hostplugin.py
+++ b/tests/protocol/test_hostplugin.py
@@ -222,7 +222,7 @@ class TestHostPlugin(AgentTestCase):
                 patch_api.return_value = API_VERSION
                 plugin.put_vm_status(status_blob, sas_url, block_blob_type)
 
-                self.assertTrue(patch_http.call_count == 1)
+                self.assertTrue(patch_http.call_count == 2)
                 self._validate_hostplugin_args(
                     patch_http.call_args_list[0],
                     test_goal_state,
@@ -274,7 +274,7 @@ class TestHostPlugin(AgentTestCase):
                 patch_get.return_value = api_versions
                 host_client.put_vm_status(status_blob, sas_url)
 
-                self.assertTrue(patch_http.call_count == 1)
+                self.assertTrue(patch_http.call_count == 2)
                 self._validate_hostplugin_args(
                     patch_http.call_args_list[0],
                     test_goal_state,
@@ -314,7 +314,7 @@ class TestHostPlugin(AgentTestCase):
                 patch_get.return_value = api_versions
                 host_client.put_vm_status(status_blob, sas_url)
 
-                self.assertTrue(patch_http.call_count == 2)
+                self.assertTrue(patch_http.call_count == 3)
 
                 exp_data = self._hostplugin_data(
                                 status_blob.get_page_blob_create_headers(
@@ -330,7 +330,7 @@ class TestHostPlugin(AgentTestCase):
                                     page)
                 exp_data['requestUri'] += "?comp=page" 
                 self._validate_hostplugin_args(
-                    patch_http.call_args_list[1],
+                    patch_http.call_args_list[2],
                     test_goal_state,
                     exp_method, exp_url, exp_data)
 

--- a/tests/protocol/test_hostplugin.py
+++ b/tests/protocol/test_hostplugin.py
@@ -218,10 +218,16 @@ class TestHostPlugin(AgentTestCase):
                 plugin.put_vm_status(status_blob, sas_url, block_blob_type)
 
                 self.assertTrue(patch_http.call_count == 2)
+
+                # first call is to host plugin
                 self._validate_hostplugin_args(
                     patch_http.call_args_list[0],
                     test_goal_state,
                     exp_method, exp_url, exp_data)
+
+                # second call is to health service
+                self.assertEqual('POST', patch_http.call_args_list[1][0][0])
+                self.assertEqual('http://168.63.129.16:80/HealthService', patch_http.call_args_list[1][0][1])
 
     def test_no_fallback(self):
         """
@@ -270,10 +276,16 @@ class TestHostPlugin(AgentTestCase):
                 host_client.put_vm_status(status_blob, sas_url)
 
                 self.assertTrue(patch_http.call_count == 2)
+
+                # first call is to host plugin
                 self._validate_hostplugin_args(
                     patch_http.call_args_list[0],
                     test_goal_state,
                     exp_method, exp_url, exp_data)
+
+                # second call is to health service
+                self.assertEqual('POST', patch_http.call_args_list[1][0][0])
+                self.assertEqual('http://168.63.129.16:80/HealthService', patch_http.call_args_list[1][0][1])
 
     def test_validate_page_blobs(self):
         """Validate correct set of data is sent for page blobs"""
@@ -311,6 +323,7 @@ class TestHostPlugin(AgentTestCase):
 
                 self.assertTrue(patch_http.call_count == 3)
 
+                # first call is to host plugin
                 exp_data = self._hostplugin_data(
                     status_blob.get_page_blob_create_headers(
                         page_size))
@@ -319,6 +332,11 @@ class TestHostPlugin(AgentTestCase):
                     test_goal_state,
                     exp_method, exp_url, exp_data)
 
+                # second call is to health service
+                self.assertEqual('POST', patch_http.call_args_list[1][0][0])
+                self.assertEqual('http://168.63.129.16:80/HealthService', patch_http.call_args_list[1][0][1])
+
+                # last call is to host plugin
                 exp_data = self._hostplugin_data(
                     status_blob.get_page_blob_page_headers(
                         0, page_size),

--- a/tests/protocol/test_hostplugin.py
+++ b/tests/protocol/test_hostplugin.py
@@ -472,8 +472,9 @@ class TestHostPlugin(AgentTestCase):
 
         if sys.version_info < (2, 7):
             self.assertRaises(HttpError, host_plugin.put_vm_status, status_blob, sas_url)
-        with self.assertRaises(HttpError):
-            host_plugin.put_vm_status(status_blob=status_blob, sas_url=sas_url)
+        else:
+            with self.assertRaises(HttpError):
+                host_plugin.put_vm_status(status_blob=status_blob, sas_url=sas_url)
 
         self.assertEqual(1, patch_http_get.call_count)
         self.assertEqual(hostplugin_versions_url, patch_http_get.call_args[0][0])

--- a/tests/protocol/test_hostplugin.py
+++ b/tests/protocol/test_hostplugin.py
@@ -431,7 +431,7 @@ class TestHostPlugin(AgentTestCase):
         # get_api_versions
         patch_http_get.return_value = MockResponse(api_versions, 200)
         # put status blob
-        patch_http_put.return_value = MockResponse('', 201)
+        patch_http_put.return_value = MockResponse(None, 201)
 
         host_plugin.put_vm_status(status_blob=status_blob, sas_url=sas_url)
         self.assertEqual(1, patch_http_get.call_count)
@@ -468,8 +468,10 @@ class TestHostPlugin(AgentTestCase):
         # get_api_versions
         patch_http_get.return_value = MockResponse(api_versions, 200)
         # put status blob
-        patch_http_put.return_value = MockResponse('', 500)
+        patch_http_put.return_value = MockResponse(None, 500)
 
+        if sys.version_info < (2, 7):
+            self.assertRaises(HttpError, host_plugin.put_vm_status, status_blob, sas_url)
         with self.assertRaises(HttpError):
             host_plugin.put_vm_status(status_blob=status_blob, sas_url=sas_url)
 
@@ -506,12 +508,15 @@ class TestHostPlugin(AgentTestCase):
         # get_api_versions
         patch_http_get.return_value = MockResponse(api_versions, 200)
         # put status blob
-        patch_http_put.return_value = MockResponse('', 500)
+        patch_http_put.return_value = MockResponse(None, 500)
 
         host_plugin.status_error_state.is_triggered = Mock(return_value=True)
 
-        with self.assertRaises(HttpError):
-            host_plugin.put_vm_status(status_blob=status_blob, sas_url=sas_url)
+        if sys.version_info < (2, 7):
+            self.assertRaises(HttpError, host_plugin.put_vm_status, status_blob, sas_url)
+        else:
+            with self.assertRaises(HttpError):
+                host_plugin.put_vm_status(status_blob=status_blob, sas_url=sas_url)
 
         self.assertEqual(1, patch_http_get.call_count)
         self.assertEqual(hostplugin_versions_url, patch_http_get.call_args[0][0])
@@ -544,7 +549,7 @@ class MockResponse:
         self.status = status_code
 
     def read(self):
-        return self.body
+        return self.body if sys.version_info[0] == 2 else bytes(self.body, encoding='utf-8')
 
 
 if __name__ == '__main__':

--- a/tests/protocol/test_wire.py
+++ b/tests/protocol/test_wire.py
@@ -28,13 +28,14 @@ wireserver_url = '168.63.129.16'
 
 @patch("time.sleep")
 @patch("azurelinuxagent.common.protocol.wire.CryptUtil")
+@patch("azurelinuxagent.common.protocol.healthservice.HealthService.report")
 class TestWireProtocol(AgentTestCase):
 
     def setUp(self):
         super(TestWireProtocol, self).setUp()
         HostPluginProtocol.set_default_channel(False)
     
-    def _test_getters(self, test_data, MockCryptUtil, _):
+    def _test_getters(self, test_data, __, MockCryptUtil, _):
         MockCryptUtil.side_effect = test_data.mock_crypt_util
 
         with patch.object(restutil, 'http_get', test_data.mock_http_get):
@@ -93,9 +94,7 @@ class TestWireProtocol(AgentTestCase):
         #    HostingEnvironmentConfig, will be retrieved the expected number
         self.assertEqual(2, test_data.call_counts["hostingenvuri"])
 
-    def test_call_storage_kwargs(self,
-                                 mock_cryptutil,
-                                 mock_sleep):
+    def test_call_storage_kwargs(self, *args):
         from azurelinuxagent.common.utils import restutil
         with patch.object(restutil, 'http_get') as http_patch:
             http_req = restutil.http_get
@@ -289,7 +288,6 @@ class TestWireProtocol(AgentTestCase):
 
             host_plugin_get_artifact_url_and_headers.assert_called_with(testurl)
 
-
     def test_get_in_vm_artifacts_profile_default(self, *args):
         wire_protocol_client = WireProtocol(wireserver_url).client
         wire_protocol_client.ext_conf = ExtensionsConfig(None)
@@ -302,8 +300,7 @@ class TestWireProtocol(AgentTestCase):
         self.assertEqual(dict(onHold='true'), in_vm_artifacts_profile.__dict__)
         self.assertTrue(in_vm_artifacts_profile.is_on_hold())
 
-    @patch("time.sleep")
-    def test_fetch_manifest_fallback(self, patch_sleep,  *args):
+    def test_fetch_manifest_fallback(self, *args):
         uri1 = ExtHandlerVersionUri()
         uri1.uri = 'ext_uri'
         uris = DataContractList(ExtHandlerVersionUri)

--- a/tests/protocol/test_wire.py
+++ b/tests/protocol/test_wire.py
@@ -80,7 +80,8 @@ class TestWireProtocol(AgentTestCase):
         test_data = WireProtocolData(DATA_FILE_EXT_NO_PUBLIC)
         self._test_getters(test_data, *args)
 
-    def test_getters_with_stale_goal_state(self, *args):
+    @patch("azurelinuxagent.common.protocol.healthservice.HealthService.report_host_plugin_extension_artifact")
+    def test_getters_with_stale_goal_state(self, patch_report, *args):
         test_data = WireProtocolData(DATA_FILE)
         test_data.emulate_stale_goal_state = True
 
@@ -93,6 +94,7 @@ class TestWireProtocol(AgentTestCase):
         #    fetched often; however, the dependent documents, such as the
         #    HostingEnvironmentConfig, will be retrieved the expected number
         self.assertEqual(2, test_data.call_counts["hostingenvuri"])
+        self.assertEqual(1, patch_report.call_count)
 
     def test_call_storage_kwargs(self, *args):
         from azurelinuxagent.common.utils import restutil
@@ -219,7 +221,8 @@ class TestWireProtocol(AgentTestCase):
                     patch_http.assert_called_once_with(testurl, wire_protocol_client.status_blob)
                     self.assertFalse(HostPluginProtocol.is_default_channel())
 
-    def test_upload_status_blob_unknown_type_assumes_block(self, *args):
+    @patch("azurelinuxagent.common.protocol.hostplugin.HostPluginProtocol.ensure_initialized")
+    def test_upload_status_blob_unknown_type_assumes_block(self, _, *args):
         vmstatus = VMStatus(message="Ready", status="Ready")
         wire_protocol_client = WireProtocol(wireserver_url).client
         wire_protocol_client.ext_conf = ExtensionsConfig(None)

--- a/tests/protocol/test_wire.py
+++ b/tests/protocol/test_wire.py
@@ -28,7 +28,7 @@ wireserver_url = '168.63.129.16'
 
 @patch("time.sleep")
 @patch("azurelinuxagent.common.protocol.wire.CryptUtil")
-@patch("azurelinuxagent.common.protocol.healthservice.HealthService.report")
+@patch("azurelinuxagent.common.protocol.healthservice.HealthService._report")
 class TestWireProtocol(AgentTestCase):
 
     def setUp(self):

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -11,8 +11,12 @@ import azurelinuxagent.ga.exthandlers as exthandlers
 import azurelinuxagent.ga.monitor as monitor
 import azurelinuxagent.ga.update as update
 
+
+@patch('azurelinuxagent.common.osutil.get_osutil')
+@patch('azurelinuxagent.common.protocol.get_protocol_util')
+@patch('azurelinuxagent.common.protocol.util.ProtocolUtil.get_protocol')
 class TestImportHandler(AgentTestCase):
-    def test_get_handler(self):
+    def test_get_handler(self, *args):
         osutil.get_osutil()
         protocol.get_protocol_util()
         dhcp.get_dhcp_handler()

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -12,11 +12,8 @@ import azurelinuxagent.ga.monitor as monitor
 import azurelinuxagent.ga.update as update
 
 
-@patch('azurelinuxagent.common.osutil.get_osutil')
-@patch('azurelinuxagent.common.protocol.get_protocol_util')
-@patch('azurelinuxagent.common.protocol.util.ProtocolUtil.get_protocol')
 class TestImportHandler(AgentTestCase):
-    def test_get_handler(self, *args):
+    def test_get_handler(self):
         osutil.get_osutil()
         protocol.get_protocol_util()
         dhcp.get_dhcp_handler()

--- a/tests/utils/test_rest_util.py
+++ b/tests/utils/test_rest_util.py
@@ -389,16 +389,6 @@ class TestHttpOperations(AgentTestCase):
 
     @patch("time.sleep")
     @patch("azurelinuxagent.common.utils.restutil._http_request")
-    def test_http_request_raises_for_bad_request(self, _http_request, _sleep):
-        _http_request.side_effect = [
-            Mock(status=httpclient.BAD_REQUEST)
-        ]
-
-        self.assertRaises(ResourceGoneError, restutil.http_get, "https://foo.bar")
-        self.assertEqual(1, _http_request.call_count)
-
-    @patch("time.sleep")
-    @patch("azurelinuxagent.common.utils.restutil._http_request")
     def test_http_request_raises_for_resource_gone(self, _http_request, _sleep):
         _http_request.side_effect = [
             Mock(status=httpclient.GONE)


### PR DESCRIPTION
The intent of this work is to add health signals for the host channel, which we can use to monitor PF rollouts. The following signals are in place:

#### GuestAgentPluginHeartbeat
- monitors the host plugin process is alive by calling `/health`
- check every 1m, send every 1m, failure > 5m unhealthy
```
{
  "Version": "1.0",
  "Observations": [
    {
      "IsHealthy": true,
      "Description": "",
      "Value": "",
      "ObservationName": "GuestAgentPluginHeartbeat"
    }
  ],
  "Api": "reporttargethealth",
  "Source": "WALinuxAgent"
}
```
#### GuestAgentPluginVersions
- monitors the host plugin channel is available by calling `/versions`
- determine health on usage (process start), send immediately, no failure rollup
```
{
  "Version": "1.0",
  "Observations": [
    {
      "Description": "",
      "Value": "",
      "IsHealthy": true,
      "ObservationName": "GuestAgentPluginVersions"
    }
  ],
  "Api": "reporttargethealth",
  "Source": "WALinuxAgent"
}
```
#### GuestAgentPluginArtifact
- monitors the `/extensionArtifact` api
- failure is determined by status codes `5xx`, except `502`, which is an upstream failure
- determine health on usage (extension/manifest/agent download), send every 1m, failure > 5m unhealthy
- we fetch for the purpose of extension handling (WireClient) and agent updates (GuestAgent), and may want to distinguish between these signals, so the source is listed in the `Description` field
- WireClient:
```
{
  "Version": "1.0",
  "Observations": [
    {
      "IsHealthy": true,
      "Description": "WireClient",
      "Value": "",
      "ObservationName": "GuestAgentPluginArtifact"
    }
  ],
  "Api": "reporttargethealth",
  "Source": "WALinuxAgent"
}
```
- GuestAgent:
```
{
  "Version": "1.0",
  "Observations": [
    {
      "IsHealthy": true,
      "Description": "GuestAgent",
      "Value": "",
      "ObservationName": "GuestAgentPluginArtifact"
    }
  ],
  "Api": "reporttargethealth",
  "Source": "WALinuxAgent"
}
```
#### GuestAgentPluginStatus
- monitors the `/status` api
- failure is determined by status codes `5xx`, except `502`, which is an upstream failure
- check every goal_state_interval (3s), send every 1m, failure > 5m unhealthy
```
{
  "Api": "reporttargethealth",
  "Observations": [
    {
      "Value": "",
      "ObservationName": "GuestAgentPluginStatus",
      "Description": "",
      "IsHealthy": true
    }
  ],
  "Version": "1.0",
  "Source": "WALinuxAgent"
}
```

Observations are reported to `http://{wireserver_ip}:80/HealthService`

Additional changes
- removed 400s from the `ResourceGoneError`; this is legacy host plugin behavior which has since been fixed
- switched extension package downloads from the base handler to client `fetch`, to simplify number of changes
- updated the logging prefix to `ExtHandler`, for brevity
- removed enable events from the logs, for clarity
- updated tests accordingly