### PR TITLE
Change all implementations of get_dhcp_pid to use run_command

### DIFF
--- a/azurelinuxagent/common/osutil/alpine.py
+++ b/azurelinuxagent/common/osutil/alpine.py
@@ -32,7 +32,7 @@ class AlpineOSUtil(DefaultOSUtil):
         return True
 
     def get_dhcp_pid(self):
-        return shellutil.run_command(["pidof", "dhcpcd"]).strip()
+        return self._get_dhcp_pid(["pidof", "dhcpcd"])
 
     def restart_if(self, ifname):
         logger.info('restarting {} (sort of, actually SIGHUPing dhcpcd)'.format(ifname))

--- a/azurelinuxagent/common/osutil/arch.py
+++ b/azurelinuxagent/common/osutil/arch.py
@@ -52,7 +52,7 @@ class ArchUtil(DefaultOSUtil):
         return shellutil.run("systemctl stop {0}".format(self.service_name), chk_err=False)
 
     def get_dhcp_pid(self):
-        return shellutil.run_command(["pidof", "systemd-networkd"]).strip()
+        return self._get_dhcp_pid(["pidof", "systemd-networkd"])
 
     def conf_sshd(self, disable_password):
         # Don't whack the system default sshd conf

--- a/azurelinuxagent/common/osutil/bigip.py
+++ b/azurelinuxagent/common/osutil/bigip.py
@@ -97,7 +97,7 @@ class BigIpOSUtil(DefaultOSUtil):
         return shellutil.run("/sbin/chkconfig --del {0}".format(self.service_name), chk_err=False)
 
     def get_dhcp_pid(self):
-        return shellutil.run_command(["/sbin/pidof", "dhclient"]).strip()
+        return self._get_dhcp_pid(["/sbin/pidof", "dhclient"])
 
     def set_hostname(self, hostname):
         """Set the static hostname of the device

--- a/azurelinuxagent/common/osutil/clearlinux.py
+++ b/azurelinuxagent/common/osutil/clearlinux.py
@@ -66,7 +66,7 @@ class ClearLinuxUtil(DefaultOSUtil):
         return shellutil.run("systemctl stop {0}".format(self.service_name), chk_err=False)
 
     def get_dhcp_pid(self):
-        return shellutil.run_command(["pidof", "systemd-networkd"]).strip()
+        return self._get_dhcp_pid(["pidof", "systemd-networkd"])
 
     def conf_sshd(self, disable_password):
         # Don't whack the system default sshd conf

--- a/azurelinuxagent/common/osutil/coreos.py
+++ b/azurelinuxagent/common/osutil/coreos.py
@@ -74,10 +74,7 @@ class CoreOSUtil(DefaultOSUtil):
         return shellutil.run("systemctl stop {0}".format(self.service_name), chk_err=False)
 
     def get_dhcp_pid(self):
-        ret = shellutil.run_get_output("systemctl show -p MainPID "
-                                       "systemd-networkd", chk_err=False)
-        pid = ret[1].split('=', 1)[-1].strip() if ret[0] == 0 else None
-        return pid if pid != '0' else None
+        return self._get_dhcp_pid(["systemctl", "show", "-p", "MainPID", "systemd-networkd"])
 
     def conf_sshd(self, disable_password):
         # In CoreOS, /etc/sshd_config is mount readonly.  Skip the setting.

--- a/azurelinuxagent/common/osutil/default.py
+++ b/azurelinuxagent/common/osutil/default.py
@@ -45,7 +45,7 @@ from azurelinuxagent.common.future import ustr
 from azurelinuxagent.common.utils.cryptutil import CryptUtil
 from azurelinuxagent.common.utils.flexible_version import FlexibleVersion
 from azurelinuxagent.common.utils.networkutil import RouteEntry, NetworkInterfaceCard
-from azurelinuxagent.common.version import DISTRO_CODE_NAME
+from azurelinuxagent.common.utils.shellutil import CommandError
 
 __RULES_FILES__ = [ "/lib/udev/rules.d/75-persistent-net-generator.rules",
                     "/etc/udev/rules.d/70-persistent-net.rules" ]
@@ -1106,8 +1106,19 @@ class DefaultOSUtil(object):
         cmd = "ip route add {0} via {1}".format(net, gateway)
         return shellutil.run(cmd, chk_err=False)
 
+    @staticmethod
+    def _text_to_pid_list(text):
+        return [int(n) for n in text.split()]
+
+    @staticmethod
+    def _get_dhcp_pid(command):
+        try:
+            return DefaultOSUtil._text_to_pid_list(shellutil.run_command(command))
+        except CommandError as exception:
+            return []
+
     def get_dhcp_pid(self):
-        return  shellutil.run_command(["pidof", "dhclient"]).strip()
+        return self._get_dhcp_pid(["pidof", "dhclient"])
 
     def set_hostname(self, hostname):
         fileutil.write_file('/etc/hostname', hostname)

--- a/azurelinuxagent/common/osutil/freebsd.py
+++ b/azurelinuxagent/common/osutil/freebsd.py
@@ -121,8 +121,7 @@ class FreeBSDOSUtil(DefaultOSUtil):
         shellutil.run("route delete 255.255.255.255 -iface {0}".format(ifname), chk_err=False)
 
     def get_dhcp_pid(self):
-        ret = shellutil.run_get_output("pgrep -n dhclient", chk_err=False)
-        return ret[1] if ret[0] == 0 else None
+        return self._get_dhcp_pid(["pgrep", "-n", "dhclient"])
 
     def eject_dvd(self, chk_err=True):
         dvd = self.get_dvd_device()

--- a/azurelinuxagent/common/osutil/nsbsd.py
+++ b/azurelinuxagent/common/osutil/nsbsd.py
@@ -16,14 +16,10 @@
 
 import azurelinuxagent.common.utils.fileutil as fileutil
 import azurelinuxagent.common.utils.shellutil as shellutil
-import azurelinuxagent.common.utils.textutil as textutil
 import azurelinuxagent.common.logger as logger
 from azurelinuxagent.common.exception import OSUtilError
 from azurelinuxagent.common.osutil.freebsd import FreeBSDOSUtil
-from azurelinuxagent.common.future import ustr
-import azurelinuxagent.common.conf as conf
 import os
-import time
 
 class NSBSDOSUtil(FreeBSDOSUtil):
 
@@ -120,12 +116,12 @@ class NSBSDOSUtil(FreeBSDOSUtil):
         shellutil.run("/usr/Firewall/sbin/nstop dhclient", chk_err=False)
 
     def get_dhcp_pid(self):
-        ret = None
+        ret = ""
         pidfile = "/var/run/dhclient.pid"
 
         if os.path.isfile(pidfile):
             ret = fileutil.read_file(pidfile, encoding='ascii')
-        return ret
+        return self._text_to_pid_list(ret)
 
     def eject_dvd(self, chk_err=True):
         pass

--- a/azurelinuxagent/common/osutil/openbsd.py
+++ b/azurelinuxagent/common/osutil/openbsd.py
@@ -226,9 +226,7 @@ class OpenBSDOSUtil(DefaultOSUtil):
                       "{0}".format(ifname), chk_err=False)
 
     def get_dhcp_pid(self):
-        ret, output = shellutil.run_get_output("pgrep -n dhclient",
-                                               chk_err=False)
-        return output if ret == 0 else None
+        return self._get_dhcp_pid(["pgrep", "-n", "dhclient"])
 
     def get_dvd_device(self, dev_dir='/dev'):
         pattern = r'cd[0-9]c'

--- a/azurelinuxagent/common/osutil/openwrt.py
+++ b/azurelinuxagent/common/osutil/openwrt.py
@@ -63,7 +63,7 @@ class OpenWRTOSUtil(DefaultOSUtil):
                                "output:{2}").format(username, retcode, out))
 
     def get_dhcp_pid(self):
-        return shellutil.run_command(["pidof", self.dhclient_name]).strip()
+        return self._get_dhcp_pid(["pidof", self.dhclient_name])
 
     def get_nic_state(self):
         """

--- a/azurelinuxagent/common/osutil/redhat.py
+++ b/azurelinuxagent/common/osutil/redhat.py
@@ -72,7 +72,7 @@ class Redhat6xOSUtil(DefaultOSUtil):
 
     # Override
     def get_dhcp_pid(self):
-        return shellutil.run_command(["pidof", "dhclient"]).strip()
+        return self._get_dhcp_pid(["pidof", "dhclient"])
 
     def set_hostname(self, hostname):
         """

--- a/azurelinuxagent/common/osutil/suse.py
+++ b/azurelinuxagent/common/osutil/suse.py
@@ -45,7 +45,7 @@ class SUSE11OSUtil(DefaultOSUtil):
         shellutil.run("hostname {0}".format(hostname), chk_err=False)
 
     def get_dhcp_pid(self):
-        return shellutil.run_command(["pidof", self.dhclient_name]).strip()
+        return self._get_dhcp_pid(["pidof", self.dhclient_name])
 
     def is_dhcp_enabled(self):
         return True

--- a/azurelinuxagent/common/osutil/ubuntu.py
+++ b/azurelinuxagent/common/osutil/ubuntu.py
@@ -60,7 +60,7 @@ class Ubuntu12OSUtil(Ubuntu14OSUtil):
 
     # Override
     def get_dhcp_pid(self):
-        return shellutil.run_command(["pidof", "dhclient3"]).strip()
+        return self._get_dhcp_pid(["pidof", "dhclient3"])
 
     def mount_cgroups(self):
         pass
@@ -96,7 +96,7 @@ class Ubuntu18OSUtil(Ubuntu16OSUtil):
         self.service_name = self.get_service_name()
 
     def get_dhcp_pid(self):
-        return shellutil.run_command(["pidof", "systemd-networkd"]).strip()
+        return self._get_dhcp_pid(["pidof", "systemd-networkd"])
 
     def start_network(self):
         return shellutil.run("systemctl start systemd-networkd", chk_err=False)

--- a/tests/common/osutil/test_alpine.py
+++ b/tests/common/osutil/test_alpine.py
@@ -14,10 +14,10 @@
 #
 # Requires Python 2.6+ and Openssl 1.0+
 #
-import azurelinuxagent.common.osutil.default as osutil
 from azurelinuxagent.common.osutil.alpine import AlpineOSUtil
-from .test_default import osutil_get_dhcp_pid_should_return_a_pid
+from .test_default import osutil_get_dhcp_pid_should_return_a_list_of_pids
 from tests.tools import *
+
 
 class TestAlpineOSUtil(AgentTestCase):
     def setUp(self):
@@ -26,8 +26,8 @@ class TestAlpineOSUtil(AgentTestCase):
     def tearDown(self):
         AgentTestCase.tearDown(self)
 
-    def test_get_dhcp_pid_should_return_a_pid(self):
-        osutil_get_dhcp_pid_should_return_a_pid(self, AlpineOSUtil())
+    def test_get_dhcp_pid_should_return_a_list_of_pids(self):
+        osutil_get_dhcp_pid_should_return_a_list_of_pids(self, AlpineOSUtil())
 
 
 if __name__ == '__main__':

--- a/tests/common/osutil/test_arch.py
+++ b/tests/common/osutil/test_arch.py
@@ -15,8 +15,9 @@
 # Requires Python 2.6+ and Openssl 1.0+
 #
 from azurelinuxagent.common.osutil.arch import ArchUtil
-from .test_default import osutil_get_dhcp_pid_should_return_a_pid
+from .test_default import osutil_get_dhcp_pid_should_return_a_list_of_pids
 from tests.tools import *
+
 
 class TestArchUtil(AgentTestCase):
     def setUp(self):
@@ -25,8 +26,8 @@ class TestArchUtil(AgentTestCase):
     def tearDown(self):
         AgentTestCase.tearDown(self)
 
-    def test_get_dhcp_pid_should_return_a_pid(self):
-        osutil_get_dhcp_pid_should_return_a_pid(self, ArchUtil())
+    def test_get_dhcp_pid_should_return_a_list_of_pids(self):
+        osutil_get_dhcp_pid_should_return_a_list_of_pids(self, ArchUtil())
 
 
 if __name__ == '__main__':

--- a/tests/common/osutil/test_bigip.py
+++ b/tests/common/osutil/test_bigip.py
@@ -23,7 +23,7 @@ import azurelinuxagent.common.utils.shellutil as shellutil
 
 from azurelinuxagent.common.exception import OSUtilError
 from azurelinuxagent.common.osutil.bigip import BigIpOSUtil
-from .test_default import osutil_get_dhcp_pid_should_return_a_pid
+from .test_default import osutil_get_dhcp_pid_should_return_a_list_of_pids
 from tests.tools import *
 
 
@@ -313,8 +313,8 @@ class TestBigIpOSUtil(AgentTestCase):
     def tearDown(self):
         AgentTestCase.tearDown(self)
 
-    def test_get_dhcp_pid_should_return_a_pid(self):
-        osutil_get_dhcp_pid_should_return_a_pid(self, BigIpOSUtil())
+    def test_get_dhcp_pid_should_return_a_list_of_pids(self):
+        osutil_get_dhcp_pid_should_return_a_list_of_pids(self, BigIpOSUtil())
 
 
 if __name__ == '__main__':

--- a/tests/common/osutil/test_coreos.py
+++ b/tests/common/osutil/test_coreos.py
@@ -14,12 +14,12 @@
 #
 # Requires Python 2.6+ and Openssl 1.0+
 #
-from azurelinuxagent.common.osutil.clearlinux import ClearLinuxUtil
+from azurelinuxagent.common.osutil.coreos import CoreOSUtil
 from .test_default import osutil_get_dhcp_pid_should_return_a_list_of_pids
 from tests.tools import *
 
 
-class TestClearLinuxUtil(AgentTestCase):
+class TestAlpineOSUtil(AgentTestCase):
     def setUp(self):
         AgentTestCase.setUp(self)
 
@@ -27,7 +27,7 @@ class TestClearLinuxUtil(AgentTestCase):
         AgentTestCase.tearDown(self)
 
     def test_get_dhcp_pid_should_return_a_list_of_pids(self):
-        osutil_get_dhcp_pid_should_return_a_list_of_pids(self, ClearLinuxUtil())
+        osutil_get_dhcp_pid_should_return_a_list_of_pids(self, CoreOSUtil())
 
 
 if __name__ == '__main__':

--- a/tests/common/osutil/test_freebsd.py
+++ b/tests/common/osutil/test_freebsd.py
@@ -14,12 +14,12 @@
 #
 # Requires Python 2.6+ and Openssl 1.0+
 #
-from azurelinuxagent.common.osutil.clearlinux import ClearLinuxUtil
+from azurelinuxagent.common.osutil.freebsd import FreeBSDOSUtil
 from .test_default import osutil_get_dhcp_pid_should_return_a_list_of_pids
 from tests.tools import *
 
 
-class TestClearLinuxUtil(AgentTestCase):
+class TestAlpineOSUtil(AgentTestCase):
     def setUp(self):
         AgentTestCase.setUp(self)
 
@@ -27,7 +27,7 @@ class TestClearLinuxUtil(AgentTestCase):
         AgentTestCase.tearDown(self)
 
     def test_get_dhcp_pid_should_return_a_list_of_pids(self):
-        osutil_get_dhcp_pid_should_return_a_list_of_pids(self, ClearLinuxUtil())
+        osutil_get_dhcp_pid_should_return_a_list_of_pids(self, FreeBSDOSUtil())
 
 
 if __name__ == '__main__':

--- a/tests/common/osutil/test_nsbsd.py
+++ b/tests/common/osutil/test_nsbsd.py
@@ -1,0 +1,87 @@
+# Copyright 2019 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Requires Python 2.6+ and Openssl 1.0+
+#
+from azurelinuxagent.common.utils.fileutil import read_file
+from azurelinuxagent.common.osutil.nsbsd import NSBSDOSUtil
+from .test_default import osutil_get_dhcp_pid_should_return_a_list_of_pids
+from tests.tools import *
+from os import path
+
+
+class TestNSBSDOSUtil(AgentTestCase):
+    dhclient_pid_file = "/var/run/dhclient.pid"
+
+    def setUp(self):
+        AgentTestCase.setUp(self)
+
+    def tearDown(self):
+        AgentTestCase.tearDown(self)
+
+    def test_get_dhcp_pid_should_return_a_list_of_pids(self):
+        with patch.object(NSBSDOSUtil, "resolver"):  # instantiating NSBSDOSUtil requires a resolver
+            original_isfile = path.isfile
+
+            def mock_isfile(path):
+                return True if path == self.dhclient_pid_file else original_isfile(path)
+
+            original_read_file = read_file
+
+            def mock_read_file(file, *args, **kwargs):
+                return "123" if file == self.dhclient_pid_file else original_read_file(file, *args, **kwargs)
+
+            with patch("os.path.isfile", mock_isfile):
+                with patch("azurelinuxagent.common.osutil.nsbsd.fileutil.read_file", mock_read_file):
+                    pid_list = NSBSDOSUtil().get_dhcp_pid()
+
+            self.assertEquals(pid_list, [123])
+
+    def test_get_dhcp_pid_should_return_an_empty_list_when_the_dhcp_client_is_not_running(self):
+        with patch.object(NSBSDOSUtil, "resolver"):  # instantiating NSBSDOSUtil requires a resolver
+            #
+            # PID file does not exist
+            #
+            original_isfile = path.isfile
+
+            def mock_isfile(path):
+                return False if path == self.dhclient_pid_file else original_isfile(path)
+
+            with patch("os.path.isfile", mock_isfile):
+                pid_list = NSBSDOSUtil().get_dhcp_pid()
+
+            self.assertEquals(pid_list, [])
+
+            #
+            # PID file is empty
+            #
+            original_isfile = path.isfile
+
+            def mock_isfile(path):
+                return True if path == self.dhclient_pid_file else original_isfile(path)
+
+            original_read_file = read_file
+
+            def mock_read_file(file, *args, **kwargs):
+                return "" if file == self.dhclient_pid_file else original_read_file(file, *args, **kwargs)
+
+            with patch("os.path.isfile", mock_isfile):
+                with patch("azurelinuxagent.common.osutil.nsbsd.fileutil.read_file", mock_read_file):
+                    pid_list = NSBSDOSUtil().get_dhcp_pid()
+
+            self.assertEquals(pid_list, [])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/common/osutil/test_openbsd.py
+++ b/tests/common/osutil/test_openbsd.py
@@ -14,12 +14,12 @@
 #
 # Requires Python 2.6+ and Openssl 1.0+
 #
-from azurelinuxagent.common.osutil.clearlinux import ClearLinuxUtil
+from azurelinuxagent.common.osutil.openbsd import OpenBSDOSUtil
 from .test_default import osutil_get_dhcp_pid_should_return_a_list_of_pids
 from tests.tools import *
 
 
-class TestClearLinuxUtil(AgentTestCase):
+class TestAlpineOSUtil(AgentTestCase):
     def setUp(self):
         AgentTestCase.setUp(self)
 
@@ -27,7 +27,7 @@ class TestClearLinuxUtil(AgentTestCase):
         AgentTestCase.tearDown(self)
 
     def test_get_dhcp_pid_should_return_a_list_of_pids(self):
-        osutil_get_dhcp_pid_should_return_a_list_of_pids(self, ClearLinuxUtil())
+        osutil_get_dhcp_pid_should_return_a_list_of_pids(self, OpenBSDOSUtil())
 
 
 if __name__ == '__main__':

--- a/tests/common/osutil/test_openwrt.py
+++ b/tests/common/osutil/test_openwrt.py
@@ -15,8 +15,9 @@
 # Requires Python 2.6+ and Openssl 1.0+
 #
 from azurelinuxagent.common.osutil.openwrt import OpenWRTOSUtil
-from .test_default import osutil_get_dhcp_pid_should_return_a_pid
+from .test_default import osutil_get_dhcp_pid_should_return_a_list_of_pids
 from tests.tools import *
+
 
 class TestOpenWRTOSUtil(AgentTestCase):
     def setUp(self):
@@ -25,8 +26,8 @@ class TestOpenWRTOSUtil(AgentTestCase):
     def tearDown(self):
         AgentTestCase.tearDown(self)
 
-    def test_get_dhcp_pid_should_return_a_pid(self):
-        osutil_get_dhcp_pid_should_return_a_pid(self, OpenWRTOSUtil())
+    def test_get_dhcp_pid_should_return_a_list_of_pids(self):
+        osutil_get_dhcp_pid_should_return_a_list_of_pids(self, OpenWRTOSUtil())
 
 
 if __name__ == '__main__':

--- a/tests/common/osutil/test_redhat.py
+++ b/tests/common/osutil/test_redhat.py
@@ -15,8 +15,9 @@
 # Requires Python 2.6+ and Openssl 1.0+
 #
 from azurelinuxagent.common.osutil.redhat import Redhat6xOSUtil
-from .test_default import osutil_get_dhcp_pid_should_return_a_pid
+from .test_default import osutil_get_dhcp_pid_should_return_a_list_of_pids
 from tests.tools import *
+
 
 class TestRedhat6xOSUtil(AgentTestCase):
     def setUp(self):
@@ -25,8 +26,8 @@ class TestRedhat6xOSUtil(AgentTestCase):
     def tearDown(self):
         AgentTestCase.tearDown(self)
 
-    def test_get_dhcp_pid_should_return_a_pid(self):
-        osutil_get_dhcp_pid_should_return_a_pid(self, Redhat6xOSUtil())
+    def test_get_dhcp_pid_should_return_a_list_of_pids(self):
+        osutil_get_dhcp_pid_should_return_a_list_of_pids(self, Redhat6xOSUtil())
 
 
 if __name__ == '__main__':

--- a/tests/common/osutil/test_suse.py
+++ b/tests/common/osutil/test_suse.py
@@ -15,8 +15,9 @@
 # Requires Python 2.6+ and Openssl 1.0+
 #
 from azurelinuxagent.common.osutil.suse import SUSE11OSUtil
-from .test_default import osutil_get_dhcp_pid_should_return_a_pid
+from .test_default import osutil_get_dhcp_pid_should_return_a_list_of_pids
 from tests.tools import *
+
 
 class TestSUSE11OSUtil(AgentTestCase):
     def setUp(self):
@@ -25,8 +26,8 @@ class TestSUSE11OSUtil(AgentTestCase):
     def tearDown(self):
         AgentTestCase.tearDown(self)
 
-    def test_get_dhcp_pid_should_return_a_pid(self):
-        osutil_get_dhcp_pid_should_return_a_pid(self, SUSE11OSUtil())
+    def test_get_dhcp_pid_should_return_a_list_of_pids(self):
+        osutil_get_dhcp_pid_should_return_a_list_of_pids(self, SUSE11OSUtil())
 
 
 if __name__ == '__main__':

--- a/tests/common/osutil/test_ubuntu.py
+++ b/tests/common/osutil/test_ubuntu.py
@@ -15,8 +15,9 @@
 # Requires Python 2.6+ and Openssl 1.0+
 #
 from azurelinuxagent.common.osutil.ubuntu import Ubuntu12OSUtil, Ubuntu18OSUtil
-from .test_default import osutil_get_dhcp_pid_should_return_a_pid
+from .test_default import osutil_get_dhcp_pid_should_return_a_list_of_pids
 from tests.tools import *
+
 
 class TestUbuntu12OSUtil(AgentTestCase):
     def setUp(self):
@@ -25,8 +26,8 @@ class TestUbuntu12OSUtil(AgentTestCase):
     def tearDown(self):
         AgentTestCase.tearDown(self)
 
-    def test_get_dhcp_pid_should_return_a_pid(self):
-        osutil_get_dhcp_pid_should_return_a_pid(self, Ubuntu12OSUtil())
+    def test_get_dhcp_pid_should_return_a_list_of_pids(self):
+        osutil_get_dhcp_pid_should_return_a_list_of_pids(self, Ubuntu12OSUtil())
 
 
 class TestUbuntu18OSUtil(AgentTestCase):
@@ -36,8 +37,8 @@ class TestUbuntu18OSUtil(AgentTestCase):
     def tearDown(self):
         AgentTestCase.tearDown(self)
 
-    def test_get_dhcp_pid_should_return_a_pid(self):
-        osutil_get_dhcp_pid_should_return_a_pid(self, Ubuntu18OSUtil())
+    def test_get_dhcp_pid_should_return_a_list_of_pids(self):
+        osutil_get_dhcp_pid_should_return_a_list_of_pids(self, Ubuntu18OSUtil())
 
 
 if __name__ == '__main__':

--- a/tests/ga/test_env.py
+++ b/tests/ga/test_env.py
@@ -42,26 +42,26 @@ class TestEnvHandler(AgentTestCase):
     def test_get_dhcp_client_pid_should_return_a_sorted_list_of_pids(self):
         with patch("azurelinuxagent.common.utils.shellutil.run_command", return_value="11 9 5 22 4 6"):
             pids = EnvHandler().get_dhcp_client_pid()
-            self.assertEquals(pids, ["11", "22", "4", "5", "6", "9"])
+            self.assertEquals(pids, [4, 5, 6, 9, 11, 22])
 
-    def test_get_dhcp_client_pid_should_return_none_and_log_a_warning_when_dhcp_client_is_not_running(self):
+    def test_get_dhcp_client_pid_should_return_an_empty_list_and_log_a_warning_when_dhcp_client_is_not_running(self):
         with patch("azurelinuxagent.common.osutil.default.shellutil.run_command", side_effect=lambda _: self.shellutil_run_command(["pidof", "non-existing-process"])):
             with patch('azurelinuxagent.common.logger.Logger.warn') as mock_warn:
                 pids = EnvHandler().get_dhcp_client_pid()
 
-        self.assertIsNone(pids)
+        self.assertEquals(pids, [])
 
         self.assertEquals(mock_warn.call_count, 1)
         args, kwargs = mock_warn.call_args
         message = args[0]
         self.assertEquals("Dhcp client is not running.", message)
 
-    def test_get_dhcp_client_pid_should_return_none_and_log_an_error_when_an_invalid_command_is_used(self):
+    def test_get_dhcp_client_pid_should_return_and_empty_list_and_log_an_error_when_an_invalid_command_is_used(self):
         with patch("azurelinuxagent.common.osutil.default.shellutil.run_command", side_effect=lambda _: self.shellutil_run_command(["non-existing-command"])):
             with patch('azurelinuxagent.common.logger.Logger.error') as mock_error:
                 pids = EnvHandler().get_dhcp_client_pid()
 
-        self.assertIsNone(pids)
+        self.assertEquals(pids, [])
 
         self.assertEquals(mock_error.call_count, 1)
         args, kwargs = mock_error.call_args
@@ -82,31 +82,31 @@ class TestEnvHandler(AgentTestCase):
             with patch("azurelinuxagent.common.osutil.default.shellutil.run_command", side_effect=lambda _: self.shellutil_run_command(["pidof", "non-existing-process"])):
                 # it should log the first error
                 pids = env_handler.get_dhcp_client_pid()
-                self.assertIsNone(pids)
+                self.assertEquals(pids, [])
                 assert_warnings(1)
 
                 # it should not log subsequent errors
                 for i in range(0, 3):
                     pids = env_handler.get_dhcp_client_pid()
-                    self.assertIsNone(pids)
+                    self.assertEquals(pids, [])
                     self.assertEquals(mock_warn.call_count, 1)
 
             with patch("azurelinuxagent.common.osutil.default.shellutil.run_command", return_value="123"):
                 # now it should succeed
                 pids = env_handler.get_dhcp_client_pid()
-                self.assertEquals(pids, ["123"])
+                self.assertEquals(pids, [123])
                 assert_warnings(1)
 
             with patch("azurelinuxagent.common.osutil.default.shellutil.run_command", side_effect=lambda _: self.shellutil_run_command(["pidof", "non-existing-process"])):
                 # it should log the new error
                 pids = env_handler.get_dhcp_client_pid()
-                self.assertIsNone(pids)
+                self.assertEquals(pids, [])
                 assert_warnings(2)
 
                 # it should not log subsequent errors
                 for i in range(0, 3):
                     pids = env_handler.get_dhcp_client_pid()
-                    self.assertIsNone(pids)
+                    self.assertEquals(pids, [])
                     self.assertEquals(mock_warn.call_count, 2)
 
     def test_handle_dhclient_restart_should_reconfigure_network_routes_when_dhcp_client_restarts(self):
@@ -116,7 +116,7 @@ class TestEnvHandler(AgentTestCase):
             #
             # before the first call to handle_dhclient_restart, EnvHandler configures the network routes and initializes the DHCP PIDs
             #
-            with patch.object(env_handler, "get_dhcp_client_pid", return_value=["123"]):
+            with patch.object(env_handler, "get_dhcp_client_pid", return_value=[123]):
                 env_handler.dhcp_handler.conf_routes()
                 env_handler.dhcp_id_list = env_handler.get_dhcp_client_pid()
                 self.assertEquals(mock_conf_routes.call_count, 1)
@@ -125,7 +125,7 @@ class TestEnvHandler(AgentTestCase):
             # if the dhcp client has not been restarted then it should not reconfigure the network routes
             #
             def mock_check_pid_alive(pid):
-                if pid == "123":
+                if pid == 123:
                     return True
                 raise Exception("Unexpected PID: {0}".format(pid))
 
@@ -138,12 +138,12 @@ class TestEnvHandler(AgentTestCase):
             # if the process was restarted then it should reconfigure the network routes
             #
             def mock_check_pid_alive(pid):
-                if pid == "123":
+                if pid == 123:
                     return False
                 raise Exception("Unexpected PID: {0}".format(pid))
 
             with patch("azurelinuxagent.common.osutil.default.DefaultOSUtil.check_pid_alive", side_effect=mock_check_pid_alive):
-                with patch.object(env_handler, "get_dhcp_client_pid", return_value=["456", "789"]):
+                with patch.object(env_handler, "get_dhcp_client_pid", return_value=[456, 789]):
                     env_handler.handle_dhclient_restart()
                     self.assertEquals(mock_conf_routes.call_count, 2)  # count increased
 
@@ -151,7 +151,7 @@ class TestEnvHandler(AgentTestCase):
             # if the new dhcp client has not been restarted then it should not reconfigure the network routes
             #
             def mock_check_pid_alive(pid):
-                if pid in ["456", "789"]:
+                if pid in [456, 789]:
                     return True
                 raise Exception("Unexpected PID: {0}".format(pid))
 


### PR DESCRIPTION
All implementations of get_dhcp_pid now use run_command instead of run_get_output.

I made a few changes in the interfaces; will add comment in the PR to point them out.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/walinuxagent/1625)
<!-- Reviewable:end -->
