### PR TITLE
Invalid container configuration

### DIFF
--- a/azurelinuxagent/common/protocol/hostplugin.py
+++ b/azurelinuxagent/common/protocol/hostplugin.py
@@ -118,6 +118,7 @@ class HostPluginProtocol(object):
             if restutil.request_failed(response):
                 error_response = restutil.read_response_error(response)
                 logger.error("HostGAPlugin: Failed Get API versions: {0}".format(error_response))
+                is_healthy = not restutil.request_failed_at_hostplugin(response)
             else:
                 return_val = ustr(remove_bom(response.read()), encoding='utf-8')
                 is_healthy = True

--- a/tests/protocol/test_healthservice.py
+++ b/tests/protocol/test_healthservice.py
@@ -201,6 +201,7 @@ class TestHealthService(AgentTestCase):
         self.assert_status_code(status_code=200, expected_healthy=True)
         self.assert_status_code(status_code=201, expected_healthy=True)
         self.assert_status_code(status_code=302, expected_healthy=True)
+        self.assert_status_code(status_code=400, expected_healthy=True)
         self.assert_status_code(status_code=416, expected_healthy=True)
         self.assert_status_code(status_code=419, expected_healthy=True)
         self.assert_status_code(status_code=429, expected_healthy=True)

--- a/tests/utils/test_rest_util.py
+++ b/tests/utils/test_rest_util.py
@@ -25,6 +25,7 @@ from azurelinuxagent.common.future import httpclient, ustr
 
 from tests.tools import *
 
+
 class TestIOErrorCounter(AgentTestCase):
     def test_increment_hostplugin(self):
         restutil.IOErrorCounter.reset()
@@ -454,6 +455,19 @@ class TestHttpOperations(AgentTestCase):
     def test_http_request_raises_for_resource_gone(self, _http_request, _sleep):
         _http_request.side_effect = [
             Mock(status=httpclient.GONE)
+        ]
+
+        self.assertRaises(ResourceGoneError, restutil.http_get, "https://foo.bar")
+        self.assertEqual(1, _http_request.call_count)
+
+    @patch("time.sleep")
+    @patch("azurelinuxagent.common.utils.restutil._http_request")
+    def test_http_request_raises_for_invalid_container_configuration(self, _http_request, _sleep):
+        def read():
+            return b'{ "errorCode": "InvalidContainerConfiguration", "message": "Invalid request." }'
+
+        _http_request.side_effect = [
+            Mock(status=httpclient.BAD_REQUEST, reason='Bad Request', read=read)
         ]
 
         self.assertRaises(ResourceGoneError, restutil.http_get, "https://foo.bar")


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Issue #1294 

Making requests to HostGAPlugin uses a `container-id` header, which is part of goal state. When a VM live-migrates, or goal state is outdated for another reason, and we make a request with this outdated container-id, we receive a `400` with `InvalidContainerConfiguration`. This should really be a `410`, but in order to address the issue now, the fix is to map these specific `400`s to `410`s. This will trigger a forced goal state update when `_upgrade_available` is called. 

Before this call happens we may try heartbeat against HostGAPlugin, which would fail for the same reason. In that case we should not report failure; this addresses a mismatch in behavior compared to the other APIs we report against. 

---

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes in the description.
- [x] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [x] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).