### PR TITLE
Extension state cleanup

### DIFF
--- a/azurelinuxagent/pa/deprovision/default.py
+++ b/azurelinuxagent/pa/deprovision/default.py
@@ -19,16 +19,20 @@
 
 import glob
 import os.path
+import re
 import signal
 import sys
 
 import azurelinuxagent.common.conf as conf
 import azurelinuxagent.common.utils.fileutil as fileutil
 import azurelinuxagent.common.utils.shellutil as shellutil
+from azurelinuxagent.common import version
 
 from azurelinuxagent.common.exception import ProtocolError
 from azurelinuxagent.common.osutil import get_osutil
 from azurelinuxagent.common.protocol import get_protocol_util
+from azurelinuxagent.ga.exthandlers import HANDLER_NAME_PATTERN
+
 
 def read_input(message):
     if sys.version_info[0] >= 3:
@@ -118,6 +122,20 @@ class DeprovisionHandler(object):
         actions.append(DeprovisionAction(fileutil.rm_files,
                                          ["/var/lib/NetworkManager/dhclient-*.lease"]))
 
+    def del_ext_handler_files(self, warnings, actions):
+        ext_dirs = [d for d in os.listdir(conf.get_lib_dir())
+                    if os.path.isdir(os.path.join(conf.get_lib_dir(), d))
+                    and re.match(HANDLER_NAME_PATTERN, d) is not None
+                    and not version.is_agent_path(d)]
+
+        for ext_dir in ext_dirs:
+            ext_base = os.path.join(conf.get_lib_dir(), ext_dir)
+            files = glob.glob(os.path.join(ext_base, 'status', '*.status'))
+            files += glob.glob(os.path.join(ext_base, 'config', '*.settings'))
+            files += glob.glob(os.path.join(ext_base, 'config', 'HandlerStatus'))
+
+            if len(files) > 0:
+                actions.append(DeprovisionAction(fileutil.rm_files, files))
 
     def del_lib_dir_files(self, warnings, actions):
         known_files = [
@@ -221,6 +239,7 @@ class DeprovisionHandler(object):
                     include_once=False, deluser=False)
         self.del_dhcp_lease(warnings, actions)
         self.del_lib_dir_files(warnings, actions)
+        self.del_ext_handler_files(warnings, actions)
 
         return warnings, actions
 


### PR DESCRIPTION
## Description

1. On vm or disk migration, clear out status and settings files; fixes #948

Example:
```
/var/lib/waagent/Microsoft.Azure.Extensions.CustomScript-2.0.6/status/*.status
/var/lib/waagent/Microsoft.Azure.Extensions.CustomScript-2.0.6/config/*.settings
/var/lib/waagent/Microsoft.Azure.Extensions.CustomScript-2.0.6/config/HandlerStatus
```

2. When reporting extension status, use the goal-state (current) sequence number, not the largest on disk; fixes #1116

Example:
```
{
  "handlerName": "Microsoft.Azure.Extensions.CustomScript",
  "handlerVersion": "2.0.6",
  "status": "Ready",
  "code": 0,
  "formattedMessage": {
    "lang": "en-US",
    "message": "Plugin enabled"
  },
  "runtimeSettingsStatus": {
**  "sequenceNumber": "366",
    "settingsStatus": {
      "timestampUTC": "2018-06-29T15:36:04Z",
      "status": {
        "name": "Microsoft.Azure.Extensions.CustomScript",
        "operation": "Enable",
        "status": "success",
        "formattedMessage": {
          "lang": "en-US",
          "message": "Enable succeeded: ..."
        }
      }
    }
  }
}
```

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).