### PR TITLE
Verify extension deletion scenario

### DIFF
--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -319,22 +319,13 @@ class ExtHandlersHandler(object):
 
         try:
             state = ext_handler.properties.state
-            max_retries = 5
-            retry_count = 0
-            while ext_handler_i.decide_version(target_state=state) is None:
-                if retry_count >= max_retries:
-                    err_msg = "Unable to find manifest for extension {0}".format(ext_handler_i.ext_handler.name)
-                    ext_handler_i.set_operation(WALAEventOperation.Download)
-                    ext_handler_i.set_handler_status(message=ustr(err_msg), code=-1)
-                    ext_handler_i.report_event(message=ustr(err_msg), is_success=False)
-                    return
-                time.sleep(2**retry_count * 10)
-                retry_count += 1
-            if retry_count != 0:
+            if ext_handler_i.decide_version(target_state=state) is None:
+                err_msg = "Unable to find manifest for extension {0}".format(ext_handler_i.ext_handler.name)
                 ext_handler_i.set_operation(WALAEventOperation.Download)
-                err_msg = "Able to find manifest for extension {0} after {1} failed attempts.".format(
-                    ext_handler_i.ext_handler.name, retry_count)
-                ext_handler_i.report_event(message=ustr(err_msg))
+                ext_handler_i.set_handler_status(message=ustr(err_msg), code=-1)
+                ext_handler_i.report_event(message=ustr(err_msg), is_success=False)
+                return
+
             self.get_artifact_error_state.reset()
             if not ext_handler_i.is_upgrade and self.last_etag == etag:
                 if self.log_etag:

--- a/tests/data/wire/manifest_deletion.xml
+++ b/tests/data/wire/manifest_deletion.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PluginVersionManifest xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+    <Plugins>
+        <Plugin>
+            <Version>1.0.0</Version>
+            <Uris>
+                <Uri>http://foo.bar/zar/OSTCExtensions.ExampleHandlerLinux__1.0.0</Uri>
+            </Uris>
+        </Plugin>
+    </Plugins>
+</PluginVersionManifest>

--- a/tests/protocol/mockwiredata.py
+++ b/tests/protocol/mockwiredata.py
@@ -58,6 +58,10 @@ DATA_FILE_EXT_ROLLINGUPGRADE["ext_conf"] = "wire/ext_conf_upgradeguid.xml"
 DATA_FILE_EXT_SEQUENCING = DATA_FILE.copy()
 DATA_FILE_EXT_SEQUENCING["ext_conf"] = "wire/ext_conf_sequencing.xml"
 
+DATA_FILE_EXT_DELETION = DATA_FILE.copy()
+DATA_FILE_EXT_DELETION["manifest"] = "wire/manifest_deletion.xml"
+
+
 class WireProtocolData(object):
     def __init__(self, data_files=DATA_FILE):
         self.emulate_stale_goal_state = False


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

- since #959 was opened we have made some changes in how we call `decide_version`, this avoids the issue listed
- adds a unit test to verify behavior
- code cleanup to remove retry in `decide_version`, as this wait is not useful
- unit test cleanup so extension tests can be run with cgroups disabled
- closes #959 

---

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [x] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).