### PR TITLE
Cgroup support for monitoring agent and extensions

### DIFF
--- a/azurelinuxagent/common/cgroups.py
+++ b/azurelinuxagent/common/cgroups.py
@@ -1,0 +1,689 @@
+# Copyright 2018 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Requires Python 2.6+ and Openssl 1.0+
+
+import errno
+import os
+import re
+import time
+
+from azurelinuxagent.common import logger
+from azurelinuxagent.common.osutil import get_osutil
+from azurelinuxagent.common.utils import fileutil
+from azurelinuxagent.common.version import AGENT_NAME, CURRENT_VERSION
+
+
+BASE_CGROUPS = '/sys/fs/cgroup'
+WRAPPER_CGROUP_NAME = "Agent+Extensions"
+METRIC_HIERARCHIES = ['cpu', 'memory']
+MEMORY_DEFAULT = -1
+
+# cpu  813599 3940 909253 154538746 874851 0 6589 0 0 0
+# cpu0 401094 1516 453006 77276738 452939 0 3312 0 0 0
+# cpu1 412505 2423 456246 77262007 421912 0 3276 0 0 0
+re_all_CPUs = re.compile('^cpu .*')
+re_user_system_times = re.compile('user (\d+)\nsystem (\d+)\n')
+
+related_services = {
+    "Microsoft.OSTCExtensions.LinuxDiagnostic":    ["omid", "omsagent-LAD", "mdsd-lde"],
+    "Microsoft.Azure.Diagnostics.LinuxDiagnostic": ["omid", "omsagent-LAD", "mdsd-lde"],
+}
+
+
+class CGroupsException(Exception):
+
+    def __init__(self, msg):
+
+        self.msg = msg
+        if CGroups.enabled():
+            pid = os.getpid()
+            # logger.verbose("[{0}] Disabling cgroup support: {1}".format(pid, msg))
+            # CGroups.disable()
+
+    def __str__(self):
+        return repr(self.msg)
+
+
+class Cpu(object):
+    def __init__(self, cgt):
+        """
+        Initialize data collection for the Cpu hierarchy. User must call update() before attempting to get
+        any useful metrics.
+
+        :param cgt: CGroupsTelemetry
+        :return:
+        """
+        self.cgt = cgt
+        self.current_cpu_total = self.get_current_cpu_total()
+        self.previous_cpu_total = 0
+        self.current_system_cpu = Cpu.get_current_system_cpu()
+        self.previous_system_cpu = 0
+
+    def __str__(self):
+        return "Cgroup: Current {0}, previous {1}; System: Current {2}, previous {3}".format(
+            self.current_cpu_total, self.previous_cpu_total, self.current_system_cpu, self.previous_system_cpu
+        )
+
+    def get_current_cpu_total(self):
+        """
+        Compute the number of USER_HZ of CPU time (user and system) consumed by this cgroup since boot.
+
+        :return: int
+        """
+        cpu_total = 0
+        cpu_stat = self.cgt.cgroup.get_file('cpu', 'cpuacct.stat')
+        if cpu_stat is not None:
+            m = re_user_system_times.match(cpu_stat)
+            if m:
+                cpu_total = int(m.groups()[0]) + int(m.groups()[1])
+        return cpu_total
+
+    @staticmethod
+    def get_proc_stat():
+        """
+        Get the contents of /proc/stat.
+        :return: A single string with the contents of /proc/stat
+        :rtype: str
+        """
+        results = None
+        try:
+            results = fileutil.read_file('/proc/stat')
+        except (OSError, IOError) as ex:
+            logger.warn("Couldn't read /proc/stat: {0}".format(ex.strerror))
+
+        return results
+
+    @staticmethod
+    def get_current_system_cpu():
+        """
+        Compute the number of USER_HZ units of time that have elapsed in all categories, across all cores, since boot.
+
+        :return: int
+        """
+        system_cpu = 0
+        proc_stat = Cpu.get_proc_stat()
+        if proc_stat is not None:
+            for line in proc_stat.splitlines():
+                if re_all_CPUs.match(line):
+                    system_cpu = sum(int(i) for i in line.split()[1:7])
+                    break
+        return system_cpu
+
+    def update(self):
+        """
+        Update all raw data required to compute metrics of interest. The intent is to call update() once, then
+        call the various get_*() methods which use this data, which we've collected exactly once.
+        """
+        self.previous_cpu_total = self.current_cpu_total
+        self.previous_system_cpu = self.current_system_cpu
+        self.current_cpu_total = self.get_current_cpu_total()
+        self.current_system_cpu = Cpu.get_current_system_cpu()
+
+    def get_cpu_percent(self):
+        """
+        Compute the percent CPU time used by this cgroup over the elapsed time since the last time this instance was
+        update()ed.  If the cgroup fully consumed 2 cores on a 4 core system, return 200.
+
+        :return: float
+        """
+        cpu_delta = self.current_cpu_total - self.previous_cpu_total
+        system_delta = max(1, self.current_system_cpu - self.previous_system_cpu)
+
+        return round(float(cpu_delta * self.cgt.cpu_count * 100) / float(system_delta), 3)
+
+    def collect(self):
+        """
+        Collect and return a list of all cpu metrics. If no metrics are collected, return an empty list.
+
+        :return: [(str, str, float)]
+        """
+        self.update()
+        usage = self.get_cpu_percent()
+        return [("Process", "% Processor Time", usage)]
+
+
+class Memory(object):
+    def __init__(self, cgt):
+        """
+        Initialize data collection for the Memory hierarchy
+
+        :param cgt: CGroupsTelemetry
+        :return:
+        """
+        self.cgt = cgt
+
+    def update(self):
+        pass
+
+    def collect(self):
+        """
+        Collect and return a list of all memory metrics
+        """
+        self.update()
+        return []
+
+
+class CGroupsTelemetry(object):
+    """
+    Encapsulate the cgroup-based telemetry for the agent or one of its extensions, or for the aggregation across
+    the agent and all of its extensions. These objects should have lifetimes that span the time window over which
+    measurements are desired; in general, they're not terribly effective at providing instantaneous measurements.
+    """
+    _tracked = {}
+    _metrics = {
+        "cpu": Cpu,
+        "memory": Memory
+    }
+    _hierarchies = list(_metrics.keys())
+    tracked_names = set()
+
+    @staticmethod
+    def metrics_hierarchies():
+        return CGroupsTelemetry._hierarchies
+
+    @staticmethod
+    def track_cgroup(cgroup):
+        """
+        Create a CGroupsTelemetry object to track a particular CGroups instance. Typical usage:
+        1) Create a CGroups object
+        2) Ask CGroupsTelemetry to track it
+        3) Tell the CGroups object to add one or more processes (or let systemd handle that, for its cgroups)
+
+        :param CGroups cgroup: The cgroup to track
+        """
+        name = cgroup.name
+        if not CGroupsTelemetry.is_tracked(name):
+            tracker = CGroupsTelemetry(name, cgroup=cgroup)
+            CGroupsTelemetry._tracked[name] = tracker
+
+    @staticmethod
+    def track_systemd_service(name):
+        """
+        If not already tracking it, create the CGroups object for a systemd service and track it.
+
+        :param str name: Service name (without .service suffix) to be tracked.
+        """
+        service_name = "{0}.service".format(name)
+        if not CGroupsTelemetry.is_tracked(service_name):
+            cgroup = CGroups.for_systemd_service(service_name)
+            tracker = CGroupsTelemetry(service_name, cgroup=cgroup)
+            CGroupsTelemetry._tracked[service_name] = tracker
+
+    @staticmethod
+    def track_extension(name, cgroup=None):
+        """
+        Create all required CGroups to track all metrics for an extension and its associated services.
+
+        :param str name: Full name of the extension to be tracked
+        :param CGroups cgroup: CGroup for the extension itself. This method will create it if none is supplied.
+        """
+        if not CGroupsTelemetry.is_tracked(name):
+            cgroup = CGroups.for_extension(name) if cgroup is None else cgroup
+            logger.info("Now tracking cgroup {0}".format(name))
+            CGroupsTelemetry.track_cgroup(cgroup)
+        if CGroups.is_systemd_manager():
+            if name in related_services:
+                for service_name in related_services[name]:
+                    CGroupsTelemetry.track_systemd_service(service_name)
+
+    @staticmethod
+    def is_tracked(name):
+        return name in CGroupsTelemetry._tracked
+
+    @staticmethod
+    def stop_tracking(name):
+        """
+        Stop tracking telemetry for the CGroups associated with an extension. If any system services are being
+        tracked, those will continue to be tracked; multiple extensions might rely upon the same service.
+
+        :param str name: Extension to be dropped from tracking
+        """
+        if CGroupsTelemetry.is_tracked(name):
+            del (CGroupsTelemetry._tracked[name])
+
+    @staticmethod
+    def collect_all_tracked():
+        """
+        Return a dictionary mapping from the name of a tracked cgroup to the list of collected metrics for that cgroup.
+
+        :returns: Dictionary of list collected metrics (metric class, metric name, value), by cgroup
+        :rtype: dict(str: [(str, str, float)])
+        """
+        results = {}
+        for cgroup_name, collector in CGroupsTelemetry._tracked.items():
+            cgroup_name = cgroup_name if cgroup_name else WRAPPER_CGROUP_NAME
+            results[cgroup_name] = collector.collect()
+        return results
+
+    @staticmethod
+    def update_tracked(ext_handlers):
+        """
+        Track CGroups for all enabled extensions.
+        Track CGroups for services created by enabled extensions.
+        Stop tracking CGroups for not-enabled extensions.
+
+        :param List(ExtHandler) ext_handlers:
+        """
+        not_enabled_extensions = set()
+        for extension in ext_handlers:
+            if extension.properties.state == u"enabled":
+                CGroupsTelemetry.track_extension(extension.name)
+            else:
+                not_enabled_extensions.add(extension.name)
+
+        names_now_tracked = set(CGroupsTelemetry._tracked.keys())
+        if CGroupsTelemetry.tracked_names != names_now_tracked:
+            now_tracking = " ".join("[{0}]".format(name) for name in names_now_tracked)
+            if len(now_tracking):
+                logger.info("After updating cgroup telemetry, tracking {0}".format(now_tracking))
+            else:
+                logger.warn("After updating cgroup telemetry, tracking no cgroups.")
+            CGroupsTelemetry.tracked_names = names_now_tracked
+
+    def __init__(self, name, cgroup=None):
+        """
+        Create the necessary state to collect metrics for the agent, one of its extensions, or the aggregation across
+        the agent and all of its extensions. To access aggregated metrics, instantiate this object with an empty string
+        or None.
+
+        :param name: str
+        """
+        if name is None:
+            name = ""
+        self.name = name
+        if cgroup is None:
+            cgroup = CGroups.for_extension(name)
+        self.cgroup = cgroup
+        self.cpu_count = CGroups.get_num_cores()
+        self.current_wall_time = time.time()
+        self.previous_wall_time = 0
+
+        self.data = {}
+        for hierarchy in CGroupsTelemetry.metrics_hierarchies():
+            self.data[hierarchy] = CGroupsTelemetry._metrics[hierarchy](self)
+
+    def collect(self):
+        """
+        Return a list of collected metrics. Each element is a tuple of
+        (metric group name, metric name, metric value)
+        :return: [(str, str, float)]
+        """
+        results = []
+        for collector in self.data.values():
+            results.extend(collector.collect())
+        return results
+
+
+class CGroups(object):
+    """
+    This class represents the cgroup folders for the agent or an extension. This is a pretty lightweight object
+    without much state worth preserving; it's not unreasonable to create one just when you need it.
+    """
+    # whether cgroup support is enabled
+    _enabled = True
+    _hierarchies = CGroupsTelemetry.metrics_hierarchies()
+    _use_systemd = None     # Tri-state: None (i.e. "unknown"), True, False
+    _osutil = get_osutil()
+
+    @staticmethod
+    def _construct_custom_path_for_hierarchy(hierarchy, cgroup_name):
+        return os.path.join(BASE_CGROUPS, hierarchy, AGENT_NAME, cgroup_name).rstrip(os.path.sep)
+
+    @staticmethod
+    def _construct_systemd_path_for_hierarchy(hierarchy, cgroup_name):
+        return os.path.join(BASE_CGROUPS, hierarchy, 'system.slice', cgroup_name).rstrip(os.path.sep)
+
+    @staticmethod
+    def for_extension(name):
+        return CGroups(name, CGroups._construct_custom_path_for_hierarchy)
+
+    @staticmethod
+    def for_systemd_service(name):
+        return CGroups(name.lower(), CGroups._construct_systemd_path_for_hierarchy)
+
+    def __init__(self, name, path_maker):
+        """
+        Construct CGroups object. Create appropriately-named directory for each hierarchy of interest.
+
+        :param str name: Name for the cgroup (usually the full name of the extension)
+        :param path_maker: Function which constructs the root path for a given hierarchy where this cgroup lives
+        """
+        if name == "":
+            self.name = "Agents+Extensions"
+            self.is_wrapper_cgroup = True
+        else:
+            self.name = name
+            self.is_wrapper_cgroup = False
+
+        self.cgroups = {}
+
+        if not self.enabled():
+            return
+
+        system_hierarchies = os.listdir(BASE_CGROUPS)
+        for hierarchy in CGroups._hierarchies:
+            if hierarchy not in system_hierarchies:
+                raise CGroupsException("Hierarchy {0} is not mounted".format(hierarchy))
+
+            cgroup_name = "" if self.is_wrapper_cgroup else self.name
+            cgroup_path = path_maker(hierarchy, cgroup_name)
+            if not os.path.isdir(cgroup_path):
+                logger.info("Creating cgroup directory {0}".format(cgroup_path))
+                CGroups._try_mkdir(cgroup_path)
+            self.cgroups[hierarchy] = cgroup_path
+
+    @staticmethod
+    def is_systemd_manager():
+        """
+        Determine if systemd is managing system services. Many extensions are structured as a set of services,
+        including the agent itself; systemd expects those services to remain in the cgroups in which it placed them.
+        If this process (presumed to be the agent) is in a cgroup that looks like one created by systemd, we can
+        assume systemd is in use.
+
+        :return: True if systemd is managing system services
+        :rtype: Bool
+        """
+        if CGroups._use_systemd is None:
+            hierarchy = METRIC_HIERARCHIES[0]
+            path = CGroups.get_my_cgroup_folder(hierarchy)
+            CGroups._use_systemd = path.startswith(CGroups._construct_systemd_path_for_hierarchy(hierarchy, ""))
+        return CGroups._use_systemd
+
+    @staticmethod
+    def _try_mkdir(path):
+        """
+        Try to create a directory, recursively. If it already exists as such, do nothing. Raise the appropriate
+        exception should an error occur.
+
+        :param path: str
+        """
+        if not os.path.isdir(path):
+            try:
+                os.makedirs(path, 0o755)
+            except OSError as e:
+                if e.errno == errno.EEXIST:
+                    if not os.path.isdir(path):
+                        raise CGroupsException(
+                            "Create directory for cgroup {0}: normal file already exists with that name".format(path)
+                        )
+                    else:
+                        pass    # There was a race to create the directory, but it's there now, and that's fine
+                elif e.errno == errno.EACCES:
+                    # This is unexpected, as the agent runs as root
+                    raise CGroupsException("Create directory for cgroup {0}: permission denied".format(path))
+                else:
+                    raise
+
+    def add(self, pid):
+        """
+        Add a process to the cgroups for this agent/extension.
+        """
+        if not self.enabled():
+            return
+
+        if self.is_wrapper_cgroup:
+            raise CGroupsException("Cannot add a process to the Agents+Extensions wrapper cgroup")
+
+        if not self._osutil.check_pid_alive(pid):
+            raise CGroupsException('PID {0} does not exist'.format(pid))
+        for hierarchy, cgroup in self.cgroups.items():
+            tasks_file = self._get_cgroup_file(hierarchy, 'cgroup.procs')
+            fileutil.append_file(tasks_file, "{0}\n".format(pid))
+
+    @staticmethod
+    def enabled():
+        return CGroups._enabled
+
+    @staticmethod
+    def disable():
+        CGroups._enabled = False
+
+    @staticmethod
+    def enable():
+        CGroups._enabled = True
+
+    def set_limits(self):
+        """
+        Set per-hierarchy limits based on the cgroup name (agent or particular extension)
+        """
+        # TODO: set limits, simply record telemetry for now
+        # cg.set_cpu_limit(50)
+        # cg.set_memory_limit(500)
+        pass
+
+    @staticmethod
+    def _apply_wrapper_limits(path, hierarchy):
+        """
+        Find wrapping limits for the hierarchy and apply them to the cgroup denoted by the path
+
+        :param path: str
+        :param hierarchy: str
+        """
+        pass
+
+    @staticmethod
+    def _setup_wrapper_groups():
+        """
+        For each hierarchy, construct the wrapper cgroup and apply the appropriate limits
+        """
+        for hierarchy in METRIC_HIERARCHIES:
+            root_dir = CGroups._construct_custom_path_for_hierarchy(hierarchy, "")
+            CGroups._try_mkdir(root_dir)
+            CGroups._apply_wrapper_limits(root_dir, hierarchy)
+
+    @staticmethod
+    def setup(suppress_process_add=False):
+        """
+        Only needs to be called once, and should be called from the -daemon instance of the agent.
+            Mount the cgroup fs if necessary
+            Create wrapper cgroups for agent-plus-extensions and set limits on them;
+            Add this process to the "agent" cgroup, if required
+        Actual collection of metrics from cgroups happens in the -run-exthandlers instance
+        """
+        cgroups_enabled = False
+        try:
+            CGroups._osutil.mount_cgroups()
+            if not suppress_process_add:
+                CGroups._setup_wrapper_groups()
+                pid = int(os.getpid())
+                if not CGroups.is_systemd_manager():
+                    cg = CGroups.for_extension(AGENT_NAME)
+                    cg.add(pid)
+                    logger.info("Add daemon process pid {0} to {1} cgroup".format(pid, cg.name))
+                else:
+                    logger.info("Daemon process pid {0} cgroup managed by systemd".format(pid))
+            cgroups_enabled = True
+            status = "OK"
+        except CGroupsException as cge:
+            status = cge.msg
+
+        from azurelinuxagent.common.event import add_event, WALAEventOperation
+        add_event(
+            AGENT_NAME,
+            version=CURRENT_VERSION,
+            op=WALAEventOperation.InitializeCGroups,
+            is_success=cgroups_enabled,
+            message=status,
+            log_event=False)
+
+    @staticmethod
+    def add_to_extension_cgroup(name, pid=int(os.getpid())):
+        """
+        Create cgroup directories for this extension in each of the hierarchies and add this process to the new cgroup.
+        Should only be called when creating sub-processes and invoked inside the fork/exec window. As a result,
+        there's no point in returning the CGroups object itself; the goal is to move the child process into the
+        cgroup before the new code even starts running.
+
+        :param str name: Short name of extension, suitable for naming directories in the filesystem
+        :param int pid: Process id of extension to be added to the cgroup
+        """
+        if not CGroups.enabled():
+            return
+        if name == AGENT_NAME:
+            logger.warn('Extension cgroup name cannot match agent cgroup name ({0})'.format(AGENT_NAME))
+            return
+
+        try:
+            logger.info("Move process {0} into cgroups for extension {1}".format(pid, name))
+            CGroups.for_extension(name).add(pid)
+        except Exception as ex:
+            logger.warn("Unable to move process {0} into cgroups for extension {1}: {2}".format(pid, name, ex))
+
+    @staticmethod
+    def get_my_cgroup_path(hierarchy_id):
+        """
+        Get the cgroup path "suffix" for this process for the given hierarchy ID. The leading "/" is always stripped,
+        so the suffix is suitable for passing to os.path.join(). (If the process is in the root cgroup, an empty
+        string is returned, and os.path.join() will still do the right thing.)
+
+        :param hierarchy_id: str
+        :return: str
+        """
+        cgroup_paths = fileutil.read_file("/proc/self/cgroup")
+        for entry in cgroup_paths.splitlines():
+            fields = entry.split(':')
+            if fields[0] == hierarchy_id:
+                return fields[2].lstrip(os.path.sep)
+        raise CGroupsException("This process belongs to no cgroup for hierarchy ID {0}".format(hierarchy_id))
+
+    @staticmethod
+    def get_hierarchy_id(hierarchy):
+        """
+        Get the cgroups hierarchy ID for a given hierarchy name
+
+        :param hierarchy:
+        :return: str
+        """
+        cgroup_states = fileutil.read_file("/proc/cgroups")
+        for entry in cgroup_states.splitlines():
+            fields = entry.split('\t')
+            if fields[0] == hierarchy:
+                return fields[1]
+        raise CGroupsException("Cgroup hierarchy {0} not found in /proc/cgroups".format(hierarchy))
+
+    @staticmethod
+    def get_my_cgroup_folder(hierarchy):
+        """
+        Find the path of the cgroup in which this process currently lives for the given hierarchy.
+
+        :param hierarchy: str
+        :return: str
+        """
+        hierarchy_id = CGroups.get_hierarchy_id(hierarchy)
+        return os.path.join(BASE_CGROUPS, hierarchy, CGroups.get_my_cgroup_path(hierarchy_id))
+
+    def _get_cgroup_file(self, hierarchy, file_name):
+        return os.path.join(self.cgroups[hierarchy], file_name)
+
+    @staticmethod
+    def _convert_cpu_limit_to_fraction(value):
+        """
+        Convert a CPU limit from percent (e.g. 50 meaning 50%) to a decimal fraction (0.50).
+        :return: Fraction of one CPU to be made available (e.g. 0.5 means half a core)
+        :rtype: float
+        """
+        try:
+            limit = float(value)
+        except ValueError:
+            raise CGroupsException('CPU Limit must be convertible to a float')
+
+        if limit <= float(0) or limit > float(CGroups.get_num_cores() * 100):
+            raise CGroupsException('CPU Limit must be between 0 and 100 * numCores')
+
+        return limit / 100.0
+
+    def get_file(self, hierarchy, file_name):
+        """
+        Retrieve the value of a parameter from a hierarchy.
+
+        :param hierarchy: str
+        :param file_name: str
+        :return: st
+        """
+        if hierarchy in self.cgroups:
+            parameter_file = self._get_cgroup_file(hierarchy, file_name)
+            try:
+                return fileutil.read_file(parameter_file)
+            except Exception:
+                raise CGroupsException("Could not retrieve cgroup file {0}/{1}".format(hierarchy, file_name))
+        else:
+            raise CGroupsException("{0} subsystem not available in cgroup {1}. cgroup paths: {2}".format(
+                hierarchy, self.name, self.cgroups))
+
+    def get_parameter(self, hierarchy, parameter_name):
+        """
+        Retrieve the value of a parameter from a hierarchy.
+
+        :param hierarchy: str
+        :param parameter_name: str
+        :return: str
+        """
+        values = self.get_file(hierarchy, parameter_name).splitlines
+        return values[0]
+
+    def set_cpu_limit(self, limit=None):
+        """
+        Limit this cgroup to a percentage of a single core. limit=10 means 10% of one core; 150 means 150%, which
+        is useful only in multi-core systems.
+        To limit a cgroup to utilize 10% of a single CPU, use the following commands:
+            # echo 10000 > /cgroup/cpu/red/cpu.cfs_quota_us
+            # echo 100000 > /cgroup/cpu/red/cpu.cfs_period_us
+
+        :param limit:
+        """
+        if limit is None:
+            return
+
+        if 'cpu' in self.cgroups:
+            total_units = float(self.get_parameter('cpu', 'cpu.cfs_period_us'))
+            limit_units = self._convert_cpu_limit_to_fraction(limit) * total_units
+            cpu_shares_file = self._get_cgroup_file('cpu', 'cpu.cfs_quota_us')
+            fileutil.write_file(cpu_shares_file, "{0}\n".format(limit_units))
+        else:
+            raise CGroupsException("CPU hierarchy not available in this cgroup")
+
+    @staticmethod
+    def get_num_cores():
+        """
+        Return the number of CPU cores exposed to this system.
+
+        :return: int
+        """
+        return CGroups._osutil.get_processor_cores()
+
+    @staticmethod
+    def _format_memory_value(unit, limit=None):
+        units = {'bytes': 1, 'kilobytes': 1024, 'megabytes': 1024*1024, 'gigabytes': 1024*1024*1024}
+        if unit not in units:
+            raise CGroupsException("Unit must be one of {0}".format(units.keys()))
+        if limit is None:
+            value = MEMORY_DEFAULT
+        else:
+            try:
+                limit = float(limit)
+            except ValueError:
+                raise CGroupsException('Limit must be convertible to a float')
+            else:
+                value = int(limit * units[unit])
+        return value
+
+    def set_memory_limit(self, limit=None, unit='megabytes'):
+        if 'memory' in self.cgroups:
+            value = self._format_memory_value(unit, limit)
+            memory_limit_file = self._get_cgroup_file('memory', 'memory.limit_in_bytes')
+            with open(memory_limit_file, 'w+') as f:
+                f.write("{0}\n".format(value))
+        else:
+            raise CGroupsException("Memory hierarchy not available in this cgroup")

--- a/azurelinuxagent/common/osutil/default.py
+++ b/azurelinuxagent/common/osutil/default.py
@@ -284,6 +284,9 @@ class DefaultOSUtil(object):
         return id_that == id_this or \
             id_that == self._correct_instance_id(id_this)
 
+    def is_cgroups_supported(self):
+        return False
+
     def mount_cgroups(self):
         pass
 

--- a/azurelinuxagent/common/osutil/default.py
+++ b/azurelinuxagent/common/osutil/default.py
@@ -19,6 +19,7 @@
 import array
 import base64
 import datetime
+import errno
 import fcntl
 import glob
 import multiprocessing
@@ -1111,7 +1112,11 @@ class DefaultOSUtil(object):
         try:
             pid = int(pid)
             os.kill(pid, 0)
-        except (OSError, ValueError, TypeError):
+        except (ValueError, TypeError):
+            return False
+        except OSError as e:
+            if e.errno == errno.EPERM:
+                return True
             return False
         return True
 

--- a/azurelinuxagent/common/osutil/default.py
+++ b/azurelinuxagent/common/osutil/default.py
@@ -281,6 +281,9 @@ class DefaultOSUtil(object):
         return id_that == id_this or \
             id_that == self._correct_instance_id(id_this)
 
+    def mount_cgroups(self):
+        pass
+
     def get_agent_conf_file_path(self):
         return self.agent_conf_file_path
 
@@ -618,8 +621,8 @@ class DefaultOSUtil(object):
                 time.sleep(1)
         return False
 
-    def mount(self, dvd, mount_point, option="", chk_err=True):
-        cmd = "mount {0} {1} {2}".format(option, dvd, mount_point)
+    def mount(self, device, mount_point, option="", chk_err=True):
+        cmd = "mount {0} {1} {2}".format(option, device, mount_point)
         retcode, err = shellutil.run_get_output(cmd, chk_err)
         if retcode != 0:
             detail = "[{0}] returned {1}: {2}".format(cmd, retcode, err)
@@ -1100,7 +1103,12 @@ class DefaultOSUtil(object):
         return multiprocessing.cpu_count()
 
     def check_pid_alive(self, pid):
-        return pid is not None and os.path.isdir(os.path.join('/proc', pid))
+        try:
+            pid = int(pid)
+            os.kill(pid, 0)
+        except (OSError, ValueError, TypeError):
+            return False
+        return True
 
     @property
     def is_64bit(self):

--- a/azurelinuxagent/common/osutil/freebsd.py
+++ b/azurelinuxagent/common/osutil/freebsd.py
@@ -247,3 +247,7 @@ class FreeBSDOSUtil(DefaultOSUtil):
                     if not possible.startswith('pass'):
                         return possible
         return None
+
+    @staticmethod
+    def get_total_cpu_ticks_since_boot():
+        return 0

--- a/azurelinuxagent/common/osutil/gaia.py
+++ b/azurelinuxagent/common/osutil/gaia.py
@@ -139,16 +139,16 @@ class GaiaOSUtil(DefaultOSUtil):
     def eject_dvd(self, chk_err=True):
         logger.warn('eject is not supported on GAiA')
 
-    def mount(self, dvd, mount_point, option="", chk_err=True):
-        logger.info('mount {0} {1} {2}', dvd, mount_point, option)
+    def mount(self, device, mount_point, option="", chk_err=True):
+        logger.info('mount {0} {1} {2}', device, mount_point, option)
         if 'udf,iso9660' in option:
             ret, out = super(GaiaOSUtil, self).mount(
-                dvd, mount_point, option=option.replace('udf,iso9660', 'udf'),
+                device, mount_point, option=option.replace('udf,iso9660', 'udf'),
                 chk_err=chk_err)
             if not ret:
                 return ret, out
         return super(GaiaOSUtil, self).mount(
-            dvd, mount_point, option=option, chk_err=chk_err)
+            device, mount_point, option=option, chk_err=chk_err)
 
     def allow_dhcp_broadcast(self):
         logger.info('allow_dhcp_broadcast is ignored on GAiA')

--- a/azurelinuxagent/common/osutil/openbsd.py
+++ b/azurelinuxagent/common/osutil/openbsd.py
@@ -345,3 +345,7 @@ class OpenBSDOSUtil(DefaultOSUtil):
         Return device name attached to ide port 'n'.
         """
         return "wd{0}".format(port_id)
+
+    @staticmethod
+    def get_total_cpu_ticks_since_boot():
+        return 0

--- a/azurelinuxagent/common/osutil/ubuntu.py
+++ b/azurelinuxagent/common/osutil/ubuntu.py
@@ -53,6 +53,11 @@ class Ubuntu14OSUtil(DefaultOSUtil):
     def get_dhcp_lease_endpoint(self):
         return self.get_endpoint_from_leases_path('/var/lib/dhcp/dhclient.*.leases')
 
+    def is_cgroups_supported(self):
+        if 'TRAVIS' in os.environ and os.environ['TRAVIS'] == 'true':
+            return False
+        return True
+
     def mount_cgroups(self):
         try:
             if not os.path.exists(_cgroup_path()):

--- a/azurelinuxagent/common/osutil/ubuntu.py
+++ b/azurelinuxagent/common/osutil/ubuntu.py
@@ -16,12 +16,19 @@
 # Requires Python 2.6+ and Openssl 1.0+
 #
 
+import os
 import time
 
 import azurelinuxagent.common.logger as logger
+import azurelinuxagent.common.utils.fileutil as fileutil
 import azurelinuxagent.common.utils.shellutil as shellutil
 
+from azurelinuxagent.common.future import ustr
 from azurelinuxagent.common.osutil.default import DefaultOSUtil
+
+
+def _cgroup_path(tail=""):
+    return os.path.join('/sys/fs/cgroup/', tail).rstrip(os.path.sep)
 
 
 class Ubuntu14OSUtil(DefaultOSUtil):
@@ -46,6 +53,35 @@ class Ubuntu14OSUtil(DefaultOSUtil):
     def get_dhcp_lease_endpoint(self):
         return self.get_endpoint_from_leases_path('/var/lib/dhcp/dhclient.*.leases')
 
+    def mount_cgroups(self):
+        try:
+            if not os.path.exists(_cgroup_path()):
+                fileutil.mkdir(_cgroup_path())
+                self.mount(device='cgroup_root',
+                           mount_point=_cgroup_path(),
+                           option="-t tmpfs",
+                           chk_err=False)
+            elif not os.path.isdir(_cgroup_path()):
+                logger.error("Could not mount cgroups: ordinary file at {0}".format(_cgroup_path()))
+                return
+
+            for metric_hierarchy in ['cpu,cpuacct', 'memory']:
+                target_path = _cgroup_path(metric_hierarchy)
+                if not os.path.exists(target_path):
+                    fileutil.mkdir(target_path)
+                self.mount(device=metric_hierarchy,
+                           mount_point=target_path,
+                           option="-t cgroup -o {0}".format(metric_hierarchy),
+                           chk_err=False)
+
+            for metric_hierarchy in ['cpu', 'cpuacct']:
+                target_path = _cgroup_path(metric_hierarchy)
+                if not os.path.exists(target_path):
+                    os.symlink(_cgroup_path('cpu,cpuacct'), target_path)
+
+        except Exception as e:
+            logger.error("Could not mount cgroups: {0}", ustr(e))
+
 
 class Ubuntu12OSUtil(Ubuntu14OSUtil):
     def __init__(self):
@@ -56,6 +92,8 @@ class Ubuntu12OSUtil(Ubuntu14OSUtil):
         ret = shellutil.run_get_output("pidof dhclient3", chk_err=False)
         return ret[1] if ret[0] == 0 else None
 
+    def mount_cgroups(self):
+        pass
 
 class Ubuntu16OSUtil(Ubuntu14OSUtil):
     """
@@ -69,6 +107,12 @@ class Ubuntu16OSUtil(Ubuntu14OSUtil):
 
     def unregister_agent_service(self):
         return shellutil.run("systemctl mask walinuxagent", chk_err=False)
+
+    def mount_cgroups(self):
+        """
+        Mounted by default in Ubuntu 16.04
+        """
+        pass
 
 
 class Ubuntu18OSUtil(Ubuntu16OSUtil):
@@ -127,3 +171,9 @@ class UbuntuSnappyOSUtil(Ubuntu14OSUtil):
     def __init__(self):
         super(UbuntuSnappyOSUtil, self).__init__()
         self.conf_file_path = '/apps/walinuxagent/current/waagent.conf'
+
+    def mount_cgroups(self):
+        """
+        Already mounted in Snappy
+        """
+        pass

--- a/azurelinuxagent/common/version.py
+++ b/azurelinuxagent/common/version.py
@@ -113,7 +113,7 @@ def get_distro():
 
 AGENT_NAME = "WALinuxAgent"
 AGENT_LONG_NAME = "Azure Linux Agent"
-AGENT_VERSION = '2.2.25.1'
+AGENT_VERSION = '2.2.27'
 AGENT_LONG_VERSION = "{0}-{1}".format(AGENT_NAME, AGENT_VERSION)
 AGENT_DESCRIPTION = """
 The Azure Linux Agent supports the provisioning and running of Linux

--- a/azurelinuxagent/common/version.py
+++ b/azurelinuxagent/common/version.py
@@ -113,7 +113,7 @@ def get_distro():
 
 AGENT_NAME = "WALinuxAgent"
 AGENT_LONG_NAME = "Azure Linux Agent"
-AGENT_VERSION = '2.2.27'
+AGENT_VERSION = '2.2.25.1'
 AGENT_LONG_VERSION = "{0}-{1}".format(AGENT_NAME, AGENT_VERSION)
 AGENT_DESCRIPTION = """
 The Azure Linux Agent supports the provisioning and running of Linux

--- a/azurelinuxagent/daemon/main.py
+++ b/azurelinuxagent/daemon/main.py
@@ -26,6 +26,7 @@ import azurelinuxagent.common.conf as conf
 import azurelinuxagent.common.logger as logger
 import azurelinuxagent.common.utils.fileutil as fileutil
 
+from azurelinuxagent.common.cgroups import CGroups
 from azurelinuxagent.common.event import add_event, WALAEventOperation
 from azurelinuxagent.common.future import ustr
 from azurelinuxagent.common.osutil import get_osutil
@@ -65,6 +66,7 @@ class DaemonHandler(object):
                     PY_VERSION_MICRO)
 
         self.check_pid()
+        CGroups.setup()
 
         # If FIPS is enabled, set the OpenSSL environment variable
         # Note:

--- a/azurelinuxagent/ga/monitor.py
+++ b/azurelinuxagent/ga/monitor.py
@@ -391,10 +391,7 @@ class MonitorHandler(object):
         # Track metrics for the roll-up cgroup and for the agent cgroup
         try:
             CGroupsTelemetry.track_cgroup(CGroups.for_extension(""))
-            if CGroups.is_systemd_manager():
-                CGroupsTelemetry.track_systemd_service(AGENT_NAME)
-            else:
-                CGroupsTelemetry.track_cgroup(CGroups.for_extension(AGENT_NAME))
+            CGroupsTelemetry.track_agent(CGroups.for_extension(AGENT_NAME))
         except Exception as e:
             logger.error("monitor: Exception tracking wrapper and agent: {0} [{1}]", e, traceback.format_exc())
 

--- a/azurelinuxagent/ga/monitor.py
+++ b/azurelinuxagent/ga/monitor.py
@@ -21,14 +21,15 @@ import os
 import platform
 import time
 import threading
+import traceback
 import uuid
 
 import azurelinuxagent.common.conf as conf
-import azurelinuxagent.common.utils.fileutil as fileutil
 import azurelinuxagent.common.logger as logger
 from azurelinuxagent.common.errorstate import ErrorState
 
-from azurelinuxagent.common.event import add_event, WALAEventOperation
+from azurelinuxagent.common.cgroups import CGroups, CGroupsTelemetry
+from azurelinuxagent.common.event import add_event, report_metric, WALAEventOperation
 from azurelinuxagent.common.exception import EventError, ProtocolError, OSUtilError, HttpError
 from azurelinuxagent.common.future import ustr
 from azurelinuxagent.common.osutil import get_osutil
@@ -96,6 +97,7 @@ class MonitorHandler(object):
 
     EVENT_COLLECTION_PERIOD = datetime.timedelta(minutes=1)
     TELEMETRY_HEARTBEAT_PERIOD = datetime.timedelta(minutes=30)
+    CGROUP_TELEMETRY_PERIOD = datetime.timedelta(minutes=5)
     # host plugin
     HOST_PLUGIN_HEARTBEAT_PERIOD = datetime.timedelta(minutes=1)
     HOST_PLUGIN_HEALTH_PERIOD = datetime.timedelta(minutes=5)
@@ -111,6 +113,7 @@ class MonitorHandler(object):
         self.event_thread = None
         self.last_event_collection = None
         self.last_telemetry_heartbeat = None
+        self.last_cgroup_telemetry = None
         self.last_host_plugin_heartbeat = None
         self.last_imds_heartbeat = None
         self.protocol = None
@@ -247,11 +250,13 @@ class MonitorHandler(object):
 
     def daemon(self):
         min_delta = min(MonitorHandler.TELEMETRY_HEARTBEAT_PERIOD,
+                        MonitorHandler.CGROUP_TELEMETRY_PERIOD,
                         MonitorHandler.EVENT_COLLECTION_PERIOD,
                         MonitorHandler.HOST_PLUGIN_HEARTBEAT_PERIOD,
                         MonitorHandler.IMDS_HEARTBEAT_PERIOD).seconds
         while self.should_run:
             self.send_telemetry_heartbeat()
+            self.send_cgroup_telemetry()
             self.collect_and_send_events()
             self.send_host_plugin_heartbeat()
             self.send_imds_heartbeat()
@@ -379,3 +384,25 @@ class MonitorHandler(object):
                 logger.warn("Failed to send heartbeat: {0}", e)
 
             self.last_telemetry_heartbeat = datetime.datetime.utcnow()
+
+    def send_cgroup_telemetry(self):
+        if self.last_cgroup_telemetry is None:
+            self.last_cgroup_telemetry = datetime.datetime.utcnow()
+
+        if datetime.datetime.utcnow() >= (self.last_telemetry_heartbeat + MonitorHandler.CGROUP_TELEMETRY_PERIOD):
+            try:
+                for cgroup_name, metrics in CGroupsTelemetry.collect_all_tracked().items():
+                    for metric_group, metric_name, value in metrics:
+                        if value > 0:
+                            report_metric(metric_group, metric_name, cgroup_name, value)
+            except Exception as e:
+                logger.warn("Failed to collect performance metrics: {0} [{1}]", e, traceback.format_exc())
+
+            # Look for extension cgroups we're not already tracking and track them
+            try:
+                ext_handlers_list, incarnation = self.protocol.get_ext_handlers()
+                CGroupsTelemetry.update_tracked(ext_handlers_list.extHandlers)
+            except Exception as e:
+                logger.warn("Monitor: updating tracked extensions raised {0}: {1}", e, traceback.format_exc())
+
+            self.last_cgroup_telemetry = datetime.datetime.utcnow()

--- a/tests/common/test_cgroups.py
+++ b/tests/common/test_cgroups.py
@@ -59,7 +59,8 @@ def make_root_cgroups():
     return CGroups("root", path_maker)
 
 
-@unittest.skip("CGroups cannot be tested within a docker container")
+@unittest.skipIf("TRAVIS" in os.environ and os.environ["TRAVIS"] == "true",
+                 "CGroups cannot be tested within a docker container")
 class TestCGroups(AgentTestCase):
     @classmethod
     def setUpClass(cls):

--- a/tests/common/test_cgroups.py
+++ b/tests/common/test_cgroups.py
@@ -1,0 +1,177 @@
+# Copyright 2018 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Requires Python 2.4+ and Openssl 1.0+
+#
+
+from __future__ import print_function
+
+from azurelinuxagent.common.cgroups import CGroupsTelemetry, CGroups, CGroupsException, BASE_CGROUPS, Cpu
+from tests.tools import *
+
+import os
+import random
+import time
+
+
+def consume_cpu_time():
+    waste = 0
+    for x in range(1, 200000):
+        waste += random.random()
+    return waste
+
+
+def make_self_cgroups():
+    """
+    Build a CGroups object for the cgroup to which this process already belongs
+
+    :return: CGroups containing this process
+    :rtype: CGroups
+    """
+    def path_maker(hierarchy, __):
+        suffix = CGroups.get_my_cgroup_path(CGroups.get_hierarchy_id('cpu'))
+        return os.path.join(BASE_CGROUPS, hierarchy, suffix)
+
+    return CGroups("inplace", path_maker)
+
+
+def make_root_cgroups():
+    """
+    Build a CGroups object for the topmost cgroup
+
+    :return: CGroups for most-encompassing cgroup
+    :rtype: CGroups
+    """
+    def path_maker(hierarchy, _):
+        return os.path.join(BASE_CGROUPS, hierarchy)
+
+    return CGroups("root", path_maker)
+
+
+@unittest.skip("CGroups cannot be tested within a docker container")
+class TestCGroups(AgentTestCase):
+    @classmethod
+    def setUpClass(cls):
+        CGroups.setup(True)
+        super(AgentTestCase, cls).setUpClass()
+
+    def test_cgroup_utilities(self):
+        """
+        Test utilities for querying cgroup metadata
+        """
+        cpu_id = CGroups.get_hierarchy_id('cpu')
+        self.assertGreater(int(cpu_id), 0)
+        memory_id = CGroups.get_hierarchy_id('memory')
+        self.assertGreater(int(memory_id), 0)
+        self.assertNotEqual(cpu_id, memory_id)
+
+    def test_telemetry_inplace(self):
+        """
+        Test raw measures and basic statistics for the cgroup in which this process is currently running.
+        """
+        cg = make_self_cgroups()
+        self.assertIn('cpu', cg.cgroups)
+        self.assertIn('memory', cg.cgroups)
+        ct = CGroupsTelemetry("test", cg)
+        cpu = Cpu(ct)
+        self.assertGreater(cpu.current_system_cpu, 0)
+
+        consume_cpu_time()  # Eat some CPU
+        cpu.update()
+
+        self.assertGreater(cpu.current_cpu_total, cpu.previous_cpu_total)
+        self.assertGreater(cpu.current_system_cpu, cpu.previous_system_cpu)
+
+        percent_used = cpu.get_cpu_percent()
+        self.assertGreater(percent_used, 0)
+
+    def test_telemetry_in_place_non_root(self):
+        """
+        Ensure this (non-root) cgroup has distinct metrics from the root cgroup.
+        """
+        # Does nothing on systems where the default cgroup for a randomly-created process (like this test invocation)
+        # is the root cgroup.
+        cg = make_self_cgroups()
+        root = make_root_cgroups()
+        if cg.cgroups['cpu'] != root.cgroups['cpu']:
+            ct = CGroupsTelemetry("test", cg)
+            cpu = Cpu(ct)
+            self.assertLess(cpu.current_cpu_total, cpu.current_system_cpu)
+
+            consume_cpu_time()  # Eat some CPU
+            time.sleep(1)       # Generate some idle time
+            cpu.update()
+            self.assertLess(cpu.current_cpu_total, cpu.current_system_cpu)
+
+    def test_telemetry_instantiation(self):
+        """
+        Tracking a cgroup for an extension; collect all metrics.
+        """
+        # Record initial state
+        initial_cgroup = make_self_cgroups()
+
+        # Put the process into a different cgroup, consume some resources, ensure we see them end-to-end
+        test_cgroup = CGroups.for_extension("agent_unittest")
+        self.assertIn('cpu', test_cgroup.cgroups)
+        self.assertIn('memory', test_cgroup.cgroups)
+        test_cgroup.add(os.getpid())
+        self.assertNotEqual(initial_cgroup.cgroups['cpu'], test_cgroup.cgroups['cpu'])
+        CGroupsTelemetry.track_cgroup(test_cgroup)
+        self.assertTrue(CGroupsTelemetry.is_tracked("agent_unittest"))
+        consume_cpu_time()
+        time.sleep(1)
+        metrics = CGroupsTelemetry.collect_all_tracked()
+        my_metrics = metrics["agent_unittest"]
+        self.assertEqual(len(my_metrics), 1)
+        metric_family, metric_name, metric_value = my_metrics[0]
+        self.assertEqual(metric_family, "Process")
+        self.assertEqual(metric_name, "% Processor Time")
+        self.assertGreater(metric_value, 0.0)
+
+        # Restore initial state
+        CGroupsTelemetry.stop_tracking("agent_unittest")
+        initial_cgroup.add(os.getpid())
+
+    def test_cpu_telemetry(self):
+        """
+        Test Cpu telemetry class
+        """
+        cg = make_self_cgroups()
+        self.assertIn('cpu', cg.cgroups)
+        self.assertIn('memory', cg.cgroups)
+        ct = CGroupsTelemetry('test', cg)
+        self.assertIs(cg, ct.cgroup)
+        cpu = Cpu(ct)
+        self.assertIs(cg, cpu.cgt.cgroup)
+        ticks_before = cpu.current_cpu_total
+        consume_cpu_time()
+        time.sleep(1)
+        cpu.update()
+        ticks_after = cpu.current_cpu_total
+        self.assertGreater(ticks_after, ticks_before)
+        p2 = cpu.get_cpu_percent()
+        self.assertGreater(p2, 0)
+        self.assertLess(p2, 100)
+
+    def test_format_memory_value(self):
+        """
+        Test formatting of memory amounts into human-readable units
+        """
+        self.assertEqual(-1, CGroups._format_memory_value('bytes', None))
+        self.assertEqual(2048, CGroups._format_memory_value('kilobytes', 2))
+        self.assertEqual(0, CGroups._format_memory_value('kilobytes', 0))
+        self.assertEqual(2048000, CGroups._format_memory_value('kilobytes', 2000))
+        self.assertEqual(2048*1024, CGroups._format_memory_value('megabytes', 2))
+        self.assertEqual((1024 + 512) * 1024 * 1024, CGroups._format_memory_value('gigabytes', 1.5))
+        self.assertRaises(CGroupsException, CGroups._format_memory_value, 'KiloBytes', 1)

--- a/tests/common/test_cgroups.py
+++ b/tests/common/test_cgroups.py
@@ -59,7 +59,7 @@ def make_root_cgroups():
     return CGroups("root", path_maker)
 
 
-@unittest.skipIf(not CGroups.enabled(), "CGroups not supported in this environment")
+@skip_if_predicate_false(CGroups.enabled, "CGroups not supported in this environment")
 class TestCGroups(AgentTestCase):
     @classmethod
     def setUpClass(cls):

--- a/tests/common/test_cgroups.py
+++ b/tests/common/test_cgroups.py
@@ -59,8 +59,7 @@ def make_root_cgroups():
     return CGroups("root", path_maker)
 
 
-@unittest.skipIf("TRAVIS" in os.environ and os.environ["TRAVIS"] == "true",
-                 "CGroups cannot be tested within a docker container")
+@unittest.skipIf(not CGroups.enabled(), "CGroups not supported in this environment")
 class TestCGroups(AgentTestCase):
     @classmethod
     def setUpClass(cls):

--- a/tests/ga/test_monitor.py
+++ b/tests/ga/test_monitor.py
@@ -31,9 +31,9 @@ class TestMonitor(AgentTestCase):
     def test_parse_xml_event(self, *args):
         data_str = load_data('ext/event.xml')
         event = parse_xml_event(data_str)
-        self.assertNotEquals(None, event)
-        self.assertNotEquals(0, event.parameters)
-        self.assertNotEquals(None, event.parameters[0])
+        self.assertNotEqual(None, event)
+        self.assertNotEqual(0, event.parameters)
+        self.assertNotEqual(None, event.parameters[0])
 
     def test_add_sysinfo(self, *args):
         data_str = load_data('ext/event.xml')
@@ -60,28 +60,28 @@ class TestMonitor(AgentTestCase):
         monitor_handler.sysinfo = sysinfo
         monitor_handler.add_sysinfo(event)
 
-        self.assertNotEquals(None, event)
-        self.assertNotEquals(0, event.parameters)
-        self.assertNotEquals(None, event.parameters[0])
+        self.assertNotEqual(None, event)
+        self.assertNotEqual(0, event.parameters)
+        self.assertNotEqual(None, event.parameters[0])
         counter = 0
         for p in event.parameters:
             if p.name == vm_name_param:
-                self.assertEquals(vm_name, p.value)
+                self.assertEqual(vm_name, p.value)
                 counter += 1
             elif p.name == tenant_name_param:
-                self.assertEquals(tenant_name, p.value)
+                self.assertEqual(tenant_name, p.value)
                 counter += 1
             elif p.name == role_name_param:
-                self.assertEquals(role_name, p.value)
+                self.assertEqual(role_name, p.value)
                 counter += 1
             elif p.name == role_instance_name_param:
-                self.assertEquals(role_instance_name, p.value)
+                self.assertEqual(role_instance_name, p.value)
                 counter += 1
             elif p.name == container_id_param:
-                self.assertEquals(container_id, p.value)
+                self.assertEqual(container_id, p.value)
                 counter += 1
 
-        self.assertEquals(5, counter)
+        self.assertEqual(5, counter)
 
     @patch("azurelinuxagent.ga.monitor.MonitorHandler.send_telemetry_heartbeat")
     @patch("azurelinuxagent.ga.monitor.MonitorHandler.collect_and_send_events")
@@ -120,6 +120,7 @@ class TestMonitor(AgentTestCase):
 
         monitor_handler.stop()
 
+    @patch("azurelinuxagent.ga.monitor.MonitorHandler.send_cgroup_telemetry")
     def test_heartbeat_timings_updates_after_window(self, *args):
         monitor_handler = get_monitor_handler()
 
@@ -156,6 +157,7 @@ class TestMonitor(AgentTestCase):
 
         monitor_handler.stop()
 
+    @patch("azurelinuxagent.ga.monitor.MonitorHandler.send_cgroup_telemetry")
     def test_heartbeat_timings_no_updates_within_window(self, *args):
         monitor_handler = get_monitor_handler()
 
@@ -193,6 +195,7 @@ class TestMonitor(AgentTestCase):
         monitor_handler.stop()
 
     @patch("azurelinuxagent.common.protocol.healthservice.HealthService.report_host_plugin_heartbeat")
+    @patch("azurelinuxagent.ga.monitor.MonitorHandler.send_cgroup_telemetry")
     def test_heartbeat_creates_signal(self, patch_report_heartbeat, *args):
         monitor_handler = get_monitor_handler()
         monitor_handler.init_protocols()

--- a/tests/ga/test_monitor.py
+++ b/tests/ga/test_monitor.py
@@ -86,9 +86,11 @@ class TestMonitor(AgentTestCase):
     @patch("azurelinuxagent.ga.monitor.MonitorHandler.send_telemetry_heartbeat")
     @patch("azurelinuxagent.ga.monitor.MonitorHandler.collect_and_send_events")
     @patch("azurelinuxagent.ga.monitor.MonitorHandler.send_host_plugin_heartbeat")
+    @patch("azurelinuxagent.ga.monitor.MonitorHandler.send_cgroup_telemetry")
     @patch("azurelinuxagent.ga.monitor.MonitorHandler.send_imds_heartbeat")
     def test_heartbeats(self,
                         patch_imds_heartbeat,
+                        patch_cgroup_telemetry,
                         patch_hostplugin_heartbeat,
                         patch_send_events,
                         patch_telemetry_heartbeat,
@@ -104,6 +106,7 @@ class TestMonitor(AgentTestCase):
         self.assertEqual(0, patch_send_events.call_count)
         self.assertEqual(0, patch_telemetry_heartbeat.call_count)
         self.assertEqual(0, patch_imds_heartbeat.call_count)
+        self.assertEqual(0, patch_cgroup_telemetry.call_count)
 
         monitor_handler.start()
         time.sleep(1)
@@ -113,6 +116,7 @@ class TestMonitor(AgentTestCase):
         self.assertNotEqual(0, patch_send_events.call_count)
         self.assertNotEqual(0, patch_telemetry_heartbeat.call_count)
         self.assertNotEqual(0, patch_imds_heartbeat.call_count)
+        self.assertNotEqual(0, patch_cgroup_telemetry.call_count)
 
         monitor_handler.stop()
 

--- a/tests/ga/test_monitor.py
+++ b/tests/ga/test_monitor.py
@@ -195,7 +195,6 @@ class TestMonitor(AgentTestCase):
         monitor_handler.stop()
 
     @patch("azurelinuxagent.common.protocol.healthservice.HealthService.report_host_plugin_heartbeat")
-    @patch("azurelinuxagent.ga.monitor.MonitorHandler.send_cgroup_telemetry")
     def test_heartbeat_creates_signal(self, patch_report_heartbeat, *args):
         monitor_handler = get_monitor_handler()
         monitor_handler.init_protocols()

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -63,7 +63,9 @@ _MAX_LENGTH = 120
 
 def skip_if_predicate_false(predicate, message):
     if not predicate():
-        return unittest.skip(message)
+        if hasattr(unittest, "skip"):
+            return unittest.skip(message)
+        return lambda func: None
     return lambda func: func
 
 

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -61,7 +61,13 @@ def _do_nothing():
 _MAX_LENGTH = 120
 
 
-def safe_repr(obj, short=False):
+def skip_if_predicate_false(predicate, message):
+    if not predicate():
+        return unittest.skip(message)
+    return lambda func: func
+
+
+def _safe_repr(obj, short=False):
     """
     Copied from Python 3.x
     """
@@ -115,22 +121,22 @@ class AgentTestCase(unittest.TestCase):
 
     def emulate_assertIn(self, a, b, msg=None):
         if a not in b:
-            msg = msg if msg is not None else "{0} not found in {1}".format(safe_repr(a), safe_repr(b))
+            msg = msg if msg is not None else "{0} not found in {1}".format(_safe_repr(a), _safe_repr(b))
             self.fail(msg)
 
     def emulate_assertNotIn(self, a, b, msg=None):
         if a in b:
-            msg = msg if msg is not None else "{0} unexpectedly found in {1}".format(safe_repr(a), safe_repr(b))
+            msg = msg if msg is not None else "{0} unexpectedly found in {1}".format(_safe_repr(a), _safe_repr(b))
             self.fail(msg)
 
     def emulate_assertGreater(self, a, b, msg=None):
         if not a > b:
-            msg = msg if msg is not None else '{0} not greater than {1}'.format(safe_repr(a), safe_repr(b))
+            msg = msg if msg is not None else '{0} not greater than {1}'.format(_safe_repr(a), _safe_repr(b))
             self.fail(msg)
 
     def emulate_assertLess(self, a, b, msg=None):
         if not a < b:
-            msg = msg if msg is not None else '{0} not less than {1}'.format(safe_repr(a), safe_repr(b))
+            msg = msg if msg is not None else '{0} not less than {1}'.format(_safe_repr(a), _safe_repr(b))
             self.fail(msg)
 
     @staticmethod

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -28,7 +28,7 @@ from functools import wraps
 
 import time
 
-import azurelinuxagent.common.event
+import azurelinuxagent.common.event as event
 import azurelinuxagent.common.conf as conf
 import azurelinuxagent.common.logger as logger
 from azurelinuxagent.common.utils import fileutil
@@ -58,13 +58,39 @@ def _do_nothing():
     pass
 
 
+_MAX_LENGTH = 120
+
+
+def safe_repr(obj, short=False):
+    """
+    Copied from Python 3.x
+    """
+    try:
+        result = repr(obj)
+    except Exception:
+        result = object.__repr__(obj)
+    if not short or len(result) < _MAX_LENGTH:
+        return result
+    return result[:_MAX_LENGTH] + ' [truncated]...'
+
+
 class AgentTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
+        # Setup newer unittest assertions missing in prior versions of Python
+
         if not hasattr(cls, "assertRegex"):
             cls.assertRegex = cls.assertRegexpMatches if hasattr(cls, "assertRegexpMatches") else _do_nothing
         if not hasattr(cls, "assertNotRegex"):
             cls.assertNotRegex = cls.assertNotRegexpMatches if hasattr(cls, "assertNotRegexpMatches") else _do_nothing
+        if not hasattr(cls, "assertIn"):
+            cls.assertIn = cls.emulate_assertIn
+        if not hasattr(cls, "assertNotIn"):
+            cls.assertNotIn = cls.emulate_assertNotIn
+        if not hasattr(cls, "assertGreater"):
+            cls.assertGreater = cls.emulate_assertGreater
+        if not hasattr(cls, "assertLess"):
+            cls.assertLess = cls.emulate_assertLess
 
     def setUp(self):
         prefix = "{0}_".format(self.__class__.__name__)
@@ -80,12 +106,32 @@ class AgentTestCase(unittest.TestCase):
 
         conf.get_agent_pid_file_path = Mock(return_value=os.path.join(self.tmp_dir, "waagent.pid"))
 
-        azurelinuxagent.common.event.init_event_status(self.tmp_dir)
-        azurelinuxagent.common.event.init_event_logger(self.tmp_dir)
+        event.init_event_status(self.tmp_dir)
+        event.init_event_logger(self.tmp_dir)
 
     def tearDown(self):
         if not debug and self.tmp_dir is not None:
             shutil.rmtree(self.tmp_dir)
+
+    def emulate_assertIn(self, a, b, msg=None):
+        if a not in b:
+            msg = msg if msg is not None else "{0} not found in {1}".format(safe_repr(a), safe_repr(b))
+            self.fail(msg)
+
+    def emulate_assertNotIn(self, a, b, msg=None):
+        if a in b:
+            msg = msg if msg is not None else "{0} unexpectedly found in {1}".format(safe_repr(a), safe_repr(b))
+            self.fail(msg)
+
+    def emulate_assertGreater(self, a, b, msg=None):
+        if not a > b:
+            msg = msg if msg is not None else '{0} not greater than {1}'.format(safe_repr(a), safe_repr(b))
+            self.fail(msg)
+
+    def emulate_assertLess(self, a, b, msg=None):
+        if not a < b:
+            msg = msg if msg is not None else '{0} not less than {1}'.format(safe_repr(a), safe_repr(b))
+            self.fail(msg)
 
     @staticmethod
     def _create_files(tmp_dir, prefix, suffix, count, with_sleep=0):


### PR DESCRIPTION
Passes hand smoke-tests on Ubuntu 14.04 (without systemd) and 16.04 (with systemd). Unit tests are disabled to keep Travis from trying to run them; mounting the cgroup device doesn't seem to work terribly well within containers, at least as Travis has them configured.