### PR TITLE
Add tooling to capture route table as a list of RouteEntry objects

### DIFF
--- a/azurelinuxagent/common/osutil/default.py
+++ b/azurelinuxagent/common/osutil/default.py
@@ -807,8 +807,7 @@ class DefaultOSUtil(object):
                 route_list.append(route_obj)
         return route_list
 
-    @staticmethod
-    def get_route_table():
+    def get_route_table(self):
         """
         Construct a list of all network routes known to this system.
 

--- a/azurelinuxagent/common/utils/networkutil.py
+++ b/azurelinuxagent/common/utils/networkutil.py
@@ -1,0 +1,58 @@
+#
+# Copyright 2018 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Requires Python 2.6+ and Openssl 1.0+
+#
+
+
+class RouteEntry(object):
+    """
+    Represents a single route. The destination, gateway, and mask members are hex representations of the IPv4 address in
+    network byte order.
+    """
+    def __init__(self, interface, destination, gateway, mask, flags, metric):
+        self.interface = interface
+        self.destination = destination
+        self.gateway = gateway
+        self.mask = mask
+        self.flags = int(flags, 16)
+        self.metric = int(metric)
+
+    @staticmethod
+    def _net_hex_to_dotted_quad(value):
+        if len(value) != 8:
+            raise Exception("String to dotted quad conversion must be 8 characters")
+        octets = []
+        for idx in range(6, -2, -2):
+            octets.append(str(int(value[idx:idx+2], 16)))
+        return ".".join(octets)
+
+    def destination_quad(self):
+        return self._net_hex_to_dotted_quad(self.destination)
+
+    def gateway_quad(self):
+        return self._net_hex_to_dotted_quad(self.gateway)
+
+    def mask_quad(self):
+        return self._net_hex_to_dotted_quad(self.mask)
+
+    def __str__(self):
+        return "Iface: {0}\tDestination: {1}\tGateway: {2}\tMask: {3}\tFlags: {4}\tMetric: {5}" \
+               .format(self.interface, self.destination_quad(), self.gateway_quad(), self.mask_quad(),
+                       self.flags, self.metric)
+
+    def __repr__(self):
+        return 'RouteEntry("{0}", "{1}", "{2}", "{3}", "{4}", "{5}")'\
+            .format(self.interface, self.destination, self.gateway, self.mask, self.flags, self.metric)

--- a/tests/common/osutil/test_default.py
+++ b/tests/common/osutil/test_default.py
@@ -93,28 +93,40 @@ class TestOSUtil(AgentTestCase):
                         self.assertTrue(msg in ustr(ose))
                         self.assertTrue(patch_run.call_count == 6)
 
-    @patch(actual_get_proc_net_route, return_value=[])
     def test_empty_proc_net_route(self):
-        self.assertEqual(len(osutil.DefaultOSUtil().get_route_table()), 0)
+        routing_table = ""
 
-    @patch(actual_get_proc_net_route, return_value=['Iface\tDestination\tGateway \tFlags\tRefCnt\tUse\tMetric\tMask\t\tMTU\tWindow\tIRTT           '])
+        mo = mock.mock_open(read_data=routing_table)
+        with patch(open_patch(), mo):
+            self.assertEqual(len(osutil.DefaultOSUtil().get_route_table()), 0)
+
     def test_no_routes(self):
-        self.assertEqual(len(osutil.DefaultOSUtil().get_route_table()), 0)
+        routing_table = 'Iface\tDestination\tGateway \tFlags\tRefCnt\tUse\tMetric\tMask\t\tMTU\tWindow\tIRTT        \n'
 
-    @patch(actual_get_proc_net_route, return_value=['Iface\tDestination\tGateway \tFlags\t\tUse\tMetric\t'])
+        mo = mock.mock_open(read_data=routing_table)
+        with patch(open_patch(), mo):
+            self.assertEqual(len(osutil.DefaultOSUtil().get_route_table()), 0)
+
     def test_bogus_proc_net_route(self):
-        self.assertEqual(len(osutil.DefaultOSUtil().get_route_table()), 0)
+        routing_table = 'Iface\tDestination\tGateway \tFlags\t\tUse\tMetric\t\neth0\t00000000\t00000000\t0001\t\t0\t0\n'
 
-    @patch(actual_get_proc_net_route, return_value=[
-        'Iface   Destination     Gateway         Flags   RefCnt  Use     Metric  Mask            MTU     Window  IRTT ',
-        'eth0    00000000        C1BB910A        0003    0       0       0       00000000        0       0       0',
-        'eth0    C0BB910A        00000000        0001    0       0       0       C0FFFFFF        0       0       0',
-        'eth0    10813FA8        C1BB910A        000F    0       0       0       FFFFFFFF        0       0       0',
-        'eth0    FEA9FEA9        C1BB910A        0007    0       0       0       FFFFFFFF        0       0       0',
-        'docker0 002BA8C0        00000000        0001    0       0       10      00FFFFFF        0       0       0'
-    ])
+        mo = mock.mock_open(read_data=routing_table)
+        with patch(open_patch(), mo):
+            self.assertEqual(len(osutil.DefaultOSUtil().get_route_table()), 0)
+
     def test_valid_routes(self):
-        route_list = osutil.DefaultOSUtil().get_route_table()
+        routing_table = \
+            'Iface\tDestination\tGateway \tFlags\tRefCnt\tUse\tMetric\tMask\t\tMTU\tWindow\tIRTT   \n' \
+            'eth0\t00000000\tC1BB910A\t0003\t0\t0\t0\t00000000\t0\t0\t0    \n' \
+            'eth0\tC0BB910A\t00000000\t0001\t0\t0\t0\tC0FFFFFF\t0\t0\t0    \n' \
+            'eth0\t10813FA8\tC1BB910A\t000F\t0\t0\t0\tFFFFFFFF\t0\t0\t0    \n' \
+            'eth0\tFEA9FEA9\tC1BB910A\t0007\t0\t0\t0\tFFFFFFFF\t0\t0\t0    \n' \
+            'docker0\t002BA8C0\t00000000\t0001\t0\t0\t10\t00FFFFFF\t0\t0\t0    \n'
+
+        mo = mock.mock_open(read_data=routing_table)
+        with patch(open_patch(), mo):
+            route_list = osutil.DefaultOSUtil().get_route_table()
+
         self.assertEqual(len(route_list), 5)
         self.assertEqual(route_list[0].gateway_quad(), '10.145.187.193')
         self.assertEqual(route_list[1].gateway_quad(), '0.0.0.0')

--- a/tests/utils/test_network_util.py
+++ b/tests/utils/test_network_util.py
@@ -1,0 +1,43 @@
+# Copyright 2018 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Requires Python 2.6+ and Openssl 1.0+
+#
+
+import errno
+from socket import htonl
+
+
+import azurelinuxagent.common.utils.fileutil as fileutil
+import azurelinuxagent.common.utils.networkutil as networkutil
+
+
+from azurelinuxagent.common.future import ustr
+from tests.tools import *
+
+
+class TestNetworkOperations(AgentTestCase):
+    def test_route_entry(self):
+        interface = "eth0"
+        mask = "C0FFFFFF"    # 255.255.255.192
+        destination = "C0BB910A"    #
+        gateway = "C1BB910A"
+        flags = "1"
+        metric = "0"
+
+        expected = 'Iface: eth0\tDestination: 10.145.187.192\tGateway: 10.145.187.193\tMask: 255.255.255.192\tFlags: 1\tMetric: 0'
+
+        entry = networkutil.RouteEntry(interface, destination, gateway, mask, flags, metric)
+
+        self.assertEqual(str(entry), expected)


### PR DESCRIPTION
This duplicates other functionality in osutil. The goal is to log the route table at startup and when it changes; this PR, and the ones to follow, will deliberately not perturb existing code so as to minimize the possibility of breakage in paths that are known to work. Cleanup issues will be filed to use the common mechanism.