### PR TITLE
Allow Clear Linux detection in python2 and python3

### DIFF
--- a/azurelinuxagent/common/osutil/factory.py
+++ b/azurelinuxagent/common/osutil/factory.py
@@ -46,8 +46,7 @@ def get_osutil(distro_name=DISTRO_NAME,
     if distro_name == "arch":
         return ArchUtil()
 
-    if distro_name == "clear linux os for intel architecture" \
-            or distro_name == "clear linux software for intel architecture":
+    if "Clear Linux" in distro_full_name:
         return ClearLinuxUtil()
 
     if distro_name == "ubuntu":

--- a/azurelinuxagent/pa/deprovision/factory.py
+++ b/azurelinuxagent/pa/deprovision/factory.py
@@ -40,7 +40,7 @@ def get_deprovision_handler(distro_name=DISTRO_NAME,
             return UbuntuDeprovisionHandler()
     if distro_name == "coreos":
         return CoreOSDeprovisionHandler()
-    if distro_name == "clear linux":
+    if "Clear Linux" in distro_full_name:
         return ClearLinuxDeprovisionHandler()
 
     return DeprovisionHandler()

--- a/setup.py
+++ b/setup.py
@@ -107,8 +107,7 @@ def get_data_files(name, version, fullname):
         set_udev_files(data_files)
         set_files(data_files, dest="/usr/share/oem",
                   src=["init/coreos/cloud-config.yml"])
-    elif name == 'clear linux os for intel architecture' \
-            or name == 'clear linux software for intel architecture':
+    elif "Clear Linux" in fullname:
         set_bin_files(data_files, dest="/usr/bin")
         set_conf_files(data_files, dest="/usr/share/defaults/waagent",
                        src=["config/clearlinux/waagent.conf"])


### PR DESCRIPTION
The version.py has three variables where stores:

*In case it is run in python2 and by using platform.linux_distribution
 + DISTRO_NAME      = os-release -> NAME
 + DISTRO_VERSION   = os-release -> VERSION
 + DISTRO_FULL_NAME = os-release -> NAME

*In case it is run in python3.7 and by using distro.linux_distribution
(since platform.linux_distribution deprecated according to
https://bugs.python.org/issue1322)
 + DISTRO_NAME      = os-release -> ID
 + DISTRO_VERSION   = os-release -> VERSION
 + DISTRO_FULL_NAME = os-release -> NAME

Due the possibility of Clear Linux NAME modification it's been decided
to look only for "Clear Linux" in the DISTRO_FULL_NAME string,
so in this manner both scenarios above will work as expected.

---

### PR information
- [X ] The title of the PR is clear and informative.
- [X ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [X] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [X] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).