### PR TITLE
Suppress 'Errno 2' messages when deleting extensions

### DIFF
--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -925,8 +925,7 @@ class ExtHandlerInstance(object):
                 # some extensions uninstall asynchronously so ignore error 2 while removing them
                 def on_rmtree_error(_, __, exc_info):
                     _, exception, _ = exc_info
-                    if not isinstance(exception,
-                                      OSError) or exception.errno != 2:  # [Errno 2] No such file or directory
+                    if not isinstance(exception, OSError) or exception.errno != 2:  # [Errno 2] No such file or directory
                         raise exception
 
                 shutil.rmtree(base_dir, onerror=on_rmtree_error)

--- a/tests/ga/test_exthandlers_exthandlerinstance.py
+++ b/tests/ga/test_exthandlers_exthandlerinstance.py
@@ -1,0 +1,95 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache License.
+
+from azurelinuxagent.ga.exthandlers import ExtHandlerInstance
+from azurelinuxagent.common.protocol.restapi import ExtHandler, ExtHandlerProperties
+from tests.tools import *
+
+
+class ExtHandlerInstanceTestCase(AgentTestCase):
+    def setUp(self):
+        AgentTestCase.setUp(self)
+
+        ext_handler_properties = ExtHandlerProperties()
+        ext_handler_properties.version = "1.2.3"
+        ext_handler = ExtHandler(name='foo')
+        ext_handler.properties = ext_handler_properties
+        self.ext_handler_instance = ExtHandlerInstance(ext_handler=ext_handler, protocol=None)
+
+        self.extension_directory = os.path.join(self.tmp_dir, "extension_directory")
+        self.mock_get_base_dir = patch.object(self.ext_handler_instance, "get_base_dir", return_value=self.extension_directory)
+        self.mock_get_base_dir.start()
+
+    def tearDown(self):
+        self.mock_get_base_dir.stop()
+
+    def test_rm_ext_handler_dir_should_remove_the_extension_directory(self):
+        os.mkdir(self.extension_directory)
+        os.mknod(os.path.join(self.extension_directory, "extension_file1"))
+        os.mknod(os.path.join(self.extension_directory, "extension_file2"))
+        os.mknod(os.path.join(self.extension_directory, "extension_file3"))
+
+        self.ext_handler_instance.rm_ext_handler_dir()
+
+        self.assertFalse(os.path.exists(self.extension_directory))
+
+    def test_rm_ext_handler_dir_should_report_an_event_if_an_error_occurrs_while_deleting_the_extension_directory(self):
+        extension_directory = os.path.join(self.tmp_dir, "extension_directory")
+        os.mkdir(extension_directory)
+        os.mknod(os.path.join(extension_directory, "extension_file1"))
+        os.mknod(os.path.join(extension_directory, "extension_file2"))
+        os.mknod(os.path.join(extension_directory, "extension_file3"))
+
+        original_remove = shutil.os.remove
+
+        def mock_remove(path):
+            if path.endswith("extension_file2"):
+                mock_remove.exception_raised = True
+                raise IOError("A mocked error")
+            original_remove(path)
+
+        with patch.object(shutil.os, "remove", mock_remove) as mock_remove:
+            with patch.object(self.ext_handler_instance, "report_event") as mock_report_event:
+                self.ext_handler_instance.rm_ext_handler_dir()
+
+        args, kwargs = mock_report_event.call_args
+        self.assertTrue("A mocked error" in kwargs["message"])
+
+        self.assertTrue(mock_remove.exception_raised)  # verify the mock was actually called
+
+    def test_rm_ext_handler_dir_should_not_report_an_event_if_the_extension_directory_does_not_exist(self):
+        if os.path.exists(self.extension_directory):
+            os.rmdir(self.extension_directory)
+
+        with patch.object(self.ext_handler_instance, "report_event") as mock_report_event:
+            self.ext_handler_instance.rm_ext_handler_dir()
+
+        mock_report_event.assert_not_called()
+
+    def test_rm_ext_handler_dir_should_not_report_an_event_if_a_child_is_removed_asynchronously(self):
+        os.mkdir(self.extension_directory)
+        os.mknod(os.path.join(self.extension_directory, "extension_file1"))
+        os.mknod(os.path.join(self.extension_directory, "extension_file2"))
+        os.mknod(os.path.join(self.extension_directory, "extension_file3"))
+
+        # Some extensions uninstall asynchronously and the files we are trying to remove may be removed
+        # while shutil.rmtree is traversing the extension's directory. Mock this by deleting a file
+        # twice (the second call will produce "[Errno 2] No such file or directory", which should not be
+        # reported as a telemetry event.
+        original_remove = shutil.os.remove
+
+        def mock_remove(path):
+            if path.endswith("extension_file2"):
+                original_remove(path)
+                mock_remove.file_deleted_asynchronously = True
+            original_remove(path)
+
+        with patch.object(shutil.os, "remove", mock_remove) as mock_remove:
+            with patch.object(self.ext_handler_instance, "report_event") as mock_report_event:
+                self.ext_handler_instance.rm_ext_handler_dir()
+
+        mock_report_event.assert_not_called()
+
+        self.assertTrue(mock_remove.file_deleted_asynchronously)  # verify the mock was actually called
+        self.assertFalse(os.path.exists(self.extension_directory))  # verify the error produced by the mock did not prevent the deletion
+


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

DCR reports this error intermittently:

> Failed to remove extension handler directory: [Errno 2] No such file or directory: 'omsagent-1.6.1-3.universal.x64.deb'

Apparently, some extensions do part of their uninstall asynchronously so they may be deleting their files while the agent is trying to do the same.

Added code to suppress those errors (they can prevent full deletion of the extension directory).

<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/walinuxagent/1504)
<!-- Reviewable:end -->
