### PR TITLE
Allow short circuiting of telemetry pipeline in metadata protocol situations

### DIFF
--- a/azurelinuxagent/common/protocol/metadata.py
+++ b/azurelinuxagent/common/protocol/metadata.py
@@ -148,6 +148,10 @@ class MetadataProtocol(Protocol):
         # Metadata protocol does not support overprovisioning
         return False
 
+    def supports_telemetry(self):
+        # Metadata protocol does not support telemetry
+        return False
+
     def detect(self):
         self.get_vminfo()
         trans_prv_file = os.path.join(conf.get_lib_dir(),

--- a/azurelinuxagent/common/protocol/restapi.py
+++ b/azurelinuxagent/common/protocol/restapi.py
@@ -361,3 +361,6 @@ class Protocol(DataContract):
 
     def supports_overprovisioning(self):
         return True
+
+    def supports_telemetry(self):
+        return True

--- a/azurelinuxagent/ga/monitor.py
+++ b/azurelinuxagent/ga/monitor.py
@@ -412,7 +412,7 @@ class MonitorHandler(object):
             logger.warn("Monitor: cgroups not initialized: {0}", ustr(e))
             logger.verbose(traceback.format_exc())
 
-    def send_cgroup_telemetry(self):
+    def send_cgroup_telemetry(self): 
         if self.last_cgroup_telemetry is None:
             self.last_cgroup_telemetry = datetime.datetime.utcnow()
 
@@ -456,7 +456,9 @@ class MonitorHandler(object):
 
             # Look for extension cgroups we're not already tracking and track them
             try:
-                CGroupsTelemetry.update_tracked(self.protocol.client.get_current_handlers())
+                if self.protocol.supports_telemetry:
+                    # Only emit if the underlying protocol supports telemetry
+                    CGroupsTelemetry.update_tracked(self.protocol.client.get_current_handlers())
             except Exception as e:
                 logger.warn("Monitor: failed to update cgroups tracked extensions: {0}", ustr(e))
                 logger.verbose(traceback.format_exc())


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Issue # 1502
Adds an abstraction override for supporting telemetry which only kicks in for metadata protocol instances

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/walinuxagent/1503)
<!-- Reviewable:end -->
