### PR TITLE
Clean up old daemon cgroups

### DIFF
--- a/azurelinuxagent/common/cgroupconfigurator.py
+++ b/azurelinuxagent/common/cgroupconfigurator.py
@@ -105,6 +105,13 @@ class CGroupConfigurator(object):
 
             self._invoke_cgroup_operation(__impl, "Failed to create a cgroup for the VM Agent; resource usage for the Agent will not be tracked")
 
+        def cleanup_old_cgroups(self):
+            def __impl():
+                self._cgroups_api.cleanup_old_cgroups()
+
+            self._invoke_cgroup_operation(__impl, "Failed to update the tracking of the daemon; resource usage "
+                                                  "of the agent will not include the daemon process.")
+
         def create_extension_cgroups_root(self):
             """
             Creates the container (directory/cgroup) that includes the cgroups for all extensions (/sys/fs/cgroup/*/walinuxagent.extensions)

--- a/azurelinuxagent/daemon/main.py
+++ b/azurelinuxagent/daemon/main.py
@@ -69,6 +69,7 @@ class DaemonHandler(object):
         self.initialize_environment()
 
         CGroupConfigurator.get_instance().create_agent_cgroups(track_cgroups=False)
+        CGroupConfigurator.get_instance().cleanup_old_cgroups()
 
         # If FIPS is enabled, set the OpenSSL environment variable
         # Note:

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -452,6 +452,7 @@ class UpdateHandler(object):
     def _ensure_cgroups_initialized(self):
         configurator = CGroupConfigurator.get_instance()
         configurator.create_agent_cgroups(track_cgroups=True)
+        configurator.cleanup_old_cgroups()
         configurator.create_extension_cgroups_root()
 
     def _evaluate_agent_health(self, latest_agent):

--- a/tests/common/test_cgroupapi.py
+++ b/tests/common/test_cgroupapi.py
@@ -163,7 +163,6 @@ rdma	6	1	1
             self.assertIn('Error in cgroup controller "cpu": A test exception.', message)
 
 
-@skip_if_predicate_true(is_systemd_present, "FileSystem cgroups API doesn't manage cgroups on systems using systemd.")
 class FileSystemCgroupsApiTestCase(AgentTestCase):
 
     def setUp(self):
@@ -181,6 +180,43 @@ class FileSystemCgroupsApiTestCase(AgentTestCase):
         self.mock__base_cgroups.stop()
 
         AgentTestCase.tearDown(self)
+
+    def test_cleanup_old_cgroups_should_move_daemon_pid_on_all_controllers(self):
+        # Set up the mock /var/run/waagent.pid file
+        daemon_pid = "42"
+        daemon_pid_file_tmp = os.path.join(self.tmp_dir, "waagent.pid")
+        with open(daemon_pid_file_tmp, "w") as f:
+            f.write(daemon_pid)
+
+        # Set up old controller cgroups and add the daemon PID to them
+        old_cpu_cgroup = os.path.join(self.cgroups_file_system_root, "cpu", "WALinuxAgent", "WALinuxAgent")
+        old_memory_cgroup = os.path.join(self.cgroups_file_system_root, "memory", "WALinuxAgent", "WALinuxAgent")
+
+        os.makedirs(old_cpu_cgroup)
+        os.makedirs(old_memory_cgroup)
+
+        fileutil.write_file(os.path.join(old_cpu_cgroup, "cgroup.procs"), daemon_pid + "\n")
+        fileutil.write_file(os.path.join(old_memory_cgroup, "cgroup.procs"), daemon_pid + "\n")
+
+        # Set up new controller cgroups and add another PID to them
+        new_cpu_cgroup = os.path.join(self.cgroups_file_system_root, "cpu", VM_AGENT_CGROUP_NAME)
+        new_memory_cgroup = os.path.join(self.cgroups_file_system_root, "memory", VM_AGENT_CGROUP_NAME)
+
+        os.makedirs(new_cpu_cgroup)
+        os.makedirs(new_memory_cgroup)
+
+        fileutil.write_file(os.path.join(new_cpu_cgroup, "cgroup.procs"), "999\n")
+        fileutil.write_file(os.path.join(new_memory_cgroup, "cgroup.procs"), "999\n")
+
+        with patch("azurelinuxagent.common.cgroupapi.DAEMON_PID_FILE", daemon_pid_file_tmp):
+            FileSystemCgroupsApi().cleanup_old_cgroups()
+
+        # The method should have added the daemon PID to the new controllers
+        new_cpu_contents = fileutil.read_file(os.path.join(new_cpu_cgroup, "cgroup.procs"))
+        new_memory_contents = fileutil.read_file(os.path.join(new_memory_cgroup, "cgroup.procs"))
+
+        self.assertTrue(daemon_pid in new_cpu_contents)
+        self.assertTrue(daemon_pid in new_memory_contents)
 
     def test_create_agent_cgroups_should_create_cgroups_on_all_controllers(self):
         agent_cgroups = FileSystemCgroupsApi().create_agent_cgroups()

--- a/tests/common/test_cgroupconfigurator.py
+++ b/tests/common/test_cgroupconfigurator.py
@@ -106,6 +106,7 @@ class CGroupConfiguratorTestCase(AgentTestCase):
         # List of operations to test, and the functions to mock used in order to do verifications
         operations = [
             [lambda: configurator.create_agent_cgroups(track_cgroups=False), "azurelinuxagent.common.cgroupapi.FileSystemCgroupsApi.create_agent_cgroups"],
+            [lambda: configurator.cleanup_old_cgroups(),                     "azurelinuxagent.common.cgroupapi.FileSystemCgroupsApi.cleanup_old_cgroups"],
             [lambda: configurator.create_extension_cgroups_root(),           "azurelinuxagent.common.cgroupapi.FileSystemCgroupsApi.create_extension_cgroups_root"],
             [lambda: configurator.create_extension_cgroups("A.B.C-1.0.0"),   "azurelinuxagent.common.cgroupapi.FileSystemCgroupsApi.create_extension_cgroups"],
             [lambda: configurator.remove_extension_cgroups("A.B.C-1.0.0"),   "azurelinuxagent.common.cgroupapi.FileSystemCgroupsApi.remove_extension_cgroups"]
@@ -123,6 +124,7 @@ class CGroupConfiguratorTestCase(AgentTestCase):
         # List of operations to test, and the functions to mock in order to raise exceptions
         operations = [
             [lambda: configurator.create_agent_cgroups(track_cgroups=False), "azurelinuxagent.common.cgroupapi.FileSystemCgroupsApi.create_agent_cgroups"],
+            [lambda: configurator.cleanup_old_cgroups(),                     "azurelinuxagent.common.cgroupapi.FileSystemCgroupsApi.cleanup_old_cgroups"],
             [lambda: configurator.create_extension_cgroups_root(),           "azurelinuxagent.common.cgroupapi.FileSystemCgroupsApi.create_extension_cgroups_root"],
             [lambda: configurator.create_extension_cgroups("A.B.C-1.0.0"),   "azurelinuxagent.common.cgroupapi.FileSystemCgroupsApi.create_extension_cgroups"],
             [lambda: configurator.remove_extension_cgroups("A.B.C-1.0.0"),   "azurelinuxagent.common.cgroupapi.FileSystemCgroupsApi.remove_extension_cgroups"]


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Daemons from version 2.2.31 to 2.2.40 added their PID to a now-obsolete cgroup `WALinuxAgent/WALinuxAgent`. Add logic to move that PID to the new cgroup, `walinuxagent.service` for each controller to ensure we track both the daemon and extension handler process.

<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/walinuxagent/1595)
<!-- Reviewable:end -->
