### PR TITLE
Better handling for missing certs

### DIFF
--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -15,16 +15,17 @@
 # limitations under the License.
 #
 # Requires Python 2.6+ and Openssl 1.0+
-
-from datetime import datetime
-
+import datetime
 import json
 import os
 import random
 import re
 import sys
 import time
+import traceback
 import xml.sax.saxutils as saxutils
+
+from datetime import datetime
 
 import azurelinuxagent.common.conf as conf
 import azurelinuxagent.common.utils.fileutil as fileutil
@@ -586,8 +587,7 @@ class WireClient(object):
         try:
             fileutil.write_file(local_file, data)
         except IOError as e:
-            fileutil.clean_ioerror(e,
-                paths=[local_file])
+            fileutil.clean_ioerror(e, paths=[local_file])
             raise ProtocolError("Failed to write cache: {0}".format(e))
 
     @staticmethod
@@ -784,9 +784,9 @@ class WireClient(object):
                 goal_state = None
 
             except Exception as e:
-                log_method = logger.verbose if type(e) is ProtocolError else logger.warn
+                log_method = logger.verbose if type(e) is ProtocolError else logger.error
                 log_method("Exception processing GoalState-related files: "
-                           "{0}".format(ustr(e)))
+                           "{0} [{1}]".format(ustr(e), traceback.format_exc()))
 
                 if retry < max_retry-1:
                     continue

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -784,12 +784,9 @@ class WireClient(object):
                 goal_state = None
 
             except Exception as e:
-                log_method = logger.info \
-                                if type(e) is ProtocolError \
-                                else logger.warn
-                log_method(
-                    "Exception processing GoalState-related files: {0}".format(
-                        ustr(e)))
+                log_method = logger.verbose if type(e) is ProtocolError else logger.warn
+                log_method("Exception processing GoalState-related files: "
+                           "{0}".format(ustr(e)))
 
                 if retry < max_retry-1:
                     continue

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -779,6 +779,9 @@ class WireClient(object):
 
                 return
 
+            except IOError as e:
+                logger.warn("IOError processing goal state, retrying [{0}]", ustr(e))
+
             except ResourceGoneError:
                 logger.info("GoalState is stale -- re-fetching")
                 goal_state = None

--- a/azurelinuxagent/common/utils/cryptutil.py
+++ b/azurelinuxagent/common/utils/cryptutil.py
@@ -49,18 +49,27 @@ class CryptUtil(object):
                 prv_file, crt_file))
 
     def get_pubkey_from_prv(self, file_name):
+        if not os.path.exists(file_name):
+            raise IOError("File not found: {0}", file_name)
+
         cmd = "{0} rsa -in {1} -pubout 2>/dev/null".format(self.openssl_cmd, 
                                                            file_name)
         pub = shellutil.run_get_output(cmd)[1]
         return pub
 
     def get_pubkey_from_crt(self, file_name):
+        if not os.path.exists(file_name):
+            raise IOError("File not found: {0}", file_name)
+
         cmd = "{0} x509 -in {1} -pubkey -noout".format(self.openssl_cmd, 
                                                        file_name)
         pub = shellutil.run_get_output(cmd)[1]
         return pub
 
     def get_thumbprint_from_crt(self, file_name):
+        if not os.path.exists(file_name):
+            raise IOError("File not found: {0}", file_name)
+
         cmd = "{0} x509 -in {1} -fingerprint -noout".format(self.openssl_cmd,
                                                             file_name)
         thumbprint = shellutil.run_get_output(cmd)[1]
@@ -68,6 +77,12 @@ class CryptUtil(object):
         return thumbprint
 
     def decrypt_p7m(self, p7m_file, trans_prv_file, trans_cert_file, pem_file):
+        if not os.path.exists(p7m_file):
+            raise IOError("File not found: {0}", p7m_file)
+
+        if not os.path.exists(trans_prv_file):
+            raise IOError("File not found: {0}", trans_prv_file)
+
         cmd = ("{0} cms -decrypt -in {1} -inkey {2} -recip {3} "
                "| {4} pkcs12 -nodes -password pass: -out {5}"
                "").format(self.openssl_cmd, p7m_file, trans_prv_file, 

--- a/azurelinuxagent/common/utils/cryptutil.py
+++ b/azurelinuxagent/common/utils/cryptutil.py
@@ -61,8 +61,8 @@ class CryptUtil(object):
         return pub
 
     def get_thumbprint_from_crt(self, file_name):
-        cmd="{0} x509 -in {1} -fingerprint -noout".format(self.openssl_cmd, 
-                                                          file_name)
+        cmd = "{0} x509 -in {1} -fingerprint -noout".format(self.openssl_cmd,
+                                                            file_name)
         thumbprint = shellutil.run_get_output(cmd)[1]
         thumbprint = thumbprint.rstrip().split('=')[1].replace(':', '').upper()
         return thumbprint

--- a/azurelinuxagent/common/utils/shellutil.py
+++ b/azurelinuxagent/common/utils/shellutil.py
@@ -76,7 +76,7 @@ def run_get_output(cmd, chk_err=True, log_cmd=True):
     Reports exceptions to Error if chk_err parameter is True
     """
     if log_cmd:
-        logger.verbose(u"Run '{0}'", cmd)
+        logger.verbose(u"Command: [{0}]", cmd)
     try:
         output = subprocess.check_output(cmd,
                                          stderr=subprocess.STDOUT,
@@ -84,22 +84,21 @@ def run_get_output(cmd, chk_err=True, log_cmd=True):
         output = ustr(output,
                       encoding='utf-8',
                       errors="backslashreplace")
+    except subprocess.CalledProcessError as e:
+        output = ustr(e.output,
+                      encoding='utf-8',
+                      errors="backslashreplace")
+        if chk_err:
+            msg = u"Command: [{0}], " \
+                  u"return code: [{1}], " \
+                  u"result: [{2}]".format(cmd, e.returncode, output)
+            logger.error(msg)
+        return e.returncode, output
     except Exception as e:
-        if type(e) is subprocess.CalledProcessError:
-            output = ustr(e.output,
-                        encoding='utf-8',
-                        errors="backslashreplace")
-            if chk_err:
-                if log_cmd:
-                    logger.error(u"Command: '{0}'", e.cmd)
-                logger.error(u"Return code: {0}", e.returncode)
-                logger.error(u"Result: {0}", output)
-            return e.returncode, output
-        else:
-            logger.error(
-                u"'{0}' raised unexpected exception: '{1}'".format(
-                    cmd, ustr(e)))
-            return -1, ustr(e)
+        if chk_err:
+            logger.error(u"Command [{0}] raised unexpected exception: [{1}]"
+                         .format(cmd, ustr(e)))
+        return -1, ustr(e)
     return 0, output
 
 


### PR DESCRIPTION
- slightly more graceful handling of this error case
- logging cleanup
- minor pep8 fixes

This mainly raises an IOError for the case when cert files are not found. For the moment there is no behavior change, just slightly different logging, but now that the errors are handled separately we can decide whether to hide those that are transient.