### PR TITLE
Correctly exclude tests from packages to be installed 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -222,7 +222,7 @@ setuptools.setup(
     platforms='Linux',
     url='https://github.com/Azure/WALinuxAgent',
     license='Apache License Version 2.0',
-    packages=find_packages(exclude=["tests"]),
+    packages=find_packages(exclude=["tests*"]),
     py_modules=["__main__"],
     install_requires=requires,
     cmdclass={


### PR DESCRIPTION
Currently `tests` package are mistakenly installed. Wildcard is required to specify excluded packages.