### PR TITLE
Handle different kernel builds on SUSE Linux Enterprise

### DIFF
--- a/azurelinuxagent/pa/rdma/suse.py
+++ b/azurelinuxagent/pa/rdma/suse.py
@@ -1,6 +1,6 @@
 # Microsoft Azure Linux Agent
 #
-# Copyright 2017 Microsoft Corporation
+# Copyright 2018 Microsoft Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -40,7 +40,23 @@ class SUSERDMAHandler(RDMAHandler):
         zypper_remove = 'zypper -n rm %s'
         zypper_search = 'zypper -n se -s %s'
         zypper_unlock = 'zypper removelock %s'
-        package_name = 'msft-rdma-kmp-default'
+        package_name = 'dummy'
+        # Figure out the kernel that is running to find the proper kmp
+        cmd = 'uname -r'
+        status, kernel_release = shellutil.run_get_output(cmd)
+        if 'default' in kernel_release:
+            package_name = 'msft-rdma-kmp-default'
+            info_msg = 'RDMA: Detected kernel-default'
+            logger.info(info_msg)
+        elif 'azure' in kernel_release:
+            package_name = 'msft-rdma-kmp-azure'
+            info_msg = 'RDMA: Detected kernel-azure'
+            logger.info(info_msg)
+        else:
+            error_msg = 'RDMA: Could not detect kernel build, unable to '
+            error_msg += 'load kernel module. Kernel release: "%s"'
+            logger.error(error_msg % kernel_release)
+            return
         cmd = zypper_search % package_name
         status, repo_package_info = shellutil.run_get_output(cmd)
         driver_package_versions = []


### PR DESCRIPTION

<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Issue # <!-- if any -->
SUSE has introduced the kernel-azure build to support faster feature
    enablement for Azure than is possible with the kernel-default build.
    This requires that the RDMA kernel modules are built against both
    kernels. Therefore the agent must install the proper package for the
    running kernel.

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).