### PR TITLE
Reduce the frequency of log statements

### DIFF
--- a/azurelinuxagent/common/logger.py
+++ b/azurelinuxagent/common/logger.py
@@ -45,13 +45,13 @@ class Logger(object):
     def set_prefix(self, prefix):
         self.prefix = prefix
 
-    def is_period_elapsed(self, delta, h):
+    def _is_period_elapsed(self, delta, h):
         return h not in self.logger.periodic_messages or \
             (self.logger.periodic_messages[h] + delta) <= datetime.now()
 
     def _periodic(self, delta, log_level_op, msg_format, *args):
         h = hash(msg_format)
-        if self.is_period_elapsed(delta, h):
+        if self._is_period_elapsed(delta, h):
             log_level_op(msg_format, *args)
             self.logger.periodic_messages[h] = datetime.now()
 
@@ -80,7 +80,7 @@ class Logger(object):
         self.log(LogLevel.ERROR, msg_format, *args)
 
     def log(self, level, msg_format, *args):
-        #if msg_format is not unicode convert it to unicode
+        # if msg_format is not unicode convert it to unicode
         if type(msg_format) is not ustr:
             msg_format = ustr(msg_format, errors="backslashreplace")
         if len(args) > 0:

--- a/azurelinuxagent/common/utils/shellutil.py
+++ b/azurelinuxagent/common/utils/shellutil.py
@@ -98,9 +98,9 @@ def run_get_output(cmd, chk_err=True, log_cmd=True, expected_errors=[]):
                   u"return code: [{1}], " \
                   u"result: [{2}]".format(cmd, e.returncode, output)
             if e.returncode in expected_errors:
-                logger.info(msg)
+                logger.periodic_info(logger.EVERY_FIFTEEN_MINUTES, msg)
             else:
-                logger.error(msg)
+                logger.periodic_error(logger.EVERY_FIFTEEN_MINUTES, msg)
         return e.returncode, output
     except Exception as e:
         if chk_err:

--- a/tests/utils/test_shell_util.py
+++ b/tests/utils/test_shell_util.py
@@ -72,18 +72,22 @@ class RunGetOutputTestCase(AgentTestCase):
         command_in_message = args[1]
         self.assertEqual(command_in_message, command)
 
-
     def test_it_should_log_command_failures_as_errors(self):
+        logger_delta = str("logger.EVERY_FIFTEEN_MINUTES")
         return_code = 99
         command = "exit {0}".format(return_code)
 
         with patch("azurelinuxagent.common.utils.shellutil.logger", autospec=True) as mock_logger:
             shellutil.run_get_output(command, log_cmd=False)
 
-        self.assertEquals(mock_logger.error.call_count, 1)
+        self.assertEquals(mock_logger.periodic_error.call_count, 1)
 
-        args, kwargs = mock_logger.error.call_args
-        message = args[0]  # message is similar to "Command: [exit 99], return code: [99], result: []"
+        args, kwargs = mock_logger.periodic_error.call_args
+
+        time_delta = str(args[0])
+        self.assertIn(logger_delta, time_delta)
+
+        message = args[1]  # message is similar to "Command: [exit 99], return code: [99], result: []"
         self.assertIn("[{0}]".format(command), message)
         self.assertIn("[{0}]".format(return_code), message)
 
@@ -92,16 +96,21 @@ class RunGetOutputTestCase(AgentTestCase):
         self.assertEquals(mock_logger.warn.call_count, 0)
 
     def test_it_should_log_expected_errors_as_info(self):
+        logger_delta = str("logger.EVERY_FIFTEEN_MINUTES")
         return_code = 99
         command = "exit {0}".format(return_code)
 
         with patch("azurelinuxagent.common.utils.shellutil.logger", autospec=True) as mock_logger:
             shellutil.run_get_output(command, log_cmd=False, expected_errors=[return_code])
 
-        self.assertEquals(mock_logger.info.call_count, 1)
+        self.assertEquals(mock_logger.periodic_info.call_count, 1)
 
-        args, kwargs = mock_logger.info.call_args
-        message = args[0]  # message is similar to "Command: [exit 99], return code: [99], result: []"
+        args, kwargs = mock_logger.periodic_info.call_args
+
+        time_delta = str(args[0])
+        self.assertIn(logger_delta, time_delta)
+
+        message = args[1]  # message is similar to "Command: [exit 99], return code: [99], result: []"
         self.assertIn("[{0}]".format(command), message)
         self.assertIn("[{0}]".format(return_code), message)
 
@@ -110,16 +119,21 @@ class RunGetOutputTestCase(AgentTestCase):
         self.assertEquals(mock_logger.error.call_count, 0)
 
     def test_it_should_log_unexpected_errors_as_errors(self):
+        logger_delta = str("logger.EVERY_FIFTEEN_MINUTES")
         return_code = 99
         command = "exit {0}".format(return_code)
 
         with patch("azurelinuxagent.common.utils.shellutil.logger", autospec=True) as mock_logger:
             shellutil.run_get_output(command, log_cmd=False, expected_errors=[return_code + 1])
 
-        self.assertEquals(mock_logger.error.call_count, 1)
+        self.assertEquals(mock_logger.periodic_error.call_count, 1)
 
-        args, kwargs = mock_logger.error.call_args
-        message = args[0]  # message is similar to "Command: [exit 99], return code: [99], result: []"
+        args, kwargs = mock_logger.periodic_error.call_args
+
+        time_delta = str(args[0])
+        self.assertIn(logger_delta, time_delta)
+
+        message = args[1]  # message is similar to "Command: [exit 99], return code: [99], result: []"
         self.assertIn("[{0}]".format(command), message)
         self.assertIn("[{0}]".format(return_code), message)
 


### PR DESCRIPTION

## Description
Change the logging of errors and info to be periodic when running the `run_get_output`. This would help in reducing the log statements which occur for very verbose logs.

Issue #1393
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes in the description.
- [x] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [x] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/walinuxagent/1577)
<!-- Reviewable:end -->
