### PR TITLE
Enforce cgroups limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ OS.SshClientAliveInterval=180
 OS.SshDir=/etc/ssh
 HttpProxy.Host=None
 HttpProxy.Port=None
+CGroups.EnforceLimits=y
 ```
 
 The various configuration options are described in detail below. Configuration
@@ -451,6 +452,14 @@ _Default: None_
 If set, the agent will use this proxy server to access the internet. These values
 *will* override the `http_proxy` or `https_proxy` environment variables. Lastly,
 `HttpProxy.Host` is required (if to be used) and `HttpProxy.Port` is optional.
+
+#### __CGroups.EnforceLimits__
+
+_Type: Boolean_  
+_Default: y_
+
+If set, the agent will attempt to set cgroups limits for cpu and memory for the agent process itself
+as well as extension processes. See the wiki for further details on this.
 
 ### Telemetry
 

--- a/azurelinuxagent/common/conf.py
+++ b/azurelinuxagent/common/conf.py
@@ -109,7 +109,8 @@ __SWITCH_OPTIONS__ = {
     "ResourceDisk.Format": False,
     "ResourceDisk.EnableSwap": False,
     "AutoUpdate.Enabled": True,
-    "EnableOverProvisioning": True
+    "EnableOverProvisioning": True,
+    "CGroups.EnforceLimits": True,
 }
 
 
@@ -362,3 +363,7 @@ def get_allow_http(conf=__conf__):
 
 def get_disable_agent_file_path(conf=__conf__):
     return os.path.join(get_lib_dir(conf), DISABLE_AGENT_FILE)
+
+
+def get_cgroups_enforce_limits(conf=__conf__):
+    return conf.get_switch("CGroups.EnforceLimits", True)

--- a/azurelinuxagent/common/event.py
+++ b/azurelinuxagent/common/event.py
@@ -74,6 +74,7 @@ class WALAEventOperation:
     ReportStatusExtended = "ReportStatusExtended"
     Restart = "Restart"
     SequenceNumberMismatch = "SequenceNumberMismatch"
+    SetCGroupsLimits = "SetCGroupsLimits"
     SkipUpdate = "SkipUpdate"
     UnhandledError = "UnhandledError"
     UnInstall = "UnInstall"

--- a/config/alpine/waagent.conf
+++ b/config/alpine/waagent.conf
@@ -93,3 +93,6 @@ OS.SshDir=/etc/ssh
 
 # Add firewall rules to protect access to Azure host node services
 OS.EnableFirewall=y
+
+# Enforce control groups limits on the agent and extensions
+CGroups.EnforceLimits=y

--- a/config/bigip/waagent.conf
+++ b/config/bigip/waagent.conf
@@ -97,3 +97,6 @@ AutoUpdate.Enabled=y
 
 # Add firewall rules to protect access to Azure host node services
 OS.EnableFirewall=y
+
+# Enforce control groups limits on the agent and extensions
+CGroups.EnforceLimits=y

--- a/config/coreos/waagent.conf
+++ b/config/coreos/waagent.conf
@@ -119,3 +119,6 @@ OS.AllowHTTP=y
 
 # Add firewall rules to protect access to Azure host node services
 OS.EnableFirewall=y
+
+# Enforce control groups limits on the agent and extensions
+CGroups.EnforceLimits=y

--- a/config/debian/waagent.conf
+++ b/config/debian/waagent.conf
@@ -121,3 +121,6 @@ OS.SshDir=/etc/ssh
 # Note:
 # - The default is false to protect the state of existing VMs
 OS.EnableFirewall=n
+
+# Enforce control groups limits on the agent and extensions
+CGroups.EnforceLimits=y

--- a/config/freebsd/waagent.conf
+++ b/config/freebsd/waagent.conf
@@ -117,3 +117,6 @@ OS.SudoersDir=/usr/local/etc/sudoers.d
 
 # Add firewall rules to protect access to Azure host node services
 OS.EnableFirewall=y
+
+# Enforce control groups limits on the agent and extensions
+CGroups.EnforceLimits=n

--- a/config/ubuntu/waagent.conf
+++ b/config/ubuntu/waagent.conf
@@ -107,3 +107,6 @@ OS.SshDir=/etc/ssh
 
 # Add firewall rules to protect access to Azure host node services
 OS.EnableFirewall=y
+
+# Enforce control groups limits on the agent and extensions
+CGroups.EnforceLimits=y

--- a/config/waagent.conf
+++ b/config/waagent.conf
@@ -119,3 +119,6 @@ OS.SshDir=/etc/ssh
 
 # Add firewall rules to protect access to Azure host node services
 OS.EnableFirewall=y
+
+# Enforce control groups limits on the agent and extensions
+CGroups.EnforceLimits=y

--- a/tests/common/test_conf.py
+++ b/tests/common/test_conf.py
@@ -66,7 +66,8 @@ class TestConf(AgentTestCase):
         "AutoUpdate.GAFamily": "Prod",
         "EnableOverProvisioning": True,
         "OS.AllowHTTP": False,
-        "OS.EnableFirewall": False
+        "OS.EnableFirewall": False,
+        "CGroups.EnforceLimits": True,
     }
 
     def setUp(self):

--- a/tests/data/test_waagent.conf
+++ b/tests/data/test_waagent.conf
@@ -129,3 +129,6 @@ OS.SshDir=/notareal/path
 # Note:
 # - The default is false to protect the state of existing VMs
 OS.EnableFirewall=n
+
+# Enforce control groups limits on the agent and extensions
+CGroups.EnforceLimits=y

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -26,6 +26,7 @@ EXPECTED_CONFIGURATION = \
 """AutoUpdate.Enabled = True
 AutoUpdate.GAFamily = Prod
 Autoupdate.Frequency = 3600
+CGroups.EnforceLimits = True
 DVD.MountPoint = /mnt/cdrom/secure
 DetectScvmmEnv = False
 EnableOverProvisioning = True


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

- closes #1316 
- add a global configuration flag for enforcing cgroups limits
- enforce limits by default on non-systemd-managed cgroups
- exclude CustomScript and RunCommand extensions
- add telemetry for enforced limits
- adds unit tests

---

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes in the description.
- [x] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [x] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).