### PR TITLE
Take wireserver address from option 245 in DHCP lease

### DIFF
--- a/tests/common/osutil/test_default.py
+++ b/tests/common/osutil/test_default.py
@@ -308,12 +308,23 @@ class TestOSUtil(AgentTestCase):
                 self.assertTrue(endpoint is not None)
                 self.assertEqual(endpoint, "168.63.129.16")
 
+    def test_dhcp_lease_custom_dns(self):
+        """
+        Validate that the wireserver address is coming from option 245
+        (on default configurations the address is also available in the domain-name-servers option, but users
+         may set up a custom dns server on their vnet)
+        """
+        with patch.object(glob, "glob", return_value=['/var/lib/dhcp/dhclient.eth0.leases']):
+            with patch(open_patch(), mock.mock_open(read_data=load_data("dhcp.leases.custom.dns"))):
+                endpoint = get_osutil(distro_name='ubuntu', distro_version='14.04').get_dhcp_lease_endpoint()
+                self.assertEqual(endpoint, "168.63.129.16")
+
     def test_dhcp_lease_multi(self):
         with patch.object(glob, "glob", return_value=['/var/lib/dhcp/dhclient.eth0.leases']):
             with patch(open_patch(), mock.mock_open(read_data=load_data("dhcp.leases.multi"))):
                 endpoint = get_osutil(distro_name='ubuntu', distro_version='12.04').get_dhcp_lease_endpoint()
                 self.assertTrue(endpoint is not None)
-                self.assertEqual(endpoint, "second")
+                self.assertEqual(endpoint, "168.63.129.2")
 
     def test_get_total_mem(self):
         """

--- a/tests/data/dhcp.leases.custom.dns
+++ b/tests/data/dhcp.leases.custom.dns
@@ -10,7 +10,7 @@ lease {
   option domain-name-servers invalid;
   option dhcp-renewal-time 4294967295;
   option rfc3442-classless-static-routes 0,10,0,1,1,32,168,63,129,16,10,0,1,1;
-  option unknown-245 a8:3f:81:10;
+  option unknown-245 a8:3f:81:01;
   option dhcp-rebinding-time 4294967295;
   option domain-name "qylsde3bnlhu5dstzf3bav5inc.fx.internal.cloudapp.net";
   renew 0 2152/07/23 23:27:10;
@@ -28,7 +28,7 @@ lease {
   option dhcp-server-identifier 168.63.129.16;
   option domain-name-servers expired;
   option dhcp-renewal-time 4294967295;
-  option unknown-245 a8:3f:81:10;
+  option unknown-245 a8:3f:81:02;
   option dhcp-rebinding-time 4294967295;
   option domain-name "qylsde3bnlhu5dstzf3bav5inc.fx.internal.cloudapp.net";
   renew 4 2015/06/16 16:58:54;

--- a/tests/data/dhcp.leases.custom.dns
+++ b/tests/data/dhcp.leases.custom.dns
@@ -7,34 +7,15 @@ lease {
   option routers 10.0.1.1;
   option dhcp-message-type 5;
   option dhcp-server-identifier 168.63.129.16;
-  option domain-name-servers first;
+  option domain-name-servers invalid;
   option dhcp-renewal-time 4294967295;
   option rfc3442-classless-static-routes 0,10,0,1,1,32,168,63,129,16,10,0,1,1;
-  option unknown-245 a8:3f:81:01;
+  option unknown-245 a8:3f:81:10;
   option dhcp-rebinding-time 4294967295;
   option domain-name "qylsde3bnlhu5dstzf3bav5inc.fx.internal.cloudapp.net";
   renew 0 2152/07/23 23:27:10;
   rebind 0 2152/07/23 23:27:10;
-  expire 0 2152/07/23 23:27:10;
-}
-lease {
-  interface "eth0";
-  fixed-address 10.0.1.4;
-  server-name "RDE41D2D9BB18C";
-  option subnet-mask 255.255.255.0;
-  option dhcp-lease-time 4294967295;
-  option routers 10.0.1.1;
-  option dhcp-message-type 5;
-  option dhcp-server-identifier 168.63.129.16;
-  option domain-name-servers second;
-  option dhcp-renewal-time 4294967295;
-  option rfc3442-classless-static-routes 0,10,0,1,1,32,168,63,129,16,10,0,1,1;
-  option unknown-245 a8:3f:81:02;
-  option dhcp-rebinding-time 4294967295;
-  option domain-name "qylsde3bnlhu5dstzf3bav5inc.fx.internal.cloudapp.net";
-  renew 0 2152/07/23 23:27:10;
-  rebind 0 2152/07/23 23:27:10;
-  expire 0 2152/07/23 23:27:10;
+  expire 0 never;
 }
 lease {
   interface "eth0";
@@ -47,11 +28,29 @@ lease {
   option dhcp-server-identifier 168.63.129.16;
   option domain-name-servers expired;
   option dhcp-renewal-time 4294967295;
+  option unknown-245 a8:3f:81:10;
+  option dhcp-rebinding-time 4294967295;
+  option domain-name "qylsde3bnlhu5dstzf3bav5inc.fx.internal.cloudapp.net";
+  renew 4 2015/06/16 16:58:54;
+  rebind 4 2015/06/16 16:58:54;
+  expire 4 2015/06/16 16:58:54;
+}
+lease {
+  interface "eth0";
+  fixed-address 10.0.1.4;
+  server-name "RDE41D2D9BB18C";
+  option subnet-mask 255.255.255.0;
+  option dhcp-lease-time 4294967295;
+  option routers 10.0.1.1;
+  option dhcp-message-type 5;
+  option dhcp-server-identifier 168.63.129.16;
+  option domain-name-servers 8.8.8.8;
+  option dhcp-renewal-time 4294967295;
   option rfc3442-classless-static-routes 0,10,0,1,1,32,168,63,129,16,10,0,1,1;
-  option unknown-245 a8:3f:81:03;
+  option unknown-245 a8:3f:81:10;
   option dhcp-rebinding-time 4294967295;
   option domain-name "qylsde3bnlhu5dstzf3bav5inc.fx.internal.cloudapp.net";
   renew 0 2152/07/23 23:27:10;
   rebind 0 2152/07/23 23:27:10;
-  expire 0 2012/07/23 23:27:10;
+  expire 0 2152/07/23 23:27:10;
 }


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Fixes #1176

On default vnet configurations, the wireserver address shows up both on domain-name-servers and option 245. Currently we take the address from domain-name-servers. If the vnet has a custom DNS server, domain-name-servers will have the address of that server, not of wireserver. Changed the code to take the address from option 245 instead.

---

### PR information
- [x] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).