### PR TITLE
Check for cgroups files

### DIFF
--- a/azurelinuxagent/common/cgroups.py
+++ b/azurelinuxagent/common/cgroups.py
@@ -630,6 +630,10 @@ class CGroups(object):
         """
         if hierarchy in self.cgroups:
             parameter_file = self._get_cgroup_file(hierarchy, file_name)
+
+            if not os.path.exists(parameter_file):
+                raise IOError(errno.ENOENT, "File not found", parameter_file)
+
             try:
                 return fileutil.read_file(parameter_file)
             except Exception:
@@ -652,6 +656,9 @@ class CGroups(object):
         try:
             values = self.get_file_contents(hierarchy, parameter_name).splitlines()
             result = values[0]
+        except IOError:
+            # ignore if the file does not exist yet
+            pass
         except IndexError:
             parameter_filename = self._get_cgroup_file(hierarchy, parameter_name)
             logger.periodic(logger.EVERY_DAY, "File {0} is empty but should not be".format(parameter_filename))


### PR DESCRIPTION
- when cgroups files do not exist raise IOError
- ignore errors when the file does not exist yet