### PR TITLE
udev: move the rules on systemd-enabled platforms to /usr/lib/udev

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,19 +86,20 @@ def get_data_files(name, version, fullname):
         set_bin_files(data_files)
         set_conf_files(data_files)
         set_logrotate_files(data_files)
-        set_udev_files(data_files)
         if version.startswith("6"):
             set_sysv_files(data_files)
+            set_udev_files(data_files)
         else:
             # redhat7.0+ use systemd
             set_systemd_files(data_files, dest="/usr/lib/systemd/system")
+            set_udev_files(data_files, dest="/lib/udev/rules.d")
             if version.startswith("7.1"):
                 # TODO this is a mitigation to systemctl bug on 7.1
                 set_sysv_files(data_files)
     elif name == 'arch':
         set_bin_files(data_files, dest="/usr/bin")
         set_conf_files(data_files, src=["config/arch/waagent.conf"])
-        set_udev_files(data_files)
+        set_udev_files(data_files, dest="/lib/udev/rules.d")
         set_systemd_files(data_files, dest='/usr/lib/systemd/system',
                           src=["init/arch/waagent.service"])
     elif name == 'coreos':
@@ -119,34 +120,37 @@ def get_data_files(name, version, fullname):
         set_bin_files(data_files)
         set_conf_files(data_files, src=["config/ubuntu/waagent.conf"])
         set_logrotate_files(data_files)
-        set_udev_files(data_files)
         if version.startswith("12") or version.startswith("14"):
             # Ubuntu12.04/14.04 - uses upstart
             set_files(data_files, dest="/etc/init",
                       src=["init/ubuntu/walinuxagent.conf"])
             set_files(data_files, dest='/etc/default',
                       src=['init/ubuntu/walinuxagent'])
+            set_udev_files(data_files)
         elif fullname == 'Snappy Ubuntu Core':
             set_files(data_files, dest="<TODO>",
                       src=["init/ubuntu/snappy/walinuxagent.yml"])
+            set_udev_files(data_files)
         else:
             # Ubuntu15.04+ uses systemd
             set_systemd_files(data_files,
                               src=["init/ubuntu/walinuxagent.service"])
+            set_udev_files(data_files, dest="/lib/udev/rules.d")
     elif name == 'suse' or name == 'opensuse':
         set_bin_files(data_files)
         set_conf_files(data_files, src=["config/suse/waagent.conf"])
         set_logrotate_files(data_files)
-        set_udev_files(data_files)
         if fullname == 'SUSE Linux Enterprise Server' and \
                 version.startswith('11') or \
                 fullname == 'openSUSE' and version.startswith(
                     '13.1'):
             set_sysv_files(data_files, dest='/etc/init.d',
                            src=["init/suse/waagent"])
+            set_udev_files(data_files)
         else:
             # sles 12+ and openSUSE 13.2+ use systemd
             set_systemd_files(data_files, dest='/usr/lib/systemd/system')
+            set_udev_files(data_files, dest="/lib/udev/rules.d")
     elif name == 'freebsd':
         set_bin_files(data_files, dest="/usr/local/sbin")
         set_conf_files(data_files, src=["config/freebsd/waagent.conf"])
@@ -166,7 +170,7 @@ def get_data_files(name, version, fullname):
         set_bin_files(data_files)
         set_conf_files(data_files, src=["config/iosxe/waagent.conf"])
         set_logrotate_files(data_files)
-        set_udev_files(data_files)
+        set_udev_files(data_files, dest="/lib/udev/rules.d")
         set_systemd_files(data_files, dest="/usr/lib/systemd/system")
         if version.startswith("7.1"):
             # TODO this is a mitigation to systemctl bug on 7.1


### PR DESCRIPTION
## Description

The /etc directory contains user configuration, potentially overriding
the vendor-supplied rules that go to /usr/lib.

Let's prefer that directory on platforms that use systemd; we can be sure
that those platforms support rules in /usr/lib.

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [x] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).