### PR TITLE
Resetting the poll times when the metric is cleared.

### DIFF
--- a/azurelinuxagent/common/cgroupstelemetry.py
+++ b/azurelinuxagent/common/cgroupstelemetry.py
@@ -194,6 +194,8 @@ class Metric(object):
         self._last_poll_time = dt.utcnow()
 
     def clear(self):
+        self._first_poll_time = None
+        self._last_poll_time = None
         self._data *= 0
 
     def average(self):

--- a/tests/common/test_cgroupstelemetry.py
+++ b/tests/common/test_cgroupstelemetry.py
@@ -700,7 +700,6 @@ class TestMetric(AgentTestCase):
         self.assertEqual(None, test_metric.max())
         self.assertEqual(None, test_metric.min())
         self.assertEqual(None, test_metric.average())
-        # self.assertEqual("None", test_metric.append())
 
     def test_metrics(self):
         num_polls = 10
@@ -714,3 +713,12 @@ class TestMetric(AgentTestCase):
         self.assertListEqual(generate_metric_list(test_values), [test_metric.average(), test_metric.min(),
                                                                  test_metric.max(), test_metric.median(),
                                                                  test_metric.count()])
+
+        test_metric.clear()
+        self.assertEqual("None", test_metric.first_poll_time())
+        self.assertEqual("None", test_metric.last_poll_time())
+        self.assertEqual(0, test_metric.count())
+        self.assertEqual(None, test_metric.median())
+        self.assertEqual(None, test_metric.max())
+        self.assertEqual(None, test_metric.min())
+        self.assertEqual(None, test_metric.average())


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
Currently, the poll times are not reset, causing the stale first-poll time to show up in the reporting period. This change is to reset the poll periods.

<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [X] If applicable, the PR references the bug/issue that it fixes in the description.
- [x] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [X] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/walinuxagent/1583)
<!-- Reviewable:end -->
