### PR TITLE
Retrieve latest container id from cache when sending telemetry events

### DIFF
--- a/azurelinuxagent/common/event.py
+++ b/azurelinuxagent/common/event.py
@@ -28,6 +28,7 @@ import azurelinuxagent.common.conf as conf
 import azurelinuxagent.common.logger as logger
 from azurelinuxagent.common.exception import EventError
 from azurelinuxagent.common.future import ustr
+from azurelinuxagent.common.protocol.wire import CONTAINER_ID
 from azurelinuxagent.common.protocol.restapi import TelemetryEventParam, \
     TelemetryEvent, \
     get_properties
@@ -93,6 +94,7 @@ SHOULD_ENCODE_MESSAGE_OP = [
     WALAEventOperation.Install,
     WALAEventOperation.UnInstall,
 ]
+
 
 class EventStatus(object):
     EVENT_STATUS_FILE = "event_status.json"
@@ -277,6 +279,7 @@ class EventLogger(object):
         event.parameters.append(TelemetryEventParam('Message', message))
         event.parameters.append(TelemetryEventParam('Duration', duration))
         event.parameters.append(TelemetryEventParam('ExtensionType', evt_type))
+        event.parameters.append(TelemetryEventParam('ContainerId', os.environ.get(CONTAINER_ID, None)))
 
         data = get_properties(event)
         try:

--- a/azurelinuxagent/common/event.py
+++ b/azurelinuxagent/common/event.py
@@ -28,7 +28,7 @@ import azurelinuxagent.common.conf as conf
 import azurelinuxagent.common.logger as logger
 from azurelinuxagent.common.exception import EventError
 from azurelinuxagent.common.future import ustr
-from azurelinuxagent.common.protocol.wire import CONTAINER_ID
+from azurelinuxagent.common.protocol.wire import CONTAINER_ID_ENV_VARIABLE
 from azurelinuxagent.common.protocol.restapi import TelemetryEventParam, \
     TelemetryEvent, \
     get_properties
@@ -279,7 +279,8 @@ class EventLogger(object):
         event.parameters.append(TelemetryEventParam('Message', message))
         event.parameters.append(TelemetryEventParam('Duration', duration))
         event.parameters.append(TelemetryEventParam('ExtensionType', evt_type))
-        event.parameters.append(TelemetryEventParam('ContainerId', os.environ.get(CONTAINER_ID, None)))
+        event.parameters.append(TelemetryEventParam('ContainerId',
+                                                    os.environ.get(CONTAINER_ID_ENV_VARIABLE, "UNINITIALIZED")))
 
         data = get_properties(event)
         try:

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -56,7 +56,8 @@ MANIFEST_FILE_NAME = "{0}.{1}.manifest.xml"
 AGENTS_MANIFEST_FILE_NAME = "{0}.{1}.agentsManifest"
 TRANSPORT_CERT_FILE_NAME = "TransportCert.pem"
 TRANSPORT_PRV_FILE_NAME = "TransportPrivate.pem"
-CONTAINER_ID = "AZURE_GUEST_AGENT_CONTAINER_ID"
+# Store the last retrieved container id as an environment variable to be shared between threads for telemetry purposes
+CONTAINER_ID_ENV_VARIABLE = "AZURE_GUEST_AGENT_CONTAINER_ID"
 
 PROTOCOL_VERSION = "2012-11-30"
 ENDPOINT_FINE_NAME = "WireServer"
@@ -1352,7 +1353,7 @@ class GoalState(object):
         self.role_config_name = findtext(role_config, "ConfigName")
         container = find(xml_doc, "Container")
         self.container_id = findtext(container, "ContainerId")
-        os.environ[CONTAINER_ID] = self.container_id
+        os.environ[CONTAINER_ID_ENV_VARIABLE] = self.container_id
         self.remote_access_uri = findtext(container, "RemoteAccessInfo")
         lbprobe_ports = find(xml_doc, "LBProbePorts")
         self.load_balancer_probe_port = findtext(lbprobe_ports, "Port")

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -56,6 +56,7 @@ MANIFEST_FILE_NAME = "{0}.{1}.manifest.xml"
 AGENTS_MANIFEST_FILE_NAME = "{0}.{1}.agentsManifest"
 TRANSPORT_CERT_FILE_NAME = "TransportCert.pem"
 TRANSPORT_PRV_FILE_NAME = "TransportPrivate.pem"
+CONTAINER_ID = "AZURE_GUEST_AGENT_CONTAINER_ID"
 
 PROTOCOL_VERSION = "2012-11-30"
 ENDPOINT_FINE_NAME = "WireServer"
@@ -112,7 +113,6 @@ class WireProtocol(Protocol):
         vminfo.tenantName = hosting_env.deployment_name
         vminfo.roleName = hosting_env.role_name
         vminfo.roleInstanceName = goal_state.role_instance_id
-        vminfo.containerId = goal_state.container_id
         return vminfo
 
     def get_certs(self):
@@ -840,12 +840,6 @@ class WireClient(object):
             self.goal_state = GoalState(xml_text)
         return self.goal_state
 
-    def get_container_id_from_goal_state(self):
-        if self.goal_state is None:
-            return None
-
-        return self.goal_state.container_id
-
     def get_hosting_env(self):
         if self.hosting_env is None:
             local_file = os.path.join(conf.get_lib_dir(),
@@ -1358,6 +1352,7 @@ class GoalState(object):
         self.role_config_name = findtext(role_config, "ConfigName")
         container = find(xml_doc, "Container")
         self.container_id = findtext(container, "ContainerId")
+        os.environ[CONTAINER_ID] = self.container_id
         self.remote_access_uri = findtext(container, "RemoteAccessInfo")
         lbprobe_ports = find(xml_doc, "LBProbePorts")
         self.load_balancer_probe_port = findtext(lbprobe_ports, "Port")

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -840,6 +840,12 @@ class WireClient(object):
             self.goal_state = GoalState(xml_text)
         return self.goal_state
 
+    def get_container_id_from_goal_state(self):
+        if self.goal_state is None:
+            return None
+
+        return self.goal_state.container_id
+
     def get_hosting_env(self):
         if self.hosting_env is None:
             local_file = os.path.join(conf.get_lib_dir(),

--- a/azurelinuxagent/ga/monitor.py
+++ b/azurelinuxagent/ga/monitor.py
@@ -188,8 +188,6 @@ class MonitorHandler(object):
                                                     vminfo.roleName))
             self.sysinfo.append(TelemetryEventParam("RoleInstanceName",
                                                     vminfo.roleInstanceName))
-            self.sysinfo.append(TelemetryEventParam("ContainerId",
-                                                    vminfo.containerId))
         except ProtocolError as e:
             logger.warn("Failed to get system info: {0}", ustr(e))
 
@@ -245,7 +243,6 @@ class MonitorHandler(object):
                     try:
                         event = parse_event(data_str)
                         self.add_sysinfo(event)
-                        self.update_container_id(event)
                         event_list.events.append(event)
                     except (ValueError, ProtocolError) as e:
                         logger.warn("Failed to decode event file: {0}", ustr(e))
@@ -287,19 +284,6 @@ class MonitorHandler(object):
                 logger.verbose("Remove existing event parameter: [{0}:{1}]", param.name, param.value)
                 event.parameters.remove(param)
         event.parameters.extend(self.sysinfo)
-
-    def update_container_id(self, event):
-        last_known_container_id = self.protocol.client.get_container_id_from_goal_state()
-        if last_known_container_id is None:
-            return
-
-        for i, param in enumerate(event.parameters):
-            if param.name == "ContainerId":
-                if param.value == last_known_container_id:
-                    # No update needed
-                    return
-                updated_parameter = TelemetryEventParam("ContainerId", last_known_container_id)
-                event.parameters[i] = updated_parameter
 
     def send_imds_heartbeat(self):
         """

--- a/tests/common/test_event.py
+++ b/tests/common/test_event.py
@@ -46,13 +46,17 @@ class TestEvent(AgentTestCase):
             os.environ.pop(event.CONTAINER_ID_ENV_VARIABLE, None)
             event.add_event(name='dummy_name')
             data = fileutil.read_file(tmp_file)
-            self.assertIn('{"name": "ContainerId", "value": "UNINITIALIZED"}', data)
+            self.assertTrue('{"name": "ContainerId", "value": "UNINITIALIZED"}' in data or
+                            '{"value": "UNINITIALIZED", "name": "ContainerId"}' in data)
 
             # Container id is set as an environment variable explicitly
             os.environ[event.CONTAINER_ID_ENV_VARIABLE] = '424242'
             event.add_event(name='dummy_name')
             data = fileutil.read_file(tmp_file)
-            self.assertIn('{{"name": "ContainerId", "value": "{0}"}}'.format(os.environ[event.CONTAINER_ID_ENV_VARIABLE]), data)
+            self.assertTrue('{{"name": "ContainerId", "value": "{0}"}}'.format(
+                                os.environ[event.CONTAINER_ID_ENV_VARIABLE]) in data or
+                            '{{"value": "{0}", "name": "ContainerId"}}'.format(
+                                os.environ[event.CONTAINER_ID_ENV_VARIABLE]) in data)
 
             # Container id is set as an environment variable when parsing the goal state
             xml_text = load_data("wire/goal_state.xml")
@@ -61,7 +65,8 @@ class TestEvent(AgentTestCase):
             container_id = goal_state.container_id
             event.add_event(name='dummy_name')
             data = fileutil.read_file(tmp_file)
-            self.assertIn('{{"name": "ContainerId", "value": "{0}"}}'.format(container_id), data)
+            self.assertTrue('{{"name": "ContainerId", "value": "{0}"}}'.format(container_id) in data or
+                            '{{"value": "{0}", "name": "ContainerId"}}'.format(container_id), data)
 
             # Container id is updated as the goal state changes, both in telemetry event and in environment variables
             new_container_id = "z6d5526c-5ac2-4200-b6e2-56f2b70c5ab2"
@@ -74,7 +79,8 @@ class TestEvent(AgentTestCase):
 
             # Assert both the environment variable and telemetry event got updated
             self.assertEquals(os.environ[event.CONTAINER_ID_ENV_VARIABLE], new_container_id)
-            self.assertIn('{{"name": "ContainerId", "value": "{0}"}}'.format(new_container_id), data)
+            self.assertTrue('{{"name": "ContainerId", "value": "{0}"}}'.format(new_container_id) in data or
+                            '{{"value": "{0}", "name": "ContainerId"}}'.format(new_container_id), data)
 
         os.environ.pop(event.CONTAINER_ID_ENV_VARIABLE)
 

--- a/tests/ga/test_extension.py
+++ b/tests/ga/test_extension.py
@@ -28,11 +28,11 @@ from azurelinuxagent.ga.exthandlers import *
 from azurelinuxagent.common.protocol.wire import WireProtocol, InVMArtifactsProfile
 
 # Mock sleep to reduce test execution time
-SLEEP = time.sleep
+MOCK_SLEEP = time.sleep
 
 
 def mock_sleep(sec=0.01):
-    SLEEP(sec)
+    MOCK_SLEEP(sec)
 
 
 def do_not_run_test():

--- a/tests/ga/test_extension.py
+++ b/tests/ga/test_extension.py
@@ -27,6 +27,7 @@ from azurelinuxagent.common.protocol.restapi import Extension
 from azurelinuxagent.ga.exthandlers import *
 from azurelinuxagent.common.protocol.wire import WireProtocol, InVMArtifactsProfile
 
+# Mock sleep to reduce test execution time
 SLEEP = time.sleep
 
 

--- a/tests/ga/test_extension.py
+++ b/tests/ga/test_extension.py
@@ -27,6 +27,12 @@ from azurelinuxagent.common.protocol.restapi import Extension
 from azurelinuxagent.ga.exthandlers import *
 from azurelinuxagent.common.protocol.wire import WireProtocol, InVMArtifactsProfile
 
+SLEEP = time.sleep
+
+
+def mock_sleep(sec=0.01):
+    SLEEP(sec)
+
 
 def do_not_run_test():
     return True
@@ -294,6 +300,7 @@ class ExtensionTestCase(AgentTestCase):
             CGroupConfigurator.get_instance().disable()
 
 
+@patch('time.sleep', side_effect=lambda _: mock_sleep(0.001))
 @patch("azurelinuxagent.common.protocol.wire.CryptUtil")
 @patch("azurelinuxagent.common.utils.restutil.http_get")
 class TestExtension(ExtensionTestCase):
@@ -320,7 +327,7 @@ class TestExtension(ExtensionTestCase):
         self.assertEquals(0, len(vm_status.vmAgent.extensionHandlers))
         return
 
-    def _create_mock(self, test_data, mock_http_get, MockCryptUtil):
+    def _create_mock(self, test_data, mock_http_get, MockCryptUtil, *args):
         """Test enable/disable/uninstall of an extension"""
         handler = get_exthandlers_handler()
 

--- a/tests/ga/test_extension.py
+++ b/tests/ga/test_extension.py
@@ -28,11 +28,11 @@ from azurelinuxagent.ga.exthandlers import *
 from azurelinuxagent.common.protocol.wire import WireProtocol, InVMArtifactsProfile
 
 # Mock sleep to reduce test execution time
-MOCK_SLEEP = time.sleep
+SLEEP = time.sleep
 
 
 def mock_sleep(sec=0.01):
-    MOCK_SLEEP(sec)
+    SLEEP(sec)
 
 
 def do_not_run_test():

--- a/tests/ga/test_monitor.py
+++ b/tests/ga/test_monitor.py
@@ -97,19 +97,16 @@ class TestMonitor(AgentTestCase):
         tenant_name = 'dummy_tenant'
         role_name = 'dummy_role'
         role_instance_name = 'dummy_role_instance'
-        container_id = 'dummy_container_id'
 
         vm_name_param = "VMName"
         tenant_name_param = "TenantName"
         role_name_param = "RoleName"
         role_instance_name_param = "RoleInstanceName"
-        container_id_param = "ContainerId"
 
         sysinfo = [TelemetryEventParam(vm_name_param, vm_name),
                    TelemetryEventParam(tenant_name_param, tenant_name),
                    TelemetryEventParam(role_name_param, role_name),
-                   TelemetryEventParam(role_instance_name_param, role_instance_name),
-                   TelemetryEventParam(container_id_param, container_id)]
+                   TelemetryEventParam(role_instance_name_param, role_instance_name)]
         monitor_handler.sysinfo = sysinfo
         monitor_handler.add_sysinfo(event)
 
@@ -130,36 +127,8 @@ class TestMonitor(AgentTestCase):
             elif p.name == role_instance_name_param:
                 self.assertEqual(role_instance_name, p.value)
                 counter += 1
-            elif p.name == container_id_param:
-                self.assertEqual(container_id, p.value)
-                counter += 1
 
-        self.assertEqual(5, counter)
-
-    def test_update_container_id(self, *args):
-        old_container_id = "old_container_id"
-        new_container_id = "new_container_id"
-
-        event = TelemetryEvent()
-        event.parameters.append(TelemetryEventParam("ContainerId", old_container_id))
-        event.parameters.append(TelemetryEventParam("Message", "dummy message"))
-
-        monitor_handler = get_monitor_handler()
-        monitor_handler.protocol = WireProtocol("foo.bar")
-
-        with patch("azurelinuxagent.common.protocol.wire.WireClient.get_container_id_from_goal_state",
-                   return_value=None):
-            monitor_handler.update_container_id(event)
-            for p in event.parameters:
-                if p.name == "ContainerId":
-                    self.assertEquals(p.value, old_container_id)
-
-        with patch("azurelinuxagent.common.protocol.wire.WireClient.get_container_id_from_goal_state",
-                   return_value=new_container_id):
-            monitor_handler.update_container_id(event)
-            for p in event.parameters:
-                if p.name == "ContainerId":
-                    self.assertEquals(p.value, new_container_id)
+        self.assertEqual(4, counter)
 
     @patch("azurelinuxagent.ga.monitor.MonitorHandler.send_telemetry_heartbeat")
     @patch("azurelinuxagent.ga.monitor.MonitorHandler.collect_and_send_events")

--- a/tests/ga/test_monitor.py
+++ b/tests/ga/test_monitor.py
@@ -136,6 +136,31 @@ class TestMonitor(AgentTestCase):
 
         self.assertEqual(5, counter)
 
+    def test_update_container_id(self, *args):
+        old_container_id = "old_container_id"
+        new_container_id = "new_container_id"
+
+        event = TelemetryEvent()
+        event.parameters.append(TelemetryEventParam("ContainerId", old_container_id))
+        event.parameters.append(TelemetryEventParam("Message", "dummy message"))
+
+        monitor_handler = get_monitor_handler()
+        monitor_handler.protocol = WireProtocol("foo.bar")
+
+        with patch("azurelinuxagent.common.protocol.wire.WireClient.get_container_id_from_goal_state",
+                   return_value=None):
+            monitor_handler.update_container_id(event)
+            for p in event.parameters:
+                if p.name == "ContainerId":
+                    self.assertEquals(p.value, old_container_id)
+
+        with patch("azurelinuxagent.common.protocol.wire.WireClient.get_container_id_from_goal_state",
+                   return_value=new_container_id):
+            monitor_handler.update_container_id(event)
+            for p in event.parameters:
+                if p.name == "ContainerId":
+                    self.assertEquals(p.value, new_container_id)
+
     @patch("azurelinuxagent.ga.monitor.MonitorHandler.send_telemetry_heartbeat")
     @patch("azurelinuxagent.ga.monitor.MonitorHandler.collect_and_send_events")
     @patch("azurelinuxagent.ga.monitor.MonitorHandler.send_host_plugin_heartbeat")


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Today, we populate a group of parameters called `vminfo` once at the start of the monitoring thread. One of these parameters is `ContainerId` which can change without redeploying the resource and restarting the agent (e.g. during live migration).

Adding the functionality to fetch the `ContainerId` parameter during the construction of the telemetry event from the process environment variables. The value is set during a goal state update.

<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/walinuxagent/1628)
<!-- Reviewable:end -->
