### PR TITLE
Updating the osinfo to list

### DIFF
--- a/azurelinuxagent/common/version.py
+++ b/azurelinuxagent/common/version.py
@@ -85,9 +85,9 @@ def get_distro():
     else:
         try:
             # dist() removed in Python 3.7
-            osinfo = platform.dist()
+            osinfo = list(platform.dist()) + ['']
         except:
-            osinfo = ('UNKNOWN', 'FFFF', '')
+            osinfo = ['UNKNOWN', 'FFFF', '', '']
 
     # The platform.py lib has issue with detecting oracle linux distribution.
     # Merge the following patch provided by oracle as a temporary fix.

--- a/tests/common/test_version.py
+++ b/tests/common/test_version.py
@@ -19,12 +19,66 @@ from __future__ import print_function
 
 import textwrap
 
-import mock
+import mock, platform
 
 from azurelinuxagent.common.version import set_current_agent, \
     AGENT_LONG_VERSION, AGENT_VERSION, AGENT_NAME, AGENT_NAME_PATTERN, \
-    get_f5_platform
+    get_f5_platform, get_distro
 from tests.tools import *
+
+
+def freebsd_system():
+    return ["FreeBSD"]
+
+
+def freebsd_system_release(x, y, z):
+    return "10.0"
+
+
+def openbsd_system():
+    return ["OpenBSD"]
+
+
+def openbsd_system_release(x, y, z):
+    return "20.0"
+
+
+def default_system():
+    return [""]
+
+
+def default_system_no_linux_distro():
+    return '', '', ''
+
+
+class TestAgentVersion(AgentTestCase):
+    def setUp(self):
+        AgentTestCase.setUp(self)
+        return
+
+    @mock.patch('platform.system', side_effect=freebsd_system)
+    @mock.patch('re.sub', side_effect=freebsd_system_release)
+    def test_distro_is_correct_format_when_freebsd(self, platform_system_name, mock_variable):
+        osinfo = get_distro()
+        freebsd_list = ['freebsd', "10.0", '', 'freebsd']
+        self.assertListEqual(freebsd_list, osinfo)
+        return
+
+    @mock.patch('platform.system', side_effect=openbsd_system)
+    @mock.patch('re.sub', side_effect=openbsd_system_release)
+    def test_distro_is_correct_format_when_openbsd(self, platform_system_name, mock_variable):
+        osinfo = get_distro()
+        openbsd_list = ['openbsd', "20.0", '', 'openbsd']
+        self.assertListEqual(openbsd_list, osinfo)
+        return
+
+    @mock.patch('platform.system', side_effect=default_system)
+    @mock.patch('platform.dist', side_effect=default_system_no_linux_distro)
+    def test_distro_is_correct_format_when_default_case(self, platform_system_name, default_system_no_linux):
+        osinfo = get_distro()
+        default_list = ['', '', '', '']
+        self.assertListEqual(default_list, osinfo)
+        return
 
 
 class TestCurrentAgentName(AgentTestCase):

--- a/tests/common/test_version.py
+++ b/tests/common/test_version.py
@@ -19,7 +19,7 @@ from __future__ import print_function
 
 import textwrap
 
-import mock, platform
+import mock
 
 from azurelinuxagent.common.version import set_current_agent, \
     AGENT_LONG_VERSION, AGENT_VERSION, AGENT_NAME, AGENT_NAME_PATTERN, \

--- a/tests/common/test_version.py
+++ b/tests/common/test_version.py
@@ -50,6 +50,9 @@ def default_system():
 def default_system_no_linux_distro():
     return '', '', ''
 
+def default_system_exception():
+    raise Exception
+
 
 class TestAgentVersion(AgentTestCase):
     def setUp(self):
@@ -77,6 +80,14 @@ class TestAgentVersion(AgentTestCase):
     def test_distro_is_correct_format_when_default_case(self, platform_system_name, default_system_no_linux):
         osinfo = get_distro()
         default_list = ['', '', '', '']
+        self.assertListEqual(default_list, osinfo)
+        return
+
+    @mock.patch('platform.system', side_effect=default_system)
+    @mock.patch('platform.dist', side_effect=default_system_exception)
+    def test_distro_is_correct_for_exception_case(self, platform_system_name, default_system_no_linux):
+        osinfo = get_distro()
+        default_list = ['unknown', 'FFFF', '', '']
         self.assertListEqual(default_list, osinfo)
         return
 

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -18,8 +18,9 @@
 """
 Define util functions for unit test
 """
-
+import difflib
 import os
+import pprint
 import re
 import shutil
 import tempfile
@@ -279,47 +280,6 @@ class AgentTestCase(unittest.TestCase):
         msg = self._formatMessage(msg, standardMsg)
         self.fail(msg)
 
-
-    # def emulate_assertListEqual(self, list1, list2, msg=None):
-    #     differing = None
-    #     try:
-    #         len1 = len(list1)
-    #     except (TypeError, NotImplementedError):
-    #         differing = 'First list has no length.    Non-sequence?'
-    #
-    #     if differing is None:
-    #         try:
-    #             len2 = len(list2)
-    #         except (TypeError, NotImplementedError):
-    #             differing = 'Second list has no length.    Non-sequence?'
-    #
-    #     if differing is None:
-    #         if list1 == list2:
-    #             return
-    #
-    #         for i in xrange(min(len1, len2)):
-    #             try:
-    #                 item1 = list1[i]
-    #             except (TypeError, IndexError, NotImplementedError):
-    #                 differing += ('\nUnable to index element %d of first %s\n' %
-    #                              (i, 'list'))
-    #                 break
-    #
-    #             try:
-    #                 item2 = list2[i]
-    #             except (TypeError, IndexError, NotImplementedError):
-    #                 differing += ('\nUnable to index element %d of second %s\n' %
-    #                               (i, 'list'))
-    #                 break
-    #
-    #             if item1 != item2:
-    #                 differing += ('\nFirst differing element %d:\n%s\n%s\n' %
-    #                 break
-    #         else:
-    #             if (len1 == len2 and seq_type is None and
-    #                 type(seq1) != type(seq2)):
-    #                 # The sequences are the same, but have differing types.
-    #                 return
 
     @staticmethod
     def _create_files(tmp_dir, prefix, suffix, count, with_sleep=0):

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -60,6 +60,17 @@ def _do_nothing():
 
 _MAX_LENGTH = 120
 
+_MAX_LENGTH_SAFE_REPR = 80
+
+def safe_repr(obj, short=False):
+    try:
+        result = repr(obj)
+    except Exception:
+        result = object.__repr__(obj)
+    if not short or len(result) < _MAX_LENGTH:
+        return result
+    return result[:_MAX_LENGTH_SAFE_REPR] + ' [truncated]...'
+
 
 def skip_if_predicate_false(predicate, message):
     if not predicate():
@@ -111,6 +122,8 @@ class AgentTestCase(unittest.TestCase):
             cls.assertIsNone = cls.emulate_assertIsNone
         if not hasattr(cls, "assertIsNotNone"):
             cls.assertIsNone = cls.emulate_assertIsNotNone
+        if not hasattr(cls, "assertListEqual"):
+            cls.assertListEqual = cls.emulate_assertListEqual
 
     def setUp(self):
         prefix = "{0}_".format(self.__class__.__name__)
@@ -162,6 +175,151 @@ class AgentTestCase(unittest.TestCase):
         if x is None:
             msg = msg if msg is not None else '{0} is None'.format(_safe_repr(x))
             self.fail(msg)
+
+    def emulate_assertListEqual(self, seq1, seq2, msg=None, seq_type=None):
+        """An equality assertion for ordered sequences (like lists and tuples).
+
+        For the purposes of this function, a valid ordered sequence type is one
+        which can be indexed, has a length, and has an equality operator.
+
+        Args:
+            seq1: The first sequence to compare.
+            seq2: The second sequence to compare.
+            seq_type: The expected datatype of the sequences, or None if no
+                    datatype should be enforced.
+            msg: Optional message to use on failure instead of a list of
+                    differences.
+        """
+        if seq_type is not None:
+            seq_type_name = seq_type.__name__
+            if not isinstance(seq1, seq_type):
+                raise self.failureException('First sequence is not a %s: %s'
+                                        % (seq_type_name, safe_repr(seq1)))
+            if not isinstance(seq2, seq_type):
+                raise self.failureException('Second sequence is not a %s: %s'
+                                        % (seq_type_name, safe_repr(seq2)))
+        else:
+            seq_type_name = "sequence"
+
+        differing = None
+        try:
+            len1 = len(seq1)
+        except (TypeError, NotImplementedError):
+            differing = 'First %s has no length.    Non-sequence?' % (
+                    seq_type_name)
+
+        if differing is None:
+            try:
+                len2 = len(seq2)
+            except (TypeError, NotImplementedError):
+                differing = 'Second %s has no length.    Non-sequence?' % (
+                        seq_type_name)
+
+        if differing is None:
+            if seq1 == seq2:
+                return
+
+            seq1_repr = safe_repr(seq1)
+            seq2_repr = safe_repr(seq2)
+            if len(seq1_repr) > 30:
+                seq1_repr = seq1_repr[:30] + '...'
+            if len(seq2_repr) > 30:
+                seq2_repr = seq2_repr[:30] + '...'
+            elements = (seq_type_name.capitalize(), seq1_repr, seq2_repr)
+            differing = '%ss differ: %s != %s\n' % elements
+
+            for i in xrange(min(len1, len2)):
+                try:
+                    item1 = seq1[i]
+                except (TypeError, IndexError, NotImplementedError):
+                    differing += ('\nUnable to index element %d of first %s\n' %
+                                 (i, seq_type_name))
+                    break
+
+                try:
+                    item2 = seq2[i]
+                except (TypeError, IndexError, NotImplementedError):
+                    differing += ('\nUnable to index element %d of second %s\n' %
+                                 (i, seq_type_name))
+                    break
+
+                if item1 != item2:
+                    differing += ('\nFirst differing element %d:\n%s\n%s\n' %
+                                 (i, safe_repr(item1), safe_repr(item2)))
+                    break
+            else:
+                if (len1 == len2 and seq_type is None and
+                    type(seq1) != type(seq2)):
+                    # The sequences are the same, but have differing types.
+                    return
+
+            if len1 > len2:
+                differing += ('\nFirst %s contains %d additional '
+                             'elements.\n' % (seq_type_name, len1 - len2))
+                try:
+                    differing += ('First extra element %d:\n%s\n' %
+                                  (len2, safe_repr(seq1[len2])))
+                except (TypeError, IndexError, NotImplementedError):
+                    differing += ('Unable to index element %d '
+                                  'of first %s\n' % (len2, seq_type_name))
+            elif len1 < len2:
+                differing += ('\nSecond %s contains %d additional '
+                             'elements.\n' % (seq_type_name, len2 - len1))
+                try:
+                    differing += ('First extra element %d:\n%s\n' %
+                                  (len1, safe_repr(seq2[len1])))
+                except (TypeError, IndexError, NotImplementedError):
+                    differing += ('Unable to index element %d '
+                                  'of second %s\n' % (len1, seq_type_name))
+        standardMsg = differing
+        diffMsg = '\n' + '\n'.join(
+            difflib.ndiff(pprint.pformat(seq1).splitlines(),
+                          pprint.pformat(seq2).splitlines()))
+        standardMsg = self._truncateMessage(standardMsg, diffMsg)
+        msg = self._formatMessage(msg, standardMsg)
+        self.fail(msg)
+
+
+    # def emulate_assertListEqual(self, list1, list2, msg=None):
+    #     differing = None
+    #     try:
+    #         len1 = len(list1)
+    #     except (TypeError, NotImplementedError):
+    #         differing = 'First list has no length.    Non-sequence?'
+    #
+    #     if differing is None:
+    #         try:
+    #             len2 = len(list2)
+    #         except (TypeError, NotImplementedError):
+    #             differing = 'Second list has no length.    Non-sequence?'
+    #
+    #     if differing is None:
+    #         if list1 == list2:
+    #             return
+    #
+    #         for i in xrange(min(len1, len2)):
+    #             try:
+    #                 item1 = list1[i]
+    #             except (TypeError, IndexError, NotImplementedError):
+    #                 differing += ('\nUnable to index element %d of first %s\n' %
+    #                              (i, 'list'))
+    #                 break
+    #
+    #             try:
+    #                 item2 = list2[i]
+    #             except (TypeError, IndexError, NotImplementedError):
+    #                 differing += ('\nUnable to index element %d of second %s\n' %
+    #                               (i, 'list'))
+    #                 break
+    #
+    #             if item1 != item2:
+    #                 differing += ('\nFirst differing element %d:\n%s\n%s\n' %
+    #                 break
+    #         else:
+    #             if (len1 == len2 and seq_type is None and
+    #                 type(seq1) != type(seq2)):
+    #                 # The sequences are the same, but have differing types.
+    #                 return
 
     @staticmethod
     def _create_files(tmp_dir, prefix, suffix, count, with_sleep=0):


### PR DESCRIPTION
The issue seen when running on a Mac is

```
======================================================================
ERROR: Failure: TypeError ('tuple' object does not support item assignment)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/varadmeru/work/microsoft/github/WALinuxAgent/venv2.7/lib/python2.7/site-packages/nose/loader.py", line 418, in loadTestsFromName
    addr.filename, addr.module)
  File "/Users/varadmeru/work/microsoft/github/WALinuxAgent/venv2.7/lib/python2.7/site-packages/nose/importer.py", line 47, in importFromPath
    return self.importFromDir(dir_path, fqname)
  File "/Users/varadmeru/work/microsoft/github/WALinuxAgent/venv2.7/lib/python2.7/site-packages/nose/importer.py", line 94, in importFromDir
    mod = load_module(part_fqname, fh, filename, desc)
  File "/Users/varadmeru/work/microsoft/github/WALinuxAgent/tests/test_import.py", line 1, in <module>
    from tests.tools import *
  File "/Users/varadmeru/work/microsoft/github/WALinuxAgent/tests/tools.py", line 31, in <module>
    import azurelinuxagent.common.event as event
  File "/Users/varadmeru/work/microsoft/github/WALinuxAgent/azurelinuxagent/common/event.py", line 33, in <module>
    from azurelinuxagent.common.protocol.restapi import TelemetryEventParam, \
  File "/Users/varadmeru/work/microsoft/github/WALinuxAgent/azurelinuxagent/common/protocol/__init__.py", line 18, in <module>
    from azurelinuxagent.common.protocol.util import get_protocol_util, \
  File "/Users/varadmeru/work/microsoft/github/WALinuxAgent/azurelinuxagent/common/protocol/util.py", line 34, in <module>
    from azurelinuxagent.common.osutil import get_osutil
  File "/Users/varadmeru/work/microsoft/github/WALinuxAgent/azurelinuxagent/common/osutil/__init__.py", line 18, in <module>
    from azurelinuxagent.common.osutil.factory import get_osutil
  File "/Users/varadmeru/work/microsoft/github/WALinuxAgent/azurelinuxagent/common/osutil/factory.py", line 20, in <module>
    from azurelinuxagent.common.version import *
  File "/Users/varadmeru/work/microsoft/github/WALinuxAgent/azurelinuxagent/common/version.py", line 135, in <module>
    __distro__ = get_distro()
  File "/Users/varadmeru/work/microsoft/github/WALinuxAgent/azurelinuxagent/common/version.py", line 110, in get_distro
    osinfo[0] = osinfo[0].strip('"').strip(' ').lower()
TypeError: 'tuple' object does not support item assignment

----------------------------------------------------------------------
Ran 58 tests in 0.104s

FAILED (errors=39)
```

The issue seems to be 
```
    if 'FreeBSD' in platform.system():
        release = re.sub('\-.*\Z', '', ustr(platform.release()))
        osinfo = ['freebsd', release, '', 'freebsd']          <------------------ A
    elif 'OpenBSD' in platform.system():
        release = re.sub('\-.*\Z', '', ustr(platform.release()))
        osinfo = ['openbsd', release, '', 'openbsd']          <------------------ B
    elif 'Linux' in platform.system():
        osinfo = get_linux_distribution(0, 'alpine')
    else:
        try:
            # dist() removed in Python 3.7
            osinfo = platform.dist()          <------------------ C
        except:
            osinfo = ('UNKNOWN', 'FFFF', '')          <------------------ D
```

`A`/`B` are lists (other calls return , whereas `C`/`D` returns a tuple. And for a platforms which are not listed in `A` and `B`, `C` is called, which returns a tuple.