### PR TITLE
Use append_file in Redhat6xOSUtil.openssl_to_openssh()

### DIFF
--- a/azurelinuxagent/common/osutil/redhat.py
+++ b/azurelinuxagent/common/osutil/redhat.py
@@ -68,7 +68,7 @@ class Redhat6xOSUtil(DefaultOSUtil):
             ssh_rsa_pubkey = cryptutil.asn1_to_ssh(pubkey)
         except CryptError as e:
             raise OSUtilError(ustr(e))
-        fileutil.write_file(output_file, ssh_rsa_pubkey)
+        fileutil.append_file(output_file, ssh_rsa_pubkey)
 
     # Override
     def get_dhcp_pid(self):


### PR DESCRIPTION
The ARM osprofile supports multiple SSH keys to embed into the user'ss
authorized_keys file. In DefaultOSUtil.openssl_to_openssh() we simply
run ssh-keygen and append ('>>') any public keys to the authorized_keys
file.

However, in older RHEL6 we did not have the PKCS8 module available with
ssh-keygen, so we wrote a different routine to handle this conversion
manually, Redhat6xOSUtil.openssl_to_openssh(). This function has a bug
that uses the write_file() utility function instead of append_file().
This fixes the bug.

<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).