### PR TITLE
Fix for sending wrong header to HostGA /extensionManifest calls

### DIFF
--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -609,6 +609,8 @@ class WireClient(object):
                 continue
 
             response = None
+            host = self.get_host_plugin()
+
             if not HostPluginProtocol.is_default_channel():
                 response = self.fetch(version.uri)
 
@@ -620,7 +622,7 @@ class WireClient(object):
                                    "switching to host plugin")
 
                 try:
-                    host = self.get_host_plugin()
+                    # host = self.get_host_plugin()
                     uri, headers = host.get_artifact_request(version.uri)
                     response = self.fetch(uri, headers, use_proxy=False)
 
@@ -630,13 +632,14 @@ class WireClient(object):
                     HostPluginProtocol.set_default_channel(True)
                     raise
 
-                host.manifest_uri = version.uri
+                # host.manifest_uri = version.uri
                 logger.verbose("Manifest downloaded successfully from host plugin")
                 if not HostPluginProtocol.is_default_channel():
                     logger.info("Setting host plugin as default channel")
                     HostPluginProtocol.set_default_channel(True)
 
             if response:
+                host.manifest_uri = version.uri
                 return response
 
         raise ProtocolError("Failed to fetch manifest from all sources")

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -622,7 +622,6 @@ class WireClient(object):
                                    "switching to host plugin")
 
                 try:
-                    # host = self.get_host_plugin()
                     uri, headers = host.get_artifact_request(version.uri)
                     response = self.fetch(uri, headers, use_proxy=False)
 
@@ -632,7 +631,6 @@ class WireClient(object):
                     HostPluginProtocol.set_default_channel(True)
                     raise
 
-                # host.manifest_uri = version.uri
                 logger.verbose("Manifest downloaded successfully from host plugin")
                 if not HostPluginProtocol.is_default_channel():
                     logger.info("Setting host plugin as default channel")

--- a/tests/protocol/test_wire.py
+++ b/tests/protocol/test_wire.py
@@ -415,23 +415,23 @@ class TestWireProtocol(AgentTestCase):
         manifest_return = "manifest.xml"
 
         with patch.object(WireClient, "get_host_plugin", return_value=mock_host):
-            with patch.object(HostPluginProtocol, "get_artifact_request", return_value=[host_uri, {}]):
+            mock_host.get_artifact_request = MagicMock(return_value=[host_uri, {}])
 
-                # First test tried to download directly from blob and asserts manifest_uri is set
-                with patch.object(WireClient, "fetch", return_value=manifest_return) as patch_fetch:
-                    fetch_manifest_mock = client.fetch_manifest(uris)
-                    self.assertEqual(fetch_manifest_mock, manifest_return)
-                    self.assertEqual(patch_fetch.call_count, 1)
-                    self.assertEqual(mock_host.manifest_uri, uri1.uri)
+            # First test tried to download directly from blob and asserts manifest_uri is set
+            with patch.object(WireClient, "fetch", return_value=manifest_return) as patch_fetch:
+                fetch_manifest_mock = client.fetch_manifest(uris)
+                self.assertEqual(fetch_manifest_mock, manifest_return)
+                self.assertEqual(patch_fetch.call_count, 1)
+                self.assertEqual(mock_host.manifest_uri, uri1.uri)
 
-                # Second test tries to download from the HostGA (by failing the direct download) and asserts manifest_uri is set
-                with patch.object(WireClient, "fetch") as patch_fetch:
-                    patch_fetch.side_effect = [None, manifest_return]
-                    fetch_manifest_mock = client.fetch_manifest(uris)
-                    self.assertEqual(fetch_manifest_mock, manifest_return)
-                    self.assertEqual(patch_fetch.call_count, 2)
-                    self.assertEqual(mock_host.manifest_uri, uri1.uri)
-                    self.assertTrue(HostPluginProtocol.is_default_channel())
+            # Second test tries to download from the HostGA (by failing the direct download) and asserts manifest_uri is set
+            with patch.object(WireClient, "fetch") as patch_fetch:
+                patch_fetch.side_effect = [None, manifest_return]
+                fetch_manifest_mock = client.fetch_manifest(uris)
+                self.assertEqual(fetch_manifest_mock, manifest_return)
+                self.assertEqual(patch_fetch.call_count, 2)
+                self.assertEqual(mock_host.manifest_uri, uri1.uri)
+                self.assertTrue(HostPluginProtocol.is_default_channel())
 
     def test_get_in_vm_artifacts_profile_host_ga_plugin(self, *args):
         wire_protocol_client = WireProtocol(wireserver_url).client

--- a/tests/protocol/test_wire.py
+++ b/tests/protocol/test_wire.py
@@ -420,16 +420,16 @@ class TestWireProtocol(AgentTestCase):
             with patch.object(HostPluginProtocol,
                               "get_artifact_request",
                               return_value=[host_uri, {}]):
-                with patch.object(WireClient,
-                                  "fetch",
-                                  return_value=manifest_return) as patch_fetch:
+
+                # First fetch works (direct download works)
+                with patch.object(WireClient, "fetch", return_value=manifest_return) as patch_fetch:
                     HostPluginProtocol.set_default_channel(False)
                     self.assertEqual(client.fetch_manifest(uris), manifest_return)
                     self.assertEqual(patch_fetch.call_count, 1)
                     self.assertEqual(mock_host.manifest_uri, uri1.uri)
 
-                with patch.object(WireClient,
-                                  "fetch") as patch_fetch:
+                # First fetch fails, 2nd fetch works (HostGA)
+                with patch.object(WireClient, "fetch") as patch_fetch:
                     patch_fetch.side_effect = [None, manifest_return]
                     self.assertEqual(client.fetch_manifest(uris), manifest_return)
                     self.assertEqual(patch_fetch.call_count, 2)

--- a/tests/protocol/test_wire.py
+++ b/tests/protocol/test_wire.py
@@ -423,7 +423,6 @@ class TestWireProtocol(AgentTestCase):
 
                 # First fetch works (direct download works)
                 with patch.object(WireClient, "fetch", return_value=manifest_return) as patch_fetch:
-                    HostPluginProtocol.set_default_channel(False)
                     self.assertEqual(client.fetch_manifest(uris), manifest_return)
                     self.assertEqual(patch_fetch.call_count, 1)
                     self.assertEqual(mock_host.manifest_uri, uri1.uri)

--- a/tests/protocol/test_wire.py
+++ b/tests/protocol/test_wire.py
@@ -424,7 +424,7 @@ class TestWireProtocol(AgentTestCase):
                     self.assertEqual(patch_fetch.call_count, 1)
                     self.assertEqual(mock_host.manifest_uri, uri1.uri)
 
-                # Second test tries to download from the HostGA and asserts manifest_uri is set
+                # Second test tries to download from the HostGA (by failing the direct download) and asserts manifest_uri is set
                 with patch.object(WireClient, "fetch") as patch_fetch:
                     patch_fetch.side_effect = [None, manifest_return]
                     fetch_manifest_mock = client.fetch_manifest(uris)


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

This PR is to fix the bug where we don't send the correct headers for /extensionArtifacts calls made to HostGA.

<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [x] The title of the PR is clear and informative.
- [X] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [X] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [X] If applicable, the PR references the bug/issue that it fixes in the description.
- [X] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [X] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/walinuxagent/1510)
<!-- Reviewable:end -->
