### PR TITLE
Remove unnecessary code from is_cgroups_supported

### DIFF
--- a/azurelinuxagent/common/osutil/default.py
+++ b/azurelinuxagent/common/osutil/default.py
@@ -304,17 +304,9 @@ class DefaultOSUtil(object):
     @staticmethod
     def is_cgroups_supported():
         """
-        Enabled by default; disabled in WSL and Trusty.
+        Enabled by default; disabled if the base path of cgroups doesn't exist.
         """
-        is_wsl = '-Microsoft-' in platform.platform()
-        supported = True
-        base_fs_exists = os.path.exists(BASE_CGROUPS)
-
-        # Fails on Trusty based systems as cgroups is not mounted by default.
-        if DISTRO_CODE_NAME.lower() is "trusty":
-            supported = False
-
-        return not is_wsl and base_fs_exists and supported
+        return os.path.exists(BASE_CGROUPS)
 
     @staticmethod
     def _cgroup_path(tail=""):


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Remove leftover and incorrect code that references WSL and Trusty. The only criteria for determining if cgroups is supported is if the path `/sys/fs/cgroups` exists or not.

Issue #1597 <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/walinuxagent/1599)
<!-- Reviewable:end -->
