### PR TITLE
Stream large downloads to disk

### DIFF
--- a/azurelinuxagent/common/protocol/metadata.py
+++ b/azurelinuxagent/common/protocol/metadata.py
@@ -304,6 +304,17 @@ class MetadataProtocol(Protocol):
                 logger.verbose("Incarnation is out of date. Update goalstate.")
         raise ProtocolError("Exceeded max retry updating goal state")
 
+    def download_ext_handler_pkg(self, uri, destination, headers=None, use_proxy=True):
+        success = False
+        try:
+            resp = restutil.http_get(uri, headers=headers, use_proxy=use_proxy)
+            if restutil.request_succeeded(resp):
+                fileutil.write_file(destination, bytearray(resp.read()), asbin=True)
+                success = True
+        except Exception as e:
+            logger.warn("Failed to download from: {0}".format(uri), e)
+        return success
+
 
 class Certificates(object):
     """

--- a/azurelinuxagent/common/protocol/restapi.py
+++ b/azurelinuxagent/common/protocol/restapi.py
@@ -21,6 +21,7 @@ import azurelinuxagent.common.logger as logger
 import azurelinuxagent.common.utils.restutil as restutil
 from azurelinuxagent.common.exception import ProtocolError, HttpError
 from azurelinuxagent.common.future import ustr
+from azurelinuxagent.common.utils import fileutil
 from azurelinuxagent.common.version import DISTRO_VERSION, DISTRO_NAME, CURRENT_VERSION
 
 
@@ -299,11 +300,13 @@ class TelemetryEventList(DataContract):
     def __init__(self):
         self.events = DataContractList(TelemetryEvent)
 
+
 class RemoteAccessUser(DataContract):
     def __init__(self, name, encrypted_password, expiration):
         self.name = name
         self.encrypted_password = encrypted_password
         self.expiration = expiration
+
 
 class RemoteAccessUsersList(DataContract):
     def __init__(self):
@@ -338,15 +341,8 @@ class Protocol(DataContract):
     def get_artifacts_profile(self):
         raise NotImplementedError()
 
-    def download_ext_handler_pkg(self, uri, headers=None, use_proxy=True):
-        pkg = None
-        try:
-            resp = restutil.http_get(uri, headers=headers, use_proxy=use_proxy)
-            if restutil.request_succeeded(resp):
-                pkg = resp.read()
-        except Exception as e:
-            logger.warn("Failed to download from: {0}".format(uri), e)
-        return pkg
+    def download_ext_handler_pkg(self, uri, destination, headers=None, use_proxy=True):
+        raise NotImplementedError()
 
     def report_provision_status(self, provision_status):
         raise NotImplementedError()

--- a/azurelinuxagent/common/utils/restutil.py
+++ b/azurelinuxagent/common/utils/restutil.py
@@ -52,7 +52,7 @@ RETRY_CODES = [
     httpclient.SERVICE_UNAVAILABLE,
     httpclient.GATEWAY_TIMEOUT,
     httpclient.INSUFFICIENT_STORAGE,
-    429, # Request Rate Limit Exceeded
+    429,  # Request Rate Limit Exceeded
 ]
 
 RESOURCE_GONE_CODES = [
@@ -215,14 +215,14 @@ def _http_request(method, host, rel_uri, port=None, data=None, secure=False,
 
     if secure:
         conn = httpclient.HTTPSConnection(conn_host,
-                                        conn_port,
-                                        timeout=10)
+                                          conn_port,
+                                          timeout=10)
         if use_proxy:
             conn.set_tunnel(host, port)
     else:
         conn = httpclient.HTTPConnection(conn_host,
-                                        conn_port,
-                                        timeout=10)
+                                         conn_port,
+                                         timeout=10)
 
     logger.verbose("HTTP connection [{0}] [{1}] [{2}] [{3}]",
                    method,
@@ -321,8 +321,7 @@ def http_request(method,
 
             if request_failed(resp):
                 if _is_retry_status(resp.status, retry_codes=retry_codes):
-                    msg = '[HTTP Retry] {0} {1} -- Status Code {2}'.format(
-                        method, url, resp.status)
+                    msg = '[HTTP Retry] {0} {1} -- Status Code {2}'.format(method, url, resp.status)
                     # Note if throttled and ensure a safe, minimum number of
                     # retry attempts
                     if _is_throttle_status(resp.status):
@@ -343,25 +342,28 @@ def http_request(method,
             return resp
 
         except httpclient.HTTPException as e:
-            msg = '[HTTP Failed] {0} {1} -- HttpException {2}'.format(
-                method, redact_sas_tokens_in_urls(url), e)
+            clean_url = redact_sas_tokens_in_urls(url)
+            msg = '[HTTP Failed] {0} {1} -- HttpException {2}'.format(method, clean_url, e)
             if _is_retry_exception(e):
                 continue
             break
 
         except IOError as e:
             IOErrorCounter.increment(host=host, port=port)
-            msg = '[HTTP Failed] {0} {1} -- IOError {2}'.format(
-                method, redact_sas_tokens_in_urls(url), e)
+            clean_url = redact_sas_tokens_in_urls(url)
+            msg = '[HTTP Failed] {0} {1} -- IOError {2}'.format(method, clean_url, e)
             continue
 
-    raise HttpError("{0} -- {1} attempts made".format(msg,attempt))
+    raise HttpError("{0} -- {1} attempts made".format(msg, attempt))
 
 
-def http_get(url, headers=None, use_proxy=False,
-                max_retry=DEFAULT_RETRIES,
-                retry_codes=RETRY_CODES,
-                retry_delay=DELAY_IN_SECONDS):
+def http_get(url,
+             headers=None,
+             use_proxy=False,
+             max_retry=DEFAULT_RETRIES,
+             retry_codes=RETRY_CODES,
+             retry_delay=DELAY_IN_SECONDS):
+
     return http_request("GET",
                         url, None, headers=headers,
                         use_proxy=use_proxy,
@@ -370,10 +372,13 @@ def http_get(url, headers=None, use_proxy=False,
                         retry_delay=retry_delay)
 
 
-def http_head(url, headers=None, use_proxy=False,
-                max_retry=DEFAULT_RETRIES,
-                retry_codes=RETRY_CODES,
-                retry_delay=DELAY_IN_SECONDS):
+def http_head(url,
+              headers=None,
+              use_proxy=False,
+              max_retry=DEFAULT_RETRIES,
+              retry_codes=RETRY_CODES,
+              retry_delay=DELAY_IN_SECONDS):
+
     return http_request("HEAD",
                         url, None, headers=headers,
                         use_proxy=use_proxy,
@@ -382,10 +387,14 @@ def http_head(url, headers=None, use_proxy=False,
                         retry_delay=retry_delay)
 
 
-def http_post(url, data, headers=None, use_proxy=False,
-                max_retry=DEFAULT_RETRIES,
-                retry_codes=RETRY_CODES,
-                retry_delay=DELAY_IN_SECONDS):
+def http_post(url,
+              data,
+              headers=None,
+              use_proxy=False,
+              max_retry=DEFAULT_RETRIES,
+              retry_codes=RETRY_CODES,
+              retry_delay=DELAY_IN_SECONDS):
+
     return http_request("POST",
                         url, data, headers=headers,
                         use_proxy=use_proxy,
@@ -394,10 +403,14 @@ def http_post(url, data, headers=None, use_proxy=False,
                         retry_delay=retry_delay)
 
 
-def http_put(url, data, headers=None, use_proxy=False,
-                max_retry=DEFAULT_RETRIES,
-                retry_codes=RETRY_CODES,
-                retry_delay=DELAY_IN_SECONDS):
+def http_put(url,
+             data,
+             headers=None,
+             use_proxy=False,
+             max_retry=DEFAULT_RETRIES,
+             retry_codes=RETRY_CODES,
+             retry_delay=DELAY_IN_SECONDS):
+
     return http_request("PUT",
                         url, data, headers=headers,
                         use_proxy=use_proxy,
@@ -406,10 +419,13 @@ def http_put(url, data, headers=None, use_proxy=False,
                         retry_delay=retry_delay)
 
 
-def http_delete(url, headers=None, use_proxy=False,
+def http_delete(url,
+                headers=None,
+                use_proxy=False,
                 max_retry=DEFAULT_RETRIES,
                 retry_codes=RETRY_CODES,
                 retry_delay=DELAY_IN_SECONDS):
+
     return http_request("DELETE",
                         url, None, headers=headers,
                         use_proxy=use_proxy,

--- a/tests/protocol/test_wire.py
+++ b/tests/protocol/test_wire.py
@@ -16,9 +16,13 @@
 #
 
 import glob
+import stat
+import zipfile
 
 from azurelinuxagent.common import event
 from azurelinuxagent.common.protocol.wire import *
+from azurelinuxagent.common.utils.shellutil import run_get_output
+from tests.common.osutil.test_default import running_under_travis
 from tests.protocol.mockwiredata import *
 
 data_with_bom = b'\xef\xbb\xbfhehe'
@@ -172,6 +176,35 @@ class TestWireProtocol(AgentTestCase):
         self.assertEqual(patch_request.call_count, 1)
         self.assertEqual(patch_http.call_args_list[0][0][1], ext_uri)
         self.assertEqual(patch_http.call_args_list[1][0][1], host_uri)
+
+    @skip_if_predicate_true(running_under_travis, "Travis unit tests should not have external dependencies")
+    def test_download_ext_handler_pkg_stream(self, *args):
+        ext_uri = 'https://dcrdata.blob.core.windows.net/files/packer.zip'
+        tmp = tempfile.mkdtemp()
+        destination = os.path.join(tmp, 'test_download_ext_handler_pkg_stream.zip')
+
+        success = WireProtocol(wireserver_url).download_ext_handler_pkg(ext_uri, destination)
+        self.assertTrue(success)
+        self.assertTrue(os.path.exists(destination))
+
+        # verify size
+        self.assertEqual(18380915, os.stat(destination).st_size)
+
+        # verify unzip
+        zipfile.ZipFile(destination).extractall(tmp)
+        packer = os.path.join(tmp, 'packer')
+        self.assertTrue(os.path.exists(packer))
+        fileutil.chmod(packer, os.stat(packer).st_mode | stat.S_IXUSR)
+
+        # verify unpacked size
+        self.assertEqual(87393596, os.stat(packer).st_size)
+
+        # execute, verify result
+        packer_version = '{0} --version'.format(packer)
+        rc, stdout = run_get_output(packer_version)
+        self.assertEqual(0, rc)
+        self.assertEqual('1.2.5\n', stdout)
+
 
     @patch("azurelinuxagent.common.protocol.wire.WireClient.update_goal_state")
     def test_upload_status_blob_default(self, *args):

--- a/tests/protocol/test_wire.py
+++ b/tests/protocol/test_wire.py
@@ -162,10 +162,11 @@ class TestWireProtocol(AgentTestCase):
     def test_download_ext_handler_pkg_fallback(self, patch_request, patch_get_host, patch_http, *args):
         ext_uri = 'extension_uri'
         host_uri = 'host_uri'
+        destination = 'destination'
         patch_get_host.return_value = HostPluginProtocol(host_uri, 'container_id', 'role_config')
         patch_request.return_value = [host_uri, {}]
 
-        WireProtocol(wireserver_url).download_ext_handler_pkg(ext_uri)
+        WireProtocol(wireserver_url).download_ext_handler_pkg(ext_uri, destination)
 
         self.assertEqual(patch_http.call_count, 2)
         self.assertEqual(patch_request.call_count, 1)


### PR DESCRIPTION
## Description

- when fetching extension packages we should not buffer the entire response content in memory
- manifests, agent downloads, and all other downloads are unchanged
- move the default download implementation out of `Protocol` and into `MetadataProtocol` for clarity
- minor cleanup and layout fixes in restutil
- adds a unit test for large downloads which is disabled in Travis
- closes #1138 

---

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes in the description.
- [x] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [x] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).