### PR TITLE
Improve systemd tests and reset stdout/stderr

### DIFF
--- a/azurelinuxagent/common/cgroupapi.py
+++ b/azurelinuxagent/common/cgroupapi.py
@@ -438,11 +438,6 @@ After=system-{1}.slice""".format(extension_name, EXTENSIONS_ROOT_CGROUP_NAME)
             # unit's name. Since the scope name is only known to systemd-run, and not to the extension itself,
             # if scope_name appears in the output, we are certain systemd-run managed to run.
             if scope_name not in process_output:
-                logger.warn('Failed to run systemd-run for unit {0}.scope '
-                            'Process exited with code {1} and output {2}'.format(scope_name,
-                                                                                 return_code,
-                                                                                 process_output))
-
                 add_event(AGENT_NAME,
                           version=CURRENT_VERSION,
                           op=WALAEventOperation.InvokeCommandUsingSystemd,
@@ -451,6 +446,9 @@ After=system-{1}.slice""".format(extension_name, EXTENSIONS_ROOT_CGROUP_NAME)
                                   'Process exited with code {1} and output {2}'.format(scope_name,
                                                                                        return_code,
                                                                                        process_output))
+                # Reset the stdout and stderr
+                stdout.truncate(0)
+                stderr.truncate(0)
 
                 # Try starting the process without systemd-run
                 process = subprocess.Popen(

--- a/azurelinuxagent/common/utils/processutil.py
+++ b/azurelinuxagent/common/utils/processutil.py
@@ -34,7 +34,7 @@ def read_output(stdout, stderr):
 
         return format_stdout_stderr(stdout, stderr)
     except Exception as e:
-        return format_stdout_stderr("", "Cannot read stdout/stderr: {0}".format(str(e)))
+        return format_stdout_stderr("", "Cannot read stdout/stderr: {0}".format(ustr(e)))
 
 
 def format_stdout_stderr(stdout, stderr, max_len=TELEMETRY_MESSAGE_MAX_LEN):

--- a/tests/utils/test_process_util.py
+++ b/tests/utils/test_process_util.py
@@ -14,11 +14,48 @@
 #
 # Requires Python 2.6+ and Openssl 1.0+
 #
-from azurelinuxagent.common.utils.processutil import format_stdout_stderr
+from azurelinuxagent.common.utils.processutil import format_stdout_stderr, read_output
 from tests.tools import *
 
 
 class TestProcessUtils(AgentTestCase):
+    def setUp(self):
+        AgentTestCase.setUp(self)
+        self.tmp_dir = tempfile.mkdtemp()
+        self.stdout = tempfile.TemporaryFile(dir=self.tmp_dir, mode="w+b")
+        self.stderr = tempfile.TemporaryFile(dir=self.tmp_dir, mode="w+b")
+
+        self.stdout.write("The quick brown fox jumps over the lazy dog.".encode("utf-8"))
+        self.stderr.write("The five boxing wizards jump quickly.".encode("utf-8"))
+
+    def tearDown(self):
+        if self.tmp_dir is not None:
+            shutil.rmtree(self.tmp_dir)
+
+    def test_read_output_it_should_return_no_content(self):
+        with patch('azurelinuxagent.common.utils.processutil.TELEMETRY_MESSAGE_MAX_LEN', 0):
+            expected = "[stdout]\n\n\n[stderr]\n"
+            actual = read_output(self.stdout, self.stderr)
+            self.assertEqual(expected, actual)
+
+    def test_read_output_it_should_truncate_the_content(self):
+        with patch('azurelinuxagent.common.utils.processutil.TELEMETRY_MESSAGE_MAX_LEN', 10):
+            expected = "[stdout]\nThe quick \n\n[stderr]\nThe five b"
+            actual = read_output(self.stdout, self.stderr)
+            self.assertEqual(expected, actual)
+
+    def test_read_output_it_should_return_all_content(self):
+        with patch('azurelinuxagent.common.utils.processutil.TELEMETRY_MESSAGE_MAX_LEN', 50):
+            expected = "[stdout]\nThe quick brown fox jumps over the lazy dog.\n\n" \
+                       "[stderr]\nThe five boxing wizards jump quickly."
+            actual = read_output(self.stdout, self.stderr)
+            self.assertEqual(expected, actual)
+
+    def test_read_output_it_should_handle_exceptions(self):
+        with patch('azurelinuxagent.common.utils.processutil.TELEMETRY_MESSAGE_MAX_LEN', "type error"):
+            actual = read_output(self.stdout, self.stderr)
+            self.assertIn("Cannot read stdout/stderr", actual)
+
     def test_format_stdout_stderr00(self):
         """
         If stdout and stderr are both smaller than the max length,


### PR DESCRIPTION
Address leftover comments from https://github.com/Azure/WALinuxAgent/pull/1556:
- improve systemd tests
- reset stdout/stderr before invoking another subprocess
- add unit tests for `azurelinuxagent.utils.processutil.read_output`
- add unit tests for logging when calling `azurelinuxagent.common.event.add_event`

<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/walinuxagent/1563)
<!-- Reviewable:end -->
