### PR TITLE
do not version the extension log folder

### DIFF
--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -1115,8 +1115,7 @@ class ExtHandlerInstance(object):
         return os.path.join(self.get_base_dir(), 'HandlerEnvironment.json')
 
     def get_log_dir(self):
-        return os.path.join(conf.get_ext_log_dir(), self.ext_handler.name,
-                            str(self.ext_handler.properties.version))
+        return os.path.join(conf.get_ext_log_dir(), self.ext_handler.name)
 
 
 class HandlerEnvironment(object):


### PR DESCRIPTION
- extension logs are placed in `/var/log/azure/<ext>-<version` but the version is fluid; it is more useful to have a complete view of extension logs, independent of version
- fixes #1158

---

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [x] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).