### PR TITLE
Improve HostGAPlugin update and add retry logic when header is stale

### DIFF
--- a/azurelinuxagent/common/exception.py
+++ b/azurelinuxagent/common/exception.py
@@ -148,6 +148,15 @@ class HttpError(AgentError):
         super(HttpError, self).__init__(msg, inner)
 
 
+class HostPluginConfigError(AgentError):
+    """
+    Http request failure
+    """
+
+    def __init__(self, msg=None, inner=None):
+        super(HostPluginConfigError, self).__init__(msg, inner)
+
+
 class EventError(AgentError):
     """
     Event reporting error

--- a/azurelinuxagent/common/exception.py
+++ b/azurelinuxagent/common/exception.py
@@ -148,13 +148,13 @@ class HttpError(AgentError):
         super(HttpError, self).__init__(msg, inner)
 
 
-class HostPluginConfigError(AgentError):
+class InvalidContainerError(HttpError):
     """
-    Http request failure
+    Container id sent in the header is invalid
     """
 
     def __init__(self, msg=None, inner=None):
-        super(HostPluginConfigError, self).__init__(msg, inner)
+        super(InvalidContainerError, self).__init__(msg, inner)
 
 
 class EventError(AgentError):

--- a/azurelinuxagent/common/protocol/hostplugin.py
+++ b/azurelinuxagent/common/protocol/hostplugin.py
@@ -23,9 +23,8 @@ import json
 
 from azurelinuxagent.common import logger
 from azurelinuxagent.common.errorstate import ErrorState, ERROR_STATE_HOST_PLUGIN_FAILURE
-from azurelinuxagent.common.exception import HttpError, ProtocolError, \
-                                            ResourceGoneError
-from azurelinuxagent.common.future import ustr, httpclient
+from azurelinuxagent.common.exception import HttpError, ProtocolError
+from azurelinuxagent.common.future import ustr
 from azurelinuxagent.common.protocol.healthservice import HealthService
 from azurelinuxagent.common.utils import restutil
 from azurelinuxagent.common.utils import textutil
@@ -110,6 +109,7 @@ class HostPluginProtocol(object):
         try:
             headers = {HEADER_CONTAINER_ID: self.container_id}
             response = restutil.http_get(url, headers)
+
             if restutil.request_failed(response):
                 error_response = restutil.read_response_error(response)
                 logger.error("HostGAPlugin: Failed Get API versions: {0}".format(error_response))

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -166,6 +166,8 @@ class WireProtocol(Protocol):
 
     def download_ext_handler_pkg(self, uri, destination, headers=None, use_proxy=True):
         direct_func = lambda: self.client.stream(uri, destination, headers=None, use_proxy=True)
+        # NOTE: the host_func may be called after refreshing the goal state, be careful about any goal state data
+        # in the lambda.
         host_func = lambda: self.download_ext_handler_pkg_through_host(uri, destination)
 
         try:
@@ -615,6 +617,8 @@ class WireClient(object):
                 continue
 
             direct_func = lambda: self.fetch(version.uri)
+            # NOTE: the host_func may be called after refreshing the goal state, be careful about any goal state data
+            # in the lambda.
             host_func = lambda: self.fetch_manifest_through_host(version.uri)
 
             try:
@@ -996,6 +1000,9 @@ class WireClient(object):
         # refresh the goal state and try again. If successful, set the host plugin channel as default. If failed,
         # raise the exception.
 
+        # NOTE: direct_func and host_func are passed as lambdas. Be careful about capturing goal state data in them as
+        # they will not be refreshed even if a goal state refresh is called before retrying the host_func.
+
         if not HostPluginProtocol.is_default_channel():
             ret = None
             try:
@@ -1246,6 +1253,8 @@ class WireClient(object):
         if self.has_artifacts_profile_blob():
             blob = self.ext_conf.artifacts_profile_blob
             direct_func = lambda: self.fetch(blob)
+            # NOTE: the host_func may be called after refreshing the goal state, be careful about any goal state data
+            # in the lambda.
             host_func = lambda: self.get_artifacts_profile_through_host(blob)
 
             logger.verbose("Retrieving the artifacts profile")

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -27,7 +27,7 @@ from datetime import datetime
 import azurelinuxagent.common.conf as conf
 import azurelinuxagent.common.utils.textutil as textutil
 from azurelinuxagent.common.exception import ProtocolNotFoundError, \
-    ResourceGoneError, ExtensionDownloadError, HostPluginConfigError
+    ResourceGoneError, ExtensionDownloadError, InvalidContainerError
 from azurelinuxagent.common.future import httpclient, bytebuffer
 from azurelinuxagent.common.protocol.hostplugin import HostPluginProtocol
 from azurelinuxagent.common.protocol.restapi import *
@@ -62,7 +62,7 @@ ENDPOINT_FINE_NAME = "WireServer"
 
 SHORT_WAITING_INTERVAL = 1  # 1 second
 
-MAX_EVENT_BUFFER_SIZE = 2**16 - 2**10
+MAX_EVENT_BUFFER_SIZE = 2 ** 16 - 2 ** 10
 
 
 class UploadError(HttpError):
@@ -165,11 +165,13 @@ class WireProtocol(Protocol):
         return success
 
     def download_ext_handler_pkg(self, uri, destination, headers=None, use_proxy=True):
-        success = self.client.stream(uri, destination, headers=headers, use_proxy=use_proxy)
+        direct_func = lambda: self.client.stream(uri, destination, headers=headers, use_proxy=use_proxy)
+        host_func = lambda: self.download_ext_handler_pkg_through_host(uri, destination)
 
-        if not success:
-            logger.verbose("Download did not succeed, falling back to host plugin")
-            success = self.client.call_function_with_goal_state_refresh_and_retry(lambda: self.download_ext_handler_pkg_through_host(uri, destination))
+        try:
+            success = self.client.send_request_using_appropriate_channel(direct_func, host_func)
+        except Exception:
+            success = False
 
         return success
 
@@ -259,10 +261,10 @@ def ga_status_to_guest_info(ga_status):
     Convert VMStatus object to status blob format
     """
     v1_ga_guest_info = {
-        "computerName" : ga_status.hostname,
-        "osName" : ga_status.osname,
-        "osVersion" : ga_status.osversion,
-        "version" : ga_status.version,
+        "computerName": ga_status.hostname,
+        "osName": ga_status.osname,
+        "osVersion": ga_status.osversion,
+        "version": ga_status.version,
     }
     return v1_ga_guest_info
 
@@ -273,9 +275,9 @@ def ga_status_to_v1(ga_status):
         'message': ga_status.message
     }
     v1_ga_status = {
-        "version" : ga_status.version,
-        "status" : ga_status.status,
-        "formattedMessage" : formatted_msg
+        "version": ga_status.version,
+        "status": ga_status.status,
+        "formattedMessage": formatted_msg
     }
     return v1_ga_status
 
@@ -612,36 +614,18 @@ class WireClient(object):
                 logger.verbose('The specified manifest URL is empty, ignored.')
                 continue
 
-            response = None
-            host = self.get_host_plugin()
+            direct_func = lambda: self.fetch(version.uri)
+            host_func = lambda: self.fetch_manifest_through_host(version.uri)
 
-            if not HostPluginProtocol.is_default_channel():
-                response = self.fetch(version.uri)
+            try:
+                response = self.send_request_using_appropriate_channel(direct_func, host_func)
 
-            if not response:
-                if HostPluginProtocol.is_default_channel():
-                    logger.verbose("Using host plugin as default channel")
-                else:
-                    logger.verbose("Failed to download manifest, "
-                                   "switching to host plugin")
-
-                try:
-                    response = self.call_function_with_goal_state_refresh_and_retry(lambda: self.fetch_manifest_through_host(version.uri))
-
-                # If the HostPlugin rejects the request,
-                # let the error continue, but set to use the HostPlugin
-                except ResourceGoneError:
-                    HostPluginProtocol.set_default_channel(True)
-                    raise
-
-                logger.verbose("Manifest downloaded successfully from host plugin")
-                if not HostPluginProtocol.is_default_channel():
-                    logger.info("Setting host plugin as default channel")
-                    HostPluginProtocol.set_default_channel(True)
-
-            if response:
-                host.manifest_uri = version.uri
-                return response
+                if response:
+                    host = self.get_host_plugin()
+                    host.manifest_uri = version.uri
+                    return response
+            except Exception as e:
+                logger.warn("Exception when fetching manifest. Error: {0}".format(ustr(e)))
 
         raise ExtensionDownloadError("Failed to fetch manifest from all sources")
 
@@ -678,10 +662,10 @@ class WireClient(object):
         resp = None
         try:
             resp = self.call_storage_service(
-                        restutil.http_get,
-                        uri,
-                        headers=headers,
-                        use_proxy=use_proxy)
+                restutil.http_get,
+                uri,
+                headers=headers,
+                use_proxy=use_proxy)
 
             if restutil.request_failed(resp):
                 error_response = restutil.read_response_error(resp)
@@ -699,7 +683,7 @@ class WireClient(object):
 
         except (HttpError, ProtocolError, IOError) as e:
             logger.verbose("Fetch failed from [{0}]: {1}", uri, e)
-            if isinstance(e, ResourceGoneError):
+            if isinstance(e, ResourceGoneError) or isinstance(e, InvalidContainerError):
                 raise
         return resp
 
@@ -734,7 +718,7 @@ class WireClient(object):
         if goal_state.remote_access_uri is None:
             # Nothing in accounts data.  Just return, nothing to do.
             return
-        xml_text = self.fetch_config(goal_state.remote_access_uri, 
+        xml_text = self.fetch_config(goal_state.remote_access_uri,
                                      self.get_header_for_cert())
         self.remote_access = RemoteAccess(xml_text)
         local_file = os.path.join(conf.get_lib_dir(), REMOTE_ACCESS_FILE_NAME.format(self.remote_access.incarnation))
@@ -752,7 +736,7 @@ class WireClient(object):
         xml_text = self.fetch_cache(remote_access_file)
         remote_access = RemoteAccess(xml_text)
         return remote_access
-        
+
     def update_ext_conf(self, goal_state):
         if goal_state.ext_uri is None:
             logger.info("ExtensionsConfig.xml uri is empty")
@@ -803,7 +787,7 @@ class WireClient(object):
                             self.update_host_plugin(current_goal_state_from_configuration.container_id,
                                                     current_goal_state_from_configuration.role_config_name)
 
-                            return                
+                            return
                 self.goal_state_flusher.flush(datetime.utcnow())
 
                 self.goal_state = current_goal_state_from_configuration
@@ -833,7 +817,7 @@ class WireClient(object):
                     logger.error("ProtocolError processing goal state, giving up [{0}]", ustr(e))
 
             except Exception as e:
-                if retry < max_retry-1:
+                if retry < max_retry - 1:
                     logger.verbose("Exception processing goal state, retrying: [{0}]", ustr(e))
                 else:
                     logger.error("Exception processing goal state, giving up: [{0}]", ustr(e))
@@ -903,27 +887,18 @@ class WireClient(object):
                 local_file = os.path.join(conf.get_lib_dir(), local_file)
                 xml_text = self.fetch_cache(local_file)
                 self.ext_conf = ExtensionsConfig(xml_text)
-        return self.ext_conf      
+        return self.ext_conf
 
     def get_ext_manifest(self, ext_handler, goal_state):
-        for update_goal_state in [False, True]:
-            try:
-                if update_goal_state:
-                    self.update_goal_state(forced=True)
-                    goal_state = self.get_goal_state()
+        local_file = MANIFEST_FILE_NAME.format(ext_handler.name, goal_state.incarnation)
+        local_file = os.path.join(conf.get_lib_dir(), local_file)
 
-                local_file = MANIFEST_FILE_NAME.format(
-                                ext_handler.name,
-                                goal_state.incarnation)
-                local_file = os.path.join(conf.get_lib_dir(), local_file)
-                xml_text = self.fetch_manifest(ext_handler.versionUris)
-                self.save_cache(local_file, xml_text)
-                return ExtensionManifest(xml_text)
-
-            except ResourceGoneError:
-                continue
-
-        raise ExtensionDownloadError("Failed to retrieve extension manifest")
+        try:
+            xml_text = self.fetch_manifest(ext_handler.versionUris)
+            self.save_cache(local_file, xml_text)
+            return ExtensionManifest(xml_text)
+        except Exception as e:
+            raise ExtensionDownloadError("Failed to retrieve extension manifest. Error: {0}".format(ustr(e)))
 
     def filter_package_list(self, family, ga_manifest, goal_state):
         complete_list = ga_manifest.pkg_list
@@ -961,29 +936,17 @@ class WireClient(object):
             return allowed_list
 
     def get_gafamily_manifest(self, vmagent_manifest, goal_state):
-        for update_goal_state in [False, True]:
-            try:
-                if update_goal_state:
-                    self.update_goal_state(forced=True)
-                    goal_state = self.get_goal_state()
+        self._remove_stale_agent_manifest(vmagent_manifest.family, goal_state.incarnation)
 
-                self._remove_stale_agent_manifest(
-                    vmagent_manifest.family,
-                    goal_state.incarnation)
+        local_file = MANIFEST_FILE_NAME.format(vmagent_manifest.family, goal_state.incarnation)
+        local_file = os.path.join(conf.get_lib_dir(), local_file)
 
-                local_file = MANIFEST_FILE_NAME.format(
-                                vmagent_manifest.family,
-                                goal_state.incarnation)
-                local_file = os.path.join(conf.get_lib_dir(), local_file)
-                xml_text = self.fetch_manifest(
-                            vmagent_manifest.versionsManifestUris)
-                fileutil.write_file(local_file, xml_text)
-                return ExtensionManifest(xml_text)
-
-            except ResourceGoneError:
-                continue
-
-        raise ProtocolError("Failed to retrieve GAFamily manifest")
+        try:
+            xml_text = self.fetch_manifest(vmagent_manifest.versionsManifestUris)
+            fileutil.write_file(local_file, xml_text)
+            return ExtensionManifest(xml_text)
+        except Exception as e:
+            raise ProtocolError("Failed to retrieve GAFamily manifest. Error: {0}".format(ustr(e)))
 
     def _remove_stale_agent_manifest(self, family, incarnation):
         """
@@ -1020,27 +983,61 @@ class WireClient(object):
                      "advised by Fabric.").format(PROTOCOL_VERSION)
             raise ProtocolNotFoundError(error)
 
-    def call_function_with_goal_state_refresh_and_retry(self, func):
-        # Acts as a wrapper for functions that call HostGAPlugin where either the container id or
-        # role config filename are found in the request header, as they can become stale. The mitigation is to
-        # force a refresh of the goal state and immediately retry issuing the request.
+    def send_request_using_appropriate_channel(self, direct_func, host_func):
+        # A wrapper method for all function calls that send HTTP requests. The purpose of the method is to
+        # define which channel to use, direct or through the host plugin. For the host plugin channel,
+        # also implement a retry mechanism.
+
+        # By default, the direct channel is the default channel. If that is the case, try getting a response
+        # through that channel. On failure, fall back to the host plugin channel.
+
+        # When using the host plugin channel, regardless if it's set as default or not, try sending the request first.
+        # On specific failures that indicate a stale goal state (such as resource gone or invalid container parameter),
+        # refresh the goal state and try again. If successful, set the host plugin channel as default. If failed,
+        # raise the exception.
+
+        if not HostPluginProtocol.is_default_channel():
+            ret = None
+            try:
+                logger.verbose("Using the direct channel")
+                ret = direct_func()
+            except (ResourceGoneError, InvalidContainerError) as e:
+                logger.warn("Failed to get a response using the direct channel, switching to host plugin."
+                            "Error: {0}".format(ustr(e)))
+
+            # If the return value is not None and is not False, the request succeeded
+            if ret:
+                return ret
+            else:
+                logger.warn("Failed to get a response using the direct channel, switching to host plugin.")
+        else:
+            logger.verbose("Using host plugin as default channel")
+
         try:
-            return func()
-        except HostPluginConfigError as e:
-            msg = "HostGAPlugin is misconfigured. ContainerId: {0}, role config file: {1}." \
-                  "Fetching new parameters and retrying the call. Error: {2}".format(self.host_plugin.container_id,
-                                                                                     self.host_plugin.role_config_name,
-                                                                                     ustr(e))
+            ret = host_func()
+        except (ResourceGoneError, InvalidContainerError) as e:
+            msg = "Failed to get a response with the current host plugin configuration." \
+                  "ContainerId: {0}, role config file: {1}. Fetching new parameters and retrying the call." \
+                  "Error: {2}".format(self.host_plugin.container_id, self.host_plugin.role_config_name, ustr(e))
             logger.warn(msg)
 
             self.update_goal_state(forced=True)
-            msg = "HostGAPlugin reconfigured with new parameters. " \
+            msg = "Host plugin reconfigured with new parameters. " \
                   "ContainerId: {0}, role config file: {1}.".format(self.host_plugin.container_id,
                                                                     self.host_plugin.role_config_name)
             logger.info(msg)
-            return func()
+
+            ret = host_func()
         except Exception:
             raise
+
+        logger.info("Got a response using the host plugin channel.")
+
+        if not HostPluginProtocol.is_default_channel():
+            logger.info("Setting host plugin as default channel")
+            HostPluginProtocol.set_default_channel(True)
+
+        return ret
 
     def upload_status_blob(self):
         self.update_goal_state()
@@ -1068,15 +1065,13 @@ class WireClient(object):
         # direct route.
         #
         # The code previously preferred the "direct" route always, and only fell back
-        # to the HostPlugin *if* there was an error.  We would like to move to
+        # to the HostPlugin *if* there was an error. We would like to move to
         # the HostPlugin for all traffic, but this is a big change.  We would like
         # to see how this behaves at scale, and have a fallback should things go
-        # wrong.  This is why we try HostPlugin then direct.
+        # wrong. This is why we try HostPlugin then direct.
         try:
             host = self.get_host_plugin()
-            self.call_function_with_goal_state_refresh_and_retry(lambda: host.put_vm_status(self.status_blob,
-                                                                                            ext_conf.status_upload_blob,
-                                                                                            ext_conf.status_upload_blob_type))
+            host.put_vm_status(self.status_blob, ext_conf.status_upload_blob, ext_conf.status_upload_blob_type)
             return
         except ResourceGoneError:
             # do not attempt direct, force goal state update and wait to try again
@@ -1193,7 +1188,7 @@ class WireClient(object):
 
     def report_status_event(self, message, is_success):
         from azurelinuxagent.common.event import report_event, \
-                WALAEventOperation
+            WALAEventOperation
 
         report_event(op=WALAEventOperation.ReportStatus,
                      is_success=is_success,
@@ -1235,7 +1230,7 @@ class WireClient(object):
 
     def has_artifacts_profile_blob(self):
         return self.ext_conf and not \
-               textutil.is_str_none_or_whitespace(self.ext_conf.artifacts_profile_blob)
+            textutil.is_str_none_or_whitespace(self.ext_conf.artifacts_profile_blob)
 
     def get_artifacts_profile_through_host(self, blob):
         host = self.get_host_plugin()
@@ -1245,53 +1240,36 @@ class WireClient(object):
 
     def get_artifacts_profile(self):
         artifacts_profile = None
-        for update_goal_state in [False, True]:
+
+        if self.has_artifacts_profile_blob():
+            blob = self.ext_conf.artifacts_profile_blob
+            direct_func = lambda: self.fetch(blob)
+            host_func = lambda: self.get_artifacts_profile_through_host(blob)
+
+            logger.verbose("Retrieving the artifacts profile")
+
             try:
-                if update_goal_state:
-                    self.update_goal_state(forced=True)
-
-                if self.has_artifacts_profile_blob():
-                    blob = self.ext_conf.artifacts_profile_blob
-
-                    profile = None
-                    if not HostPluginProtocol.is_default_channel():
-                        logger.verbose("Retrieving the artifacts profile")
-                        profile = self.fetch(blob)
-
-                    if profile is None:
-                        if HostPluginProtocol.is_default_channel():
-                            logger.verbose("Using host plugin as default channel")
-                        else:
-                            logger.verbose("Failed to download artifacts profile, "
-                                           "switching to host plugin")
-
-                        profile = self.call_function_with_goal_state_refresh_and_retry(lambda: self.get_artifacts_profile_through_host(blob))
-
-                    if not textutil.is_str_empty(profile):
-                        logger.verbose("Artifacts profile downloaded")
-                        try:
-                            artifacts_profile = InVMArtifactsProfile(profile)
-                        except Exception:
-                            logger.warn("Could not parse artifacts profile blob")
-                            msg = "Content: [{0}]".format(profile)
-                            logger.verbose(msg)
-
-                            from azurelinuxagent.common.event import report_event, WALAEventOperation
-                            report_event(op=WALAEventOperation.ArtifactsProfileBlob,
-                                         is_success=False,
-                                         message=msg,
-                                         log_event=False)
-
-                return artifacts_profile
-
-            except ResourceGoneError:
-                HostPluginProtocol.set_default_channel(True)
-                continue
-
+                profile = self.send_request_using_appropriate_channel(direct_func, host_func)
             except Exception as e:
                 logger.warn("Exception retrieving artifacts profile: {0}".format(ustr(e)))
+                return None
 
-        return None
+            if not textutil.is_str_empty(profile):
+                logger.verbose("Artifacts profile downloaded")
+                try:
+                    artifacts_profile = InVMArtifactsProfile(profile)
+                except Exception:
+                    logger.warn("Could not parse artifacts profile blob")
+                    msg = "Content: [{0}]".format(profile)
+                    logger.verbose(msg)
+
+                    from azurelinuxagent.common.event import report_event, WALAEventOperation
+                    report_event(op=WALAEventOperation.ArtifactsProfileBlob,
+                                 is_success=False,
+                                 message=msg,
+                                 log_event=False)
+
+        return artifacts_profile
 
 
 class VersionInfo(object):
@@ -1421,6 +1399,7 @@ class RemoteAccess(object):
     """
     Object containing information about user accounts
     """
+
     #
     # <RemoteAccess>
     #   <Version/>
@@ -1469,10 +1448,12 @@ class RemoteAccess(object):
         remote_access_user = RemoteAccessUser(name, encrypted_password, expiration)
         return remote_access_user
 
+
 class UserAccount(object):
     """
     Stores information about single user account
     """
+
     def __init__(self):
         self.Name = None
         self.EncryptedPassword = None
@@ -1500,7 +1481,7 @@ class Certificates(object):
         data = findtext(xml_doc, "Data")
         if data is None:
             return
-    
+
         # if the certificates format is not Pkcs7BlobWithPfxContents do not parse it
         certificateFormat = findtext(xml_doc, "Format")
         if certificateFormat and certificateFormat != "Pkcs7BlobWithPfxContents":
@@ -1771,6 +1752,7 @@ class InVMArtifactsProfile(object):
     * encryptedHealthChecks (optional)
     * encryptedApplicationProfile (optional)
     """
+
     def __init__(self, artifacts_profile):
         if not textutil.is_str_empty(artifacts_profile):
             self.__dict__.update(parse_json(artifacts_profile))

--- a/tests/ga/test_update.py
+++ b/tests/ga/test_update.py
@@ -1341,15 +1341,6 @@ class TestUpdate(UpdateTestCase):
     def test_upgrade_available_returns_true_on_first_use(self):
         self.assertTrue(self._test_upgrade_available())
 
-    def test_upgrade_available_will_refresh_goal_state(self):
-        protocol = self._create_protocol()
-        protocol.emulate_stale_goal_state()
-        self.assertTrue(self._test_upgrade_available(protocol=protocol))
-        self.assertEqual(2, protocol.call_counts["get_vmagent_manifests"])
-        self.assertEqual(1, protocol.call_counts["get_vmagent_pkgs"])
-        self.assertEqual(1, protocol.call_counts["update_goal_state"])
-        self.assertTrue(protocol.goal_state_forced)
-
     def test_upgrade_available_handles_missing_family(self):
         extensions_config = ExtensionsConfig(load_data("wire/ext_conf_missing_family.xml"))
         protocol = ProtocolMock()

--- a/tests/protocol/test_wire.py
+++ b/tests/protocol/test_wire.py
@@ -747,10 +747,6 @@ class TestWireClient(AgentTestCase):
     def test_fetch_manifest_should_not_invoke_host_channel_when_direct_channel_succeeds(self, mock_get_artifact_request, *args):
         mock_get_artifact_request.return_value = "dummy_url", "dummy_header"
         client = WireClient("foo.bar")
-        uri1 = ExtHandlerVersionUri()
-        uri1.uri = 'ext_uri1'
-        uri2 = ExtHandlerVersionUri()
-        uri2.uri = 'ext_uri2'
 
         HostPluginProtocol.set_default_channel(False)
         mock_successful_response = MockResponse(body=b"OK", status_code=200)
@@ -776,10 +772,6 @@ class TestWireClient(AgentTestCase):
     def test_fetch_manifest_should_use_host_channel_when_direct_channel_fails(self, mock_get_artifact_request, *args):
         mock_get_artifact_request.return_value = "dummy_url", "dummy_header"
         client = WireClient("foo.bar")
-        uri1 = ExtHandlerVersionUri()
-        uri1.uri = 'ext_uri1'
-        uri2 = ExtHandlerVersionUri()
-        uri2.uri = 'ext_uri2'
 
         HostPluginProtocol.set_default_channel(False)
 
@@ -812,10 +804,6 @@ class TestWireClient(AgentTestCase):
     def test_fetch_manifest_should_retry_the_host_channel_after_reloading_goal_state(self, mock_get_artifact_request, *args):
         mock_get_artifact_request.return_value = "dummy_url", "dummy_header"
         client = WireClient("foo.bar")
-        uri1 = ExtHandlerVersionUri()
-        uri1.uri = 'ext_uri1'
-        uri2 = ExtHandlerVersionUri()
-        uri2.uri = 'ext_uri2'
 
         HostPluginProtocol.set_default_channel(False)
 
@@ -845,10 +833,6 @@ class TestWireClient(AgentTestCase):
     def test_fetch_manifest_should_update_goal_state_and_not_change_default_channel_if_host_fails(self, mock_get_artifact_request, *args):
         mock_get_artifact_request.return_value = "dummy_url", "dummy_header"
         client = WireClient("foo.bar")
-        uri1 = ExtHandlerVersionUri()
-        uri1.uri = 'ext_uri1'
-        uri2 = ExtHandlerVersionUri()
-        uri2.uri = 'ext_uri2'
 
         HostPluginProtocol.set_default_channel(False)
         mock_failed_response = MockResponse(body=b"", status_code=httpclient.GONE)

--- a/tests/protocol/test_wire.py
+++ b/tests/protocol/test_wire.py
@@ -631,7 +631,33 @@ class TestWireClient(AgentTestCase):
 
     @patch("azurelinuxagent.common.protocol.wire.WireClient.get_goal_state")
     @patch("azurelinuxagent.common.protocol.hostplugin.HostPluginProtocol.get_artifact_request")
-    def test_download_ext_handler_pkg_should_use_retry_logic(self, mock_get_artifact_request, *args):
+    def test_download_ext_handler_pkg_should_not_invoke_host_channel_when_direct_channel_succeeds(self, mock_get_artifact_request, *args):
+        mock_get_artifact_request.return_value = "dummy_url", "dummy_header"
+        protocol = WireProtocol("foo.bar")
+        HostPluginProtocol.set_default_channel(False)
+
+        mock_successful_response = MockResponse(body=b"OK", status_code=200)
+        destination = os.path.join(self.tmp_dir, "tmp_file")
+
+        # Direct channel succeeds
+        with patch("azurelinuxagent.common.utils.restutil._http_request", return_value=mock_successful_response):
+            with patch("azurelinuxagent.common.protocol.wire.WireClient.update_goal_state") as mock_update_goal_state:
+                with patch("azurelinuxagent.common.protocol.wire.WireClient.stream", wraps=protocol.client.stream) \
+                        as patch_direct:
+                    with patch("azurelinuxagent.common.protocol.wire.WireProtocol.download_ext_handler_pkg_through_host",
+                               wraps=protocol.download_ext_handler_pkg_through_host) as patch_host:
+                        ret = protocol.download_ext_handler_pkg("uri", destination)
+                        self.assertEquals(ret, True)
+
+                        self.assertEquals(patch_host.call_count, 0)
+                        self.assertEquals(patch_direct.call_count, 1)
+                        self.assertEquals(mock_update_goal_state.call_count, 0)
+
+                        self.assertEquals(HostPluginProtocol.is_default_channel(), False)
+
+    @patch("azurelinuxagent.common.protocol.wire.WireClient.get_goal_state")
+    @patch("azurelinuxagent.common.protocol.hostplugin.HostPluginProtocol.get_artifact_request")
+    def test_download_ext_handler_pkg_should_use_host_channel_when_direct_channel_fails(self, mock_get_artifact_request, *args):
         mock_get_artifact_request.return_value = "dummy_url", "dummy_header"
         protocol = WireProtocol("foo.bar")
         HostPluginProtocol.set_default_channel(False)
@@ -640,85 +666,72 @@ class TestWireClient(AgentTestCase):
         mock_successful_response = MockResponse(body=b"OK", status_code=200)
         destination = os.path.join(self.tmp_dir, "tmp_file")
 
-        original_direct = protocol.client.stream
-        original_host = protocol.download_ext_handler_pkg_through_host
-
-        def mock_direct(*args, **kwargs):
-            return original_direct(*args, **kwargs)
-
-        def mock_host(*args, **kwargs):
-            return original_host(*args, **kwargs)
-
-        # Direct channel succeeds
-        with patch("azurelinuxagent.common.utils.restutil._http_request", return_value=mock_successful_response):
-            with patch("azurelinuxagent.common.protocol.wire.WireClient.update_goal_state") as mock_update_goal_state:
-                with patch("tests.protocol.test_wire.MockResponse.read", return_value=b"OK"):
-                    with patch("azurelinuxagent.common.protocol.wire.WireClient.stream",
-                               side_effect=mock_direct) as patch_direct:
-                        with patch("azurelinuxagent.common.protocol.wire.WireProtocol.download_ext_handler_pkg_through_host",
-                                   side_effect=mock_host) as patch_host:
-                            ret = protocol.download_ext_handler_pkg("uri", destination)
-                            self.assertEquals(ret, True)
-
-                            self.assertEquals(patch_host.call_count, 0)
-                            self.assertEquals(patch_direct.call_count, 1)
-                            self.assertEquals(mock_update_goal_state.call_count, 0)
-
-                            self.assertEquals(HostPluginProtocol.is_default_channel(), False)
-
         # Direct channel fails, host channel succeeds. Goal state should not have been updated and host channel
         # should have been set as default.
         with patch("azurelinuxagent.common.utils.restutil._http_request",
                    side_effect=[mock_failed_response, mock_successful_response]):
             with patch("azurelinuxagent.common.protocol.wire.WireClient.update_goal_state") as mock_update_goal_state:
-                with patch('tests.protocol.test_wire.MockResponse.read', return_value=b"OK"):
-                    with patch("azurelinuxagent.common.protocol.wire.WireClient.stream",
-                               side_effect=mock_direct) as patch_direct:
-                        with patch("azurelinuxagent.common.protocol.wire.WireProtocol.download_ext_handler_pkg_through_host",
-                                   side_effect=mock_host) as patch_host:
-                            ret = protocol.download_ext_handler_pkg("uri", destination)
-                            self.assertEquals(ret, True)
+                with patch("azurelinuxagent.common.protocol.wire.WireClient.stream", wraps=protocol.client.stream) \
+                        as patch_direct:
+                    with patch("azurelinuxagent.common.protocol.wire.WireProtocol.download_ext_handler_pkg_through_host",
+                               wraps=protocol.download_ext_handler_pkg_through_host) as patch_host:
+                        ret = protocol.download_ext_handler_pkg("uri", destination)
+                        self.assertEquals(ret, True)
 
-                            self.assertEquals(patch_host.call_count, 1)
-                            # The host channel calls the direct function under the covers
-                            self.assertEquals(patch_direct.call_count, 1 + patch_host.call_count)
-                            self.assertEquals(mock_update_goal_state.call_count, 0)
+                        self.assertEquals(patch_host.call_count, 1)
+                        # The host channel calls the direct function under the covers
+                        self.assertEquals(patch_direct.call_count, 1 + patch_host.call_count)
+                        self.assertEquals(mock_update_goal_state.call_count, 0)
 
-                            self.assertEquals(HostPluginProtocol.is_default_channel(), True)
+                        self.assertEquals(HostPluginProtocol.is_default_channel(), True)
 
-        # Reset default channel
+    @patch("azurelinuxagent.common.protocol.wire.WireClient.get_goal_state")
+    @patch("azurelinuxagent.common.protocol.hostplugin.HostPluginProtocol.get_artifact_request")
+    def test_download_ext_handler_pkg_should_retry_the_host_channel_after_reloading_goal_state(self, mock_get_artifact_request, *args):
+        mock_get_artifact_request.return_value = "dummy_url", "dummy_header"
+        protocol = WireProtocol("foo.bar")
         HostPluginProtocol.set_default_channel(False)
+
+        mock_failed_response = MockResponse(body=b"", status_code=httpclient.GONE)
+        mock_successful_response = MockResponse(body=b"OK", status_code=200)
+        destination = os.path.join(self.tmp_dir, "tmp_file")
 
         # Direct channel fails, host channel fails due to stale goal state, host channel succeeds after refresh.
         # As a consequence, goal state should have been updated and host channel should have been set as default.
         with patch("azurelinuxagent.common.utils.restutil._http_request",
                    side_effect=[mock_failed_response, mock_failed_response, mock_successful_response]):
             with patch("azurelinuxagent.common.protocol.wire.WireClient.update_goal_state") as mock_update_goal_state:
-                with patch('tests.protocol.test_wire.MockResponse.read', return_value=b"OK"):
-                    with patch("azurelinuxagent.common.protocol.wire.WireClient.stream",
-                               side_effect=mock_direct) as patch_direct:
-                        with patch("azurelinuxagent.common.protocol.wire.WireProtocol.download_ext_handler_pkg_through_host",
-                                   side_effect=mock_host) as patch_host:
-                            ret = protocol.download_ext_handler_pkg("uri", destination)
-                            self.assertEquals(ret, True)
+                with patch("azurelinuxagent.common.protocol.wire.WireClient.stream", wraps=protocol.client.stream) \
+                        as patch_direct:
+                    with patch("azurelinuxagent.common.protocol.wire.WireProtocol.download_ext_handler_pkg_through_host",
+                               wraps=protocol.download_ext_handler_pkg_through_host) as patch_host:
+                        ret = protocol.download_ext_handler_pkg("uri", destination)
+                        self.assertEquals(ret, True)
 
-                            self.assertEquals(patch_host.call_count, 2)
-                            # The host channel calls the direct function under the covers
-                            self.assertEquals(patch_direct.call_count, 1 + patch_host.call_count)
-                            self.assertEquals(mock_update_goal_state.call_count, 1)
+                        self.assertEquals(patch_host.call_count, 2)
+                        # The host channel calls the direct function under the covers
+                        self.assertEquals(patch_direct.call_count, 1 + patch_host.call_count)
+                        self.assertEquals(mock_update_goal_state.call_count, 1)
 
-                            self.assertEquals(HostPluginProtocol.is_default_channel(), True)
+                        self.assertEquals(HostPluginProtocol.is_default_channel(), True)
 
-        # Reset default channel
+    @patch("azurelinuxagent.common.protocol.wire.WireClient.get_goal_state")
+    @patch("azurelinuxagent.common.protocol.hostplugin.HostPluginProtocol.get_artifact_request")
+    def test_download_ext_handler_pkg_should_update_goal_state_and_not_change_default_channel_if_host_fails(self, mock_get_artifact_request, *args):
+        mock_get_artifact_request.return_value = "dummy_url", "dummy_header"
+        protocol = WireProtocol("foo.bar")
         HostPluginProtocol.set_default_channel(False)
+
+        mock_failed_response = MockResponse(body=b"", status_code=httpclient.GONE)
+        destination = os.path.join(self.tmp_dir, "tmp_file")
 
         # Everything fails. Goal state should have been updated and host channel should not have been set as default.
         with patch("azurelinuxagent.common.utils.restutil._http_request", return_value=mock_failed_response):
             with patch("azurelinuxagent.common.protocol.wire.WireClient.update_goal_state") as mock_update_goal_state:
-                with patch("azurelinuxagent.common.protocol.wire.WireClient.stream",
-                           side_effect=mock_direct) as patch_direct:
+                with patch("azurelinuxagent.common.protocol.wire.WireClient.stream", wraps=protocol.client.stream) \
+                        as patch_direct:
                     with patch("azurelinuxagent.common.protocol.wire.WireProtocol.download_ext_handler_pkg_through_host",
-                            side_effect=mock_host) as patch_host:
+                               wraps=protocol.download_ext_handler_pkg_through_host) as patch_host:
                         ret = protocol.download_ext_handler_pkg("uri", destination)
                         self.assertEquals(ret, False)
 
@@ -731,7 +744,36 @@ class TestWireClient(AgentTestCase):
 
     @patch("azurelinuxagent.common.protocol.wire.WireClient.get_goal_state")
     @patch("azurelinuxagent.common.protocol.hostplugin.HostPluginProtocol.get_artifact_request")
-    def test_fetch_manifest_should_use_retry_logic(self, mock_get_artifact_request, *args):
+    def test_fetch_manifest_should_not_invoke_host_channel_when_direct_channel_succeeds(self, mock_get_artifact_request, *args):
+        mock_get_artifact_request.return_value = "dummy_url", "dummy_header"
+        client = WireClient("foo.bar")
+        uri1 = ExtHandlerVersionUri()
+        uri1.uri = 'ext_uri1'
+        uri2 = ExtHandlerVersionUri()
+        uri2.uri = 'ext_uri2'
+
+        HostPluginProtocol.set_default_channel(False)
+        mock_successful_response = MockResponse(body=b"OK", status_code=200)
+
+        # Direct channel succeeds
+        with patch("azurelinuxagent.common.utils.restutil._http_request", return_value=mock_successful_response):
+            with patch("azurelinuxagent.common.protocol.wire.WireClient.update_goal_state") as mock_update_goal_state:
+                with patch("azurelinuxagent.common.protocol.wire.WireClient.fetch", wraps=client.fetch) as patch_direct:
+                    with patch("azurelinuxagent.common.protocol.wire.WireClient.fetch_manifest_through_host",
+                               wraps=client.fetch_manifest_through_host) as patch_host:
+                        ret = client.fetch_manifest([VMAgentManifestUri(uri="uri1")])
+                        self.assertEquals(ret, "OK")
+
+                        self.assertEquals(patch_host.call_count, 0)
+                        # The host channel calls the direct function under the covers
+                        self.assertEquals(patch_direct.call_count, 1)
+                        self.assertEquals(mock_update_goal_state.call_count, 0)
+
+                        self.assertEquals(HostPluginProtocol.is_default_channel(), False)
+
+    @patch("azurelinuxagent.common.protocol.wire.WireClient.get_goal_state")
+    @patch("azurelinuxagent.common.protocol.hostplugin.HostPluginProtocol.get_artifact_request")
+    def test_fetch_manifest_should_use_host_channel_when_direct_channel_fails(self, mock_get_artifact_request, *args):
         mock_get_artifact_request.return_value = "dummy_url", "dummy_header"
         client = WireClient("foo.bar")
         uri1 = ExtHandlerVersionUri()
@@ -744,41 +786,14 @@ class TestWireClient(AgentTestCase):
         mock_failed_response = MockResponse(body=b"", status_code=httpclient.GONE)
         mock_successful_response = MockResponse(body=b"OK", status_code=200)
 
-        original_direct = client.fetch
-        original_host = client.fetch_manifest_through_host
-
-        def mock_direct(*args, **kwargs):
-            return original_direct(*args, **kwargs)
-
-        def mock_host(*args, **kwargs):
-            return original_host(*args, **kwargs)
-
-        # Direct channel succeeds
-        with patch("azurelinuxagent.common.utils.restutil._http_request", return_value=mock_successful_response):
-            with patch("azurelinuxagent.common.protocol.wire.WireClient.update_goal_state") as mock_update_goal_state:
-                with patch("azurelinuxagent.common.protocol.wire.WireClient.fetch",
-                           side_effect=mock_direct) as patch_direct:
-                    with patch("azurelinuxagent.common.protocol.wire.WireClient.fetch_manifest_through_host",
-                               side_effect=mock_host) as patch_host:
-                        ret = client.fetch_manifest([VMAgentManifestUri(uri="uri1")])
-                        self.assertEquals(ret, "OK")
-
-                        self.assertEquals(patch_host.call_count, 0)
-                        # The host channel calls the direct function under the covers
-                        self.assertEquals(patch_direct.call_count, 1)
-                        self.assertEquals(mock_update_goal_state.call_count, 0)
-
-                        self.assertEquals(HostPluginProtocol.is_default_channel(), False)
-
         # Direct channel fails, host channel succeeds. Goal state should not have been updated and host channel
         # should have been set as default
         with patch("azurelinuxagent.common.utils.restutil._http_request",
                    side_effect=[mock_failed_response, mock_successful_response]):
             with patch("azurelinuxagent.common.protocol.wire.WireClient.update_goal_state") as mock_update_goal_state:
-                with patch("azurelinuxagent.common.protocol.wire.WireClient.fetch",
-                           side_effect=mock_direct) as patch_direct:
+                with patch("azurelinuxagent.common.protocol.wire.WireClient.fetch", wraps=client.fetch) as patch_direct:
                     with patch("azurelinuxagent.common.protocol.wire.WireClient.fetch_manifest_through_host",
-                               side_effect=mock_host) as patch_host:
+                               wraps=client.fetch_manifest_through_host) as patch_host:
                         ret = client.fetch_manifest([VMAgentManifestUri(uri="uri1")])
                         self.assertEquals(ret, "OK")
 
@@ -792,15 +807,29 @@ class TestWireClient(AgentTestCase):
         # Reset default channel
         HostPluginProtocol.set_default_channel(False)
 
+    @patch("azurelinuxagent.common.protocol.wire.WireClient.get_goal_state")
+    @patch("azurelinuxagent.common.protocol.hostplugin.HostPluginProtocol.get_artifact_request")
+    def test_fetch_manifest_should_retry_the_host_channel_after_reloading_goal_state(self, mock_get_artifact_request, *args):
+        mock_get_artifact_request.return_value = "dummy_url", "dummy_header"
+        client = WireClient("foo.bar")
+        uri1 = ExtHandlerVersionUri()
+        uri1.uri = 'ext_uri1'
+        uri2 = ExtHandlerVersionUri()
+        uri2.uri = 'ext_uri2'
+
+        HostPluginProtocol.set_default_channel(False)
+
+        mock_failed_response = MockResponse(body=b"", status_code=httpclient.GONE)
+        mock_successful_response = MockResponse(body=b"OK", status_code=200)
+
         # Direct channel fails, host channel fails due to stale goal state, host channel succeeds after refresh.
         # As a consequence, goal state should have been updated and host channel should have been set as default.
         with patch("azurelinuxagent.common.utils.restutil._http_request",
                    side_effect=[mock_failed_response, mock_failed_response, mock_successful_response]):
             with patch("azurelinuxagent.common.protocol.wire.WireClient.update_goal_state") as mock_update_goal_state:
-                with patch("azurelinuxagent.common.protocol.wire.WireClient.fetch",
-                           side_effect=mock_direct) as patch_direct:
+                with patch("azurelinuxagent.common.protocol.wire.WireClient.fetch", wraps=client.fetch) as patch_direct:
                     with patch("azurelinuxagent.common.protocol.wire.WireClient.fetch_manifest_through_host",
-                               side_effect=mock_host) as patch_host:
+                               wraps=client.fetch_manifest_through_host) as patch_host:
                         ret = client.fetch_manifest([VMAgentManifestUri(uri="uri1")])
                         self.assertEquals(ret, "OK")
 
@@ -811,16 +840,25 @@ class TestWireClient(AgentTestCase):
 
                         self.assertEquals(HostPluginProtocol.is_default_channel(), True)
 
-        # Reset default channel
+    @patch("azurelinuxagent.common.protocol.wire.WireClient.get_goal_state")
+    @patch("azurelinuxagent.common.protocol.hostplugin.HostPluginProtocol.get_artifact_request")
+    def test_fetch_manifest_should_update_goal_state_and_not_change_default_channel_if_host_fails(self, mock_get_artifact_request, *args):
+        mock_get_artifact_request.return_value = "dummy_url", "dummy_header"
+        client = WireClient("foo.bar")
+        uri1 = ExtHandlerVersionUri()
+        uri1.uri = 'ext_uri1'
+        uri2 = ExtHandlerVersionUri()
+        uri2.uri = 'ext_uri2'
+
         HostPluginProtocol.set_default_channel(False)
+        mock_failed_response = MockResponse(body=b"", status_code=httpclient.GONE)
 
         # Everything fails. Goal state should have been updated and host channel should not have been set as default.
         with patch("azurelinuxagent.common.utils.restutil._http_request", return_value=mock_failed_response):
             with patch("azurelinuxagent.common.protocol.wire.WireClient.update_goal_state") as mock_update_goal_state:
-                with patch("azurelinuxagent.common.protocol.wire.WireClient.fetch",
-                           side_effect=mock_direct) as patch_direct:
+                with patch("azurelinuxagent.common.protocol.wire.WireClient.fetch", wraps=client.fetch) as patch_direct:
                     with patch("azurelinuxagent.common.protocol.wire.WireClient.fetch_manifest_through_host",
-                               side_effect=mock_host) as patch_host:
+                               wraps=client.fetch_manifest_through_host) as patch_host:
                         with self.assertRaises(ExtensionDownloadError):
                             client.fetch_manifest([VMAgentManifestUri(uri="uri1")])
 
@@ -833,7 +871,34 @@ class TestWireClient(AgentTestCase):
 
     @patch("azurelinuxagent.common.protocol.wire.WireClient.get_goal_state")
     @patch("azurelinuxagent.common.protocol.hostplugin.HostPluginProtocol.get_artifact_request")
-    def test_get_artifacts_profile_should_use_retry_logic(self, mock_get_artifact_request, *args):
+    def test_get_artifacts_profile_should_not_invoke_host_channel_when_direct_channel_succeeds(self, mock_get_artifact_request, *args):
+        mock_get_artifact_request.return_value = "dummy_url", "dummy_header"
+        client = WireClient("foo.bar")
+        client.ext_conf = ExtensionsConfig(None)
+        client.ext_conf.artifacts_profile_blob = "testurl"
+        json_profile = b'{ "onHold": true }'
+
+        HostPluginProtocol.set_default_channel(False)
+        mock_successful_response = MockResponse(body=json_profile, status_code=200)
+
+        # Direct channel succeeds
+        with patch("azurelinuxagent.common.utils.restutil._http_request", return_value=mock_successful_response):
+            with patch("azurelinuxagent.common.protocol.wire.WireClient.update_goal_state") as mock_update_goal_state:
+                with patch("azurelinuxagent.common.protocol.wire.WireClient.fetch", wraps=client.fetch) as patch_direct:
+                    with patch("azurelinuxagent.common.protocol.wire.WireClient.get_artifacts_profile_through_host",
+                               wraps=client.get_artifacts_profile_through_host) as patch_host:
+                        ret = client.get_artifacts_profile()
+                        self.assertIsInstance(ret, InVMArtifactsProfile)
+
+                        self.assertEquals(patch_host.call_count, 0)
+                        self.assertEquals(patch_direct.call_count, 1)
+                        self.assertEquals(mock_update_goal_state.call_count, 0)
+
+                        self.assertEquals(HostPluginProtocol.is_default_channel(), False)
+
+    @patch("azurelinuxagent.common.protocol.wire.WireClient.get_goal_state")
+    @patch("azurelinuxagent.common.protocol.hostplugin.HostPluginProtocol.get_artifact_request")
+    def test_get_artifacts_profile_should_use_host_channel_when_direct_channel_fails(self, mock_get_artifact_request, *args):
         mock_get_artifact_request.return_value = "dummy_url", "dummy_header"
         client = WireClient("foo.bar")
         client.ext_conf = ExtensionsConfig(None)
@@ -845,40 +910,14 @@ class TestWireClient(AgentTestCase):
         mock_failed_response = MockResponse(body=b"", status_code=httpclient.GONE)
         mock_successful_response = MockResponse(body=json_profile, status_code=200)
 
-        original_direct = client.fetch
-        original_host = client.get_artifacts_profile_through_host
-
-        def mock_direct(*args, **kwargs):
-            return original_direct(*args, **kwargs)
-
-        def mock_host(*args, **kwargs):
-            return original_host(*args, **kwargs)
-
-        # Direct channel succeeds
-        with patch("azurelinuxagent.common.utils.restutil._http_request", return_value=mock_successful_response):
-            with patch("azurelinuxagent.common.protocol.wire.WireClient.update_goal_state") as mock_update_goal_state:
-                with patch("azurelinuxagent.common.protocol.wire.WireClient.fetch",
-                           side_effect=mock_direct) as patch_direct:
-                    with patch("azurelinuxagent.common.protocol.wire.WireClient.get_artifacts_profile_through_host",
-                               side_effect=mock_host) as patch_host:
-                        ret = client.get_artifacts_profile()
-                        self.assertIsInstance(ret, InVMArtifactsProfile)
-
-                        self.assertEquals(patch_host.call_count, 0)
-                        self.assertEquals(patch_direct.call_count, 1)
-                        self.assertEquals(mock_update_goal_state.call_count, 0)
-
-                        self.assertEquals(HostPluginProtocol.is_default_channel(), False)
-
         # Direct channel fails, host channel succeeds. Goal state should not have been updated and host channel
         # should have been set as default
         with patch("azurelinuxagent.common.utils.restutil._http_request",
                    side_effect=[mock_failed_response, mock_successful_response]):
             with patch("azurelinuxagent.common.protocol.wire.WireClient.update_goal_state") as mock_update_goal_state:
-                with patch("azurelinuxagent.common.protocol.wire.WireClient.fetch",
-                           side_effect=mock_direct) as patch_direct:
+                with patch("azurelinuxagent.common.protocol.wire.WireClient.fetch", wraps=client.fetch) as patch_direct:
                     with patch("azurelinuxagent.common.protocol.wire.WireClient.get_artifacts_profile_through_host",
-                               side_effect=mock_host) as patch_host:
+                               wraps=client.get_artifacts_profile_through_host) as patch_host:
                         ret = client.get_artifacts_profile()
                         self.assertIsInstance(ret, InVMArtifactsProfile)
 
@@ -889,18 +928,28 @@ class TestWireClient(AgentTestCase):
 
                         self.assertEquals(HostPluginProtocol.is_default_channel(), True)
 
-        # Reset default channel
+    @patch("azurelinuxagent.common.protocol.wire.WireClient.get_goal_state")
+    @patch("azurelinuxagent.common.protocol.hostplugin.HostPluginProtocol.get_artifact_request")
+    def test_get_artifacts_profile_should_retry_the_host_channel_after_reloading_goal_state(self, mock_get_artifact_request, *args):
+        mock_get_artifact_request.return_value = "dummy_url", "dummy_header"
+        client = WireClient("foo.bar")
+        client.ext_conf = ExtensionsConfig(None)
+        client.ext_conf.artifacts_profile_blob = "testurl"
+        json_profile = b'{ "onHold": true }'
+
         HostPluginProtocol.set_default_channel(False)
+
+        mock_failed_response = MockResponse(body=b"", status_code=httpclient.GONE)
+        mock_successful_response = MockResponse(body=json_profile, status_code=200)
 
         # Direct channel fails, host channel fails due to stale goal state, host channel succeeds after refresh.
         # As a consequence, goal state should have been updated and host channel should have been set as default.
         with patch("azurelinuxagent.common.utils.restutil._http_request",
                    side_effect=[mock_failed_response, mock_failed_response, mock_successful_response]):
             with patch("azurelinuxagent.common.protocol.wire.WireClient.update_goal_state") as mock_update_goal_state:
-                with patch("azurelinuxagent.common.protocol.wire.WireClient.fetch",
-                           side_effect=mock_direct) as patch_direct:
+                with patch("azurelinuxagent.common.protocol.wire.WireClient.fetch", wraps=client.fetch) as patch_direct:
                     with patch("azurelinuxagent.common.protocol.wire.WireClient.get_artifacts_profile_through_host",
-                               side_effect=mock_host) as patch_host:
+                               wraps=client.get_artifacts_profile_through_host) as patch_host:
                         ret = client.get_artifacts_profile()
                         self.assertIsInstance(ret, InVMArtifactsProfile)
 
@@ -911,16 +960,25 @@ class TestWireClient(AgentTestCase):
 
                         self.assertEquals(HostPluginProtocol.is_default_channel(), True)
 
-        # Reset default channel
+    @patch("azurelinuxagent.common.protocol.wire.WireClient.get_goal_state")
+    @patch("azurelinuxagent.common.protocol.hostplugin.HostPluginProtocol.get_artifact_request")
+    def test_get_artifacts_profile_should_update_goal_state_and_not_change_default_channel_if_host_fails(self, mock_get_artifact_request, *args):
+        mock_get_artifact_request.return_value = "dummy_url", "dummy_header"
+        client = WireClient("foo.bar")
+        client.ext_conf = ExtensionsConfig(None)
+        client.ext_conf.artifacts_profile_blob = "testurl"
+        json_profile = b'{ "onHold": true }'
+
         HostPluginProtocol.set_default_channel(False)
+
+        mock_failed_response = MockResponse(body=b"", status_code=httpclient.GONE)
 
         # Everything fails. Goal state should have been updated and host channel should not have been set as default.
         with patch("azurelinuxagent.common.utils.restutil._http_request", return_value=mock_failed_response):
             with patch("azurelinuxagent.common.protocol.wire.WireClient.update_goal_state") as mock_update_goal_state:
-                with patch("azurelinuxagent.common.protocol.wire.WireClient.fetch",
-                           side_effect=mock_direct) as patch_direct:
+                with patch("azurelinuxagent.common.protocol.wire.WireClient.fetch", wraps=client.fetch) as patch_direct:
                     with patch("azurelinuxagent.common.protocol.wire.WireClient.get_artifacts_profile_through_host",
-                               side_effect=mock_host) as patch_host:
+                               wraps=client.get_artifacts_profile_through_host) as patch_host:
                         ret = client.get_artifacts_profile()
                         self.assertEquals(ret, None)
 
@@ -1038,7 +1096,7 @@ class MockResponse:
         self.body = body
         self.status = status_code
 
-    def read(self):
+    def read(self, *_):
         return self.body
 
 

--- a/tests/protocol/test_wire.py
+++ b/tests/protocol/test_wire.py
@@ -45,6 +45,7 @@ def get_event(message, duration=30000, evt_type="", is_internal=False, is_succes
     event.parameters.append(TelemetryEventParam('ExtensionType', evt_type))
     return event
 
+
 @patch("time.sleep")
 @patch("azurelinuxagent.common.protocol.wire.CryptUtil")
 @patch("azurelinuxagent.common.protocol.healthservice.HealthService._report")
@@ -162,7 +163,7 @@ class TestWireProtocol(AgentTestCase):
                                             use_proxy=True)
             # assert
             self.assertTrue(http_patch.call_count == 5)
-            for i in range(0,5):
+            for i in range(0, 5):
                 c = http_patch.call_args_list[i][-1]['use_proxy']
                 self.assertTrue(c == (True if i != 3 else False))
 
@@ -182,7 +183,7 @@ class TestWireProtocol(AgentTestCase):
         wire_protocol_client = WireProtocol(wireserver_url).client
         goal_state = GoalState(WireProtocolData(DATA_FILE).goal_state)
 
-        with patch.object(WireClient, "get_goal_state", return_value = goal_state) as patch_get_goal_state:
+        with patch.object(WireClient, "get_goal_state", return_value=goal_state) as patch_get_goal_state:
             host_plugin = wire_protocol_client.get_host_plugin()
             self.assertEqual(goal_state.container_id, host_plugin.container_id)
             self.assertEqual(goal_state.role_config_name, host_plugin.role_config_name)
@@ -325,7 +326,7 @@ class TestWireProtocol(AgentTestCase):
         # Test when artifacts_profile_blob is null/None
         self.assertEqual(None, wire_protocol_client.get_artifacts_profile())
 
-        #Test when artifacts_profile_blob is whitespace
+        # Test when artifacts_profile_blob is whitespace
         wire_protocol_client.ext_conf.artifacts_profile_blob = "  "
         self.assertEqual(None, wire_protocol_client.get_artifacts_profile())
 
@@ -337,18 +338,18 @@ class TestWireProtocol(AgentTestCase):
         wire_protocol_client.get_goal_state = Mock(return_value=goal_state)
 
         with patch.object(HostPluginProtocol, "get_artifact_request",
-                          return_value = ['dummy_url', {}]) as host_plugin_get_artifact_url_and_headers:
-            #Test when response body is None
+                          return_value=['dummy_url', {}]) as host_plugin_get_artifact_url_and_headers:
+            # Test when response body is None
             wire_protocol_client.call_storage_service = Mock(return_value=MockResponse(None, 200))
             in_vm_artifacts_profile = wire_protocol_client.get_artifacts_profile()
             self.assertTrue(in_vm_artifacts_profile is None)
 
-            #Test when response body is None
+            # Test when response body is None
             wire_protocol_client.call_storage_service = Mock(return_value=MockResponse('   '.encode('utf-8'), 200))
             in_vm_artifacts_profile = wire_protocol_client.get_artifacts_profile()
             self.assertTrue(in_vm_artifacts_profile is None)
 
-            #Test when response body is None
+            # Test when response body is None
             wire_protocol_client.call_storage_service = Mock(return_value=MockResponse('{ }'.encode('utf-8'), 200))
             in_vm_artifacts_profile = wire_protocol_client.get_artifacts_profile()
             self.assertEqual(dict(), in_vm_artifacts_profile.__dict__,
@@ -385,7 +386,8 @@ class TestWireProtocol(AgentTestCase):
         goal_state = GoalState(WireProtocolData(DATA_FILE).goal_state)
         wire_protocol_client.get_goal_state = Mock(return_value=goal_state)
 
-        wire_protocol_client.call_storage_service = Mock(return_value=MockResponse('{"onHold": "true"}'.encode('utf-8'), 200))
+        wire_protocol_client.call_storage_service = Mock(
+            return_value=MockResponse('{"onHold": "true"}'.encode('utf-8'), 200))
         in_vm_artifacts_profile = wire_protocol_client.get_artifacts_profile()
         self.assertEqual(dict(onHold='true'), in_vm_artifacts_profile.__dict__)
         self.assertTrue(in_vm_artifacts_profile.is_on_hold())
@@ -400,15 +402,10 @@ class TestWireProtocol(AgentTestCase):
                                        'container_id',
                                        'role_config')
         client = WireProtocol(wireserver_url).client
-        with patch.object(WireClient,
-                          "fetch",
-                          return_value=None) as patch_fetch:
-            with patch.object(WireClient,
-                              "get_host_plugin",
-                              return_value=mock_host):
-                with patch.object(HostPluginProtocol,
-                                  "get_artifact_request",
-                                  return_value=[host_uri, {}]):
+
+        with patch.object(WireClient, "fetch", return_value=None) as patch_fetch:
+            with patch.object(WireClient, "get_host_plugin", return_value=mock_host):
+                with patch.object(HostPluginProtocol, "get_artifact_request", return_value=[host_uri, {}]):
                     HostPluginProtocol.set_default_channel(False)
                     self.assertRaises(ExtensionDownloadError, client.fetch_manifest, uris)
                     self.assertEqual(patch_fetch.call_count, 2)
@@ -437,7 +434,8 @@ class TestWireProtocol(AgentTestCase):
                 self.assertEqual(patch_fetch.call_count, 1)
                 self.assertEqual(mock_host.manifest_uri, uri1.uri)
 
-            # Second test tries to download from the HostGA (by failing the direct download) and asserts manifest_uri is set
+            # Second test tries to download from the HostGA (by failing the direct download)
+            # and asserts manifest_uri is set
             with patch.object(WireClient, "fetch") as patch_fetch:
                 patch_fetch.side_effect = [None, manifest_return]
                 fetch_manifest_mock = client.fetch_manifest(uris)
@@ -496,7 +494,7 @@ class TestWireProtocol(AgentTestCase):
             'version': '1.1',
             'timestampUTC': timestamp,
             'aggregateStatus': v1_agg_status,
-            'guestOSInfo' : v1_ga_guest_info
+            'guestOSInfo': v1_ga_guest_info
         }
         self.assertEqual(json.dumps(v1_vm_status), actual.to_json())
 
@@ -545,7 +543,7 @@ class TestWireProtocol(AgentTestCase):
         event_list = TelemetryEventList()
         client = WireProtocol(wireserver_url).client
 
-        event_str = random_generator(2**15)
+        event_str = random_generator(2 ** 15)
         event_list.events.append(get_event(message=event_str))
         event_list.events.append(get_event(message=event_str))
 
@@ -567,7 +565,7 @@ class TestWireProtocol(AgentTestCase):
 
 class TestWireClient(AgentTestCase):
 
-    def test_save_or_update_goal_state_it_should_save_new_goal_state_file(self):
+    def test_save_or_update_goal_state_should_save_new_goal_state_file(self):
         # Assert the file didn't exist before
         incarnation = 42
         goal_state_file = os.path.join(conf.get_lib_dir(), "GoalState.{0}.xml".format(incarnation))
@@ -583,7 +581,7 @@ class TestWireClient(AgentTestCase):
             contents = f.readlines()
             self.assertEquals("".join(contents), xml_text)
 
-    def test_save_or_update_goal_state_it_should_update_existing_goal_state_file(self):
+    def test_save_or_update_goal_state_should_update_existing_goal_state_file(self):
         incarnation = 42
         goal_state_file = os.path.join(conf.get_lib_dir(), "GoalState.{0}.xml".format(incarnation))
         xml_text = WireProtocolData(DATA_FILE).goal_state
@@ -609,8 +607,8 @@ class TestWireClient(AgentTestCase):
             contents = f.readlines()
             self.assertEquals("".join(contents), new_goal_state)
 
-    def test_save_or_update_goal_state_it_should_update_goal_state_and_container_id_when_not_forced(self):
-        incarnation = "1" # Match the incarnation number from dummy goal state file
+    def test_save_or_update_goal_state_should_update_goal_state_and_container_id_when_not_forced(self):
+        incarnation = "1"  # Match the incarnation number from dummy goal state file
         incarnation_file = os.path.join(conf.get_lib_dir(), INCARNATION_FILE_NAME)
         with open(incarnation_file, "w") as f:
             f.write(incarnation)
@@ -634,35 +632,109 @@ class TestWireClient(AgentTestCase):
         self.assertNotEqual(old_container_id, host.container_id)
         self.assertEquals(host.container_id, "z6d5526c-5ac2-4200-b6e2-56f2b70c5ab2")
 
-    @patch("azurelinuxagent.common.protocol.wire.WireClient.update_hosting_env")
-    @patch("azurelinuxagent.common.protocol.wire.WireClient.update_shared_conf")
-    @patch("azurelinuxagent.common.protocol.wire.WireClient.update_certs")
-    @patch("azurelinuxagent.common.protocol.wire.WireClient.update_ext_conf")
-    @patch("azurelinuxagent.common.protocol.wire.WireClient.update_remote_access_conf")
-    def test_call_function_with_goal_state_refresh_and_retry_call(self, *args):
-        incarnation = "1"  # Match the incarnation number from dummy goal state file
-        incarnation_file = os.path.join(conf.get_lib_dir(), INCARNATION_FILE_NAME)
-        with open(incarnation_file, "w") as f:
-            f.write(incarnation)
-
+    def test_send_request_using_appropriate_channel_direct_func_works(self, *args):
         xml_text = WireProtocolData(DATA_FILE).goal_state
         client = WireClient(wireserver_url)
         client.goal_state = GoalState(xml_text)
-        client.save_or_update_goal_state_file("1", xml_text)
-        client.get_host_plugin()
+        client.get_host_plugin().set_default_channel(False)
 
-        def dummy_func():
-            dummy_func.counter += 1
-            if dummy_func.counter == 1:
-                raise HostPluginConfigError("Dummy exception")
-        dummy_func.counter = 0
+        def direct_func(*args):
+            direct_func.counter += 1
+            return 42
 
-        # Update the container id
-        new_goal_state = WireProtocolData(DATA_FILE).goal_state.replace("<Incarnation>1</Incarnation>",
-                                                                        "<Incarnation>2</Incarnation>")
-        with patch("azurelinuxagent.common.protocol.wire.WireClient.fetch_config", return_value=new_goal_state):
-            client.call_function_with_goal_state_refresh_and_retry(lambda: dummy_func())
-            self.assertEquals(client.goal_state.incarnation, "2")
+        def host_func(*args):
+            host_func.counter += 1
+            return None
+
+        direct_func.counter = 0
+        host_func.counter = 0
+
+        # Assert we've only called the direct channel functions and that it succeeded.
+        with patch('azurelinuxagent.common.protocol.wire.logger.verbose') as mock_logger_verbose:
+            ret = client.send_request_using_appropriate_channel(direct_func, host_func)
+            self.assertEquals(42, ret)
+            self.assertEquals(1, direct_func.counter)
+            self.assertEquals(0, host_func.counter)
+            self.assertEquals(1, mock_logger_verbose.call_count)
+
+    def test_send_request_using_appropriate_channel_host_channel_is_default(self, *args):
+        xml_text = WireProtocolData(DATA_FILE).goal_state
+        client = WireClient(wireserver_url)
+        client.goal_state = GoalState(xml_text)
+        client.get_host_plugin().set_default_channel(True)
+
+        def direct_func(*args):
+            direct_func.counter += 1
+            return 42
+
+        def host_func(*args):
+            host_func.counter += 1
+            return 43
+
+        direct_func.counter = 0
+        host_func.counter = 0
+
+        # Assert we've only called the host channel function since it's the default channel
+        with patch('azurelinuxagent.common.protocol.wire.logger.verbose') as mock_logger_verbose:
+            ret = client.send_request_using_appropriate_channel(direct_func, host_func)
+            self.assertEquals(43, ret)
+            self.assertEquals(0, direct_func.counter)
+            self.assertEquals(1, host_func.counter)
+            self.assertEquals(1, mock_logger_verbose.call_count)
+
+    def test_send_request_using_appropriate_channel_direct_func_fails_host_func_works_first_time(self, *args):
+        xml_text = WireProtocolData(DATA_FILE).goal_state
+        client = WireClient(wireserver_url)
+        client.goal_state = GoalState(xml_text)
+        host = client.get_host_plugin()
+        host.set_default_channel(False)
+
+        def direct_func(*args):
+            direct_func.counter += 1
+            raise InvalidContainerError()
+
+        def host_func(*args):
+            host_func.counter += 1
+            return 42
+
+        direct_func.counter = 0
+        host_func.counter = 0
+
+        # Assert we've called both the direct channel function and the host channel function, which succeeded.
+        # After the host channel succeeds, the host plugin should have been set as the default channel.
+        ret = client.send_request_using_appropriate_channel(direct_func, host_func)
+        self.assertEquals(42, ret)
+        self.assertEquals(1, direct_func.counter)
+        self.assertEquals(1, host_func.counter)
+        self.assertEquals(True, host.is_default_channel())
+
+    def test_send_request_using_appropriate_channel_direct_func_fails_host_func_succeeds_second_time(self, *args):
+        xml_text = WireProtocolData(DATA_FILE).goal_state
+        client = WireClient(wireserver_url)
+        client.goal_state = GoalState(xml_text)
+        client.get_host_plugin().set_default_channel(False)
+
+        def direct_func(*args):
+            direct_func.counter += 1
+            raise InvalidContainerError()
+
+        def host_func(*args):
+            host_func.counter += 1
+            if host_func.counter == 1:
+                raise ResourceGoneError("Resource is gone")
+            return 42
+
+        direct_func.counter = 0
+        host_func.counter = 0
+
+        # Assert we've called both the direct channel function (once) and the host channel function (twice).
+        # After the host channel succeeds, the host plugin should have been set as the default channel.
+        with patch('azurelinuxagent.common.protocol.wire.WireClient.update_goal_state'):
+            ret = client.send_request_using_appropriate_channel(direct_func, host_func)
+            self.assertEquals(42, ret)
+            self.assertEquals(1, direct_func.counter)
+            self.assertEquals(2, host_func.counter)
+            self.assertEquals(True, client.get_host_plugin().is_default_channel())
 
 
 class MockResponse:

--- a/tests/protocol/test_wire.py
+++ b/tests/protocol/test_wire.py
@@ -650,12 +650,10 @@ class TestWireClient(AgentTestCase):
         host_func.counter = 0
 
         # Assert we've only called the direct channel functions and that it succeeded.
-        with patch('azurelinuxagent.common.protocol.wire.logger.verbose') as mock_logger_verbose:
-            ret = client.send_request_using_appropriate_channel(direct_func, host_func)
-            self.assertEquals(42, ret)
-            self.assertEquals(1, direct_func.counter)
-            self.assertEquals(0, host_func.counter)
-            self.assertEquals(1, mock_logger_verbose.call_count)
+        ret = client.send_request_using_appropriate_channel(direct_func, host_func)
+        self.assertEquals(42, ret)
+        self.assertEquals(1, direct_func.counter)
+        self.assertEquals(0, host_func.counter)
 
     def test_send_request_using_appropriate_channel_host_channel_is_default(self, *args):
         xml_text = WireProtocolData(DATA_FILE).goal_state
@@ -675,12 +673,10 @@ class TestWireClient(AgentTestCase):
         host_func.counter = 0
 
         # Assert we've only called the host channel function since it's the default channel
-        with patch('azurelinuxagent.common.protocol.wire.logger.verbose') as mock_logger_verbose:
-            ret = client.send_request_using_appropriate_channel(direct_func, host_func)
-            self.assertEquals(43, ret)
-            self.assertEquals(0, direct_func.counter)
-            self.assertEquals(1, host_func.counter)
-            self.assertEquals(1, mock_logger_verbose.call_count)
+        ret = client.send_request_using_appropriate_channel(direct_func, host_func)
+        self.assertEquals(43, ret)
+        self.assertEquals(0, direct_func.counter)
+        self.assertEquals(1, host_func.counter)
 
     def test_send_request_using_appropriate_channel_direct_func_fails_host_func_works_first_time(self, *args):
         xml_text = WireProtocolData(DATA_FILE).goal_state

--- a/tests/utils/test_rest_util.py
+++ b/tests/utils/test_rest_util.py
@@ -15,14 +15,10 @@
 # Requires Python 2.6+ and Openssl 1.0+
 #
 
-from azurelinuxagent.common.exception import HttpError, \
-                                            ResourceGoneError
-
+from azurelinuxagent.common.exception import HttpError, ResourceGoneError, HostPluginConfigError
 import azurelinuxagent.common.utils.restutil as restutil
 from azurelinuxagent.common.utils.restutil import HTTP_USER_AGENT
-
 from azurelinuxagent.common.future import httpclient, ustr
-
 from tests.tools import *
 
 
@@ -661,7 +657,20 @@ class TestHttpOperations(AgentTestCase):
             Mock(status=httpclient.BAD_REQUEST, reason='Bad Request', read=read)
         ]
 
-        self.assertRaises(ResourceGoneError, restutil.http_get, "https://foo.bar")
+        self.assertRaises(HostPluginConfigError, restutil.http_get, "https://foo.bar")
+        self.assertEqual(1, _http_request.call_count)
+
+    @patch("time.sleep")
+    @patch("azurelinuxagent.common.utils.restutil._http_request")
+    def test_http_request_raises_for_invalid_role_configuration(self, _http_request, _sleep):
+        def read():
+            return b'{ "errorCode": "RequestRoleConfigFileNotFound", "message": "Invalid request." }'
+
+        _http_request.side_effect = [
+            Mock(status=httpclient.BAD_REQUEST, reason='Bad Request', read=read)
+        ]
+
+        self.assertRaises(HostPluginConfigError, restutil.http_get, "https://foo.bar")
         self.assertEqual(1, _http_request.call_count)
 
     @patch("time.sleep")

--- a/tests/utils/test_rest_util.py
+++ b/tests/utils/test_rest_util.py
@@ -15,7 +15,7 @@
 # Requires Python 2.6+ and Openssl 1.0+
 #
 
-from azurelinuxagent.common.exception import HttpError, ResourceGoneError, HostPluginConfigError
+from azurelinuxagent.common.exception import HttpError, ResourceGoneError, InvalidContainerError
 import azurelinuxagent.common.utils.restutil as restutil
 from azurelinuxagent.common.utils.restutil import HTTP_USER_AGENT
 from azurelinuxagent.common.future import httpclient, ustr
@@ -657,7 +657,7 @@ class TestHttpOperations(AgentTestCase):
             Mock(status=httpclient.BAD_REQUEST, reason='Bad Request', read=read)
         ]
 
-        self.assertRaises(HostPluginConfigError, restutil.http_get, "https://foo.bar")
+        self.assertRaises(InvalidContainerError, restutil.http_get, "https://foo.bar")
         self.assertEqual(1, _http_request.call_count)
 
     @patch("time.sleep")
@@ -667,10 +667,10 @@ class TestHttpOperations(AgentTestCase):
             return b'{ "errorCode": "RequestRoleConfigFileNotFound", "message": "Invalid request." }'
 
         _http_request.side_effect = [
-            Mock(status=httpclient.BAD_REQUEST, reason='Bad Request', read=read)
+            Mock(status=httpclient.GONE, reason='Resource Gone', read=read)
         ]
 
-        self.assertRaises(HostPluginConfigError, restutil.http_get, "https://foo.bar")
+        self.assertRaises(ResourceGoneError, restutil.http_get, "https://foo.bar")
         self.assertEqual(1, _http_request.call_count)
 
     @patch("time.sleep")


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
The purpose of this change is to improve the resiliency and error handling when the agent sends HTTP requests. There are two possible channels:
1) directly
2) through the host plugin

By default, the direct channel is preferred. When the communication through the direct channel fails, we fall back to the host channel. When retrying via the host channel, we refresh the goal state as it can get stale, thus resulting in a bad request (for instance, the container id is invalid or the role config file was not found). After refreshing the goal state, we try the request through the host again. If the host channel succeeds, we set it as the default channel moving forward.

Changes done in this PR are the following:
1. Since the container ID or config file can change in the goal state file without an incarnation number update, we now have to update these parameters on each goal state update, both in the goal state object and the HostGAPlugin client object.
2. HostGAPlugin throws exceptions with error codes `InvalidContainerConfiguration` and `RequestRoleConfigFileNotFound` if the container ID or the config file are incorrect. Responses with status code 400 and eror code `InvalidContainerConfiguration` are mapped to `InvalidContainerError` and responses with status code 410 and error code `RequestRoleConfigFileNotFound` are mapped to `ResourceGoneError`. Both of these errors indicate a goal state refresh and retry via host is needed.
3. The refresh and retry logic is now abstracted in the `WireClient` method `send_request_using_appropriate_channel`. It's given pointers to the direct channel function and the host channel function and decides which one to use, when to refresh the goal state and to retry.
4. Minor improvements such as new helper methods to save the goal state file and tests are added.

<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/walinuxagent/1617)
<!-- Reviewable:end -->
