### PR TITLE
Improve HealthStore signals

### DIFF
--- a/azurelinuxagent/common/event.py
+++ b/azurelinuxagent/common/event.py
@@ -55,6 +55,7 @@ class WALAEventOperation:
     Firewall = "Firewall"
     GetArtifactExtended = "GetArtifactExtended"
     HealthCheck = "HealthCheck"
+    HealthObservation = "HealthObservation"
     HeartBeat = "HeartBeat"
     HostPlugin = "HostPlugin"
     HostPluginHeartbeat = "HostPluginHeartbeat"

--- a/azurelinuxagent/common/protocol/healthservice.py
+++ b/azurelinuxagent/common/protocol/healthservice.py
@@ -20,9 +20,11 @@
 import json
 
 from azurelinuxagent.common import logger
+from azurelinuxagent.common.event import WALAEventOperation
 from azurelinuxagent.common.exception import HttpError
 from azurelinuxagent.common.future import ustr
 from azurelinuxagent.common.utils import restutil
+from azurelinuxagent.common.version import AGENT_NAME, CURRENT_VERSION
 
 
 class Observation(object):
@@ -156,5 +158,21 @@ class HealthService(object):
         except HttpError as e:
             logger.warn("HealthService: could not report observations: {0}", ustr(e))
         finally:
+            # report any failures via telemetry
+            self._report_failures()
             # these signals are not timestamped, so there is no value in persisting data
             del self.observations[:]
+
+    def _report_failures(self):
+        try:
+            logger.verbose("HealthService: report failures as telemetry")
+            from azurelinuxagent.common.event import add_event
+            for o in self.observations:
+                if not o.is_healthy:
+                    add_event(AGENT_NAME,
+                              version=CURRENT_VERSION,
+                              op=WALAEventOperation.HealthObservation,
+                              is_success=False,
+                              message=json.dumps(o.as_obj))
+        except Exception as e:
+            logger.verbose("HealthService: could not report failures: {0}".format(ustr(e)))

--- a/azurelinuxagent/common/protocol/healthservice.py
+++ b/azurelinuxagent/common/protocol/healthservice.py
@@ -20,7 +20,6 @@
 import json
 
 from azurelinuxagent.common import logger
-from azurelinuxagent.common.event import WALAEventOperation
 from azurelinuxagent.common.exception import HttpError
 from azurelinuxagent.common.future import ustr
 from azurelinuxagent.common.utils import restutil
@@ -166,7 +165,7 @@ class HealthService(object):
     def _report_failures(self):
         try:
             logger.verbose("HealthService: report failures as telemetry")
-            from azurelinuxagent.common.event import add_event
+            from azurelinuxagent.common.event import add_event, WALAEventOperation
             for o in self.observations:
                 if not o.is_healthy:
                     add_event(AGENT_NAME,

--- a/azurelinuxagent/common/protocol/hostplugin.py
+++ b/azurelinuxagent/common/protocol/hostplugin.py
@@ -96,13 +96,8 @@ class HostPluginProtocol(object):
         url = URI_FORMAT_HEALTH.format(self.endpoint,
                                        HOST_PLUGIN_PORT)
         logger.verbose("HostGAPlugin: Getting health from [{0}]", url)
-        status_ok = False
-        try:
-            response = restutil.http_get(url, max_retry=1)
-            status_ok = restutil.request_succeeded(response)
-        except HttpError as e:
-            logger.verbose("HostGAPlugin: Exception getting health", ustr(e))
-        return status_ok
+        response = restutil.http_get(url, max_retry=1)
+        return restutil.request_succeeded(response)
 
     def get_api_versions(self):
         url = URI_FORMAT_GET_API_VERSIONS.format(self.endpoint,

--- a/tests/protocol/test_hostplugin.py
+++ b/tests/protocol/test_hostplugin.py
@@ -594,6 +594,14 @@ class TestHostPlugin(AgentTestCase):
         result = host_plugin.get_health()
         self.assertFalse(result)
 
+        patch_http_get.side_effect = IOError('client IO error')
+        try:
+            host_plugin.get_health()
+            self.fail('IO error expected to be raised')
+        except IOError:
+            # expected
+            pass
+
     @patch("azurelinuxagent.common.utils.restutil.http_get",
            return_value=MockResponse(status_code=200, body=b''))
     @patch("azurelinuxagent.common.protocol.healthservice.HealthService.report_host_plugin_versions")


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

- when a request cannot be sent to host plugin, we should not report a failure to health store; we should only report a failure when we can send a request, and the response is non-200
- when we do see failed requests, we should record telemetry

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).