### PR TITLE
Fix read_route_table

### DIFF
--- a/azurelinuxagent/common/osutil/default.py
+++ b/azurelinuxagent/common/osutil/default.py
@@ -809,7 +809,7 @@ class DefaultOSUtil(object):
         try:
             with open('/proc/net/route') as routing_table:
                 return list(map(str.strip, routing_table.readlines()))
-        except OSError as e:
+        except Exception as e:
             logger.error("Cannot read route table [{0}]", ustr(e))
 
         return []


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

- when `read_route_table` raises an exception the monitor thread dies, since this is uncaught
- add a broad exception clause to prevent unhandled exceptions
- fixes #1286 

---

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes in the description.
- [x] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [x] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).