### PR TITLE
Use 1804-style deprovisioning for all versions >= 18.04

### DIFF
--- a/azurelinuxagent/pa/deprovision/factory.py
+++ b/azurelinuxagent/pa/deprovision/factory.py
@@ -34,7 +34,7 @@ def get_deprovision_handler(distro_name=DISTRO_NAME,
     if distro_name == "arch":
         return ArchDeprovisionHandler()
     if distro_name == "ubuntu":
-        if Version(distro_version) in [Version('18.04')]:
+        if Version(distro_version) >= Version('18.04'):
             return Ubuntu1804DeprovisionHandler()
         else:
             return UbuntuDeprovisionHandler()


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Enable systemd-aware deprovisioning on all versions >= 18.04

Issue #1476 

The fix for #1151 was hard-coded to apply only to 18.04. It looks like systemd is here to stay, though, so the change in deprovisioning for 18.04 should apply to all versions of Ubuntu since (and including) 18.04.

---

### PR information
- [X] The title of the PR is clear and informative.
- [X] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [X] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [X] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and Travis.CI is passing. (n/a; not amenable to unit testing, really)

### Quality of Code and Contribution Guidelines
- [X] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).