### PR TITLE
Add logging for certificate handling

### DIFF
--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -1519,6 +1519,18 @@ class Certificates(object):
                 tmp_file = prvs[pubkey]
                 prv = "{0}.prv".format(thumbprint)
                 os.rename(tmp_file, os.path.join(conf.get_lib_dir(), prv))
+                logger.info("Found private key matching thumbprint {0}".format(thumbprint))
+            else:
+                # Since private key has *no* matching certificate,
+                # it will not be named correctly
+                logger.warn("Found NO matching cert/thumbprint for private key!")
+
+        # Log if any certificates were found without matching private keys
+        # This can happen, but is useful to know for debugging
+        for pubkey in thumbprints:
+            if not pubkey in prvs:
+                msg = "Certificate with thumbprint {0} has no matching private key."
+                logger.info(msg.format(thumbprints[pubkey]))
 
         for v1_cert in v1_cert_list:
             cert = Cert()


### PR DESCRIPTION
## Add logging for certificate handling

Issue # N/A

The Agent supports installing certificates automatically, but nothing about these operations is logged. This makes it difficult to troubleshoot when things go wrong. This change adds rudimentary logging, and only emits certificate thumbprints (no key information or subject names) to protect sensitive information).

---

### PR information
- [X] The title of the PR is clear and informative.
- [X] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [X] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [X] If applicable, the PR references the bug/issue that it fixes in the description.
- [X] New Unit tests were added for the changes made and Travis.CI is passing. (N/A - this is only a logging change)

### Quality of Code and Contribution Guidelines
- [X] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/walinuxagent/1509)
<!-- Reviewable:end -->
