### PR TITLE
Logging a disable error instead of Download error on extension update…

### DIFF
--- a/azurelinuxagent/common/exception.py
+++ b/azurelinuxagent/common/exception.py
@@ -67,6 +67,15 @@ class ExtensionError(AgentError):
         self.code = code
 
 
+class ExtensionUpdateError(ExtensionError):
+    """
+    When failed to download and setup an extension
+    """
+
+    def __init__(self, msg=None, inner=None, code=-1):
+        super(ExtensionUpdateError, self).__init__(msg, inner, code)
+
+
 class ExtensionDownloadError(ExtensionError):
     """
     When failed to download and setup an extension

--- a/tests/ga/test_extension.py
+++ b/tests/ga/test_extension.py
@@ -1460,6 +1460,48 @@ class TestExtension(ExtensionTestCase):
         # On the next iteration, update should not be retried
         self._assert_handler_status(protocol.report_vm_status, "NotReady", expected_ext_count=0, version="1.0.1")
 
+    @patch('azurelinuxagent.ga.exthandlers.HandlerManifest.get_disable_command')
+    def test__old_handler_reports_failure_on_disable_fail_on_update(self, patch_get_disable_command, *args):
+        test_data = WireProtocolData(DATA_FILE_EXT_SINGLE)
+        exthandlers_handler, protocol = self._create_mock(test_data, *args)
+        old_version, new_version = "1.0.0", "1.0.1"
+
+        # Ensure initial install and enable is successful
+        exthandlers_handler.run()
+
+        self.assertEqual(0, patch_get_disable_command.call_count)
+
+        self._assert_handler_status(protocol.report_vm_status, "Ready", expected_ext_count=1, version=old_version)
+        self._assert_ext_status(protocol.report_ext_status, "success", 0)
+
+        # Next incarnation, update version
+        test_data.goal_state = test_data.goal_state.replace("<Incarnation>1<", "<Incarnation>2<")
+        test_data.ext_conf = test_data.ext_conf.replace('version="%s"' % old_version, 'version="%s"' % new_version)
+        test_data.manifest = test_data.manifest.replace(old_version, new_version)
+
+        with patch.object(ExtHandlerInstance, "report_event", autospec=True) as patch_report_event:
+            # Disable of the old extn fails
+            patch_get_disable_command.return_value = "exit 1"
+            exthandlers_handler.run()  # Download the new update the first time, and then we patch the download method.
+            self.assertEqual(1, patch_get_disable_command.call_count)
+
+            old_version_args, old_version_kwargs = patch_report_event.call_args
+            new_version_args, new_version_kwargs = patch_report_event.call_args_list[0]
+
+            self.assertEqual(new_version_args[0].ext_handler.properties.version, new_version,
+                             "The first call to report event should be from the new version of the ext-handler "
+                             "to report download succeeded")
+
+            self.assertEqual(new_version_kwargs['message'], "Download succeeded",
+                             "The message should be Download Succedded")
+
+            self.assertEqual(old_version_args[0].ext_handler.properties.version, old_version,
+                             "The last report event call should be from the old version ext-handler "
+                             "to report the event from the previous version")
+
+            # This is ensuring that the error status is being written to the new version
+        self._assert_handler_status(protocol.report_vm_status, "NotReady", expected_ext_count=0, version=new_version)
+
     @patch('azurelinuxagent.ga.exthandlers.ExtHandlersHandler.handle_ext_handler_error')
     @patch('azurelinuxagent.ga.exthandlers.HandlerManifest.get_update_command')
     def test_upgrade_failure_with_exception_handling(self, patch_get_update_command,


### PR DESCRIPTION
… failures due to disable cmd

<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
This PR is for handling the case where failure of disable.cmd in update scenario would now log from the old extension version and not the new one

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).