### PR TITLE
Fix tracking of agent cgroup (correct refactoring of init_cgroups())

### DIFF
--- a/azurelinuxagent/common/cgroups.py
+++ b/azurelinuxagent/common/cgroups.py
@@ -181,7 +181,7 @@ class CGroupsTelemetry(object):
 
         :param str name: Service name (without .service suffix) to be tracked.
         """
-        service_name = "{0}.service".format(name)
+        service_name = "{0}.service".format(name).lower()
         if CGroups.enabled() and not CGroupsTelemetry.is_tracked(service_name):
             cgroup = CGroups.for_systemd_service(service_name)
             tracker = CGroupsTelemetry(service_name, cgroup=cgroup)
@@ -208,19 +208,17 @@ class CGroupsTelemetry(object):
                     CGroupsTelemetry.track_systemd_service(service_name)
 
     @staticmethod
-    def track_agent(name):
+    def track_agent():
         """
         Create and track the correct cgroup for the agent itself. The actual cgroup depends on whether systemd
         is in use, but the caller doesn't need to know that.
-
-        :param str name: Name for the agent itself
         """
         if not CGroups.enabled():
             return
         if CGroups.is_systemd_manager():
-            CGroupsTelemetry.track_systemd_service(name)
+            CGroupsTelemetry.track_systemd_service(AGENT_NAME)
         else:
-            CGroupsTelemetry.track_cgroup(CGroups.for_extension(name))
+            CGroupsTelemetry.track_cgroup(CGroups.for_extension(AGENT_NAME))
 
     @staticmethod
     def is_tracked(name):

--- a/azurelinuxagent/ga/monitor.py
+++ b/azurelinuxagent/ga/monitor.py
@@ -391,7 +391,7 @@ class MonitorHandler(object):
         # Track metrics for the roll-up cgroup and for the agent cgroup
         try:
             CGroupsTelemetry.track_cgroup(CGroups.for_extension(""))
-            CGroupsTelemetry.track_agent(CGroups.for_extension(AGENT_NAME))
+            CGroupsTelemetry.track_agent()
         except Exception as e:
             logger.error("monitor: Exception tracking wrapper and agent: {0} [{1}]", e, traceback.format_exc())
 


### PR DESCRIPTION
Unbreak the breakage cause by the last-minute refactoring of cgroup initialization.