### PR TITLE
Poll for artifact blob

### DIFF
--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -203,7 +203,7 @@ class ExtHandlersHandler(object):
         self.protocol_util = get_protocol_util()
         self.protocol = None
         self.ext_handlers = None
-        self.last_etag = None
+        self.last_processed_etag = None
         self.log_report = False
         self.log_etag = True
         self.log_process = False
@@ -249,7 +249,7 @@ class ExtHandlersHandler(object):
 
             if self.extension_processing_allowed():
                 self.handle_ext_handlers(etag)
-                self.last_etag = etag
+                self.last_processed_etag = etag
 
             self.report_ext_handlers_status()
             self.cleanup_outdated_handlers()
@@ -416,7 +416,7 @@ class ExtHandlersHandler(object):
                 return
 
             self.get_artifact_error_state.reset()
-            if not ext_handler_i.is_upgrade and self.last_etag == etag:
+            if not ext_handler_i.is_upgrade and self.last_processed_etag == etag:
                 if self.log_etag:
                     ext_handler_i.logger.verbose("Version {0} is current for etag {1}",
                                                  ext_handler_i.pkg.version,

--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -203,7 +203,7 @@ class ExtHandlersHandler(object):
         self.protocol_util = get_protocol_util()
         self.protocol = None
         self.ext_handlers = None
-        self.last_processed_etag = None
+        self.last_etag = None
         self.log_report = False
         self.log_etag = True
         self.log_process = False
@@ -249,7 +249,7 @@ class ExtHandlersHandler(object):
 
             if self.extension_processing_allowed():
                 self.handle_ext_handlers(etag)
-                self.last_processed_etag = etag
+                self.last_etag = etag
 
             self.report_ext_handlers_status()
             self.cleanup_outdated_handlers()
@@ -416,7 +416,7 @@ class ExtHandlersHandler(object):
                 return
 
             self.get_artifact_error_state.reset()
-            if not ext_handler_i.is_upgrade and self.last_processed_etag == etag:
+            if not ext_handler_i.is_upgrade and self.last_etag == etag:
                 if self.log_etag:
                     ext_handler_i.logger.verbose("Version {0} is current for etag {1}",
                                                  ext_handler_i.pkg.version,

--- a/tests/ga/test_extension.py
+++ b/tests/ga/test_extension.py
@@ -797,6 +797,26 @@ class TestExtension(ExtensionTestCase):
             exthandlers_handler.handle_ext_handlers()
             self.assertEqual(1, patch_handle_ext_handler.call_count)
 
+    def test_last_etag_on_extension_processing(self, *args):
+        test_data = WireProtocolData(DATA_FILE)
+        exthandlers_handler, protocol = self._create_mock(test_data, *args)
+        exthandlers_handler.ext_handlers, etag = protocol.get_ext_handlers()
+        exthandlers_handler.protocol = protocol
+
+        # Disable extension handling blocking in the first run and enable in the 2nd run
+        exthandlers_handler.extension_processing_allowed = Mock(side_effect=[False, True])
+
+        exthandlers_handler.run()
+        self.assertIsNone(exthandlers_handler.last_etag,
+                          "The last etag should be None initially as extension_processing is False")
+        self.assertNotEqual(etag, exthandlers_handler.last_etag,
+                            "Last etag and etag should not be same if extension processing is disabled")
+        exthandlers_handler.run()
+        self.assertIsNotNone(exthandlers_handler.last_etag,
+                             "Last etag should not be none if extension processing is allowed")
+        self.assertEqual(etag, exthandlers_handler.last_etag,
+                         "Last etag and etag should be same if extension processing is enabled")
+
     def _assert_ext_status(self, report_ext_status, expected_status,
                            expected_seq_no):
         self.assertTrue(report_ext_status.called)

--- a/tests/ga/test_extension.py
+++ b/tests/ga/test_extension.py
@@ -794,7 +794,7 @@ class TestExtension(ExtensionTestCase):
             self.assertEqual(1, patch_handle_ext_handler.call_count)
 
     def test_last_etag_on_extension_processing(self, *args):
-        test_data = WireProtocolData(copy.deepcopy(DATA_FILE))
+        test_data = WireProtocolData(DATA_FILE)
         exthandlers_handler, protocol = self._create_mock(test_data, *args)
         exthandlers_handler.ext_handlers, etag = protocol.get_ext_handlers()
         exthandlers_handler.protocol = protocol

--- a/tests/ga/test_extension.py
+++ b/tests/ga/test_extension.py
@@ -718,41 +718,37 @@ class TestExtension(ExtensionTestCase):
         exthandlers_handler.run()
 
     def test_extension_processing_allowed(self, *args):
-        test_data = WireProtocolData(DATA_FILE)
-        exthandlers_handler, protocol = self._create_mock(test_data, *args)
-        exthandlers_handler.ext_handlers, exthandlers_handler.last_etag = protocol.get_ext_handlers()
-        exthandlers_handler.protocol = protocol
-        artifact_blob = MagicMock()
-        protocol.get_artifacts_profile = MagicMock(return_value=artifact_blob)
+        exthandlers_handler = get_exthandlers_handler()
+        exthandlers_handler.protocol = Mock()
 
         # disable extension handling in configuration
-        conf.get_extensions_enabled = Mock(return_value=False)
-        self.assertFalse(exthandlers_handler.extension_processing_allowed())
+        with patch.object(conf, 'get_extensions_enabled',  return_value=False):
+            self.assertFalse(exthandlers_handler.extension_processing_allowed())
 
         # enable extension handling in configuration
         with patch.object(conf, "get_extensions_enabled", return_value=True):
 
             # disable overprovisioning in configuration
-            conf.get_enable_overprovisioning = Mock(return_value=False)
-            self.assertTrue(exthandlers_handler.extension_processing_allowed())
+            with patch.object(conf, 'get_enable_overprovisioning', return_value=False):
+                self.assertTrue(exthandlers_handler.extension_processing_allowed())
 
             # enable overprovisioning in configuration
             with patch.object(conf, "get_enable_overprovisioning", return_value=True):
 
-                # disable protocol support for overprovisioning
-                protocol.supports_overprovisioning = Mock(return_value=False)
-                self.assertTrue(exthandlers_handler.extension_processing_allowed())
-
-                # enable protocol support for overprovisioning
-                with patch.object(protocol, "supports_overprovisioning", return_value=True):
-
-                    # Enable on_hold property in artifact_blob
-                    artifact_blob.is_on_hold = Mock(return_value=True)
-                    self.assertFalse(exthandlers_handler.extension_processing_allowed())
-
-                    # Disable on_hold property in artifact_blob
-                    artifact_blob.is_on_hold = Mock(return_value=False)
+                # disable protocol support for over-provisioning
+                with patch.object(exthandlers_handler.protocol, 'supports_overprovisioning', return_value=False):
                     self.assertTrue(exthandlers_handler.extension_processing_allowed())
+
+                # enable protocol support for over-provisioning
+                with patch.object(exthandlers_handler.protocol, "supports_overprovisioning", return_value=True):
+
+                    with patch.object(exthandlers_handler.protocol.get_artifacts_profile(), "is_on_hold",
+                                      side_effect=[True, False]):
+                        # Enable on_hold property in artifact_blob
+                        self.assertFalse(exthandlers_handler.extension_processing_allowed())
+
+                        # Disable on_hold property in artifact_blob
+                        self.assertTrue(exthandlers_handler.extension_processing_allowed())
 
     def test_handle_ext_handlers_on_hold_true(self, *args):
         test_data = WireProtocolData(DATA_FILE)
@@ -798,24 +794,23 @@ class TestExtension(ExtensionTestCase):
             self.assertEqual(1, patch_handle_ext_handler.call_count)
 
     def test_last_etag_on_extension_processing(self, *args):
-        test_data = WireProtocolData(DATA_FILE)
+        test_data = WireProtocolData(copy.deepcopy(DATA_FILE))
         exthandlers_handler, protocol = self._create_mock(test_data, *args)
         exthandlers_handler.ext_handlers, etag = protocol.get_ext_handlers()
         exthandlers_handler.protocol = protocol
 
         # Disable extension handling blocking in the first run and enable in the 2nd run
-        exthandlers_handler.extension_processing_allowed = Mock(side_effect=[False, True])
-
-        exthandlers_handler.run()
-        self.assertIsNone(exthandlers_handler.last_etag,
-                          "The last etag should be None initially as extension_processing is False")
-        self.assertNotEqual(etag, exthandlers_handler.last_etag,
-                            "Last etag and etag should not be same if extension processing is disabled")
-        exthandlers_handler.run()
-        self.assertIsNotNone(exthandlers_handler.last_etag,
-                             "Last etag should not be none if extension processing is allowed")
-        self.assertEqual(etag, exthandlers_handler.last_etag,
-                         "Last etag and etag should be same if extension processing is enabled")
+        with patch.object(exthandlers_handler, 'extension_processing_allowed', side_effect=[False, True]):
+            exthandlers_handler.run()
+            self.assertIsNone(exthandlers_handler.last_etag,
+                              "The last etag should be None initially as extension_processing is False")
+            self.assertNotEqual(etag, exthandlers_handler.last_etag,
+                                "Last etag and etag should not be same if extension processing is disabled")
+            exthandlers_handler.run()
+            self.assertIsNotNone(exthandlers_handler.last_etag,
+                                 "Last etag should not be none if extension processing is allowed")
+            self.assertEqual(etag, exthandlers_handler.last_etag,
+                             "Last etag and etag should be same if extension processing is enabled")
 
     def _assert_ext_status(self, report_ext_status, expected_status,
                            expected_seq_no):


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
This PR is to fix the bug where the agent doesn't poll for change in the artifact_blob.on_hold property and waits for a new goalstate to start extension processing.

Note: DCR testing passed (except for the known cgroup issue already fixed in develop)


Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/walinuxagent/1602)
<!-- Reviewable:end -->
