### PR TITLE
Add functinality to skip checking/installing RDMA drivers on Network Dircect Infiniband VMs

### DIFF
--- a/azurelinuxagent/common/conf.py
+++ b/azurelinuxagent/common/conf.py
@@ -173,6 +173,8 @@ def enable_rdma(conf=__conf__):
 def enable_rdma_update(conf=__conf__):
     return conf.get_switch("OS.UpdateRdmaDriver", False)
 
+def enable_check_rdma_driver(conf=__conf__):
+    return conf.get_switch("OS.CheckRdmaDriver", True)
 
 def get_logs_verbose(conf=__conf__):
     return conf.get_switch("Logs.Verbose", False)

--- a/azurelinuxagent/common/rdma.py
+++ b/azurelinuxagent/common/rdma.py
@@ -154,7 +154,10 @@ class RDMAHandler(object):
 
     def install_driver_if_needed(self):
         if self.nd_version:
-            self.install_driver()
+            if conf.enable_check_rdma_driver():
+                self.install_driver()
+            else:
+                logger.info('RDMA: check RDMA driver is disabled, skip installing driver')
         else:
             logger.info('RDMA: skip installing driver when ndversion not present\n')
 

--- a/azurelinuxagent/common/rdma.py
+++ b/azurelinuxagent/common/rdma.py
@@ -233,6 +233,11 @@ class RDMADeviceHandler(object):
     def provision_network_direct_rdma(self) :
         RDMADeviceHandler.update_dat_conf(dapl_config_paths, self.ipv4_addr)
 
+        if not conf.enable_check_rdma_driver():
+            logger.info("RDMA: skip checking RDMA driver version")
+            RDMADeviceHandler.update_network_interface(self.mac_addr, self.ipv4_addr)
+            return
+
         skip_rdma_device = False
         module_name = "hv_network_direct"
         retcode,out = shellutil.run_get_output("modprobe -R %s" % module_name, chk_err=False)

--- a/config/suse/waagent.conf
+++ b/config/suse/waagent.conf
@@ -102,6 +102,9 @@ OS.SshDir=/etc/ssh
 # Enable RDMA management and set up, should only be used in HPC images
 # OS.EnableRDMA=y
 
+# Enable checking RDMA driver version and update
+# OS.CheckRdmaDriver=y
+
 # Enable or disable goal state processing auto-update, default is enabled
 # AutoUpdate.Enabled=y
 

--- a/config/ubuntu/waagent.conf
+++ b/config/ubuntu/waagent.conf
@@ -90,6 +90,9 @@ OS.SshDir=/etc/ssh
 # Enable RDMA kernel update, this value is effective on Ubuntu
 # OS.UpdateRdmaDriver=y
 
+# Enable checking RDMA driver version and update
+# OS.CheckRdmaDriver=y
+
 # Enable or disable goal state processing auto-update, default is enabled
 # AutoUpdate.Enabled=y
 

--- a/config/waagent.conf
+++ b/config/waagent.conf
@@ -102,6 +102,9 @@ OS.SshDir=/etc/ssh
 # Enable RDMA management and set up, should only be used in HPC images
 # OS.EnableRDMA=y
 
+# Enable checking RDMA driver version and update
+# OS.CheckRdmaDriver=y
+
 # Enable or disable goal state processing auto-update, default is enabled
 # AutoUpdate.Enabled=y
 


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

This patch set adds the functionality to configure waagent to not check and install/update Network Direct RDMA drivers.

With the new HPC images, it's no longer mandatory to check/update drivers, the user can choose to skip those checks on system boot.

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).