### PR TITLE
Enable cgroups by default

### DIFF
--- a/azurelinuxagent/common/osutil/factory.py
+++ b/azurelinuxagent/common/osutil/factory.py
@@ -32,6 +32,7 @@ from .ubuntu import UbuntuOSUtil, Ubuntu12OSUtil, Ubuntu14OSUtil, \
 from .alpine import AlpineOSUtil
 from .bigip import BigIpOSUtil
 from .gaia import GaiaOSUtil
+from .iosxe import IosxeOSUtil
 
 from distutils.version import LooseVersion as Version
 

--- a/azurelinuxagent/common/osutil/ubuntu.py
+++ b/azurelinuxagent/common/osutil/ubuntu.py
@@ -16,20 +16,12 @@
 # Requires Python 2.6+ and Openssl 1.0+
 #
 
-import os
-import platform
 import time
 
 import azurelinuxagent.common.logger as logger
-import azurelinuxagent.common.utils.fileutil as fileutil
 import azurelinuxagent.common.utils.shellutil as shellutil
 
-from azurelinuxagent.common.future import ustr
 from azurelinuxagent.common.osutil.default import DefaultOSUtil
-
-
-def _cgroup_path(tail=""):
-    return os.path.join('/sys/fs/cgroup/', tail).rstrip(os.path.sep)
 
 
 class Ubuntu14OSUtil(DefaultOSUtil):
@@ -56,40 +48,6 @@ class Ubuntu14OSUtil(DefaultOSUtil):
     def get_dhcp_lease_endpoint(self):
         return self.get_endpoint_from_leases_path('/var/lib/dhcp/dhclient.*.leases')
 
-    def is_cgroups_supported(self):
-        is_wsl = '-Microsoft-' in platform.platform()
-        is_travis = 'TRAVIS' in os.environ and os.environ['TRAVIS'] == 'true'
-        return not is_wsl and not is_travis
-
-    def mount_cgroups(self):
-        try:
-            if not os.path.exists(_cgroup_path()):
-                fileutil.mkdir(_cgroup_path())
-                self.mount(device='cgroup_root',
-                           mount_point=_cgroup_path(),
-                           option="-t tmpfs",
-                           chk_err=False)
-            elif not os.path.isdir(_cgroup_path()):
-                logger.error("Could not mount cgroups: ordinary file at {0}".format(_cgroup_path()))
-                return
-
-            for metric_hierarchy in ['cpu,cpuacct', 'memory']:
-                target_path = _cgroup_path(metric_hierarchy)
-                if not os.path.exists(target_path):
-                    fileutil.mkdir(target_path)
-                self.mount(device=metric_hierarchy,
-                           mount_point=target_path,
-                           option="-t cgroup -o {0}".format(metric_hierarchy),
-                           chk_err=False)
-
-            for metric_hierarchy in ['cpu', 'cpuacct']:
-                target_path = _cgroup_path(metric_hierarchy)
-                if not os.path.exists(target_path):
-                    os.symlink(_cgroup_path('cpu,cpuacct'), target_path)
-
-        except Exception as e:
-            logger.error("Could not mount cgroups: {0}", ustr(e))
-
 
 class Ubuntu12OSUtil(Ubuntu14OSUtil):
     def __init__(self):
@@ -102,6 +60,7 @@ class Ubuntu12OSUtil(Ubuntu14OSUtil):
 
     def mount_cgroups(self):
         pass
+
 
 class Ubuntu16OSUtil(Ubuntu14OSUtil):
     """
@@ -179,9 +138,3 @@ class UbuntuSnappyOSUtil(Ubuntu14OSUtil):
     def __init__(self):
         super(UbuntuSnappyOSUtil, self).__init__()
         self.conf_file_path = '/apps/walinuxagent/current/waagent.conf'
-
-    def mount_cgroups(self):
-        """
-        Already mounted in Snappy
-        """
-        pass

--- a/azurelinuxagent/common/version.py
+++ b/azurelinuxagent/common/version.py
@@ -116,7 +116,7 @@ def get_distro():
 
 AGENT_NAME = "WALinuxAgent"
 AGENT_LONG_NAME = "Azure Linux Agent"
-AGENT_VERSION = '2.2.31.1'
+AGENT_VERSION = '2.2.31.2'
 AGENT_LONG_VERSION = "{0}-{1}".format(AGENT_NAME, AGENT_VERSION)
 AGENT_DESCRIPTION = """
 The Azure Linux Agent supports the provisioning and running of Linux

--- a/tests/ga/test_update.py
+++ b/tests/ga/test_update.py
@@ -1000,8 +1000,8 @@ class TestUpdate(UpdateTestCase):
         self.assertTrue(2 < len(self.update_handler.agents))
 
         # Purge every other agent
-        kept_agents = self.update_handler.agents[1::2]
-        purged_agents = self.update_handler.agents[::2]
+        kept_agents = self.update_handler.agents[::2]
+        purged_agents = self.update_handler.agents[1::2]
 
         # Reload and assert only the kept agents remain on disk
         self.update_handler.agents = kept_agents


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Issue #1316 

This is the first commit for #1316, which enables cgroups by default for all distros. It maintains the ability to override distro-specific functionality as part of the OS factory mechanism. 

- move cgroups implementation to the default osutil class
- cleanup the cgroups setup and logging
- update the agent version to 2.2.31.2

---

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [x] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).