### PR TITLE
Improvements in run_command

### DIFF
--- a/azurelinuxagent/common/osutil/alpine.py
+++ b/azurelinuxagent/common/osutil/alpine.py
@@ -32,11 +32,7 @@ class AlpineOSUtil(DefaultOSUtil):
         return True
 
     def get_dhcp_pid(self):
-        ret = shellutil.run_get_output('pidof dhcpcd', chk_err=False)
-        if ret[0] == 0:
-            logger.info('dhcpcd is pid {}'.format(ret[1]))
-            return ret[1].strip()
-        return None
+        return shellutil.run_command(["pidof", "dhcpcd"]).strip()
 
     def restart_if(self, ifname):
         logger.info('restarting {} (sort of, actually SIGHUPing dhcpcd)'.format(ifname))

--- a/azurelinuxagent/common/osutil/arch.py
+++ b/azurelinuxagent/common/osutil/arch.py
@@ -52,8 +52,7 @@ class ArchUtil(DefaultOSUtil):
         return shellutil.run("systemctl stop {0}".format(self.service_name), chk_err=False)
 
     def get_dhcp_pid(self):
-        ret= shellutil.run_get_output("pidof systemd-networkd")
-        return ret[1] if ret[0] == 0 else None
+        return shellutil.run_command(["pidof", "systemd-networkd"]).strip()
 
     def conf_sshd(self, disable_password):
         # Don't whack the system default sshd conf

--- a/azurelinuxagent/common/osutil/bigip.py
+++ b/azurelinuxagent/common/osutil/bigip.py
@@ -97,8 +97,7 @@ class BigIpOSUtil(DefaultOSUtil):
         return shellutil.run("/sbin/chkconfig --del {0}".format(self.service_name), chk_err=False)
 
     def get_dhcp_pid(self):
-        ret = shellutil.run_get_output("/sbin/pidof dhclient")
-        return ret[1] if ret[0] == 0 else None
+        return shellutil.run_command(["/sbin/pidof", "dhclient"]).strip()
 
     def set_hostname(self, hostname):
         """Set the static hostname of the device

--- a/azurelinuxagent/common/osutil/clearlinux.py
+++ b/azurelinuxagent/common/osutil/clearlinux.py
@@ -66,8 +66,7 @@ class ClearLinuxUtil(DefaultOSUtil):
         return shellutil.run("systemctl stop {0}".format(self.service_name), chk_err=False)
 
     def get_dhcp_pid(self):
-        ret= shellutil.run_get_output("pidof systemd-networkd")
-        return ret[1] if ret[0] == 0 else None
+        return shellutil.run_command(["pidof", "systemd-networkd"]).strip()
 
     def conf_sshd(self, disable_password):
         # Don't whack the system default sshd conf

--- a/azurelinuxagent/common/osutil/default.py
+++ b/azurelinuxagent/common/osutil/default.py
@@ -1107,8 +1107,7 @@ class DefaultOSUtil(object):
         return shellutil.run(cmd, chk_err=False)
 
     def get_dhcp_pid(self):
-        ret = shellutil.run_get_output("pidof dhclient", chk_err=False)
-        return ret[1] if ret[0] == 0 else None
+        return  shellutil.run_command(["pidof", "dhclient"]).strip()
 
     def set_hostname(self, hostname):
         fileutil.write_file('/etc/hostname', hostname)

--- a/azurelinuxagent/common/osutil/openwrt.py
+++ b/azurelinuxagent/common/osutil/openwrt.py
@@ -63,9 +63,7 @@ class OpenWRTOSUtil(DefaultOSUtil):
                                "output:{2}").format(username, retcode, out))
 
     def get_dhcp_pid(self):
-        cmd = "pidof {0}".format(self.dhclient_name)
-        ret= shellutil.run_get_output(cmd, chk_err=False)
-        return ret[1] if ret[0] == 0 else None
+        return shellutil.run_command(["pidof", self.dhclient_name]).strip()
 
     def get_nic_state(self):
         """

--- a/azurelinuxagent/common/osutil/redhat.py
+++ b/azurelinuxagent/common/osutil/redhat.py
@@ -72,8 +72,7 @@ class Redhat6xOSUtil(DefaultOSUtil):
 
     # Override
     def get_dhcp_pid(self):
-        ret = shellutil.run_get_output("pidof dhclient", chk_err=False)
-        return ret[1] if ret[0] == 0 else None
+        return shellutil.run_command(["pidof", "dhclient"]).strip()
 
     def set_hostname(self, hostname):
         """

--- a/azurelinuxagent/common/osutil/suse.py
+++ b/azurelinuxagent/common/osutil/suse.py
@@ -45,9 +45,7 @@ class SUSE11OSUtil(DefaultOSUtil):
         shellutil.run("hostname {0}".format(hostname), chk_err=False)
 
     def get_dhcp_pid(self):
-        ret = shellutil.run_get_output("pidof {0}".format(self.dhclient_name),
-                                       chk_err=False)
-        return ret[1] if ret[0] == 0 else None
+        return shellutil.run_command(["pidof", self.dhclient_name]).strip()
 
     def is_dhcp_enabled(self):
         return True

--- a/azurelinuxagent/common/osutil/ubuntu.py
+++ b/azurelinuxagent/common/osutil/ubuntu.py
@@ -60,8 +60,7 @@ class Ubuntu12OSUtil(Ubuntu14OSUtil):
 
     # Override
     def get_dhcp_pid(self):
-        ret = shellutil.run_get_output("pidof dhclient3", chk_err=False)
-        return ret[1] if ret[0] == 0 else None
+        return shellutil.run_command(["pidof", "dhclient3"]).strip()
 
     def mount_cgroups(self):
         pass
@@ -97,8 +96,7 @@ class Ubuntu18OSUtil(Ubuntu16OSUtil):
         self.service_name = self.get_service_name()
 
     def get_dhcp_pid(self):
-        ret = shellutil.run_get_output("pidof systemd-networkd")
-        return ret[1] if ret[0] == 0 else None
+        return shellutil.run_command(["pidof", "systemd-networkd"]).strip()
 
     def start_network(self):
         return shellutil.run("systemctl start systemd-networkd", chk_err=False)

--- a/azurelinuxagent/common/utils/cryptutil.py
+++ b/azurelinuxagent/common/utils/cryptutil.py
@@ -53,7 +53,7 @@ class CryptUtil(object):
             raise IOError(errno.ENOENT, "File not found", file_name)
         else:
             cmd = [self.openssl_cmd, "pkey", "-in", file_name, "-pubout"]
-            pub = shellutil.run_command(cmd)
+            pub = shellutil.run_command(cmd, log_error=True)
             return pub
 
     def get_pubkey_from_crt(self, file_name):
@@ -61,7 +61,7 @@ class CryptUtil(object):
             raise IOError(errno.ENOENT, "File not found", file_name)
         else:
             cmd = [self.openssl_cmd, "x509", "-in", file_name, "-pubkey", "-noout"]
-            pub = shellutil.run_command(cmd)
+            pub = shellutil.run_command(cmd, log_error=True)
             return pub
 
     def get_thumbprint_from_crt(self, file_name):

--- a/azurelinuxagent/common/utils/shellutil.py
+++ b/azurelinuxagent/common/utils/shellutil.py
@@ -153,9 +153,10 @@ def run_command(command, log_error=False):
         encoded_stdout = _encode_command_output(stdout)
         encoded_stderr = _encode_command_output(stderr)
         if log_error:
+            formatted_command = " ".join(command) if isinstance(command, list) else command
             logger.error(
                 "Command: [{0}], return code: [{1}], stdout: [{2}] stderr: [{3}]",
-                command,
+                formatted_command,
                 returncode,
                 encoded_stdout,
                 encoded_stderr)

--- a/azurelinuxagent/common/utils/shellutil.py
+++ b/azurelinuxagent/common/utils/shellutil.py
@@ -101,9 +101,9 @@ def run_get_output(cmd, chk_err=True, log_cmd=True, expected_errors=[]):
                   u"return code: [{1}], " \
                   u"result: [{2}]".format(cmd, e.returncode, output)
             if e.returncode in expected_errors:
-                logger.periodic_info(logger.EVERY_FIFTEEN_MINUTES, msg)
+                logger.info(msg)
             else:
-                logger.periodic_error(logger.EVERY_FIFTEEN_MINUTES, msg)
+                logger.error(msg)
         return e.returncode, output
     except Exception as e:
         if chk_err:
@@ -117,30 +117,51 @@ def _encode_command_output(output):
     return ustr(output, encoding='utf-8', errors="backslashreplace")
 
 
-def run_command(command):
+class CommandError(Exception):
     """
-    Wrapper for subprocess.Popen. Executes the given command and returns its stdout.
-    Logs any errors executing the command and raises an exception.
+    Exception raised by run_command when the command returns an error
     """
-    retcode = 0
+    @staticmethod
+    def _get_message(command, returncode):
+        command_name = command[0] if isinstance(command, list) and len(command) > 0 else command
+        return "'{0}' failed: {1}".format(command_name, returncode)
 
+    def __init__(self, command, returncode, stdout, stderr):
+        super(Exception, self).__init__(CommandError._get_message(command, returncode))
+        self.command = command
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def run_command(command, log_error=False):
+    """
+    Executes the given command and returns its stdout as a string.
+    If there are any errors executing the command it logs details about the failure and raises a RunCommandException;
+    if 'log_error' is True, it also logs details about the error.
+    """
     try:
         process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=False)
         stdout, stderr = process.communicate()
-        retcode = process.returncode
+        returncode = process.returncode
     except Exception as e:
-        logger.error(u"Cannot execute [{0}]. Error: [{1}]".format(command, ustr(e)))
+        if log_error:
+            logger.error(u"Command [{0}] raised unexpected exception: [{1}]", command, ustr(e))
         raise
 
-    if retcode != 0:
-        logger.error(u"Command: [{0}], return code: [{1}], "
-                     u"stdout: [{2}] stderr: [{3}]".format(command,
-                                                           retcode,
-                                                           _encode_command_output(stdout),
-                                                           _encode_command_output(stderr)))
-        raise Exception(u"Command [{0}] failed with return code [{1}]".format(command, retcode))
-    else:
-        return _encode_command_output(stdout)
+    if returncode != 0:
+        encoded_stdout = _encode_command_output(stdout)
+        encoded_stderr = _encode_command_output(stderr)
+        if log_error:
+            logger.error(
+                "Command: [{0}], return code: [{1}], stdout: [{2}] stderr: [{3}]",
+                command,
+                returncode,
+                encoded_stdout,
+                encoded_stderr)
+        raise CommandError(command=command, returncode=returncode, stdout=encoded_stdout, stderr=encoded_stderr)
+
+    return _encode_command_output(stdout)
 
 
 def quote(word_list):

--- a/azurelinuxagent/common/utils/shellutil.py
+++ b/azurelinuxagent/common/utils/shellutil.py
@@ -140,23 +140,25 @@ def run_command(command, log_error=False):
     If there are any errors executing the command it logs details about the failure and raises a RunCommandException;
     if 'log_error' is True, it also logs details about the error.
     """
+    def format_command(cmd):
+        return " ".join(cmd) if isinstance(cmd, list) else command
+
     try:
         process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=False)
         stdout, stderr = process.communicate()
         returncode = process.returncode
     except Exception as e:
         if log_error:
-            logger.error(u"Command [{0}] raised unexpected exception: [{1}]", command, ustr(e))
+            logger.error(u"Command [{0}] raised unexpected exception: [{1}]", format_command(command), ustr(e))
         raise
 
     if returncode != 0:
         encoded_stdout = _encode_command_output(stdout)
         encoded_stderr = _encode_command_output(stderr)
         if log_error:
-            formatted_command = " ".join(command) if isinstance(command, list) else command
             logger.error(
                 "Command: [{0}], return code: [{1}], stdout: [{2}] stderr: [{3}]",
-                formatted_command,
+                format_command(command),
                 returncode,
                 encoded_stdout,
                 encoded_stderr)

--- a/azurelinuxagent/ga/env.py
+++ b/azurelinuxagent/ga/env.py
@@ -22,9 +22,6 @@ import os
 import socket
 import time
 import threading
-
-import operator
-
 import datetime
 
 import azurelinuxagent.common.conf as conf
@@ -32,10 +29,10 @@ import azurelinuxagent.common.logger as logger
 
 from azurelinuxagent.common.dhcp import get_dhcp_handler
 from azurelinuxagent.common.event import add_periodic, WALAEventOperation
+from azurelinuxagent.common.future import ustr
 from azurelinuxagent.common.osutil import get_osutil
+from azurelinuxagent.common.utils.shellutil import CommandError
 from azurelinuxagent.common.protocol import get_protocol_util
-from azurelinuxagent.common.protocol.wire import INCARNATION_FILE_NAME
-from azurelinuxagent.common.utils import fileutil
 from azurelinuxagent.common.utils.archive import StateArchiver
 from azurelinuxagent.common.version import AGENT_NAME, CURRENT_VERSION
 
@@ -68,7 +65,7 @@ class EnvHandler(object):
         self.protocol_util = get_protocol_util()
         self.stopped = True
         self.hostname = None
-        self.dhcp_id = None
+        self.dhcp_id_list = None
         self.server_thread = None
         self.dhcp_warning_enabled = True
         self.last_archive = None
@@ -83,7 +80,7 @@ class EnvHandler(object):
         logger.info("Start env monitor service.")
         self.dhcp_handler.conf_routes()
         self.hostname = self.osutil.get_hostname_record()
-        self.dhcp_id = self.osutil.get_dhcp_pid()
+        self.dhcp_id_list = get_dhcp_client_pid()
         self.start()
 
     def is_alive(self):
@@ -107,7 +104,6 @@ class EnvHandler(object):
             self.osutil.remove_rules_files()
 
             if conf.enable_firewall():
-
                 # If the rules ever change we must reset all rules and start over again.
                 #
                 # There was a rule change at 2.2.26, which started dropping non-root traffic
@@ -117,9 +113,8 @@ class EnvHandler(object):
                     self.osutil.remove_firewall(dst_ip=protocol.endpoint, uid=os.getuid())
                     reset_firewall_fules = True
 
-                success = self.osutil.enable_firewall(
-                                dst_ip=protocol.endpoint,
-                                uid=os.getuid())
+                success = self.osutil.enable_firewall(dst_ip=protocol.endpoint, uid=os.getuid())
+
                 add_periodic(
                     logger.EVERY_HOUR,
                     AGENT_NAME,
@@ -151,25 +146,33 @@ class EnvHandler(object):
             self.osutil.publish_hostname(curr_hostname)
             self.hostname = curr_hostname
 
-    def handle_dhclient_restart(self):
-        if self.dhcp_id is None:
+    def get_dhcp_client_pid(self):
+        pid = None
+        try:
+            # get_dhcp_pid may return multiple PIDs; we split them and return an (alphabetically) sorted list
+            pid = sorted(self.osutil.get_dhcp_pid().split())
+        except CommandError as exception:
             if self.dhcp_warning_enabled:
-                logger.warn("Dhcp client is not running. ")
-            self.dhcp_id = self.osutil.get_dhcp_pid()
-            # disable subsequent error logging
-            self.dhcp_warning_enabled = self.dhcp_id is not None
+                logger.warn("Dhcp client is not running.")
+        except Exception as exception:
+            if self.dhcp_warning_enabled:
+                logger.error("Failed to get the PID of the DHCP client: {0}", ustr(exception))
+        self.dhcp_warning_enabled = pid is not None
+        return pid
+
+    def handle_dhclient_restart(self):
+        if self.dhcp_id_list is None:
+            self.dhcp_id_list = self.get_dhcp_client_pid()
             return
 
-        # the dhcp process has not changed since the last check
-        if self.osutil.check_pid_alive(self.dhcp_id.strip()):
+        if all(self.osutil.check_pid_alive(pid) for pid in self.dhcp_id_list):
             return
 
-        new_pid = self.osutil.get_dhcp_pid()
-        if new_pid is not None and new_pid != self.dhcp_id:
-            logger.info("EnvMonitor: Detected dhcp client restart. "
-                        "Restoring routing table.")
+        new_pid = self.get_dhcp_client_pid()
+        if new_pid is not None and new_pid != self.dhcp_id_list:
+            logger.info("EnvMonitor: Detected dhcp client restart. Restoring routing table.")
             self.dhcp_handler.conf_routes()
-            self.dhcp_id = new_pid
+            self.dhcp_id_list = new_pid
 
     def archive_history(self):
         """

--- a/azurelinuxagent/ga/env.py
+++ b/azurelinuxagent/ga/env.py
@@ -149,7 +149,9 @@ class EnvHandler(object):
     def get_dhcp_client_pid(self):
         pid = None
         try:
-            # get_dhcp_pid may return multiple PIDs; we split them and return an (alphabetically) sorted list
+            # get_dhcp_pid may return multiple PIDs; we split them and return a sorted list.
+            # (we sort the list because handle_dhclient_restart needs to compare the previous value with the new
+            # value and the comparison should not be affected by the order of the items in the list)
             pid = sorted(self.osutil.get_dhcp_pid().split())
         except CommandError as exception:
             if self.dhcp_warning_enabled:

--- a/tests/common/osutil/test_alpine.py
+++ b/tests/common/osutil/test_alpine.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Microsoft Corporation
+# Copyright 2019 Microsoft Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/common/osutil/test_alpine.py
+++ b/tests/common/osutil/test_alpine.py
@@ -1,0 +1,34 @@
+# Copyright 2018 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Requires Python 2.6+ and Openssl 1.0+
+#
+import azurelinuxagent.common.osutil.default as osutil
+from azurelinuxagent.common.osutil.alpine import AlpineOSUtil
+from .test_default import osutil_get_dhcp_pid_should_return_a_pid
+from tests.tools import *
+
+class TestAlpineOSUtil(AgentTestCase):
+    def setUp(self):
+        AgentTestCase.setUp(self)
+
+    def tearDown(self):
+        AgentTestCase.tearDown(self)
+
+    def test_get_dhcp_pid_should_return_a_pid(self):
+        osutil_get_dhcp_pid_should_return_a_pid(self, AlpineOSUtil())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/common/osutil/test_arch.py
+++ b/tests/common/osutil/test_arch.py
@@ -1,0 +1,33 @@
+# Copyright 2018 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Requires Python 2.6+ and Openssl 1.0+
+#
+from azurelinuxagent.common.osutil.arch import ArchUtil
+from .test_default import osutil_get_dhcp_pid_should_return_a_pid
+from tests.tools import *
+
+class TestArchUtil(AgentTestCase):
+    def setUp(self):
+        AgentTestCase.setUp(self)
+
+    def tearDown(self):
+        AgentTestCase.tearDown(self)
+
+    def test_get_dhcp_pid_should_return_a_pid(self):
+        osutil_get_dhcp_pid_should_return_a_pid(self, ArchUtil())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/common/osutil/test_arch.py
+++ b/tests/common/osutil/test_arch.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Microsoft Corporation
+# Copyright 2019 Microsoft Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/common/osutil/test_bigip.py
+++ b/tests/common/osutil/test_bigip.py
@@ -15,15 +15,15 @@
 # Requires Python 2.6+ and Openssl 1.0+
 #
 
-import os
 import socket
-import time
 
 import azurelinuxagent.common.osutil.bigip as osutil
 import azurelinuxagent.common.osutil.default as default
 import azurelinuxagent.common.utils.shellutil as shellutil
 
 from azurelinuxagent.common.exception import OSUtilError
+from azurelinuxagent.common.osutil.bigip import BigIpOSUtil
+from .test_default import osutil_get_dhcp_pid_should_return_a_pid
 from tests.tools import *
 
 
@@ -67,19 +67,6 @@ class TestBigIpOSUtil_save_sys_config(AgentTestCase):
         result = osutil.BigIpOSUtil._save_sys_config(osutil.BigIpOSUtil())
         self.assertEqual(result, 1)
         self.assertEqual(args[0].call_count, 1)
-
-
-class TestBigIpOSUtil_get_dhcp_pid(AgentTestCase):
-
-    @patch.object(shellutil, "run_get_output", return_value=(0, 8623))
-    def test_success(self, *args):
-        result = osutil.BigIpOSUtil.get_dhcp_pid(osutil.BigIpOSUtil())
-        self.assertEqual(result, 8623)
-
-    @patch.object(shellutil, "run_get_output", return_value=(1, 'foo'))
-    def test_failure(self, *args):
-        result = osutil.BigIpOSUtil.get_dhcp_pid(osutil.BigIpOSUtil())
-        self.assertEqual(result, None)
 
 
 class TestBigIpOSUtil_useradd(AgentTestCase):
@@ -317,6 +304,17 @@ class TestBigIpOSUtil_device_for_ide_port(AgentTestCase):
         self.assertEqual(args[0].call_count, 1)
         self.assertEqual(args[1].call_count, 1)
         self.assertEqual(args[2].call_count, 0)
+
+
+class TestBigIpOSUtil(AgentTestCase):
+    def setUp(self):
+        AgentTestCase.setUp(self)
+
+    def tearDown(self):
+        AgentTestCase.tearDown(self)
+
+    def test_get_dhcp_pid_should_return_a_pid(self):
+        osutil_get_dhcp_pid_should_return_a_pid(self, BigIpOSUtil())
 
 
 if __name__ == '__main__':

--- a/tests/common/osutil/test_clearlinux.py
+++ b/tests/common/osutil/test_clearlinux.py
@@ -1,0 +1,33 @@
+# Copyright 2018 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Requires Python 2.6+ and Openssl 1.0+
+#
+from azurelinuxagent.common.osutil.clearlinux import ClearLinuxUtil
+from .test_default import osutil_get_dhcp_pid_should_return_a_pid
+from tests.tools import *
+
+class TestClearLinuxUtil(AgentTestCase):
+    def setUp(self):
+        AgentTestCase.setUp(self)
+
+    def tearDown(self):
+        AgentTestCase.tearDown(self)
+
+    def test_get_dhcp_pid_should_return_a_pid(self):
+        osutil_get_dhcp_pid_should_return_a_pid(self, ClearLinuxUtil())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/common/osutil/test_clearlinux.py
+++ b/tests/common/osutil/test_clearlinux.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Microsoft Corporation
+# Copyright 2019 Microsoft Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/common/osutil/test_openwrt.py
+++ b/tests/common/osutil/test_openwrt.py
@@ -1,0 +1,33 @@
+# Copyright 2018 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Requires Python 2.6+ and Openssl 1.0+
+#
+from azurelinuxagent.common.osutil.openwrt import OpenWRTOSUtil
+from .test_default import osutil_get_dhcp_pid_should_return_a_pid
+from tests.tools import *
+
+class TestOpenWRTOSUtil(AgentTestCase):
+    def setUp(self):
+        AgentTestCase.setUp(self)
+
+    def tearDown(self):
+        AgentTestCase.tearDown(self)
+
+    def test_get_dhcp_pid_should_return_a_pid(self):
+        osutil_get_dhcp_pid_should_return_a_pid(self, OpenWRTOSUtil())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/common/osutil/test_redhat.py
+++ b/tests/common/osutil/test_redhat.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Microsoft Corporation
+# Copyright 2019 Microsoft Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/common/osutil/test_redhat.py
+++ b/tests/common/osutil/test_redhat.py
@@ -1,0 +1,33 @@
+# Copyright 2018 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Requires Python 2.6+ and Openssl 1.0+
+#
+from azurelinuxagent.common.osutil.redhat import Redhat6xOSUtil
+from .test_default import osutil_get_dhcp_pid_should_return_a_pid
+from tests.tools import *
+
+class TestRedhat6xOSUtil(AgentTestCase):
+    def setUp(self):
+        AgentTestCase.setUp(self)
+
+    def tearDown(self):
+        AgentTestCase.tearDown(self)
+
+    def test_get_dhcp_pid_should_return_a_pid(self):
+        osutil_get_dhcp_pid_should_return_a_pid(self, Redhat6xOSUtil())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/common/osutil/test_suse.py
+++ b/tests/common/osutil/test_suse.py
@@ -1,0 +1,33 @@
+# Copyright 2018 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Requires Python 2.6+ and Openssl 1.0+
+#
+from azurelinuxagent.common.osutil.suse import SUSE11OSUtil
+from .test_default import osutil_get_dhcp_pid_should_return_a_pid
+from tests.tools import *
+
+class TestSUSE11OSUtil(AgentTestCase):
+    def setUp(self):
+        AgentTestCase.setUp(self)
+
+    def tearDown(self):
+        AgentTestCase.tearDown(self)
+
+    def test_get_dhcp_pid_should_return_a_pid(self):
+        osutil_get_dhcp_pid_should_return_a_pid(self, SUSE11OSUtil())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/common/osutil/test_suse.py
+++ b/tests/common/osutil/test_suse.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Microsoft Corporation
+# Copyright 2019 Microsoft Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/common/osutil/test_ubuntu.py
+++ b/tests/common/osutil/test_ubuntu.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Microsoft Corporation
+# Copyright 2019 Microsoft Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/common/osutil/test_ubuntu.py
+++ b/tests/common/osutil/test_ubuntu.py
@@ -1,0 +1,44 @@
+# Copyright 2018 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Requires Python 2.6+ and Openssl 1.0+
+#
+from azurelinuxagent.common.osutil.ubuntu import Ubuntu12OSUtil, Ubuntu18OSUtil
+from .test_default import osutil_get_dhcp_pid_should_return_a_pid
+from tests.tools import *
+
+class TestUbuntu12OSUtil(AgentTestCase):
+    def setUp(self):
+        AgentTestCase.setUp(self)
+
+    def tearDown(self):
+        AgentTestCase.tearDown(self)
+
+    def test_get_dhcp_pid_should_return_a_pid(self):
+        osutil_get_dhcp_pid_should_return_a_pid(self, Ubuntu12OSUtil())
+
+
+class TestUbuntu18OSUtil(AgentTestCase):
+    def setUp(self):
+        AgentTestCase.setUp(self)
+
+    def tearDown(self):
+        AgentTestCase.tearDown(self)
+
+    def test_get_dhcp_pid_should_return_a_pid(self):
+        osutil_get_dhcp_pid_should_return_a_pid(self, Ubuntu18OSUtil())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/ga/test_env.py
+++ b/tests/ga/test_env.py
@@ -19,7 +19,7 @@ from azurelinuxagent.ga.env import EnvHandler
 from tests.tools import *
 
 
-class TestMonitor(AgentTestCase):
+class TestEnvHandler(AgentTestCase):
     def setUp(self):
         AgentTestCase.setUp(self)
 
@@ -44,7 +44,7 @@ class TestMonitor(AgentTestCase):
             pids = EnvHandler().get_dhcp_client_pid()
             self.assertEquals(pids, ["11", "22", "4", "5", "6", "9"])
 
-    def test_get_dhcp_client_pid_should_return_none_nad_log_a_warning_when_dhcp_client_is_not_running(self):
+    def test_get_dhcp_client_pid_should_return_none_and_log_a_warning_when_dhcp_client_is_not_running(self):
         with patch("azurelinuxagent.common.osutil.default.shellutil.run_command", side_effect=lambda _: self.shellutil_run_command(["pidof", "non-existing-process"])):
             with patch('azurelinuxagent.common.logger.Logger.warn') as mock_warn:
                 pids = EnvHandler().get_dhcp_client_pid()
@@ -56,7 +56,7 @@ class TestMonitor(AgentTestCase):
         message = args[0]
         self.assertEquals("Dhcp client is not running.", message)
 
-    def test_get_dhcp_client_pid_should_return_none_nad_log_an_error_when_an_invalid_command_is_used(self):
+    def test_get_dhcp_client_pid_should_return_none_and_log_an_error_when_an_invalid_command_is_used(self):
         with patch("azurelinuxagent.common.osutil.default.shellutil.run_command", side_effect=lambda _: self.shellutil_run_command(["non-existing-command"])):
             with patch('azurelinuxagent.common.logger.Logger.error') as mock_error:
                 pids = EnvHandler().get_dhcp_client_pid()

--- a/tests/ga/test_env.py
+++ b/tests/ga/test_env.py
@@ -1,0 +1,161 @@
+# Copyright 2018 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Requires Python 2.6+ and Openssl 1.0+
+#
+from azurelinuxagent.common.osutil.default import DefaultOSUtil, shellutil
+from azurelinuxagent.ga.env import EnvHandler
+from tests.tools import *
+
+
+class TestMonitor(AgentTestCase):
+    def setUp(self):
+        AgentTestCase.setUp(self)
+
+        # save the original run_command so that mocks can reference it
+        self.shellutil_run_command = shellutil.run_command
+
+        # save an instance of the original DefaultOSUtil so that mocks can reference it
+        self.default_osutil = DefaultOSUtil()
+
+        # AgentTestCase.setUp mocks osutil.factory._get_osutil; we override that mock for this class with a new mock
+        # that always returns the default implementation.
+        self.mock_get_osutil = patch("azurelinuxagent.common.osutil.factory._get_osutil", return_value=DefaultOSUtil())
+        self.mock_get_osutil.start()
+
+
+    def tearDown(self):
+        self.mock_get_osutil.stop()
+        AgentTestCase.tearDown(self)
+
+    def test_get_dhcp_client_pid_should_return_a_sorted_list_of_pids(self):
+        with patch("azurelinuxagent.common.utils.shellutil.run_command", return_value="11 9 5 22 4 6"):
+            pids = EnvHandler().get_dhcp_client_pid()
+            self.assertEquals(pids, ["11", "22", "4", "5", "6", "9"])
+
+    def test_get_dhcp_client_pid_should_return_none_nad_log_a_warning_when_dhcp_client_is_not_running(self):
+        with patch("azurelinuxagent.common.osutil.default.shellutil.run_command", side_effect=lambda _: self.shellutil_run_command(["pidof", "non-existing-process"])):
+            with patch('azurelinuxagent.common.logger.Logger.warn') as mock_warn:
+                pids = EnvHandler().get_dhcp_client_pid()
+
+        self.assertIsNone(pids)
+
+        self.assertEquals(mock_warn.call_count, 1)
+        args, kwargs = mock_warn.call_args
+        message = args[0]
+        self.assertEquals("Dhcp client is not running.", message)
+
+    def test_get_dhcp_client_pid_should_return_none_nad_log_an_error_when_an_invalid_command_is_used(self):
+        with patch("azurelinuxagent.common.osutil.default.shellutil.run_command", side_effect=lambda _: self.shellutil_run_command(["non-existing-command"])):
+            with patch('azurelinuxagent.common.logger.Logger.error') as mock_error:
+                pids = EnvHandler().get_dhcp_client_pid()
+
+        self.assertIsNone(pids)
+
+        self.assertEquals(mock_error.call_count, 1)
+        args, kwargs = mock_error.call_args
+        self.assertIn("Failed to get the PID of the DHCP client", args[0])
+        self.assertIn("No such file or directory", args[1])
+
+    def test_get_dhcp_client_pid_should_not_log_consecutive_errors(self):
+        env_handler = EnvHandler()
+
+        with patch('azurelinuxagent.common.logger.Logger.warn') as mock_warn:
+            def assert_warnings(count):
+                self.assertEquals(mock_warn.call_count, count)
+
+                for call_args in mock_warn.call_args_list:
+                    args, kwargs = call_args
+                    self.assertEquals("Dhcp client is not running.", args[0])
+
+            with patch("azurelinuxagent.common.osutil.default.shellutil.run_command", side_effect=lambda _: self.shellutil_run_command(["pidof", "non-existing-process"])):
+                # it should log the first error
+                pids = env_handler.get_dhcp_client_pid()
+                self.assertIsNone(pids)
+                assert_warnings(1)
+
+                # it should not log subsequent errors
+                for i in range(0, 3):
+                    pids = env_handler.get_dhcp_client_pid()
+                    self.assertIsNone(pids)
+                    self.assertEquals(mock_warn.call_count, 1)
+
+            with patch("azurelinuxagent.common.osutil.default.shellutil.run_command", return_value="123"):
+                # now it should succeed
+                pids = env_handler.get_dhcp_client_pid()
+                self.assertEquals(pids, ["123"])
+                assert_warnings(1)
+
+            with patch("azurelinuxagent.common.osutil.default.shellutil.run_command", side_effect=lambda _: self.shellutil_run_command(["pidof", "non-existing-process"])):
+                # it should log the new error
+                pids = env_handler.get_dhcp_client_pid()
+                self.assertIsNone(pids)
+                assert_warnings(2)
+
+                # it should not log subsequent errors
+                for i in range(0, 3):
+                    pids = env_handler.get_dhcp_client_pid()
+                    self.assertIsNone(pids)
+                    self.assertEquals(mock_warn.call_count, 2)
+
+    def test_handle_dhclient_restart_should_reconfigure_network_routes_when_dhcp_client_restarts(self):
+        with patch("azurelinuxagent.common.dhcp.DhcpHandler.conf_routes") as mock_conf_routes:
+            env_handler = EnvHandler()
+
+            #
+            # before the first call to handle_dhclient_restart, EnvHandler configures the network routes and initializes the DHCP PIDs
+            #
+            with patch.object(env_handler, "get_dhcp_client_pid", return_value=["123"]):
+                env_handler.dhcp_handler.conf_routes()
+                env_handler.dhcp_id_list = env_handler.get_dhcp_client_pid()
+                self.assertEquals(mock_conf_routes.call_count, 1)
+
+            #
+            # if the dhcp client has not been restarted then it should not reconfigure the network routes
+            #
+            def mock_check_pid_alive(pid):
+                if pid == "123":
+                    return True
+                raise Exception("Unexpected PID: {0}".format(pid))
+
+            with patch("azurelinuxagent.common.osutil.default.DefaultOSUtil.check_pid_alive", side_effect=mock_check_pid_alive):
+                with patch.object(env_handler, "get_dhcp_client_pid", side_effect=Exception("get_dhcp_client_pid should not have been invoked")):
+                    env_handler.handle_dhclient_restart()
+                    self.assertEquals(mock_conf_routes.call_count, 1)  # count did not change
+
+            #
+            # if the process was restarted then it should reconfigure the network routes
+            #
+            def mock_check_pid_alive(pid):
+                if pid == "123":
+                    return False
+                raise Exception("Unexpected PID: {0}".format(pid))
+
+            with patch("azurelinuxagent.common.osutil.default.DefaultOSUtil.check_pid_alive", side_effect=mock_check_pid_alive):
+                with patch.object(env_handler, "get_dhcp_client_pid", return_value=["456", "789"]):
+                    env_handler.handle_dhclient_restart()
+                    self.assertEquals(mock_conf_routes.call_count, 2)  # count increased
+
+            #
+            # if the new dhcp client has not been restarted then it should not reconfigure the network routes
+            #
+            def mock_check_pid_alive(pid):
+                if pid in ["456", "789"]:
+                    return True
+                raise Exception("Unexpected PID: {0}".format(pid))
+
+            with patch("azurelinuxagent.common.osutil.default.DefaultOSUtil.check_pid_alive", side_effect=mock_check_pid_alive):
+                with patch.object(env_handler, "get_dhcp_client_pid", side_effect=Exception("get_dhcp_client_pid should not have been invoked")):
+                    env_handler.handle_dhclient_restart()
+                    self.assertEquals(mock_conf_routes.call_count, 2)  # count did not change

--- a/tests/utils/test_shell_util.py
+++ b/tests/utils/test_shell_util.py
@@ -183,7 +183,7 @@ class RunCommandTestCase(AgentTestCase):
             self.assertEquals(mock_log_error.call_count, 1)
 
             args, kwargs = mock_log_error.call_args
-            self.assertIn(command, args, msg="The command was not logged")
+            self.assertIn("ls -d /etc nonexistent_file", args, msg="The command was not logged")
             self.assertIn(2, args, msg="The command's return code was not logged")
             self.assertIn("/etc\n", args, msg="The command's stdout was not logged")
             self.assertTrue(any("No such file or directory" in str(a) for a in args), msg="The command's stderr was not logged")

--- a/tests/utils/test_shell_util.py
+++ b/tests/utils/test_shell_util.py
@@ -17,6 +17,7 @@
 #
 
 from tests.tools import *
+from azurelinuxagent.common.logger import LogLevel
 import unittest
 import azurelinuxagent.common.utils.shellutil as shellutil
 
@@ -70,21 +71,17 @@ class RunGetOutputTestCase(AgentTestCase):
         self.assertEqual(command_in_message, command)
 
     def test_it_should_log_command_failures_as_errors(self):
-        logger_delta = str("logger.EVERY_FIFTEEN_MINUTES")
         return_code = 99
         command = "exit {0}".format(return_code)
 
         with patch("azurelinuxagent.common.utils.shellutil.logger", autospec=True) as mock_logger:
             shellutil.run_get_output(command, log_cmd=False)
 
-        self.assertEquals(mock_logger.periodic_error.call_count, 1)
+        self.assertEquals(mock_logger.error.call_count, 1)
 
-        args, kwargs = mock_logger.periodic_error.call_args
+        args, kwargs = mock_logger.error.call_args
 
-        time_delta = str(args[0])
-        self.assertIn(logger_delta, time_delta)
-
-        message = args[1]  # message is similar to "Command: [exit 99], return code: [99], result: []"
+        message = args[0]  # message is similar to "Command: [exit 99], return code: [99], result: []"
         self.assertIn("[{0}]".format(command), message)
         self.assertIn("[{0}]".format(return_code), message)
 
@@ -93,21 +90,17 @@ class RunGetOutputTestCase(AgentTestCase):
         self.assertEquals(mock_logger.warn.call_count, 0)
 
     def test_it_should_log_expected_errors_as_info(self):
-        logger_delta = str("logger.EVERY_FIFTEEN_MINUTES")
         return_code = 99
         command = "exit {0}".format(return_code)
 
         with patch("azurelinuxagent.common.utils.shellutil.logger", autospec=True) as mock_logger:
             shellutil.run_get_output(command, log_cmd=False, expected_errors=[return_code])
 
-        self.assertEquals(mock_logger.periodic_info.call_count, 1)
+        self.assertEquals(mock_logger.info.call_count, 1)
 
-        args, kwargs = mock_logger.periodic_info.call_args
+        args, kwargs = mock_logger.info.call_args
 
-        time_delta = str(args[0])
-        self.assertIn(logger_delta, time_delta)
-
-        message = args[1]  # message is similar to "Command: [exit 99], return code: [99], result: []"
+        message = args[0]  # message is similar to "Command: [exit 99], return code: [99], result: []"
         self.assertIn("[{0}]".format(command), message)
         self.assertIn("[{0}]".format(return_code), message)
 
@@ -116,21 +109,17 @@ class RunGetOutputTestCase(AgentTestCase):
         self.assertEquals(mock_logger.error.call_count, 0)
 
     def test_it_should_log_unexpected_errors_as_errors(self):
-        logger_delta = str("logger.EVERY_FIFTEEN_MINUTES")
         return_code = 99
         command = "exit {0}".format(return_code)
 
         with patch("azurelinuxagent.common.utils.shellutil.logger", autospec=True) as mock_logger:
             shellutil.run_get_output(command, log_cmd=False, expected_errors=[return_code + 1])
 
-        self.assertEquals(mock_logger.periodic_error.call_count, 1)
+        self.assertEquals(mock_logger.error.call_count, 1)
 
-        args, kwargs = mock_logger.periodic_error.call_args
+        args, kwargs = mock_logger.error.call_args
 
-        time_delta = str(args[0])
-        self.assertIn(logger_delta, time_delta)
-
-        message = args[1]  # message is similar to "Command: [exit 99], return code: [99], result: []"
+        message = args[0]  # message is similar to "Command: [exit 99], return code: [99], result: []"
         self.assertIn("[{0}]".format(command), message)
         self.assertIn("[{0}]".format(return_code), message)
 
@@ -140,43 +129,78 @@ class RunGetOutputTestCase(AgentTestCase):
 
 
 class RunCommandTestCase(AgentTestCase):
-    def test_run_command_it_should_run_without_errors(self):
-        command = ["echo", "42"]
+    def test_run_command_should_execute_the_command(self):
+        command = ["echo", "-n", "A TEST STRING"]
+        ret = shellutil.run_command(command)
+        self.assertEquals(ret, "A TEST STRING")
 
-        with patch("azurelinuxagent.common.utils.shellutil.logger", autospec=True) as mock_logger:
-            ret = shellutil.run_command(command)
-            self.assertEquals(ret, "42\n")
-            self.assertEquals(mock_logger.error.call_count, 0)
+    def test_run_command_should_raise_an_exception_when_the_command_fails(self):
+        command = ["ls", "-d", "/etc", "nonexistent_file"]
 
-    def test_run_command_it_should_log_and_raise_an_exception_from_command(self):
-        command = ["ls", "nonexistent_file"]
-        expected_returncode = 2
+        with self.assertRaises(shellutil.CommandError) as context_manager:
+            shellutil.run_command(command)
 
-        with patch("azurelinuxagent.common.utils.shellutil.logger", autospec=True) as mock_logger:
-            with self.assertRaises(Exception) as context_manager:
-                shellutil.run_command(command)
+        exception = context_manager.exception
+        self.assertEquals(str(exception), "'ls' failed: 2")
+        self.assertEquals(exception.stdout, "/etc\n")
+        self.assertIn("No such file or directory", exception.stderr)
+        self.assertEquals(exception.returncode, 2)
 
-            ex = context_manager.exception
-            exception_message = u"Command [{0}] failed with return code [{1}]".format(command, expected_returncode)
-            self.assertEquals(exception_message, ex.args[0])
-
-            self.assertEquals(mock_logger.error.call_count, 1)
-
-            logged_error_message = u"Command: [{0}], return code: [{1}]".format(command, expected_returncode)
-            self.assertIn(logged_error_message, mock_logger.error.call_args_list[0][0][0])
-
-    def test_run_command_it_should_log_and_raise_an_exception_from_invoking_command(self):
+    def test_run_command_should_raise_an_exception_when_it_cannot_execute_the_command(self):
         command = "nonexistent_command"
 
-        with patch("azurelinuxagent.common.utils.shellutil.logger", autospec=True) as mock_logger:
-            with self.assertRaises(Exception):
+        with self.assertRaises(Exception) as context_manager:
+            shellutil.run_command(command)
+
+        exception = context_manager.exception
+        self.assertIn("No such file or directory", str(exception))
+
+    def test_run_command_it_should_not_log_by_default(self):
+
+        def assert_no_message_logged(command):
+            try:
                 shellutil.run_command(command)
+            except:
+                pass
 
-            self.assertEquals(mock_logger.error.call_count, 1)
+            self.assertEquals(mock_logger.info.call_count, 0)
+            self.assertEquals(mock_logger.verbose.call_count, 0)
+            self.assertEquals(mock_logger.warn.call_count, 0)
+            self.assertEquals(mock_logger.error.call_count, 0)
 
-            logged_error_message = u"Cannot execute [{0}]. Error: [{1}".format(command,
-                                                                               "[Errno 2] No such file or directory")
-            self.assertIn(logged_error_message, mock_logger.error.call_args_list[0][0][0])
+            assert_no_message_logged(["ls", "nonexistent_file"])
+            assert_no_message_logged("nonexistent_command")
+
+    def test_run_command_it_should_log_an_error_when_log_error_is_set(self):
+        command = ["ls", "-d", "/etc", "nonexistent_file"]
+
+        with patch("azurelinuxagent.common.utils.shellutil.logger.error") as mock_log_error:
+            try:
+                shellutil.run_command(command, log_error=True)
+            except:
+                pass
+
+            self.assertEquals(mock_log_error.call_count, 1)
+
+            args, kwargs = mock_log_error.call_args
+            self.assertIn(command, args, msg="The command was not logged")
+            self.assertIn(2, args, msg="The command's return code was not logged")
+            self.assertIn("/etc\n", args, msg="The command's stdout was not logged")
+            self.assertTrue(any("No such file or directory" in str(a) for a in args), msg="The command's stderr was not logged")
+
+        command = "nonexistent_command"
+
+        with patch("azurelinuxagent.common.utils.shellutil.logger.error") as mock_log_error:
+            try:
+                shellutil.run_command(command, log_error=True)
+            except:
+                pass
+
+            self.assertEquals(mock_log_error.call_count, 1)
+
+            args, kwargs = mock_log_error.call_args
+            self.assertIn(command, args, msg="The command was not logged")
+            self.assertTrue(any("No such file or directory" in str(a) for a in args), msg="The command's stderr was not logged")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Another round of changes to run_command (which will replace the current run_get_output):

- Errors are now NOT logged by default; the caller needs to explicitly ask for it. This is to avoid situations in which inadvertently we produce too much log output (e.g. the 'pidof' message on the serial console) or disclose sensitive information.

- Created the CommandError exception, to report errors in the command

I also undid the periodic logging in run_get_output since that may lose important logging information.

I changed the implementations of osutil.get_dhcp_pid that use pidof to now use run_command instead of run_get_output.

The environment thread already had logic to report issues in get_dhcp_pid only once, but the implementations in some distros (e.g. Ubuntu 18) were using run_get_output without turning off error logging.

I fixed an issue in EnvHandler.handle_dhclient_restart that I found during testing: some distros (e.g. Ubuntu 18) may have multiple instances of the DHCP client.

I also started unit test suites for some of the distro-dependent implementations of osutil.

I will continue replacing run_get_output with run_command in later PRs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/walinuxagent/1614)
<!-- Reviewable:end -->
