### PR TITLE
Update the timeout mechanism for child processes

### DIFF
--- a/azurelinuxagent/common/version.py
+++ b/azurelinuxagent/common/version.py
@@ -113,7 +113,7 @@ def get_distro():
 
 AGENT_NAME = "WALinuxAgent"
 AGENT_LONG_NAME = "Azure Linux Agent"
-AGENT_VERSION = '2.2.29'
+AGENT_VERSION = '2.2.30'
 AGENT_LONG_VERSION = "{0}-{1}".format(AGENT_NAME, AGENT_VERSION)
 AGENT_DESCRIPTION = """
 The Azure Linux Agent supports the provisioning and running of Linux

--- a/tests/ga/test_update.py
+++ b/tests/ga/test_update.py
@@ -1000,8 +1000,8 @@ class TestUpdate(UpdateTestCase):
         self.assertTrue(2 < len(self.update_handler.agents))
 
         # Purge every other agent
-        kept_agents = self.update_handler.agents[1::2]
-        purged_agents = self.update_handler.agents[::2]
+        kept_agents = self.update_handler.agents[::2]
+        purged_agents = self.update_handler.agents[1::2]
 
         # Reload and assert only the kept agents remain on disk
         self.update_handler.agents = kept_agents


### PR DESCRIPTION
In the past we have used `poll()` to determine whether a child is active. Unfortunately that usage is flawed, and for any forked process this will always return a value. In other words our timeout enforcement has never really worked. 

The last set of changes to use `communicate(timeout)` and `os.kill(pid, 0)` do actually enforce the timeout correctly, but this is a breaking change in behavior, even though it is in the extension contract. As such we have to revert it.

In order to try and capture the process output wherever possible, I have made the following changes:

- for 3.3 and later: block for the initial timeout, then check whether the process is forked. For well-behaved short-lived and non-forking long-lived processes, this will capture output.
- earlier than 3.3: revert to the previous behavior for forked and short lived processes. For long-lived non-forked processes capture the output and terminate the process.