### PR TITLE
Do not use a subprocess to capture stdout/stderr

### DIFF
--- a/azurelinuxagent/common/utils/processutil.py
+++ b/azurelinuxagent/common/utils/processutil.py
@@ -16,17 +16,13 @@
 #
 # Requires Python 2.6+ and Openssl 1.0+
 #
-import multiprocessing
 import select
 import subprocess
-import sys
 import os
 import time
 import signal
 from errno import ESRCH
-from multiprocessing import Process
 
-import azurelinuxagent.common.logger as logger
 from azurelinuxagent.common.exception import ExtensionError
 from azurelinuxagent.common.future import ustr
 
@@ -129,10 +125,10 @@ def capture_from_process_poll(process, cmd, timeout, code):
     stdout = bytearray()
     stderr = bytearray()
 
-    def read_pipe(pipe_instance, buffer):
+    def read_pipe(pipe_instance, read_buffer):
         while True:
             block = os.read(pipe_instance.fileno(), 512)
-            buffer.extend(block)
+            read_buffer.extend(block)
             if len(block) < 512:
                 break
 


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
Do not use a subprocess to capture stdout/stderr; it caused the agent to hang. Instead, read the pipes using select.select() and os.read().

<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).