### PR TITLE
Fix for test_isloopback

### DIFF
--- a/tests/common/osutil/test_default.py
+++ b/tests/common/osutil/test_default.py
@@ -190,8 +190,11 @@ class TestOSUtil(AgentTestCase):
                 self.assertEqual(('', ''), osutil.DefaultOSUtil().get_first_if())
 
     def test_isloopback(self):
-        self.assertTrue(osutil.DefaultOSUtil().is_loopback('lo'))
-        self.assertFalse(osutil.DefaultOSUtil().is_loopback('eth0'))
+        for iface in osutil.DefaultOSUtil()._get_all_interfaces():
+            if iface == 'lo':
+                self.assertTrue(osutil.DefaultOSUtil().is_loopback(iface))
+            else:
+                self.assertFalse(osutil.DefaultOSUtil().is_loopback(iface))
 
     def test_isprimary(self):
         routing_table = "\

--- a/tests/common/osutil/test_default.py
+++ b/tests/common/osutil/test_default.py
@@ -199,7 +199,7 @@ class TestOSUtil(AgentTestCase):
             else:
                 non_loopback_count += 1
 
-        self.assertEqual(loopback_count, 1, 'Only 1 loopback network interface should exist')
+        self.assertEqual(loopback_count, 1, 'Exactly 1 loopback network interface should exist')
         self.assertGreater(loopback_count, 0, 'At least 1 non-loopback network interface should exist')
 
     def test_isloopback(self):

--- a/tests/common/osutil/test_default.py
+++ b/tests/common/osutil/test_default.py
@@ -189,6 +189,19 @@ class TestOSUtil(AgentTestCase):
             with patch.object(osutil.DefaultOSUtil, '_get_all_interfaces', return_value=fake_ifaces):
                 self.assertEqual(('', ''), osutil.DefaultOSUtil().get_first_if())
 
+    def test_get_all_interfaces(self):
+        loopback_count = 0
+        non_loopback_count = 0
+
+        for iface in osutil.DefaultOSUtil()._get_all_interfaces():
+            if iface == 'lo':
+                loopback_count += 1
+            else:
+                non_loopback_count += 1
+
+        self.assertEqual(loopback_count, 1, 'Only 1 loopback network interface should exist')
+        self.assertGreater(loopback_count, 0, 'At least 1 non-loopback network interface should exist')
+
     def test_isloopback(self):
         for iface in osutil.DefaultOSUtil()._get_all_interfaces():
             if iface == 'lo':


### PR DESCRIPTION
test_isloopback assumes there is a network interface named 'eth0'; this is not true on my system.

Instead, I am enumerating all the interfaces and running the test on all of them.