### PR TITLE
Removing the event_id 6 for reducing our telemetry load

### DIFF
--- a/azurelinuxagent/common/event.py
+++ b/azurelinuxagent/common/event.py
@@ -35,6 +35,7 @@ from azurelinuxagent.common.utils import fileutil, textutil
 from azurelinuxagent.common.version import CURRENT_VERSION
 
 _EVENT_MSG = "Event: name={0}, op={1}, message={2}, duration={3}"
+TELEMETRY_EVENT_PROVIDER_ID = "69B669B9-4AF8-4C50-BDC4-6006FA76E975"
 
 
 class WALAEventOperation:
@@ -263,11 +264,10 @@ class EventLogger(object):
         if (not is_success) and log_event:
             _log_event(name, op, message, duration, is_success=is_success)
 
-        self._add_event(duration, evt_type, is_internal, is_success, message, name, op, version, eventId=1)
-        self._add_event(duration, evt_type, is_internal, is_success, message, name, op, version, eventId=6)
+        self._add_event(duration, evt_type, is_internal, is_success, message, name, op, version, event_id=1)
 
-    def _add_event(self, duration, evt_type, is_internal, is_success, message, name, op, version, eventId):
-        event = TelemetryEvent(eventId, "69B669B9-4AF8-4C50-BDC4-6006FA76E975")
+    def _add_event(self, duration, evt_type, is_internal, is_success, message, name, op, version, event_id):
+        event = TelemetryEvent(event_id, TELEMETRY_EVENT_PROVIDER_ID)
         event.parameters.append(TelemetryEventParam('Name', name))
         event.parameters.append(TelemetryEventParam('Version', str(version)))
         event.parameters.append(TelemetryEventParam('IsInternal', is_internal))

--- a/tests/common/test_event.py
+++ b/tests/common/test_event.py
@@ -213,13 +213,17 @@ class TestEvent(AgentTestCase):
 
     def test_save_event(self):
         add_event('test', message='test event')
-        self.assertTrue(len(os.listdir(self.tmp_dir)) == 1) # We now only send 1 event for event_id = 1
+        self.assertTrue(len(os.listdir(self.tmp_dir)) == 1)
+
+        # checking the extension of the file created.
+        for filename in os.listdir(self.tmp_dir):
+            self.assertEqual(".tld", filename[-4:])
 
     def test_save_event_rollover(self):
         # We keep 1000 events only, and the older ones are removed.
 
         num_of_events = 999
-        add_event('test', message='first event') # this makes number of events to num_of_events + 1.
+        add_event('test', message='first event')  # this makes number of events to num_of_events + 1.
         for i in range(num_of_events):
             add_event('test', message='test event {0}'.format(i))
 
@@ -227,7 +231,7 @@ class TestEvent(AgentTestCase):
 
         events = os.listdir(self.tmp_dir)
         events.sort()
-        self.assertTrue(len(events) == num_of_events, "{} is not equal to {}".format(len(events), num_of_events))
+        self.assertTrue(len(events) == num_of_events, "{0} is not equal to {1}".format(len(events), num_of_events))
 
         first_event = os.path.join(self.tmp_dir, events[0])
         with open(first_event) as first_fh:
@@ -245,7 +249,7 @@ class TestEvent(AgentTestCase):
         first_event = os.path.join(self.tmp_dir, events[0])
         with open(first_event) as first_fh:
             first_event_text = first_fh.read()
-            self.assertFalse('first event' in first_event_text, "'first event' not in {}".format(first_event_text))
+            self.assertFalse('first event' in first_event_text, "'first event' not in {0}".format(first_event_text))
             self.assertTrue('test event 0' in first_event_text)
 
         last_event = os.path.join(self.tmp_dir, events[-1])

--- a/tests/common/test_event.py
+++ b/tests/common/test_event.py
@@ -20,7 +20,7 @@ from __future__ import print_function
 from datetime import datetime, timedelta
 
 from azurelinuxagent.common.event import add_event, \
-    WALAEventOperation, elapsed_milliseconds, EventLogger
+    WALAEventOperation, elapsed_milliseconds
 from azurelinuxagent.common.future import ustr
 from azurelinuxagent.common.version import CURRENT_VERSION
 
@@ -213,16 +213,21 @@ class TestEvent(AgentTestCase):
 
     def test_save_event(self):
         add_event('test', message='test event')
-        self.assertTrue(len(os.listdir(self.tmp_dir)) == 2)
+        self.assertTrue(len(os.listdir(self.tmp_dir)) == 1) # We now only send 1 event for event_id = 1
 
     def test_save_event_rollover(self):
-        add_event('test', message='first event')
-        for i in range(0, 499):
+        # We keep 1000 events only, and the older ones are removed.
+
+        num_of_events = 999
+        add_event('test', message='first event') # this makes number of events to num_of_events + 1.
+        for i in range(num_of_events):
             add_event('test', message='test event {0}'.format(i))
+
+        num_of_events += 1 # adding the first add_event.
 
         events = os.listdir(self.tmp_dir)
         events.sort()
-        self.assertTrue(len(events) == 1000)
+        self.assertTrue(len(events) == num_of_events, "{} is not equal to {}".format(len(events), num_of_events))
 
         first_event = os.path.join(self.tmp_dir, events[0])
         with open(first_event) as first_fh:
@@ -230,14 +235,17 @@ class TestEvent(AgentTestCase):
             self.assertTrue('first event' in first_event_text)
 
         add_event('test', message='last event')
+        # Adding the above event displaces the first_event
+
         events = os.listdir(self.tmp_dir)
         events.sort()
-        self.assertTrue(len(events) == 1000, "{0} events found, 1000 expected".format(len(events)))
+        self.assertTrue(len(events) == num_of_events,
+                        "{0} events found, {1} expected".format(len(events), num_of_events))
 
         first_event = os.path.join(self.tmp_dir, events[0])
         with open(first_event) as first_fh:
             first_event_text = first_fh.read()
-            self.assertFalse('first event' in first_event_text)
+            self.assertFalse('first event' in first_event_text, "'first event' not in {}".format(first_event_text))
             self.assertTrue('test event 0' in first_event_text)
 
         last_event = os.path.join(self.tmp_dir, events[-1])
@@ -261,7 +269,7 @@ class TestEvent(AgentTestCase):
         first_event = os.path.join(self.tmp_dir, events[0])
         with open(first_event) as first_fh:
             first_event_text = first_fh.read()
-            self.assertTrue('test event 1002' in first_event_text)
+            self.assertTrue('test event 1001' in first_event_text)
 
         last_event = os.path.join(self.tmp_dir, events[-1])
         with open(last_event) as last_fh:


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
Removing the event_id=6 telemetry message as we are not using the EERM table and scope jobs.

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [x] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [x] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/walinuxagent/1568)
<!-- Reviewable:end -->
