### PR TITLE
Ignore stderr from openssl commands when saving to a variable

### DIFF
--- a/azurelinuxagent/common/utils/cryptutil.py
+++ b/azurelinuxagent/common/utils/cryptutil.py
@@ -47,15 +47,13 @@ class CryptUtil(object):
                "-out {2}").format(self.openssl_cmd, prv_file, crt_file)
         rc = shellutil.run(cmd)
         if rc != 0:
-            logger.error("Failed to create {0} and {1} certificates".format(
-                prv_file, crt_file))
+            logger.error("Failed to create {0} and {1} certificates".format(prv_file, crt_file))
 
     def get_pubkey_from_prv(self, file_name):
         if not os.path.exists(file_name):
             raise IOError(errno.ENOENT, "File not found", file_name)
         else:
-            cmd = "{0} pkey -in {1} -pubout 2>/dev/null".format(self.openssl_cmd,
-                                                                file_name)
+            cmd = "{0} pkey -in {1} -pubout 2>/dev/null".format(self.openssl_cmd, file_name)
             pub = shellutil.run_get_output(cmd)[1]
             return pub
 
@@ -63,8 +61,7 @@ class CryptUtil(object):
         if not os.path.exists(file_name):
             raise IOError(errno.ENOENT, "File not found", file_name)
         else:
-            cmd = "{0} x509 -in {1} -pubkey -noout".format(self.openssl_cmd,
-                                                           file_name)
+            cmd = "{0} x509 -in {1} -pubkey -noout 2>/dev/null".format(self.openssl_cmd, file_name)
             pub = shellutil.run_get_output(cmd)[1]
             return pub
 
@@ -72,8 +69,7 @@ class CryptUtil(object):
         if not os.path.exists(file_name):
             raise IOError(errno.ENOENT, "File not found", file_name)
         else:
-            cmd = "{0} x509 -in {1} -fingerprint -noout".format(self.openssl_cmd,
-                                                                file_name)
+            cmd = "{0} x509 -in {1} -fingerprint -noout 2>/dev/null".format(self.openssl_cmd, file_name)
             thumbprint = shellutil.run_get_output(cmd)[1]
             thumbprint = thumbprint.rstrip().split('=')[1].replace(':', '').upper()
             return thumbprint

--- a/azurelinuxagent/common/utils/cryptutil.py
+++ b/azurelinuxagent/common/utils/cryptutil.py
@@ -53,24 +53,24 @@ class CryptUtil(object):
         if not os.path.exists(file_name):
             raise IOError(errno.ENOENT, "File not found", file_name)
         else:
-            cmd = "{0} pkey -in {1} -pubout 2>/dev/null".format(self.openssl_cmd, file_name)
-            pub = shellutil.run_get_output(cmd)[1]
+            cmd = "{0} pkey -in {1} -pubout".format(self.openssl_cmd, file_name)
+            pub = shellutil.run_command(cmd.split(" "))
             return pub
 
     def get_pubkey_from_crt(self, file_name):
         if not os.path.exists(file_name):
             raise IOError(errno.ENOENT, "File not found", file_name)
         else:
-            cmd = "{0} x509 -in {1} -pubkey -noout 2>/dev/null".format(self.openssl_cmd, file_name)
-            pub = shellutil.run_get_output(cmd)[1]
+            cmd = "{0} x509 -in {1} -pubkey -noout".format(self.openssl_cmd, file_name)
+            pub = shellutil.run_command(cmd.split(" "))
             return pub
 
     def get_thumbprint_from_crt(self, file_name):
         if not os.path.exists(file_name):
             raise IOError(errno.ENOENT, "File not found", file_name)
         else:
-            cmd = "{0} x509 -in {1} -fingerprint -noout 2>/dev/null".format(self.openssl_cmd, file_name)
-            thumbprint = shellutil.run_get_output(cmd)[1]
+            cmd = "{0} x509 -in {1} -fingerprint -noout".format(self.openssl_cmd, file_name)
+            thumbprint = shellutil.run_command(cmd.split(" "))
             thumbprint = thumbprint.rstrip().split('=')[1].replace(':', '').upper()
             return thumbprint
 

--- a/azurelinuxagent/common/utils/cryptutil.py
+++ b/azurelinuxagent/common/utils/cryptutil.py
@@ -20,7 +20,6 @@
 import base64
 import errno
 import struct
-import sys
 import os.path
 import subprocess
 
@@ -29,7 +28,7 @@ from azurelinuxagent.common.exception import CryptError
 
 import azurelinuxagent.common.logger as logger
 import azurelinuxagent.common.utils.shellutil as shellutil
-import azurelinuxagent.common.utils.textutil as textutil
+
 
 DECRYPT_SECRET_CMD = "{0} cms -decrypt -inform DER -inkey {1} -in /dev/stdin"
 
@@ -53,24 +52,24 @@ class CryptUtil(object):
         if not os.path.exists(file_name):
             raise IOError(errno.ENOENT, "File not found", file_name)
         else:
-            cmd = "{0} pkey -in {1} -pubout".format(self.openssl_cmd, file_name)
-            pub = shellutil.run_command(cmd.split(" "))
+            cmd = [self.openssl_cmd, "pkey", "-in", file_name, "-pubout"]
+            pub = shellutil.run_command(cmd)
             return pub
 
     def get_pubkey_from_crt(self, file_name):
         if not os.path.exists(file_name):
             raise IOError(errno.ENOENT, "File not found", file_name)
         else:
-            cmd = "{0} x509 -in {1} -pubkey -noout".format(self.openssl_cmd, file_name)
-            pub = shellutil.run_command(cmd.split(" "))
+            cmd = [self.openssl_cmd, "x509", "-in", file_name, "-pubkey", "-noout"]
+            pub = shellutil.run_command(cmd)
             return pub
 
     def get_thumbprint_from_crt(self, file_name):
         if not os.path.exists(file_name):
             raise IOError(errno.ENOENT, "File not found", file_name)
         else:
-            cmd = "{0} x509 -in {1} -fingerprint -noout".format(self.openssl_cmd, file_name)
-            thumbprint = shellutil.run_command(cmd.split(" "))
+            cmd = [self.openssl_cmd, "x509", "-in", file_name, "-fingerprint", "-noout"]
+            thumbprint = shellutil.run_command(cmd)
             thumbprint = thumbprint.rstrip().split('=')[1].replace(':', '').upper()
             return thumbprint
 

--- a/azurelinuxagent/common/utils/shellutil.py
+++ b/azurelinuxagent/common/utils/shellutil.py
@@ -120,7 +120,6 @@ def _encode_command_output(output):
 def run_command(command):
     """
     Wrapper for subprocess.Popen. Executes the given command and returns its stdout.
-    The command parameter is a list of strings, e.g. ["ps" "aux"].
     Logs any errors executing the command and raises an exception.
     """
     retcode = 0
@@ -130,7 +129,7 @@ def run_command(command):
         stdout, stderr = process.communicate()
         retcode = process.returncode
     except Exception as e:
-        logger.error(u"Command [{0}] raised unexpected exception: [{1}]".format(command, ustr(e)))
+        logger.error(u"Cannot execute [{0}]. Error: [{1}]".format(command, ustr(e)))
         raise
 
     if retcode != 0:

--- a/azurelinuxagent/common/utils/shellutil.py
+++ b/azurelinuxagent/common/utils/shellutil.py
@@ -110,6 +110,34 @@ def run_get_output(cmd, chk_err=True, log_cmd=True, expected_errors=[]):
     return 0, output
 
 
+def _encode_command_output(output):
+    return ustr(output, encoding='utf-8', errors="backslashreplace")
+
+
+def run_command(command):
+    """
+    Wrapper for subprocess.Popen.
+    Executes the given command and returns its stdout. Logs any errors executing the command and raises an exception.
+    """
+    try:
+        process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=False)
+        stdout, stderr = process.communicate()
+        retcode = process.returncode
+
+        if retcode:
+            logger.error(u"Command: [{0}], return code: [{1}], "
+                         u"stdout: [{2}] stderr: [{3}]".format(command,
+                                                               retcode,
+                                                               _encode_command_output(stdout),
+                                                               _encode_command_output(stderr)))
+            raise subprocess.CalledProcessError(retcode, command)
+    except Exception as e:
+        logger.error(u"Command [{0}] raised unexpected exception: [{1}]".format(command, ustr(e)))
+        raise
+
+    return _encode_command_output(stdout)
+
+
 def quote(word_list):
     """
     Quote a list or tuple of strings for Unix Shell as words, using the

--- a/tests/utils/test_shell_util.py
+++ b/tests/utils/test_shell_util.py
@@ -158,7 +158,7 @@ class RunCommandTestCase(AgentTestCase):
 
             ex = context_manager.exception
             exception_message = u"Command [{0}] failed with return code [{1}]".format(command, expected_returncode)
-            self.assertEquals(exception_message, ex.message)
+            self.assertEquals(exception_message, ex.args[0])
 
             self.assertEquals(mock_logger.error.call_count, 1)
 
@@ -174,8 +174,8 @@ class RunCommandTestCase(AgentTestCase):
 
             self.assertEquals(mock_logger.error.call_count, 1)
 
-            logged_error_message = u"Cannot execute [{0}]. Error: [{1}]".format(command,
-                                                                                "[Errno 2] No such file or directory")
+            logged_error_message = u"Cannot execute [{0}]. Error: [{1}".format(command,
+                                                                               "[Errno 2] No such file or directory")
             self.assertIn(logged_error_message, mock_logger.error.call_args_list[0][0][0])
 
 

--- a/tests/utils/test_shell_util.py
+++ b/tests/utils/test_shell_util.py
@@ -162,20 +162,23 @@ class RunCommandTestCase(AgentTestCase):
 
             ex = context_manager.exception
             self.assertEquals(subprocess.CalledProcessError, type(ex))
-            self.assertEquals((expected_returncode, ["ls", "nonexistent_file"]), ex.args)
+            self.assertEquals(expected_returncode, ex.returncode)
+            self.assertEquals(command, ex.cmd)
 
             self.assertEquals(mock_logger.error.call_count, 2)
 
-            logged_error_first = "Command: [{0}], return code: [{1}], " \
-                                 "stdout: [] stderr: [{2}]".format(command, expected_returncode,
-                                                                   "ls: cannot access 'nonexistent_file': "
-                                                                   "No such file or directory\n")
+            logged_error_first = u"Command: [{0}], return code: [{1}], " \
+                                 u"stdout: [] stderr: [{2}]".format(command, expected_returncode,
+                                                                    "ls: cannot access 'nonexistent_file': "
+                                                                    "No such file or directory\n")
             self.assertEquals(mock_logger.error.call_args_list[0][0][0], logged_error_first)
 
-            logged_error_second = "Command [{0}] raised unexpected exception: " \
-                                  "[Command '{0}' returned non-zero exit status {1}.]".format(command,
+            logged_error_second = u"Command [{0}] raised unexpected exception: " \
+                                  u"[Command '{0}' returned non-zero exit status {1}]".format(command,
                                                                                               expected_returncode)
-            self.assertEquals(mock_logger.error.call_args_list[1][0][0], logged_error_second)
+            # The exception message has a "." at the end of the string, depending on the Python version,
+            # not using equals.
+            self.assertIn(logged_error_second, mock_logger.error.call_args_list[1][0][0])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

When calling openssl commands, we aren't ignoring stderr and saving the output directly to a variable, which then causes dictionary key exceptions to be thrown, like in issue #1514.

<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/walinuxagent/1606)
<!-- Reviewable:end -->
