### PR TITLE
Removing re-download of zip, once correctly downloaded for any extension.

### DIFF
--- a/azurelinuxagent/common/exception.py
+++ b/azurelinuxagent/common/exception.py
@@ -66,18 +66,16 @@ class ExtensionDownloadError(ExtensionError):
     When failed to download and setup an extension
     """
 
-    def __init__(self, msg=None, inner=None):
-        super(ExtensionDownloadError, self).__init__(msg, inner)
+    def __init__(self, msg=None, inner=None, code=-1):
+        super(ExtensionDownloadError, self).__init__(msg, inner, code)
 
 
 class ExtensionOperationError(ExtensionError):
     """
     When failed to execute an extension
     """
-
     def __init__(self, msg=None, inner=None, code=-1):
-        super(ExtensionOperationError, self).__init__(msg, inner)
-        self.code = code
+        super(ExtensionOperationError, self).__init__(msg, inner, code)
 
 
 class ProvisionError(AgentError):


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
This is part one of the overall fix - This change tries to mitigate the issue caused by a buggy extension when failing to disable - When a new update arrives, the agent tries to disable and then uninstall the previous version of the extension. If the extension fails to disable, the newer version is cleaned up and the loop starts the process all over again.

Leaving a trace like the following in the logs
```
06:25:20.58 INFO [CustomScriptForLinux-1.5.4] Target handler state: enabled
06:25:20.59 INFO [CustomScriptForLinux-1.5.4] [Enable] current handler state is: notinstalled
06:25:20.70 INFO [CustomScriptForLinux-1.5.4] Initialize extension directory
06:25:20.75 INFO [CustomScriptForLinux-1.5.4] Update settings file: 6.settings
06:25:20.80 INFO [CustomScriptForLinux-1.5.3] Disable extension [customscript.py -disable]
06:25:20.85 INFO ExtHandler Move process 10753 into cgroups for extension Microsoft.OSTCExtensions.CustomScriptForLinux
06:25:21.87 WARNING [CustomScriptForLinux-1.5.4] [ExtensionError] Non-zero exit code: 2, customscript.py -disable
06:25:21.97 INFO [CustomScriptForLinux-1.5.4] Remove extension handler directory: /var/lib/waagent/Microsoft.OSTCExtensions.CustomScriptForLinux-1.5.4
06:25:25.10 INFO [CustomScriptForLinux-1.5.4] Target handler state: enabled
06:25:25.15 INFO [CustomScriptForLinux-1.5.4] [Enable] current handler state is: notinstalled
06:25:25.22 INFO [CustomScriptForLinux-1.5.4] Initialize extension directory
06:25:25.26 INFO [CustomScriptForLinux-1.5.4] Update settings file: 6.settings
06:25:25.31 INFO [CustomScriptForLinux-1.5.3] Disable extension [customscript.py -disable]
06:25:25.36 INFO ExtHandler Move process 10753 into cgroups for extension Microsoft.OSTCExtensions.CustomScriptForLinux
06:25:26.37 WARNING [CustomScriptForLinux-1.5.4] [ExtensionError] Non-zero exit code: 2, customscript.py -disable
06:25:26.48 INFO [CustomScriptForLinux-1.5.4] Remove extension handler directory: /var/lib/waagent/Microsoft.OSTCExtensions.CustomScriptForLinux-1.5.4
06:25:29.61 INFO [CustomScriptForLinux-1.5.4] Target handler state: enabled
06:25:29.65 INFO [CustomScriptForLinux-1.5.4] [Enable] current handler state is: notinstalled
06:25:29.73 INFO [CustomScriptForLinux-1.5.4] Initialize extension directory
06:25:29.78 INFO [CustomScriptForLinux-1.5.4] Update settings file: 6.settings
06:25:29.82 INFO [CustomScriptForLinux-1.5.3] Disable extension [customscript.py -disable]
06:25:29.86 INFO ExtHandler Move process 10753 into cgroups for extension Microsoft.OSTCExtensions.CustomScriptForLinux
06:25:30.88 WARNING [CustomScriptForLinux-1.5.4] [ExtensionError] Non-zero exit code: 2, customscript.py -disable
06:25:30.95 INFO [CustomScriptForLinux-1.5.4] Remove extension handler directory: /var/lib/waagent/Microsoft.OSTCExtensions.CustomScriptForLinux-1.5.4
```

Issue #1342 <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes in the description.
- [x] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [x] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).