### PR TITLE
Delete JIT accounts

### DIFF
--- a/azurelinuxagent/common/exception.py
+++ b/azurelinuxagent/common/exception.py
@@ -159,3 +159,12 @@ class ResourceGoneError(HttpError):
         if msg is None:
             msg = "Resource is gone"
         super(ResourceGoneError, self).__init__(msg, inner)
+
+
+class RemoteAccessError(AgentError):
+    """
+    Remote Access Error
+    """
+
+    def __init__(self, msg=None, inner=None):
+        super(RemoteAccessError, self).__init__(msg, inner)

--- a/azurelinuxagent/ga/remoteaccess.py
+++ b/azurelinuxagent/ga/remoteaccess.py
@@ -46,7 +46,7 @@ from pwd import getpwall
 from azurelinuxagent.common.errorstate import ErrorState
 
 from azurelinuxagent.common.event import add_event, WALAEventOperation, elapsed_milliseconds
-from azurelinuxagent.common.exception import ExtensionError, ProtocolError
+from azurelinuxagent.common.exception import ExtensionError, ProtocolError, RemoteAccessError
 from azurelinuxagent.common.future import ustr
 from azurelinuxagent.common.protocol.restapi import ExtHandlerStatus, \
                                                     ExtensionStatus, \
@@ -80,6 +80,7 @@ class RemoteAccessHandler(object):
         self.cryptUtil = CryptUtil(conf.get_openssl_cmd())
         self.remote_access = None
         self.incarnation = 0
+        self.error_message = ""
 
     def run(self):
         try:
@@ -90,8 +91,7 @@ class RemoteAccessHandler(object):
                     # something changed. Handle remote access if any.
                     self.incarnation = current_incarnation
                     self.remote_access = self.protocol.client.get_remote_access()
-                    if self.remote_access is not None:
-                        self.handle_remote_access()
+                    self.handle_remote_access()
         except Exception as e:
             msg = u"Exception processing remote access handler: {0} {1}".format(ustr(e), traceback.format_exc())
             logger.error(msg)
@@ -102,19 +102,43 @@ class RemoteAccessHandler(object):
                       message=msg)
 
     def handle_remote_access(self):
+        # Get JIT user accounts.
+        all_users = self.os_util.get_users()
+        existing_jit_users = [u[0] for u in all_users if self.validate_jit_user(u[4])]
+        self.err_message = ""
         if self.remote_access is not None:
-            # Get JIT user accounts.
-            all_users = self.os_util.get_users()
-            jit_users = set()
-            for usr in all_users:
-                if self.validate_jit_user(usr[4]):
-                    jit_users.add(usr[0])
             for acc in self.remote_access.user_list.users:
-                raw_expiration = acc.expiration
-                account_expiration = datetime.strptime(raw_expiration, REMOTE_USR_EXPIRATION_FORMAT)
-                now = datetime.utcnow()
-                if acc.name not in jit_users and now < account_expiration:
-                    self.add_user(acc.name, acc.encrypted_password, account_expiration)
+                try:
+                    raw_expiration = acc.expiration
+                    account_expiration = datetime.strptime(raw_expiration, REMOTE_USR_EXPIRATION_FORMAT)
+                    now = datetime.utcnow()
+                    if acc.name not in existing_jit_users and now < account_expiration:
+                        self.add_user(acc.name, acc.encrypted_password, account_expiration)
+                    elif acc.name in existing_jit_users and now > account_expiration:
+                        # user account expired, delete it.
+                        logger.info("user {0} expired from remote_access".format(acc.name))
+                        self.remove_user(acc.name)
+                except RemoteAccessError as rae:
+                    self.err_message = self.err_message + "Error processing user {0}. Exception: {1}"\
+                        .format(acc.name, ustr(rae))
+            for user in existing_jit_users:
+                try:
+                    if user not in [u.name for u in self.remote_access.user_list.users]:
+                        # user explicitly removed
+                        logger.info("User {0} removed from remote_access".format(user))
+                        self.remove_user(user)
+                except RemoteAccessError as rae:
+                    self.err_message = self.err_message + "Error removing user {0}. Exception: {1}"\
+                        .format(user, ustr(rae))
+        else:
+            # All users removed, remove any remaining JIT accounts.
+            for user in existing_jit_users:
+                try:
+                    logger.info("User {0} removed from remote_access. remote_access empty".format(user))
+                    self.remove_user(user)
+                except RemoteAccessError as rae:
+                    self.err_message = self.err_message + "Error removing user {0}. Exception: {1}"\
+                        .format(user, ustr(rae))
 
     def validate_jit_user(self, comment):
         return comment == REMOTE_ACCESS_ACCOUNT_COMMENT
@@ -122,40 +146,34 @@ class RemoteAccessHandler(object):
     def add_user(self, username, encrypted_password, account_expiration):
         try:
             expiration_date = (account_expiration + timedelta(days=1)).strftime(DATE_FORMAT)
-            logger.verbose("Adding user {0} with expiration date {1}"
-                           .format(username, expiration_date))
+            logger.verbose("Adding user {0} with expiration date {1}".format(username, expiration_date))
             self.os_util.useradd(username, expiration_date, REMOTE_ACCESS_ACCOUNT_COMMENT)
-        except OSError as oe:
-            logger.error("Error adding user {0}. {1}"
-                         .format(username, oe.strerror))
-            return
         except Exception as e:
-            logger.error("Error adding user {0}. {1}".format(username, ustr(e)))
-            return
+            raise RemoteAccessError("Error adding user {0}. {1}".format(username, ustr(e)))
         try:
             prv_key = os.path.join(conf.get_lib_dir(), TRANSPORT_PRIVATE_CERT)
             pwd = self.cryptUtil.decrypt_secret(encrypted_password, prv_key)
             self.os_util.chpasswd(username, pwd, conf.get_password_cryptid(), conf.get_password_crypt_salt_len())
             self.os_util.conf_sudoer(username)
-            logger.info("User '{0}' added successfully with expiration in {1}"
-                        .format(username, expiration_date))
-            return
-        except OSError as oe:
-            self.handle_failed_create(username, oe.strerror)
+            logger.info("User '{0}' added successfully with expiration in {1}".format(username, expiration_date))
         except Exception as e:
-            self.handle_failed_create(username, ustr(e))
+            try:
+                self.handle_failed_create(username)
+            except RemoteAccessError as rae:
+                raise RemoteAccessError("Error adding user {0} and error cleaning up {1}".format(username, ustr(e)), rae)
+            raise RemoteAccessError("Error adding user {0} cleanup successful".format(username), ustr(e))
 
-    def handle_failed_create(self, username, error_message):
-        logger.error("Error creating user {0}. {1}"
-                     .format(username, error_message))
+    def handle_failed_create(self, username):
         try:
             self.delete_user(username)
-        except OSError as oe:
-            logger.error("Failed to clean up after account creation for {0}. {1}"
-                         .format(username, oe.strerror()))
         except Exception as e:
-            logger.error("Failed to clean up after account creation for {0}. {1}"
-                         .format(username, str(e)))
+            raise RemoteAccessError("Failed to clean up after account creation for {0}.".format(username), e)
+
+    def remove_user(self, username):
+        try:
+            self.delete_user(username)
+        except Exception as e:
+            raise RemoteAccessError("Failed to delete user {0}".format(username), e)
 
     def delete_user(self, username):
         self.os_util.del_account(username)

--- a/azurelinuxagent/ga/remoteaccess.py
+++ b/azurelinuxagent/ga/remoteaccess.py
@@ -104,10 +104,10 @@ class RemoteAccessHandler(object):
     def handle_remote_access(self):
         # Get JIT user accounts.
         all_users = self.os_util.get_users()
-        existing_jit_users = {u[0] for u in all_users if self.validate_jit_user(u[4])}
+        existing_jit_users = set(u[0] for u in all_users if self.validate_jit_user(u[4]))
         self.err_message = ""
         if self.remote_access is not None:
-            goal_state_users = {u.name for u in self.remote_access.user_list.users}
+            goal_state_users = set(u.name for u in self.remote_access.user_list.users)
             for acc in self.remote_access.user_list.users:
                 try:
                     raw_expiration = acc.expiration

--- a/tests/ga/test_remoteaccess_handler.py
+++ b/tests/ga/test_remoteaccess_handler.py
@@ -47,14 +47,6 @@ def mock_add_event(name, op, is_success, version, message):
     TestRemoteAccessHandler.eventing_data = (name, op, is_success, version, message)
 
 
-def is_python_version_36():
-    return sys.version_info[0] == 3 and sys.version_info[1] == 6
-
-
-def is_python_version_27():
-    return sys.version_info[0] == 2 and sys.version_info[1] == 7
-
-
 class TestRemoteAccessHandler(AgentTestCase):
     eventing_data = [()]
 
@@ -96,17 +88,10 @@ class TestRemoteAccessHandler(AgentTestCase):
         rah.os_util = MockOSUtil()
         tstpassword = "]aPPEv}uNg1FPnl?"
         tstuser = ""
-        expiration_date = datetime.utcnow() + timedelta(days=1)
+        expiration = datetime.utcnow() + timedelta(days=1)
         pwd = tstpassword
         error = "Error adding user {0}. test exception for bad username".format(tstuser)
-        if is_python_version_36():
-            with self.assertRaisesRegex(RemoteAccessError, error):
-                rah.add_user(tstuser, pwd, expiration_date)
-        elif is_python_version_27():
-            with self.assertRaisesRegexp(RemoteAccessError, error):
-                rah.add_user(tstuser, pwd, expiration_date)
-        else:
-            self.assertRaises(RemoteAccessError, rah.add_user, tstuser, pwd, expiration_date)
+        self.assertRaisesRegex(RemoteAccessError, error, rah.add_user, tstuser, pwd, expiration)
         self.assertEqual(0, len(rah.os_util.get_users()))
         self.assertEqual(0, len(error_messages))
         self.assertEqual(0, len(info_messages))
@@ -119,17 +104,10 @@ class TestRemoteAccessHandler(AgentTestCase):
         rah.os_util = MockOSUtil()
         tstpassword = ""
         tstuser = "foobar"
-        expiration_date = datetime.utcnow() + timedelta(days=1)
+        expiration = datetime.utcnow() + timedelta(days=1)
         pwd = tstpassword
         error = "Error adding user {0} cleanup successful\nInner error: test exception for bad password".format(tstuser)
-        if is_python_version_36():
-            with self.assertRaisesRegex(RemoteAccessError, error):
-                rah.add_user(tstuser, pwd, expiration_date)
-        elif is_python_version_27():
-            with self.assertRaisesRegexp(RemoteAccessError, error):
-                rah.add_user(tstuser, pwd, expiration_date)
-        else:
-            self.assertRaises(RemoteAccessError, rah.add_user, tstuser, pwd, expiration_date)
+        self.assertRaisesRegex(RemoteAccessError, error, rah.add_user, tstuser, pwd, expiration)
         self.assertEqual(0, len(rah.os_util.get_users()))
         self.assertEqual(0, len(error_messages))
         self.assertEqual(1, len(info_messages))
@@ -210,14 +188,7 @@ class TestRemoteAccessHandler(AgentTestCase):
         testuser = "Carl"
         error = "Failed to clean up after account creation for {0}.\n" \
                 "Inner error: test exception, user does not exist to delete".format(testuser)
-        if is_python_version_36():
-            with self.assertRaisesRegex(RemoteAccessError, error):
-                rah.handle_failed_create(testuser)
-        elif is_python_version_27():
-            with self.assertRaisesRegexp(RemoteAccessError, error):
-                rah.handle_failed_create(testuser)
-        else:
-            self.assertRaises(RemoteAccessError, rah.handle_failed_create, testuser)
+        self.assertRaisesRegex(RemoteAccessError, error, rah.handle_failed_create, testuser)
         users = get_user_dictionary(rah.os_util.get_users())
         self.assertEqual(1, len(users.keys()))
         self.assertTrue(testusr in users, "Expected user {0} missing".format(testusr))
@@ -267,14 +238,7 @@ class TestRemoteAccessHandler(AgentTestCase):
         error = "Error adding user foobar cleanup successful\n" \
                 "Inner error: \[CryptError\] Error decoding secret\n" \
                 "Inner error: Incorrect padding".format(tstuser)
-        if is_python_version_36():
-            with self.assertRaisesRegex(RemoteAccessError, error):
-                rah.add_user(tstuser, pwd, expiration)
-        elif is_python_version_27():
-            with self.assertRaisesRegexp(RemoteAccessError, error):
-                rah.add_user(tstuser, pwd, expiration)
-        else:
-            self.assertRaises(RemoteAccessError, rah.add_user, tstuser, pwd, expiration)
+        self.assertRaisesRegex(RemoteAccessError, error, rah.add_user, tstuser, pwd, expiration)
         users = get_user_dictionary(rah.os_util.get_users())
         self.assertEqual(0, len(users))
         self.assertEqual(0, len(error_messages))
@@ -512,14 +476,7 @@ class TestRemoteAccessHandler(AgentTestCase):
         rah = RemoteAccessHandler()
         rah.os_util = MockOSUtil()
         error = "Failed to delete user {0}\nInner error: test exception, bad data".format("")
-        if is_python_version_36():
-            with self.assertRaisesRegex(RemoteAccessError, error):
-                rah.remove_user("")
-        elif is_python_version_27():
-            with self.assertRaisesRegexp(RemoteAccessError, error):
-                rah.remove_user("")
-        else:
-            self.assertRaises(RemoteAccessError, rah.remove_user, "")
+        self.assertRaisesRegex(RemoteAccessError, error, rah.remove_user, "")
 
     def test_remove_user_not_exists(self):
         rah = RemoteAccessHandler()
@@ -527,14 +484,7 @@ class TestRemoteAccessHandler(AgentTestCase):
         user = "bob"
         error = "Failed to delete user {0}\n" \
                 "Inner error: test exception, user does not exist to delete".format(user)
-        if is_python_version_36():
-            with self.assertRaisesRegex(RemoteAccessError, error):
-                rah.remove_user(user)
-        elif is_python_version_27():
-            with self.assertRaisesRegexp(RemoteAccessError, error):
-                rah.remove_user(user)
-        else:
-            self.assertRaises(RemoteAccessError, rah.remove_user, user)
+        self.assertRaisesRegex(RemoteAccessError, error, rah.remove_user, user)
 
     @patch('azurelinuxagent.common.utils.cryptutil.CryptUtil.decrypt_secret',
            return_value="]aPPEv}uNg1FPnl?")

--- a/tests/ga/test_remoteaccess_handler.py
+++ b/tests/ga/test_remoteaccess_handler.py
@@ -43,16 +43,16 @@ def log_error(msg_format, *args):
     error_messages.append(msg_format.format(args))
 
 
-def log_error(msg):
-    error_messages.append(msg)
-
-
 def mock_add_event(name, op, is_success, version, message):
     TestRemoteAccessHandler.eventing_data = (name, op, is_success, version, message)
 
 
 def is_python_version_36():
     return sys.version_info[0] == 3 and sys.version_info[1] == 6
+
+
+def is_python_version_27():
+    return sys.version_info[0] == 2 and sys.version_info[1] == 7
 
 
 class TestRemoteAccessHandler(AgentTestCase):
@@ -102,9 +102,11 @@ class TestRemoteAccessHandler(AgentTestCase):
         if is_python_version_36():
             with self.assertRaisesRegex(RemoteAccessError, error):
                 rah.add_user(tstuser, pwd, expiration_date)
-        else:
+        elif is_python_version_27():
             with self.assertRaisesRegexp(RemoteAccessError, error):
                 rah.add_user(tstuser, pwd, expiration_date)
+        else:
+            self.assertRaises(RemoteAccessError, rah.add_user, tstuser, pwd, expiration_date)
         self.assertEqual(0, len(rah.os_util.get_users()))
         self.assertEqual(0, len(error_messages))
         self.assertEqual(0, len(info_messages))
@@ -123,9 +125,11 @@ class TestRemoteAccessHandler(AgentTestCase):
         if is_python_version_36():
             with self.assertRaisesRegex(RemoteAccessError, error):
                 rah.add_user(tstuser, pwd, expiration_date)
-        else:
+        elif is_python_version_27():
             with self.assertRaisesRegexp(RemoteAccessError, error):
                 rah.add_user(tstuser, pwd, expiration_date)
+        else:
+            self.assertRaises(RemoteAccessError, rah.add_user(tstuser, pwd, expiration_date))
         self.assertEqual(0, len(rah.os_util.get_users()))
         self.assertEqual(0, len(error_messages))
         self.assertEqual(1, len(info_messages))
@@ -209,9 +213,11 @@ class TestRemoteAccessHandler(AgentTestCase):
         if is_python_version_36():
             with self.assertRaisesRegex(RemoteAccessError, error):
                 rah.handle_failed_create(testuser)
-        else:
+        elif is_python_version_27():
             with self.assertRaisesRegexp(RemoteAccessError, error):
                 rah.handle_failed_create(testuser)
+        else:
+            self.assertRaises(RemoteAccessError, rah.handle_failed_create(testuser))
         users = get_user_dictionary(rah.os_util.get_users())
         self.assertEqual(1, len(users.keys()))
         self.assertTrue(testusr in users, "Expected user {0} missing".format(testusr))
@@ -264,9 +270,11 @@ class TestRemoteAccessHandler(AgentTestCase):
         if is_python_version_36():
             with self.assertRaisesRegex(RemoteAccessError, error):
                 rah.add_user(tstuser, pwd, expiration)
-        else:
+        elif is_python_version_27():
             with self.assertRaisesRegexp(RemoteAccessError, error):
                 rah.add_user(tstuser, pwd, expiration)
+        else:
+            self.assertRaises(RemoteAccessError, rah.add_user, tstuser, pwd, expiration)
         users = get_user_dictionary(rah.os_util.get_users())
         self.assertEqual(0, len(users))
         self.assertEqual(0, len(error_messages))
@@ -507,9 +515,11 @@ class TestRemoteAccessHandler(AgentTestCase):
         if is_python_version_36():
             with self.assertRaisesRegex(RemoteAccessError, error):
                 rah.remove_user("")
-        else:
+        elif is_python_version_27():
             with self.assertRaisesRegexp(RemoteAccessError, error):
                 rah.remove_user("")
+        else:
+            self.assertRaises(RemoteAccessError, rah.remove_user, "")
 
     def test_remove_user_not_exists(self):
         rah = RemoteAccessHandler()
@@ -520,9 +530,11 @@ class TestRemoteAccessHandler(AgentTestCase):
         if is_python_version_36():
             with self.assertRaisesRegex(RemoteAccessError, error):
                 rah.remove_user(user)
-        else:
+        elif is_python_version_27():
             with self.assertRaisesRegexp(RemoteAccessError, error):
                 rah.remove_user(user)
+        else:
+            self.assertRaises(RemoteAccessError, rah.remove_user, user)
 
     @patch('azurelinuxagent.common.utils.cryptutil.CryptUtil.decrypt_secret',
            return_value="]aPPEv}uNg1FPnl?")

--- a/tests/ga/test_remoteaccess_handler.py
+++ b/tests/ga/test_remoteaccess_handler.py
@@ -129,7 +129,7 @@ class TestRemoteAccessHandler(AgentTestCase):
             with self.assertRaisesRegexp(RemoteAccessError, error):
                 rah.add_user(tstuser, pwd, expiration_date)
         else:
-            self.assertRaises(RemoteAccessError, rah.add_user(tstuser, pwd, expiration_date))
+            self.assertRaises(RemoteAccessError, rah.add_user, tstuser, pwd, expiration_date)
         self.assertEqual(0, len(rah.os_util.get_users()))
         self.assertEqual(0, len(error_messages))
         self.assertEqual(1, len(info_messages))
@@ -217,7 +217,7 @@ class TestRemoteAccessHandler(AgentTestCase):
             with self.assertRaisesRegexp(RemoteAccessError, error):
                 rah.handle_failed_create(testuser)
         else:
-            self.assertRaises(RemoteAccessError, rah.handle_failed_create(testuser))
+            self.assertRaises(RemoteAccessError, rah.handle_failed_create, testuser)
         users = get_user_dictionary(rah.os_util.get_users())
         self.assertEqual(1, len(users.keys()))
         self.assertTrue(testusr in users, "Expected user {0} missing".format(testusr))

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -167,15 +167,12 @@ class AgentTestCase(unittest.TestCase):
             self.fail(msg)
 
     def emulate_raises_regex(self, exception_type, regex, function, *args, **kwargs):
-        if PY_VERSION_MAJOR == 3 and PY_VERSION_MINOR == 6:
-            with self.assertRaisesRegex(exception_type, regex):
-                function(*args)
-        elif PY_VERSION_MAJOR == 3 and PY_VERSION_MINOR == 7:
+        if PY_VERSION_MAJOR == 2 and PY_VERSION_MINOR == 7:
             with self.assertRaisesRegexp(exception_type, regex):
-                function(*args)
+                function(*args, **kwargs)
         else:
             try:
-                function(*args)
+                function(*args, **kwargs)
             except Exception as e:
                 if re.search(regex, str(e), flags=1) is not None:
                     return

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -167,7 +167,7 @@ class AgentTestCase(unittest.TestCase):
             self.fail(msg)
 
     def emulate_raises_regex(self, exception_type, regex, function, *args, **kwargs):
-        if PY_VERSION_MAJOR == 2 and PY_VERSION_MINOR == 7:
+        if (PY_VERSION_MAJOR == 2 and PY_VERSION_MINOR >= 7) or (PY_VERSION_MAJOR == 3 and PY_VERSION_MINOR >= 2):
             with self.assertRaisesRegexp(exception_type, regex):
                 function(*args, **kwargs)
         else:


### PR DESCRIPTION
Delete flow. The intention here was to also send status back up through the wire service as something exposed to the fabric controller, but after talking with the Host Agent team, we'll need to make some changes their first so that will be implemented at a later date.