### PR TITLE
Clean up fallback logging and telemetry

### DIFF
--- a/tests/protocol/test_hostplugin.py
+++ b/tests/protocol/test_hostplugin.py
@@ -325,8 +325,8 @@ class TestHostPlugin(AgentTestCase):
                     # The agent never logs telemetry event for direct fallback
                     self.assertEqual(1, patch_add_event.call_count)
                     self.assertEqual('ReportStatus', patch_add_event.call_args[1]['op'])
-                    self.assertEqual('direct', patch_add_event.call_args[1]['message'])
-                    self.assertEqual(False, patch_add_event.call_args[1]['is_success'])
+                    self.assertTrue('Falling back to direct' in patch_add_event.call_args[1]['message'])
+                    self.assertEqual(True, patch_add_event.call_args[1]['is_success'])
 
     def test_validate_http_request(self):
         """Validate correct set of data is sent to HostGAPlugin when reporting VM status"""


### PR DESCRIPTION
```
2018/06/28 14:25:45.446696 WARNING ExtHandler direct
2018/06/28 14:25:45.457874 ERROR ExtHandler Event: name=WALinuxAgent, op=ReportStatus, message=direct, duration=0
```
Will now be a telemetry event with the message `Falling back to direct upload: {error}` which is not logged.