### PR TITLE
Implementing extension sequencing in azure linux agent

### DIFF
--- a/azurelinuxagent/common/protocol/restapi.py
+++ b/azurelinuxagent/common/protocol/restapi.py
@@ -149,15 +149,12 @@ class Dependency(object):
     """
     Represents an extension upon which another extension is dependent
     handler - the ExtHandler of the dependency
-    exts - the Extension(s) of the dependency
-    timeout - the timeout for the extension to get to the Ready state
-              timeout is expressed in minutes.
+    ext - the Extension of the dependency
     """
 
-    def __init__(self, handler=None, exts=None, timeout=None):
+    def __init__(self, handler=None, ext=None):
         self.handler = handler
-        self.exts = [] if exts is None else exts
-        self.timeout = timeout
+        self.ext = ext
 
 
 class Extension(DataContract):
@@ -188,8 +185,7 @@ class Extension(DataContract):
                 resolved_dependencies.append(
                     Dependency(
                         handler = handler,
-                        exts = [ext for ext in handler.properties.extensions
-                                if ext.name == ext_name]
+                        ext = next((ext for ext in handler.properties.extensions if ext.name == ext_name), None)
                     )
                 )
         self.dependencies = resolved_dependencies

--- a/azurelinuxagent/common/protocol/restapi.py
+++ b/azurelinuxagent/common/protocol/restapi.py
@@ -145,6 +145,21 @@ class VMAgentManifestList(DataContract):
         self.vmAgentManifests = DataContractList(VMAgentManifest)
 
 
+class Dependency(object):
+    """
+    Represents an extension upon which another extension is dependent
+    handler - the ExtHandler of the dependency
+    exts - the Extension(s) of the dependency
+    timeout - the timeout for the extension to get to the Ready state
+              timeout is expressed in minutes.
+    """
+
+    def __init__(self, handler=None, exts=None, timeout=None):
+        self.handler = handler
+        self.exts = exts
+        self.timeout = timeout
+
+
 class Extension(DataContract):
     def __init__(self,
                  name=None,
@@ -161,6 +176,23 @@ class Extension(DataContract):
         self.certificateThumbprint = certificateThumbprint
         self.dependencyLevel = dependencyLevel
         self.dependencies = [] if dependencies is None else dependencies
+
+    def resolve_dependencies(self, ext_handlers):
+        resolved_dependencies = []
+        for (handler_name, ext_name) in self.dependencies:
+            # Gracefully handle garbage cases where handler name does
+            # not exist or is not unique. Same for the extension name.
+            for handler in ext_handlers:
+                if handler_name != handler.name:
+                    continue
+                resolved_dependencies.append(
+                    Dependency(
+                        handler = handler,
+                        exts = [ext for ext in handler.properties.extensions
+                                if ext.name == ext_name]
+                    )
+                )
+        self.dependencies = resolved_dependencies
 
 
 class ExtHandlerProperties(DataContract):

--- a/azurelinuxagent/common/protocol/restapi.py
+++ b/azurelinuxagent/common/protocol/restapi.py
@@ -145,18 +145,6 @@ class VMAgentManifestList(DataContract):
         self.vmAgentManifests = DataContractList(VMAgentManifest)
 
 
-class Dependency(object):
-    """
-    Represents an extension upon which another extension is dependent
-    handler - the ExtHandler of the dependency
-    ext - the Extension of the dependency
-    """
-
-    def __init__(self, handler=None, ext=None):
-        self.handler = handler
-        self.ext = ext
-
-
 class Extension(DataContract):
     def __init__(self,
                  name=None,
@@ -164,31 +152,13 @@ class Extension(DataContract):
                  publicSettings=None,
                  protectedSettings=None,
                  certificateThumbprint=None,
-                 dependencyLevel=0,
-                 dependencies=None):
+                 dependencyLevel=0):
         self.name = name
         self.sequenceNumber = sequenceNumber
         self.publicSettings = publicSettings
         self.protectedSettings = protectedSettings
         self.certificateThumbprint = certificateThumbprint
         self.dependencyLevel = dependencyLevel
-        self.dependencies = [] if dependencies is None else dependencies
-
-    def resolve_dependencies(self, ext_handlers):
-        resolved_dependencies = []
-        for (handler_name, ext_name) in self.dependencies:
-            # Gracefully handle garbage cases where handler name does
-            # not exist or is not unique. Same for the extension name.
-            for handler in ext_handlers:
-                if handler_name != handler.name:
-                    continue
-                resolved_dependencies.append(
-                    Dependency(
-                        handler = handler,
-                        ext = next((ext for ext in handler.properties.extensions if ext.name == ext_name), None)
-                    )
-                )
-        self.dependencies = resolved_dependencies
 
 
 class ExtHandlerProperties(DataContract):

--- a/azurelinuxagent/common/protocol/restapi.py
+++ b/azurelinuxagent/common/protocol/restapi.py
@@ -156,7 +156,7 @@ class Dependency(object):
 
     def __init__(self, handler=None, exts=None, timeout=None):
         self.handler = handler
-        self.exts = exts
+        self.exts = [] if exts is None else exts
         self.timeout = timeout
 
 

--- a/azurelinuxagent/common/protocol/restapi.py
+++ b/azurelinuxagent/common/protocol/restapi.py
@@ -164,7 +164,6 @@ class Extension(DataContract):
 class ExtHandlerProperties(DataContract):
     def __init__(self):
         self.version = None
-        self.dependencyLevel = None
         self.state = None
         self.extensions = DataContractList(Extension)
 

--- a/azurelinuxagent/common/protocol/restapi.py
+++ b/azurelinuxagent/common/protocol/restapi.py
@@ -151,12 +151,16 @@ class Extension(DataContract):
                  sequenceNumber=None,
                  publicSettings=None,
                  protectedSettings=None,
-                 certificateThumbprint=None):
+                 certificateThumbprint=None,
+                 dependencyLevel=0,
+                 dependencies=None):
         self.name = name
         self.sequenceNumber = sequenceNumber
         self.publicSettings = publicSettings
         self.protectedSettings = protectedSettings
         self.certificateThumbprint = certificateThumbprint
+        self.dependencyLevel = dependencyLevel
+        self.dependencies = [] if dependencies is None else dependencies
 
 
 class ExtHandlerProperties(DataContract):
@@ -179,9 +183,11 @@ class ExtHandler(DataContract):
         self.versionUris = DataContractList(ExtHandlerVersionUri)
 
     def sort_key(self):
-        level = self.properties.dependencyLevel
-        if level is None:
+        levels = [e.dependencyLevel for e in self.properties.extensions]
+        if len(levels) == 0:
             level = 0
+        else:
+            level = min(levels)
         # Process uninstall or disabled before enabled, in reverse order
         # remap 0 to -1, 1 to -2, 2 to -3, etc
         if self.properties.state != u"enabled":

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -1530,21 +1530,6 @@ class Certificates(object):
         return file_name
 
 
-class Dependency(object):
-    """
-    Represents an extension upon which another extension is dependent
-    handler - the ExtHandler of the dependency
-    exts - the Extension(s) of the dependency
-    timeout - the timeout for the extension to get to the Ready state
-              timeout is expressed in minutes.
-    """
-
-    def __init__(self, handler=None, exts=None, timeout=None):
-        self.handler = handler
-        self.exts = exts
-        self.timeout = timeout
-
-
 class ExtensionsConfig(object):
     """
     parse ExtensionsConfig, downloading and unpacking them to /var/lib/waagent.
@@ -1593,18 +1578,7 @@ class ExtensionsConfig(object):
 
         for ext_handler in self.ext_handlers.extHandlers:
             for extension in ext_handler.properties.extensions:
-                resolved_dependencies = []
-                for (handler_name, ext_name) in extension.dependencies:
-                    # Gracefully handle garbage cases where handler name does
-                    # not exist or is not unique. Same for the extension name.
-                    handlers = [handler for handler in self.ext_handlers.extHandlers
-                                if handler_name == handler.name]
-                    for handler in handlers:
-                        exts = [e for e in handler.properties.extensions
-                                if ext_name == e.name]
-                        resolved_dependencies.append(
-                            Dependency(handler=handler, exts=exts))
-                extension.dependencies = resolved_dependencies
+                extension.resolve_dependencies(self.ext_handlers.extHandlers)
 
         self.status_upload_blob = findtext(xml_doc, "StatusUploadBlob")
         self.artifacts_profile_blob = findtext(xml_doc, "InVMArtifactsProfileBlob")

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -1622,12 +1622,14 @@ class ExtensionsConfig(object):
             logger.error("Invalid extension settings")
             return
 
+        depends_on_level = 0
         depends_on_node = find(settings[0], "DependsOn")
-
-        try:
-            depends_on_level = int(getattrib(depends_on_node, "dependencyLevel"))
-        except (ValueError, TypeError):
-            depends_on_level = 0
+        if depends_on_node != None:
+            try:
+                depends_on_level = int(getattrib(depends_on_node, "dependencyLevel"))
+            except (ValueError, TypeError):
+                logger.warn("Could not parse dependencyLevel for handler {0}. Setting it to 0".format(name))
+                depends_on_level = 0
 
         for plugin_settings_list in runtime_settings["runtimeSettings"]:
             handler_settings = plugin_settings_list["handlerSettings"]

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -1576,10 +1576,6 @@ class ExtensionsConfig(object):
             self.ext_handlers.extHandlers.append(ext_handler)
             self.parse_plugin_settings(ext_handler, plugin_settings)
 
-        for ext_handler in self.ext_handlers.extHandlers:
-            for extension in ext_handler.properties.extensions:
-                extension.resolve_dependencies(self.ext_handlers.extHandlers)
-
         self.status_upload_blob = findtext(xml_doc, "StatusUploadBlob")
         self.artifacts_profile_blob = findtext(xml_doc, "InVMArtifactsProfileBlob")
 
@@ -1626,25 +1622,12 @@ class ExtensionsConfig(object):
             logger.error("Invalid extension settings")
             return
 
-        depends_on = None
         depends_on_node = find(settings[0], "DependsOn")
-
-        depends_on_name = getattrib(depends_on_node, "name")
-        if depends_on_name == "":
-            depends_on_name = ext_handler.name
 
         try:
             depends_on_level = int(getattrib(depends_on_node, "dependencyLevel"))
         except (ValueError, TypeError):
             depends_on_level = 0
-
-        dependencies = []
-        for dependency in findall(depends_on_node, "DependsOnExtension"):
-            handler_name = getattrib(dependency, "handler")
-            ext_name = getattrib(dependency, "extension")
-            if ext_name == "":
-                ext_name = handler_name
-            dependencies.append((handler_name, ext_name))
 
         for plugin_settings_list in runtime_settings["runtimeSettings"]:
             handler_settings = plugin_settings_list["handlerSettings"]
@@ -1655,9 +1638,7 @@ class ExtensionsConfig(object):
             ext.sequenceNumber = seqNo
             ext.publicSettings = handler_settings.get("publicSettings")
             ext.protectedSettings = handler_settings.get("protectedSettings")
-            if ext.name == depends_on_name:
-                ext.dependencies = dependencies
-                ext.dependencyLevel = depends_on_level
+            ext.dependencyLevel = depends_on_level
             thumbprint = handler_settings.get(
                 "protectedSettingsCertThumbprint")
             ext.certificateThumbprint = thumbprint

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -1640,8 +1640,8 @@ class ExtensionsConfig(object):
 
         dependencies = []
         for dependency in findall(depends_on_node, "DependsOnExtension"):
-            handler_name = gettext(dependency)
-            ext_name = getattrib(dependency, "name")
+            handler_name = getattrib(dependency, "handler")
+            ext_name = getattrib(dependency, "extension")
             if ext_name == "":
                 ext_name = handler_name
             dependencies.append((handler_name, ext_name))

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -1530,6 +1530,21 @@ class Certificates(object):
         return file_name
 
 
+class Dependency(object):
+    """
+    Represents an extension upon which another extension is dependent
+    handler - the ExtHandler of the dependency
+    exts - the Extension(s) of the dependency
+    timeout - the timeout for the extension to get to the Ready state
+              timeout is expressed in minutes.
+    """
+
+    def __init__(self, handler=None, exts=None, timeout=None):
+        self.handler = handler
+        self.exts = exts
+        self.timeout = timeout
+
+
 class ExtensionsConfig(object):
     """
     parse ExtensionsConfig, downloading and unpacking them to /var/lib/waagent.
@@ -1575,6 +1590,21 @@ class ExtensionsConfig(object):
             ext_handler = self.parse_plugin(plugin)
             self.ext_handlers.extHandlers.append(ext_handler)
             self.parse_plugin_settings(ext_handler, plugin_settings)
+
+        for ext_handler in self.ext_handlers.extHandlers:
+            for extension in ext_handler.properties.extensions:
+                resolved_dependencies = []
+                for (handler_name, ext_name) in extension.dependencies:
+                    # Gracefully handle garbage cases where handler name does
+                    # not exist or is not unique. Same for the extension name.
+                    handlers = [handler for handler in self.ext_handlers.extHandlers
+                                if handler_name == handler.name]
+                    for handler in handlers:
+                        exts = [e for e in handler.properties.extensions
+                                if ext_name == e.name]
+                        resolved_dependencies.append(
+                            Dependency(handler=handler, exts=exts))
+                extension.dependencies = resolved_dependencies
 
         self.status_upload_blob = findtext(xml_doc, "StatusUploadBlob")
         self.artifacts_profile_blob = findtext(xml_doc, "InVMArtifactsProfileBlob")

--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -335,9 +335,10 @@ class ExtHandlersHandler(object):
                     time.sleep(10)
                 if (datetime.datetime.utcnow() - begin) > timeout_delta:
                     raise ExtensionError("Timeout waiting for success status "
-                                         "from dependency {}/{} for {}",
-                                         dependency.handler, ext,
-                                         ext_handler.name)
+                                         "from dependency {}/{} for {}"
+                                         "status was: {}".format(
+                                             dependency.handler.name, ext.name,
+                                             ext_handler.name, status))
 
     def handle_ext_handler(self, ext_handler, etag):
         ext_handler_i = ExtHandlerInstance(ext_handler, self.protocol)

--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -333,12 +333,12 @@ class ExtHandlersHandler(object):
 
             self.handle_ext_handler(ext_handler, etag)
 
-    '''
-    Check the status of the previous extension installed.
-    Wait until it becomes success or times out.
-    Return True if it is installed successfully. False if timed out.
-    '''
     def wait_for_prev_handler_installation(self, prev_handler, cur_handler, wait_until):
+        '''
+        Check the status of the previous extension installed.
+        Wait until it becomes success or times out.
+        Return True if it is installed successfully. False if timed out.
+        '''
         # No need to wait on anything for the very first extension
         if prev_handler == None:
             return True
@@ -356,11 +356,11 @@ class ExtHandlersHandler(object):
             # on this one can be skipped processing
             if not success_status:
                 msg = "Timeout waiting for success status " \
-                      "from dependency {0}/{1} for {2}" \
+                      "from dependency {0}/{1} for {2} " \
                       "status was: {3}".format(prev_handler.name,
                                                ext.name,
                                                cur_handler.name,
-                                               status)
+                                               status.status if status != None else None)
                 logger.info(msg)
                 add_event(AGENT_NAME,
                           version=CURRENT_VERSION,

--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -66,6 +66,7 @@ HANDLER_NAME_PATTERN = re.compile(HANDLER_PATTERN+"$", re.IGNORECASE)
 HANDLER_PKG_EXT = ".zip"
 HANDLER_PKG_PATTERN = re.compile(HANDLER_PATTERN + r"\.zip$", re.IGNORECASE)
 
+DEFAULT_EXT_TIMEOUT_MINUTES = 90
 
 def validate_has_key(obj, key, fullname):
     if key not in obj:
@@ -308,22 +309,29 @@ class ExtHandlersHandler(object):
                 logger.info("Extension handling is on hold")
                 return
 
+        dep_level = None
+        deps_wait_until = None
+        handlers_wait_until = datetime.datetime.utcnow()
+
         self.ext_handlers.extHandlers.sort(key=operator.methodcaller('sort_key'))
         for ext_handler in self.ext_handlers.extHandlers:
-            self.wait_on_ext_handler_dependencies(ext_handler)
+            if dep_level != ext_handler.sort_key():
+                dep_level = ext_handler.sort_key()
+                deps_wait_until = handlers_wait_until
+                handlers_wait_until += datetime.timedelta(seconds=(DEFAULT_EXT_TIMEOUT_MINUTES * 60))
+            self.wait_on_ext_handler_dependencies(ext_handler, deps_wait_until)
             self.handle_ext_handler(ext_handler, etag)
 
-    def wait_on_ext_handler_dependencies(self, ext_handler):
+    def wait_on_ext_handler_dependencies(self, ext_handler, wait_until):
         dependencies = sum([e.dependencies for e in ext_handler.properties.extensions], [])
         for dependency in dependencies:
             handler_i = ExtHandlerInstance(dependency.handler, self.protocol)
-            timeout = 90 if dependency.timeout is None else dependency.timeout
-            timeout = datetime.timedelta(seconds=(timeout * 60))
-            begin = datetime.datetime.utcnow()
+            if dependency.timeout is not None and dependency.timeout < DEFAULT_EXT_TIMEOUT_MINUTES:
+                wait_until -= datetime.timedelta(seconds=( (DEFAULT_EXT_TIMEOUT_MINUTES - dependency.timeout) * 60))
             for ext in dependency.exts:
                 success_status, status = handler_i.is_ext_status_success(ext)
                 while not success_status:
-                    if (datetime.datetime.utcnow() - begin) > timeout:
+                    if datetime.datetime.utcnow() > wait_until:
                         raise ExtensionError("Timeout waiting for success status "
                                              "from dependency {}/{} for {}"
                                              "status was: {}".format(

--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -321,6 +321,7 @@ class ExtHandlersHandler(object):
             timeout_delta = datetime.timedelta(seconds=(timeout * 60))
             begin = datetime.datetime.utcnow()
             for ext in dependency.exts:
+                status = None
                 while timeout_delta > (datetime.datetime.utcnow() - begin):
                     status = handler_i.collect_ext_status(ext)
                     if status is None:

--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -120,9 +120,7 @@ def parse_ext_status(ext_status, data):
     ext_status.code = status_data.get('code', 0)
     formatted_message = status_data.get('formattedMessage')
     ext_status.message = parse_formatted_message(formatted_message)
-    substatus_list = status_data.get('substatus')
-    if substatus_list is None:
-        return
+    substatus_list = status_data.get('substatus', [])
     for substatus in substatus_list:
         if substatus is not None:
             ext_status.substatusList.append(parse_ext_substatus(substatus))
@@ -312,9 +310,35 @@ class ExtHandlersHandler(object):
 
         self.ext_handlers.extHandlers.sort(key=operator.methodcaller('sort_key'))
         for ext_handler in self.ext_handlers.extHandlers:
-            # TODO: handle install in sequence, enable in parallel
+            self.wait_on_ext_handler_dependencies(ext_handler)
             self.handle_ext_handler(ext_handler, etag)
-    
+
+    def wait_on_ext_handler_dependencies(self, ext_handler):
+        dependencies = sum([e.dependencies for e in ext_handler.properties.extensions], [])
+        for dependency in dependencies:
+            handler_i = ExtHandlerInstance(dependency.handler, self.protocol)
+            timeout = 90 if dependency.timeout is None else dependency.timeout
+            timeout_delta = datetime.timedelta(seconds=(timeout * 60))
+            begin = datetime.datetime.utcnow()
+            for ext in dependency.exts:
+                while timeout_delta > (datetime.datetime.utcnow() - begin):
+                    status = handler_i.collect_ext_status(ext)
+                    if status is None:
+                        break
+                    all_success = status.status == "success"
+                    for substatus in status.substatusList:
+                        if substatus.status != "success":
+                            all_success = False
+                            break
+                    if all_success:
+                        break
+                    time.sleep(10)
+                if (datetime.datetime.utcnow() - begin) > timeout_delta:
+                    raise ExtensionError("Timeout waiting for success status "
+                                         "from dependency {}/{} for {}",
+                                         dependency.handler, ext,
+                                         ext_handler.name)
+
     def handle_ext_handler(self, ext_handler, etag):
         ext_handler_i = ExtHandlerInstance(ext_handler, self.protocol)
 

--- a/tests/data/wire/ext_conf_sequencing.xml
+++ b/tests/data/wire/ext_conf_sequencing.xml
@@ -15,14 +15,19 @@
   </GAFamilies>
 </GuestAgentExtension>
 <Plugins>
-  <Plugin name="OSTCExtensions.ExampleHandlerLinux" version="1.0.0" location="http://rdfepirv2hknprdstr03.blob.core.windows.net/b01058962be54ceca550a390fa5ff064/Microsoft.OSTCExtensions_ExampleHandlerLinux_asiaeast_manifest.xml" config="" state="enabled" autoUpgrade="false" failoverlocation="http://rdfepirv2hknprdstr04.blob.core.windows.net/b01058962be54ceca550a390fa5ff064/Microsoft.OSTCExtensions_ExampleHandlerLinux_asiaeast_manifest.xml" runAsStartupTask="false" isJson="true" dependencyLevel="2"/>
-  <Plugin name="OSTCExtensions.OtherExampleHandlerLinux" version="1.0.0" location="http://rdfepirv2hknprdstr03.blob.core.windows.net/b01058962be54ceca550a390fa5ff064/Microsoft.OSTCExtensions_OtherExampleHandlerLinux_asiaeast_manifest.xml" config="" state="enabled" autoUpgrade="false" failoverlocation="http://rdfepirv2hknprdstr04.blob.core.windows.net/b01058962be54ceca550a390fa5ff064/Microsoft.OSTCExtensions_OtherExampleHandlerLinux_asiaeast_manifest.xml" runAsStartupTask="false" isJson="true" dependencyLevel="1" />
+  <Plugin name="OSTCExtensions.ExampleHandlerLinux" version="1.0.0" location="http://rdfepirv2hknprdstr03.blob.core.windows.net/b01058962be54ceca550a390fa5ff064/Microsoft.OSTCExtensions_ExampleHandlerLinux_asiaeast_manifest.xml" config="" state="enabled" autoUpgrade="false" failoverlocation="http://rdfepirv2hknprdstr04.blob.core.windows.net/b01058962be54ceca550a390fa5ff064/Microsoft.OSTCExtensions_ExampleHandlerLinux_asiaeast_manifest.xml" runAsStartupTask="false" isJson="true" />
+  <Plugin name="OSTCExtensions.OtherExampleHandlerLinux" version="1.0.0" location="http://rdfepirv2hknprdstr03.blob.core.windows.net/b01058962be54ceca550a390fa5ff064/Microsoft.OSTCExtensions_OtherExampleHandlerLinux_asiaeast_manifest.xml" config="" state="enabled" autoUpgrade="false" failoverlocation="http://rdfepirv2hknprdstr04.blob.core.windows.net/b01058962be54ceca550a390fa5ff064/Microsoft.OSTCExtensions_OtherExampleHandlerLinux_asiaeast_manifest.xml" runAsStartupTask="false" isJson="true" />
 </Plugins>
 <PluginSettings>
   <Plugin name="OSTCExtensions.ExampleHandlerLinux" version="1.0.0">
+    <DependsOn dependencyLevel="2">
+    </DependsOn>
     <RuntimeSettings seqNo="0">{"runtimeSettings":[{"handlerSettings":{"protectedSettingsCertThumbprint":"4037FBF5F1F3014F99B5D6C7799E9B20E6871CB3","protectedSettings":"MIICWgYJK","publicSettings":{"foo":"bar"}}}]}</RuntimeSettings>
   </Plugin>
   <Plugin name="OSTCExtensions.OtherExampleHandlerLinux" version="1.0.0">
+    <DependsOn dependencyLevel="1">
+      <DependsOnExtension>OSTCExtensions.ExampleHandlerLinux</DependsOnExtension>
+    </DependsOn>
     <RuntimeSettings seqNo="0">{"runtimeSettings":[{"handlerSettings":{"protectedSettingsCertThumbprint":"4037FBF5F1F3014F99B5D6C7799E9B20E6871CB3","protectedSettings":"MIICWgYJK","publicSettings":{"foo":"bar"}}}]}</RuntimeSettings>
   </Plugin>
 </PluginSettings>

--- a/tests/data/wire/ext_conf_sequencing.xml
+++ b/tests/data/wire/ext_conf_sequencing.xml
@@ -21,7 +21,7 @@
 <PluginSettings>
   <Plugin name="OSTCExtensions.ExampleHandlerLinux" version="1.0.0">
     <DependsOn dependencyLevel="2">
-      <DependsOnExtension>OSTCExtensions.OtherExampleHandlerLinux</DependsOnExtension>
+      <DependsOnExtension handler="OSTCExtensions.OtherExampleHandlerLinux" />
     </DependsOn>
     <RuntimeSettings seqNo="0">{"runtimeSettings":[{"handlerSettings":{"protectedSettingsCertThumbprint":"4037FBF5F1F3014F99B5D6C7799E9B20E6871CB3","protectedSettings":"MIICWgYJK","publicSettings":{"foo":"bar"}}}]}</RuntimeSettings>
   </Plugin>

--- a/tests/data/wire/ext_conf_sequencing.xml
+++ b/tests/data/wire/ext_conf_sequencing.xml
@@ -21,12 +21,12 @@
 <PluginSettings>
   <Plugin name="OSTCExtensions.ExampleHandlerLinux" version="1.0.0">
     <DependsOn dependencyLevel="2">
+      <DependsOnExtension>OSTCExtensions.OtherExampleHandlerLinux</DependsOnExtension>
     </DependsOn>
     <RuntimeSettings seqNo="0">{"runtimeSettings":[{"handlerSettings":{"protectedSettingsCertThumbprint":"4037FBF5F1F3014F99B5D6C7799E9B20E6871CB3","protectedSettings":"MIICWgYJK","publicSettings":{"foo":"bar"}}}]}</RuntimeSettings>
   </Plugin>
   <Plugin name="OSTCExtensions.OtherExampleHandlerLinux" version="1.0.0">
     <DependsOn dependencyLevel="1">
-      <DependsOnExtension>OSTCExtensions.ExampleHandlerLinux</DependsOnExtension>
     </DependsOn>
     <RuntimeSettings seqNo="0">{"runtimeSettings":[{"handlerSettings":{"protectedSettingsCertThumbprint":"4037FBF5F1F3014F99B5D6C7799E9B20E6871CB3","protectedSettings":"MIICWgYJK","publicSettings":{"foo":"bar"}}}]}</RuntimeSettings>
   </Plugin>

--- a/tests/ga/test_extension.py
+++ b/tests/ga/test_extension.py
@@ -409,8 +409,8 @@ class TestExtension(ExtensionTestCase):
         self.assertTrue(exthandlers_handler.ext_handlers is not None)
         self.assertTrue(exthandlers_handler.ext_handlers.extHandlers is not None)
         self.assertEqual(len(exthandlers_handler.ext_handlers.extHandlers), 2)
-        self.assertEqual(exthandlers_handler.ext_handlers.extHandlers[0].properties.dependencyLevel, 1)
-        self.assertEqual(exthandlers_handler.ext_handlers.extHandlers[1].properties.dependencyLevel, 2)
+        self.assertEqual(exthandlers_handler.ext_handlers.extHandlers[0].properties.extensions[0].dependencyLevel, 1)
+        self.assertEqual(exthandlers_handler.ext_handlers.extHandlers[1].properties.extensions[0].dependencyLevel, 2)
 
         #Test goal state not changed
         exthandlers_handler.run()
@@ -431,8 +431,8 @@ class TestExtension(ExtensionTestCase):
         self._assert_ext_status(protocol.report_ext_status, "success", 1)
 
         self.assertEqual(len(exthandlers_handler.ext_handlers.extHandlers), 2)
-        self.assertEqual(exthandlers_handler.ext_handlers.extHandlers[0].properties.dependencyLevel, 3)
-        self.assertEqual(exthandlers_handler.ext_handlers.extHandlers[1].properties.dependencyLevel, 4)
+        self.assertEqual(exthandlers_handler.ext_handlers.extHandlers[0].properties.extensions[0].dependencyLevel, 3)
+        self.assertEqual(exthandlers_handler.ext_handlers.extHandlers[1].properties.extensions[0].dependencyLevel, 4)
 
         #Test disable
         test_data.goal_state = test_data.goal_state.replace("<Incarnation>2<",
@@ -443,8 +443,8 @@ class TestExtension(ExtensionTestCase):
                                     1, "1.0.0",
                                     expected_handler_name="OSTCExtensions.OtherExampleHandlerLinux")
         self.assertEqual(len(exthandlers_handler.ext_handlers.extHandlers), 2)
-        self.assertEqual(exthandlers_handler.ext_handlers.extHandlers[0].properties.dependencyLevel, 4)
-        self.assertEqual(exthandlers_handler.ext_handlers.extHandlers[1].properties.dependencyLevel, 3)
+        self.assertEqual(exthandlers_handler.ext_handlers.extHandlers[0].properties.extensions[0].dependencyLevel, 4)
+        self.assertEqual(exthandlers_handler.ext_handlers.extHandlers[1].properties.extensions[0].dependencyLevel, 3)
 
         #Test uninstall
         test_data.goal_state = test_data.goal_state.replace("<Incarnation>3<",
@@ -457,8 +457,8 @@ class TestExtension(ExtensionTestCase):
         exthandlers_handler.run()
         self._assert_no_handler_status(protocol.report_vm_status)
         self.assertEqual(len(exthandlers_handler.ext_handlers.extHandlers), 2)
-        self.assertEqual(exthandlers_handler.ext_handlers.extHandlers[0].properties.dependencyLevel, 6)
-        self.assertEqual(exthandlers_handler.ext_handlers.extHandlers[1].properties.dependencyLevel, 5)
+        self.assertEqual(exthandlers_handler.ext_handlers.extHandlers[0].properties.extensions[0].dependencyLevel, 6)
+        self.assertEqual(exthandlers_handler.ext_handlers.extHandlers[1].properties.extensions[0].dependencyLevel, 5)
 
     def test_ext_handler_rollingupgrade(self, *args):
         test_data = WireProtocolData(DATA_FILE_EXT_ROLLINGUPGRADE)

--- a/tests/ga/test_extension.py
+++ b/tests/ga/test_extension.py
@@ -429,6 +429,7 @@ class TestExtension(ExtensionTestCase):
                                                             "<Incarnation>2<")
         test_data.ext_conf = test_data.ext_conf.replace("seqNo=\"0\"",
                                                         "seqNo=\"1\"")
+        # Swap the dependency ordering
         test_data.ext_conf = test_data.ext_conf.replace("dependencyLevel=\"2\"",
                                                         "dependencyLevel=\"3\"")
         test_data.ext_conf = test_data.ext_conf.replace("dependencyLevel=\"1\"",
@@ -442,6 +443,9 @@ class TestExtension(ExtensionTestCase):
         self.assertEqual(exthandlers_handler.ext_handlers.extHandlers[1].properties.extensions[0].dependencyLevel, 4)
 
         #Test disable
+        # In the case of disable, the last extension to be enabled should be
+        # the first extension disabled. The first extension enabled should be
+        # the last one disabled.
         test_data.goal_state = test_data.goal_state.replace("<Incarnation>2<",
                                                             "<Incarnation>3<")
         test_data.ext_conf = test_data.ext_conf.replace("enabled", "disabled")
@@ -454,9 +458,13 @@ class TestExtension(ExtensionTestCase):
         self.assertEqual(exthandlers_handler.ext_handlers.extHandlers[1].properties.extensions[0].dependencyLevel, 3)
 
         #Test uninstall
+        # In the case of uninstall, the last extension to be installed should be
+        # the first extension uninstalled. The first extension installed
+        # should be the last one uninstalled.
         test_data.goal_state = test_data.goal_state.replace("<Incarnation>3<",
                                                             "<Incarnation>4<")
         test_data.ext_conf = test_data.ext_conf.replace("disabled", "uninstall")
+        # Swap the dependency ordering AGAIN
         test_data.ext_conf = test_data.ext_conf.replace("dependencyLevel=\"3\"",
                                                         "dependencyLevel=\"6\"")
         test_data.ext_conf = test_data.ext_conf.replace("dependencyLevel=\"4\"",

--- a/tests/ga/test_extension.py
+++ b/tests/ga/test_extension.py
@@ -18,6 +18,9 @@
 import os.path
 
 from tests.protocol.mockwiredata import *
+
+from azurelinuxagent.common.protocol.wire import Dependency
+from azurelinuxagent.common.protocol.restapi import Extension
 from azurelinuxagent.ga.exthandlers import *
 from azurelinuxagent.common.protocol.wire import WireProtocol
 
@@ -665,6 +668,63 @@ class TestExtension(ExtensionTestCase):
         exthandlers_handler.run()
         self._assert_handler_status(protocol.report_vm_status, "Ready", 1, "1.0.0")
         self._assert_ext_status(protocol.report_ext_status, "error", 0)
+
+    def _test_wait_on_ext_handler_dependencies(self, exthandlers_handler, timeout=None):
+        handler_name = "Handler"
+        exthandler = ExtHandler(name=handler_name)
+        dependency_ext = Extension(name=handler_name)
+        extension = Extension(name=handler_name)
+
+        dependency = Dependency(handler=exthandler, exts=[ dependency_ext ], timeout=timeout)
+        extension.dependencies.append(dependency)
+        exthandler.properties.extensions.append(extension)
+
+        fun = exthandlers_handler.wait_on_ext_handler_dependencies
+        if timeout is None:
+            fun(exthandler)
+        else:
+            expected_msg = "Timeout.*{0}/{1} for {2}".format(handler_name, handler_name, handler_name)
+            self.assertRaisesRegexp(ExtensionError, expected_msg, fun, exthandler)
+
+    def test_wait_on_ext_handler_dependencies_none(self, *args):
+        test_data = WireProtocolData(DATA_FILE)
+        exthandlers_handler, protocol = self._create_mock(test_data, *args)
+
+        ExtHandlerInstance.collect_ext_status = MagicMock(return_value=None)
+        self._test_wait_on_ext_handler_dependencies(exthandlers_handler)
+
+    def test_wait_on_ext_handler_dependencies_success_status(self, *args):
+        test_data = WireProtocolData(DATA_FILE)
+        exthandlers_handler, protocol = self._create_mock(test_data, *args)
+
+        status = ExtensionStatus(seq_no=0)
+        status.status = "success"
+
+        ExtHandlerInstance.collect_ext_status = MagicMock(return_value=status)
+        self._test_wait_on_ext_handler_dependencies(exthandlers_handler)
+
+    def test_wait_on_ext_handler_dependencies_success_status_with_substatus(self, *args):
+        test_data = WireProtocolData(DATA_FILE)
+        exthandlers_handler, protocol = self._create_mock(test_data, *args)
+
+        status = ExtensionStatus(seq_no=0)
+        status.status = "success"
+        substatus = ExtensionSubStatus()
+        substatus.status = "success"
+        status.substatusList.append(substatus)
+
+        ExtHandlerInstance.collect_ext_status = MagicMock(return_value=status)
+        self._test_wait_on_ext_handler_dependencies(exthandlers_handler)
+
+    def test_wait_on_ext_handler_dependencies_timeout(self, *args):
+        test_data = WireProtocolData(DATA_FILE)
+        exthandlers_handler, protocol = self._create_mock(test_data, *args)
+
+        status = ExtensionStatus(seq_no=0)
+        status.status = "error"
+
+        ExtHandlerInstance.collect_ext_status = MagicMock(return_value=status)
+        self._test_wait_on_ext_handler_dependencies(exthandlers_handler, timeout=1)
 
     def test_ext_handler_version_decide_autoupgrade_internalversion(self, *args):
         for internal in [False, True]:

--- a/tests/ga/test_extension.py
+++ b/tests/ga/test_extension.py
@@ -693,7 +693,7 @@ class TestExtension(ExtensionTestCase):
         extension.dependencies.append(dependency)
         exthandler.properties.extensions.append(extension)
 
-        exthandlers_handler.wait_on_ext_handler_dependencies(exthandler)
+        exthandlers_handler.wait_on_ext_handler_dependencies(exthandler, datetime.datetime.utcnow())
 
     def test_wait_on_ext_handler_dependencies_two_exts(self, *args):
         test_data = WireProtocolData(DATA_FILE)
@@ -709,7 +709,7 @@ class TestExtension(ExtensionTestCase):
         exthandler.properties.extensions.append(extension)
 
         ExtHandlerInstance.collect_ext_status = MagicMock(return_value=None)
-        exthandlers_handler.wait_on_ext_handler_dependencies(exthandler)
+        exthandlers_handler.wait_on_ext_handler_dependencies(exthandler, datetime.datetime.utcnow())
 
     def _test_wait_on_ext_handler_dependencies(self, exthandlers_handler, timeout=None):
         handler_name = "Handler"
@@ -723,11 +723,11 @@ class TestExtension(ExtensionTestCase):
 
         fun = exthandlers_handler.wait_on_ext_handler_dependencies
         if timeout is None:
-            fun(exthandler)
+            fun(exthandler, datetime.datetime.utcnow())
         else:
             expected_msg = "Timeout.*{0}/{1} for {2}".format(handler_name, handler_name, handler_name)
             try:
-                self.assertRaisesRegexp(ExtensionError, expected_msg, fun, exthandler)
+                self.assertRaisesRegexp(ExtensionError, expected_msg, fun, exthandler, datetime.datetime.utcnow())
             except AttributeError:
                 pass  # Python 2.6 doesn't like assertRaisesRegexp
                 


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Adding support for extension sequencing in the azure linux agent

Issue # <!-- if any -->
VMSS extensions can be installed and enabled in a sequence by specifying dependsOn property values in the ARM template. CRP processes the dependency data, builds dependency graph and generates dependency level for each extension. The dependency level information is passed on to the VM agent. The VM agent needs to parse the dependency data and install the extensions based on the dependency level.

---

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [x] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).