### PR TITLE
Changing console output default to 'n'

### DIFF
--- a/azurelinuxagent/agent.py
+++ b/azurelinuxagent/agent.py
@@ -39,32 +39,33 @@ from azurelinuxagent.common.version import AGENT_NAME, AGENT_LONG_VERSION, \
 from azurelinuxagent.common.osutil import get_osutil
 from azurelinuxagent.common.utils import fileutil
 
+
 class Agent(object):
-    def __init__(self, verbose, conf_file_path=None):
+    def __init__(self, verbose, conf_file_path=None, console_logging=False):
         """
         Initialize agent running environment.
         """
         self.conf_file_path = conf_file_path
         self.osutil = get_osutil()
 
-        #Init stdout log
+        # Init stdout log
         level = logger.LogLevel.VERBOSE if verbose else logger.LogLevel.INFO
         logger.add_logger_appender(logger.AppenderType.STDOUT, level)
 
-        #Init config
+        # Init config
         conf_file_path = self.conf_file_path \
                 if self.conf_file_path is not None \
                     else self.osutil.get_agent_conf_file_path()
         conf.load_conf_from_file(conf_file_path)
 
-        #Init log
+        # Init log
         verbose = verbose or conf.get_logs_verbose()
         level = logger.LogLevel.VERBOSE if verbose else logger.LogLevel.INFO
         logger.add_logger_appender(logger.AppenderType.FILE, level,
-                                 path="/var/log/waagent.log")
-        if conf.get_logs_console():
+                                   path="/var/log/waagent.log")
+        if conf.get_logs_console() or console_logging:
             logger.add_logger_appender(logger.AppenderType.CONSOLE, level,
-                    path="/dev/console")
+                                       path="/dev/console")
         # See issue #1035
         # logger.add_logger_appender(logger.AppenderType.TELEMETRY,
         #                            logger.LogLevel.WARNING,
@@ -81,7 +82,7 @@ class Agent(object):
                 "Exception occurred while creating extension "
                 "log directory {0}: {1}".format(ext_log_dir, e))
 
-        #Init event reporter
+        # Init event reporter
         event.init_event_status(conf.get_lib_dir())
         event_dir = os.path.join(conf.get_lib_dir(), "events")
         event.init_event_logger(event_dir)
@@ -157,7 +158,7 @@ def main(args=[]):
         start(conf_file_path=conf_file_path)
     else:
         try:
-            agent = Agent(verbose, conf_file_path=conf_file_path)
+            agent = Agent(verbose, conf_file_path=conf_file_path, console_logging=debug)
             if command == "deprovision+user":
                 agent.deprovision(force, deluser=True)
             elif command == "deprovision":

--- a/azurelinuxagent/common/conf.py
+++ b/azurelinuxagent/common/conf.py
@@ -77,7 +77,7 @@ def load_conf_from_file(conf_file_path, conf=__conf__):
     """
     Load conf file from: conf_file_path
     """
-    if os.path.isfile(conf_file_path) == False:
+    if not os.path.isfile(conf_file_path):
         raise AgentConfigError(("Missing configuration in {0}"
                                 "").format(conf_file_path))
     try:
@@ -96,7 +96,7 @@ __SWITCH_OPTIONS__ = {
     "OS.UpdateRdmaDriver": False,
     "OS.CheckRdmaDriver": False,
     "Logs.Verbose": False,
-    "Logs.Console": True,
+    "Logs.Console": False,
     "Extensions.Enabled": True,
     "Provisioning.Enabled": True,
     "Provisioning.UseCloudInit": False,
@@ -174,14 +174,18 @@ def enable_rdma(conf=__conf__):
 def enable_rdma_update(conf=__conf__):
     return conf.get_switch("OS.UpdateRdmaDriver", False)
 
+
 def enable_check_rdma_driver(conf=__conf__):
     return conf.get_switch("OS.CheckRdmaDriver", True)
+
 
 def get_logs_verbose(conf=__conf__):
     return conf.get_switch("Logs.Verbose", False)
 
+
 def get_logs_console(conf=__conf__):
-    return conf.get_switch("Logs.Console", True)
+    return conf.get_switch("Logs.Console", False)
+
 
 def get_lib_dir(conf=__conf__):
     return conf.get("Lib.Dir", "/var/lib/waagent")

--- a/config/alpine/waagent.conf
+++ b/config/alpine/waagent.conf
@@ -55,8 +55,8 @@ LBProbeResponder=y
 
 # Enable logging to serial console (y|n)
 # When stdout is not enough...
-# 'y' if not set
-Logs.Console=y
+# 'n' if not set
+Logs.Console=n
 
 # Enable verbose logging (y|n)
 Logs.Verbose=n

--- a/config/arch/waagent.conf
+++ b/config/arch/waagent.conf
@@ -58,11 +58,11 @@ ResourceDisk.MountOptions=None
 # Respond to load balancer probes if requested by Windows Azure.
 LBProbeResponder=y
 
-# Enable verbose logging (y|n)
+# Enable verbose logging, default is n
 Logs.Verbose=n
 
-# Enable Console logging, default is y
-# Logs.Console=y
+# Enable Console logging, default is n
+# Logs.Console=n
 
 # Is FIPS enabled
 OS.EnableFIPS=n

--- a/config/bigip/waagent.conf
+++ b/config/bigip/waagent.conf
@@ -59,8 +59,8 @@ LBProbeResponder=y
 # Enable verbose logging (y|n)
 Logs.Verbose=n
 
-# Enable Console logging, default is y
-# Logs.Console=y
+# Enable Console logging, default is n
+# Logs.Console=n
 
 # Is FIPS enabled
 OS.EnableFIPS=n

--- a/config/clearlinux/waagent.conf
+++ b/config/clearlinux/waagent.conf
@@ -57,11 +57,11 @@ ResourceDisk.EnableSwap=n
 # Size of the swapfile.
 ResourceDisk.SwapSizeMB=0
 
-# Enable verbose logging (y|n)
+# Enable verbose logging, default is n
 Logs.Verbose=n
 
-# Enable Console logging, default is y
-# Logs.Console=y
+# Enable Console logging, default is n
+# Logs.Console=n
 
 # Is FIPS enabled
 OS.EnableFIPS=n

--- a/config/coreos/waagent.conf
+++ b/config/coreos/waagent.conf
@@ -62,11 +62,11 @@ ResourceDisk.MountOptions=None
 # Respond to load balancer probes if requested by Windows Azure.
 LBProbeResponder=y
 
-# Enable verbose logging (y|n)
+# Enable verbose logging, default is n
 Logs.Verbose=n
 
-# Enable Console logging, default is y
-# Logs.Console=y
+# Enable Console logging, default is n
+# Logs.Console=n
 
 # Is FIPS enabled
 OS.EnableFIPS=n

--- a/config/debian/waagent.conf
+++ b/config/debian/waagent.conf
@@ -59,11 +59,11 @@ ResourceDisk.SwapSizeMB=0
 # Comma-seperated list of mount options. See man(8) for valid options.
 ResourceDisk.MountOptions=None
 
-# Enable verbose logging (y|n)
+# Enable verbose logging, default is n
 Logs.Verbose=n
 
-# Enable Console logging, default is y
-# Logs.Console=y
+# Enable Console logging, default is n
+# Logs.Console=n
 
 # Is FIPS enabled
 OS.EnableFIPS=n

--- a/config/freebsd/waagent.conf
+++ b/config/freebsd/waagent.conf
@@ -56,11 +56,11 @@ ResourceDisk.SwapSizeMB=0
 # Comma-seperated list of mount options. See man(8) for valid options.
 ResourceDisk.MountOptions=None
 
-# Enable verbose logging (y|n)
+# Enable verbose logging, default is n
 Logs.Verbose=n
 
-# Enable Console logging, default is y
-# Logs.Console=y
+# Enable Console logging, default is n
+# Logs.Console=n
 
 # Is FIPS enabled
 OS.EnableFIPS=n

--- a/config/gaia/waagent.conf
+++ b/config/gaia/waagent.conf
@@ -62,8 +62,8 @@ ResourceDisk.MountOptions=None
 # Enable verbose logging (y|n)
 Logs.Verbose=n
 
-# Enable Console logging, default is y
-# Logs.Console=y
+# Enable Console logging, default is n
+# Logs.Console=n
 
 # Is FIPS enabled
 OS.EnableFIPS=n

--- a/config/iosxe/waagent.conf
+++ b/config/iosxe/waagent.conf
@@ -58,8 +58,8 @@ ResourceDisk.MountOptions=None
 # Enable verbose logging (y|n)
 Logs.Verbose=n
 
-# Enable Console logging, default is y
-# Logs.Console=y
+# Enable Console logging, default is n
+# Logs.Console=n
 
 # Is FIPS enabled
 OS.EnableFIPS=n

--- a/config/nsbsd/waagent.conf
+++ b/config/nsbsd/waagent.conf
@@ -52,11 +52,11 @@ ResourceDisk.SwapSizeMB=0
 # Comma-seperated list of mount options. See man(8) for valid options.
 ResourceDisk.MountOptions=None
 
-# Enable verbose logging (y|n)  TODO set n
+# Enable verbose logging, default is n
 Logs.Verbose=n
 
-# Enable Console logging, default is y
-# Logs.Console=y
+# Enable Console logging, default is n
+# Logs.Console=n
 
 # Is FIPS enabled
 OS.EnableFIPS=n

--- a/config/openbsd/waagent.conf
+++ b/config/openbsd/waagent.conf
@@ -52,11 +52,11 @@ ResourceDisk.SwapSizeMB=65536
 # Comma-seperated list of mount options. See man(8) for valid options.
 ResourceDisk.MountOptions=None
 
-# Enable verbose logging (y|n)
+# Enable verbose logging, default is n
 Logs.Verbose=n
 
-# Enable Console logging, default is y
-# Logs.Console=y
+# Enable Console logging, default is n
+# Logs.Console=n
 
 # Is FIPS enabled
 OS.EnableFIPS=n

--- a/config/suse/waagent.conf
+++ b/config/suse/waagent.conf
@@ -62,11 +62,11 @@ ResourceDisk.MountOptions=None
 # Respond to load balancer probes if requested by Microsoft Azure.
 LBProbeResponder=y
 
-# Enable verbose logging (y|n)
+# Enable verbose logging, default is n
 Logs.Verbose=n
 
-# Enable Console logging, default is y
-# Logs.Console=y
+# Enable Console logging, default is n
+# Logs.Console=n
 
 # Is FIPS enabled
 OS.EnableFIPS=n

--- a/config/ubuntu/waagent.conf
+++ b/config/ubuntu/waagent.conf
@@ -62,11 +62,11 @@ ResourceDisk.MountOptions=None
 # Respond to load balancer probes if requested by Microsoft Azure.
 LBProbeResponder=y
 
-# Enable verbose logging (y|n)
+# Enable verbose logging, default is n
 Logs.Verbose=n
 
-# Enable Console logging, default is y
-# Logs.Console=y
+# Enable Console logging, default is n
+# Logs.Console=n
 
 # Is FIPS enabled
 OS.EnableFIPS=n

--- a/config/waagent.conf
+++ b/config/waagent.conf
@@ -59,11 +59,11 @@ ResourceDisk.SwapSizeMB=0
 # Comma-seperated list of mount options. See man(8) for valid options.
 ResourceDisk.MountOptions=None
 
-# Enable verbose logging (y|n)
+# Enable verbose logging, default is n
 Logs.Verbose=n
 
-# Enable Console logging, default is y
-# Logs.Console=y
+# Enable Console logging, default is n
+# Logs.Console=n
 
 # Is FIPS enabled
 OS.EnableFIPS=n

--- a/tests/data/test_waagent.conf
+++ b/tests/data/test_waagent.conf
@@ -138,3 +138,6 @@ CGroups.EnforceLimits=n
 
 # CGroups which are excluded from limits, comma separated
 CGroups.Excluded=customscript,runcommand
+
+# Enable Console logging, default is n
+Logs.Console=n


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
Changing the default option to limit console logging only for the debugging cases. This change prevents the serial console to be flooded.

Issue #1465
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes in the description.
- [x] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [x] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/walinuxagent/1575)
<!-- Reviewable:end -->
