### PR TITLE
Support both ECC and RSA keys during initialization

### DIFF
--- a/azurelinuxagent/common/utils/cryptutil.py
+++ b/azurelinuxagent/common/utils/cryptutil.py
@@ -33,6 +33,7 @@ import azurelinuxagent.common.utils.textutil as textutil
 
 DECRYPT_SECRET_CMD = "{0} cms -decrypt -inform DER -inkey {1} -in /dev/stdin"
 
+
 class CryptUtil(object):
     def __init__(self, openssl_cmd):
         self.openssl_cmd = openssl_cmd
@@ -54,7 +55,7 @@ class CryptUtil(object):
             raise IOError(errno.ENOENT, "File not found", file_name)
         else:
             cmd = "{0} pkey -in {1} -pubout 2>/dev/null".format(self.openssl_cmd,
-                                                               file_name)
+                                                                file_name)
             pub = shellutil.run_get_output(cmd)[1]
             return pub
 

--- a/azurelinuxagent/common/utils/cryptutil.py
+++ b/azurelinuxagent/common/utils/cryptutil.py
@@ -53,7 +53,7 @@ class CryptUtil(object):
         if not os.path.exists(file_name):
             raise IOError(errno.ENOENT, "File not found", file_name)
         else:
-            cmd = "{0} rsa -in {1} -pubout 2>/dev/null".format(self.openssl_cmd,
+            cmd = "{0} pkey -in {1} -pubout 2>/dev/null".format(self.openssl_cmd,
                                                                file_name)
             pub = shellutil.run_get_output(cmd)[1]
             return pub
@@ -117,7 +117,7 @@ class CryptUtil(object):
             keydata.extend(b"\0")
             keydata.extend(self.num_to_bytes(n))
             keydata_base64 = base64.b64encode(bytebuffer(keydata))
-            return ustr(b"ssh-rsa " +  keydata_base64 + b"\n", 
+            return ustr(b"ssh-rsa " +  keydata_base64 + b"\n",
                         encoding='utf-8')
         except ImportError as e:
             raise CryptError("Failed to load pyasn1.codec.der")

--- a/bin/waagent2.0
+++ b/bin/waagent2.0
@@ -3292,7 +3292,7 @@ class Certificates(object):
         index = 1
         filename = str(index) + ".prv"
         while os.path.isfile(filename):
-            pubkey = RunGetOutput(Openssl + " rsa -in " + filename + " -pubout 2> /dev/null ")[1]
+            pubkey = RunGetOutput(Openssl + " pkey -in " + filename + " -pubout 2> /dev/null ")[1]
             os.rename(filename, keys[pubkey] + ".prv")
             os.chmod(keys[pubkey] + ".prv", 0600)
             MyDistro.setSelinuxContext( keys[pubkey] + '.prv','unconfined_u:object_r:ssh_home_t:s0')

--- a/tests/data/wire/trans_pub
+++ b/tests/data/wire/trans_pub
@@ -1,0 +1,9 @@
+-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA09wkCR3pXk16iBIqMh5N
+c5YLnHMpPK4k+3hhkxVKixTSUjprTAen6DZ8/bbOtWzBb5AnPoBVaiMgSotC6ndb
+IJdlO/xFRuUeciOS9f/4n8ZoubPQbknNkikQsvYLwh9AsfYiI+Ur0s5AfTRbvhYV
+wrdCpwnorDwZxVp5JdPWvtdBwYyoSNxYmSkougwm/csy58T4kx1tcNQZj4+ztmJy
+7wpe8E9opWxzofaOuoFLx62NdvMvKt7NNQPPjmubJEnMI7lKTamiG5iDvfBTKQBQ
+9XF3svxadLKrPW/jOs5uqfAEDKivrslH+GNMF+MU693yoUaid+K/ZWfP1exgVNmx
+cQIDAQAB
+-----END PUBLIC KEY-----


### PR DESCRIPTION
* `openssl pkey` supports both RSA and ECC private keys

Fixes: #1550

<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Issue #1550 <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [X] The title of the PR is clear and informative.
- [X] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [X] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [X] If applicable, the PR references the bug/issue that it fixes in the description.
- [X] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [X] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/walinuxagent/1552)
<!-- Reviewable:end -->
