### PR TITLE
Parse null substatus as empty

### DIFF
--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -138,6 +138,9 @@ def parse_ext_status(ext_status, data):
     formatted_message = status_data.get('formattedMessage')
     ext_status.message = parse_formatted_message(formatted_message)
     substatus_list = status_data.get('substatus', [])
+    # some extensions incorrectly report an empty substatus with a null value
+    if substatus_list is None:
+        substatus_list = []
     for substatus in substatus_list:
         if substatus is not None:
             ext_status.substatusList.append(parse_ext_substatus(substatus))

--- a/tests/ga/test_exthandlers.py
+++ b/tests/ga/test_exthandlers.py
@@ -76,6 +76,57 @@ class TestExtHandlers(AgentTestCase):
         self.assertEqual(0, ext_status.sequenceNumber)
         self.assertEqual(0, len(ext_status.substatusList))
 
+    def test_parse_ext_status_should_parse_missing_substatus_as_empty(self):
+        status = '''[{
+            "status": {
+              "status": "success",
+              "formattedMessage": {
+                "lang": "en-US",
+                "message": "Command is finished."
+              },
+              "operation": "Enable",
+              "code": "0",
+              "name": "Microsoft.OSTCExtensions.CustomScriptForLinux"
+            },
+            
+            "version": "1.0",
+            "timestampUTC": "2018-04-20T21:20:24Z"
+          }
+        ]'''
+
+        extension_status = ExtensionStatus(seq_no=0)
+
+        parse_ext_status(extension_status, json.loads(status))
+
+        self.assertTrue(isinstance(extension_status.substatusList, list), 'substatus was not parsed correctly')
+        self.assertEqual(0, len(extension_status.substatusList))
+
+    def test_parse_ext_status_should_parse_null_substatus_as_empty(self):
+        status = '''[{
+            "status": {
+              "status": "success",
+              "formattedMessage": {
+                "lang": "en-US",
+                "message": "Command is finished."
+              },
+              "operation": "Enable",
+              "code": "0",
+              "name": "Microsoft.OSTCExtensions.CustomScriptForLinux",
+              "substatus": null
+            },
+
+            "version": "1.0",
+            "timestampUTC": "2018-04-20T21:20:24Z"
+          }
+        ]'''
+
+        extension_status = ExtensionStatus(seq_no=0)
+
+        parse_ext_status(extension_status, json.loads(status))
+
+        self.assertTrue(isinstance(extension_status.substatusList, list), 'substatus was not parsed correctly')
+        self.assertEqual(0, len(extension_status.substatusList))
+
     @patch('azurelinuxagent.common.event.EventLogger.add_event')
     @patch('azurelinuxagent.ga.exthandlers.ExtHandlerInstance.get_largest_seq_no')
     def assert_extension_sequence_number(self,


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

Some extensions are incorrectly reporting an empty substatus as null. Added code to convert null to empty.


<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).