### PR TITLE
Add systemd support for Debian Jessie, Stretch, and Buster

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,8 @@ from azurelinuxagent.common.version import AGENT_NAME, AGENT_VERSION, \
 from azurelinuxagent.common.osutil import get_osutil
 import setuptools
 from setuptools import find_packages
-from setuptools.command.install import install as  _install
+from setuptools.command.install import install as _install
+import subprocess
 import sys
 
 root_dir = os.path.dirname(os.path.abspath(__file__))
@@ -59,11 +60,13 @@ def set_systemd_files(data_files, dest="/lib/systemd/system",
     data_files.append((dest, src))
 
 
-def set_freebsd_rc_files(data_files, dest="/etc/rc.d/", src=["init/freebsd/waagent"]):
+def set_freebsd_rc_files(data_files, dest="/etc/rc.d/",
+                         src=["init/freebsd/waagent"]):
     data_files.append((dest, src))
 
 
-def set_openbsd_rc_files(data_files, dest="/etc/rc.d/", src=["init/openbsd/waagent"]):
+def set_openbsd_rc_files(data_files, dest="/etc/rc.d/",
+                         src=["init/openbsd/waagent"]):
     data_files.append((dest, src))
 
 
@@ -92,7 +95,6 @@ def get_data_files(name, version, fullname):
             if version.startswith("7.1"):
                 # TODO this is a mitigation to systemctl bug on 7.1
                 set_sysv_files(data_files)
-
     elif name == 'arch':
         set_bin_files(data_files, dest="/usr/bin")
         set_conf_files(data_files, src=["config/arch/waagent.conf"])
@@ -138,7 +140,7 @@ def get_data_files(name, version, fullname):
         set_udev_files(data_files)
         if fullname == 'SUSE Linux Enterprise Server' and \
                 version.startswith('11') or \
-                                fullname == 'openSUSE' and version.startswith(
+                fullname == 'openSUSE' and version.startswith(
                     '13.1'):
             set_sysv_files(data_files, dest='/etc/init.d',
                            src=["init/suse/waagent"])
@@ -158,6 +160,8 @@ def get_data_files(name, version, fullname):
         set_conf_files(data_files, src=["config/debian/waagent.conf"])
         set_logrotate_files(data_files)
         set_udev_files(data_files, dest="/lib/udev/rules.d")
+        if debian_has_systemd():
+            set_systemd_files(data_files)
     elif name == 'iosxe':
         set_bin_files(data_files)
         set_conf_files(data_files, src=["config/iosxe/waagent.conf"])
@@ -180,6 +184,14 @@ def get_data_files(name, version, fullname):
         set_udev_files(data_files)
         set_sysv_files(data_files)
     return data_files
+
+
+def debian_has_systemd():
+    try:
+        return subprocess.check_output(
+            ['cat', '/proc/1/comm']).strip() == 'systemd'
+    except subprocess.CalledProcessError:
+        return False
 
 
 class install(_install):
@@ -216,6 +228,7 @@ class install(_install):
             osutil.register_agent_service()
             osutil.stop_agent_service()
             osutil.start_agent_service()
+
 
 # Note to packagers and users from source.
 # In version 3.5 of Python distribution information handling in the platform


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

<!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

Adds support for waagent under Debian Jessie, Stretch, and Buster which all use systemd.

---

### PR information
- [X] The title of the PR is clear and informative.
- [X] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [X] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [X] If applicable, the PR references the bug/issue that it fixes in the description.
- [X] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [X] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/walinuxagent/1419)
<!-- Reviewable:end -->
