### PR TITLE
Keep track of the agent's current version

### DIFF
--- a/tests/ga/test_update.py
+++ b/tests/ga/test_update.py
@@ -999,12 +999,23 @@ class TestUpdate(UpdateTestCase):
         # Ensure at least three agents initially exist
         self.assertTrue(2 < len(self.update_handler.agents))
 
-        # Purge every other agent
-        kept_agents = self.update_handler.agents[::2]
-        purged_agents = self.update_handler.agents[1::2]
+        # Purge every other agent. Don't add the current version to agents_to_keep explicitly;
+        # the current version is never purged
+        agents_to_keep = []
+        kept_agents = []
+        purged_agents = []
+        for i in range(0, len(self.update_handler.agents)):
+            if self.update_handler.agents[i].version == CURRENT_VERSION:
+                kept_agents.append(self.update_handler.agents[i])
+            else:
+                if i % 2 == 0:
+                    agents_to_keep.append(self.update_handler.agents[i])
+                    kept_agents.append(self.update_handler.agents[i])
+                else:
+                    purged_agents.append(self.update_handler.agents[i])
 
         # Reload and assert only the kept agents remain on disk
-        self.update_handler.agents = kept_agents
+        self.update_handler.agents = agents_to_keep
         self.update_handler._purge_agents()
         self.update_handler._find_agents()
         self.assertEqual(


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Fix for one the issues reported in #1025: 

> The test case test_purge_agents is sensitive to the current version of the agent. If the agent version is even the order is kept_agents/purged_agents. If the agent version is odd it is the opposite.

The test needs to account for the current agent version, which is not purged.

<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).