### PR TITLE
Add telemetry event for HostGAPlugin retry logic

### DIFF
--- a/azurelinuxagent/common/datacontract.py
+++ b/azurelinuxagent/common/datacontract.py
@@ -1,0 +1,83 @@
+# Microsoft Azure Linux Agent
+#
+# Copyright 2019 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Requires Python 2.6+ and Openssl 1.0+
+#
+
+from azurelinuxagent.common.exception import ProtocolError
+import azurelinuxagent.common.logger as logger
+
+"""
+Data contract between guest and host
+"""
+
+
+class DataContract(object):
+    pass
+
+
+class DataContractList(list):
+    def __init__(self, item_cls):
+        self.item_cls = item_cls
+
+
+def validate_param(name, val, expected_type):
+    if val is None:
+        raise ProtocolError("{0} is None".format(name))
+    if not isinstance(val, expected_type):
+        raise ProtocolError(("{0} type should be {1} not {2}"
+                             "").format(name, expected_type, type(val)))
+
+
+def set_properties(name, obj, data):
+    if isinstance(obj, DataContract):
+        validate_param("Property '{0}'".format(name), data, dict)
+        for prob_name, prob_val in data.items():
+            prob_full_name = "{0}.{1}".format(name, prob_name)
+            try:
+                prob = getattr(obj, prob_name)
+            except AttributeError:
+                logger.warn("Unknown property: {0}", prob_full_name)
+                continue
+            prob = set_properties(prob_full_name, prob, prob_val)
+            setattr(obj, prob_name, prob)
+        return obj
+    elif isinstance(obj, DataContractList):
+        validate_param("List '{0}'".format(name), data, list)
+        for item_data in data:
+            item = obj.item_cls()
+            item = set_properties(name, item, item_data)
+            obj.append(item)
+        return obj
+    else:
+        return data
+
+
+def get_properties(obj):
+    if isinstance(obj, DataContract):
+        data = {}
+        props = vars(obj)
+        for prob_name, prob in list(props.items()):
+            data[prob_name] = get_properties(prob)
+        return data
+    elif isinstance(obj, DataContractList):
+        data = []
+        for item in obj:
+            item_data = get_properties(item)
+            data.append(item_data)
+        return data
+    else:
+        return obj

--- a/azurelinuxagent/common/datacontract.py
+++ b/azurelinuxagent/common/datacontract.py
@@ -21,7 +21,7 @@ from azurelinuxagent.common.exception import ProtocolError
 import azurelinuxagent.common.logger as logger
 
 """
-Data contract between guest and host
+Base class for data contracts between guest and host and utilities to manipulate the properties in those contracts
 """
 
 

--- a/azurelinuxagent/common/event.py
+++ b/azurelinuxagent/common/event.py
@@ -28,9 +28,8 @@ import azurelinuxagent.common.conf as conf
 import azurelinuxagent.common.logger as logger
 from azurelinuxagent.common.exception import EventError
 from azurelinuxagent.common.future import ustr
-from azurelinuxagent.common.protocol.restapi import TelemetryEventParam, \
-    TelemetryEvent, \
-    get_properties
+from azurelinuxagent.common.datacontract import get_properties
+from azurelinuxagent.common.telemetryevent import TelemetryEventParam, TelemetryEvent
 from azurelinuxagent.common.utils import fileutil, textutil
 from azurelinuxagent.common.version import CURRENT_VERSION
 

--- a/azurelinuxagent/common/protocol/imds.py
+++ b/azurelinuxagent/common/protocol/imds.py
@@ -7,7 +7,7 @@ import azurelinuxagent.common.utils.restutil as restutil
 from azurelinuxagent.common.exception import HttpError
 from azurelinuxagent.common.future import ustr
 import azurelinuxagent.common.logger as logger
-from azurelinuxagent.common.protocol.restapi import DataContract, set_properties
+from azurelinuxagent.common.datacontract import DataContract, set_properties
 from azurelinuxagent.common.utils.flexible_version import FlexibleVersion
 
 IMDS_ENDPOINT = '169.254.169.254'

--- a/azurelinuxagent/common/protocol/metadata.py
+++ b/azurelinuxagent/common/protocol/metadata.py
@@ -25,9 +25,14 @@ import sys
 import traceback
 
 import azurelinuxagent.common.conf as conf
+from azurelinuxagent.common.datacontract import get_properties, set_properties, validate_param
+from azurelinuxagent.common.exception import HttpError, ProtocolError
+import azurelinuxagent.common.logger as logger
+from azurelinuxagent.common.utils import restutil
 import azurelinuxagent.common.utils.fileutil as fileutil
 import azurelinuxagent.common.utils.shellutil as shellutil
 import azurelinuxagent.common.utils.textutil as textutil
+from azurelinuxagent.common.telemetryevent import TelemetryEventList
 
 from azurelinuxagent.common.future import httpclient
 from azurelinuxagent.common.protocol.restapi import *

--- a/azurelinuxagent/common/protocol/restapi.py
+++ b/azurelinuxagent/common/protocol/restapi.py
@@ -16,76 +16,11 @@
 #
 # Requires Python 2.6+ and Openssl 1.0+
 #
+
 import socket
-import azurelinuxagent.common.logger as logger
-import azurelinuxagent.common.utils.restutil as restutil
-from azurelinuxagent.common.exception import ProtocolError, HttpError
 from azurelinuxagent.common.future import ustr
-from azurelinuxagent.common.utils import fileutil
 from azurelinuxagent.common.version import DISTRO_VERSION, DISTRO_NAME, CURRENT_VERSION
-
-
-def validate_param(name, val, expected_type):
-    if val is None:
-        raise ProtocolError("{0} is None".format(name))
-    if not isinstance(val, expected_type):
-        raise ProtocolError(("{0} type should be {1} not {2}"
-                             "").format(name, expected_type, type(val)))
-
-
-def set_properties(name, obj, data):
-    if isinstance(obj, DataContract):
-        validate_param("Property '{0}'".format(name), data, dict)
-        for prob_name, prob_val in data.items():
-            prob_full_name = "{0}.{1}".format(name, prob_name)
-            try:
-                prob = getattr(obj, prob_name)
-            except AttributeError:
-                logger.warn("Unknown property: {0}", prob_full_name)
-                continue
-            prob = set_properties(prob_full_name, prob, prob_val)
-            setattr(obj, prob_name, prob)
-        return obj
-    elif isinstance(obj, DataContractList):
-        validate_param("List '{0}'".format(name), data, list)
-        for item_data in data:
-            item = obj.item_cls()
-            item = set_properties(name, item, item_data)
-            obj.append(item)
-        return obj
-    else:
-        return data
-
-
-def get_properties(obj):
-    if isinstance(obj, DataContract):
-        data = {}
-        props = vars(obj)
-        for prob_name, prob in list(props.items()):
-            data[prob_name] = get_properties(prob)
-        return data
-    elif isinstance(obj, DataContractList):
-        data = []
-        for item in obj:
-            item_data = get_properties(item)
-            data.append(item_data)
-        return data
-    else:
-        return obj
-
-
-class DataContract(object):
-    pass
-
-
-class DataContractList(list):
-    def __init__(self, item_cls):
-        self.item_cls = item_cls
-
-
-"""
-Data contract between guest and host
-"""
+from azurelinuxagent.common.datacontract import DataContract, DataContractList
 
 
 class VMInfo(DataContract):
@@ -284,24 +219,6 @@ class VMAgentStatus(DataContract):
 class VMStatus(DataContract):
     def __init__(self, status, message):
         self.vmAgent = VMAgentStatus(status=status, message=message)
-
-
-class TelemetryEventParam(DataContract):
-    def __init__(self, name=None, value=None):
-        self.name = name
-        self.value = value
-
-
-class TelemetryEvent(DataContract):
-    def __init__(self, eventId=None, providerId=None):
-        self.eventId = eventId
-        self.providerId = providerId
-        self.parameters = DataContractList(TelemetryEventParam)
-
-
-class TelemetryEventList(DataContract):
-    def __init__(self):
-        self.events = DataContractList(TelemetryEvent)
 
 
 class RemoteAccessUser(DataContract):

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -1061,14 +1061,14 @@ class WireClient(object):
                               message=msg,
                               log_event=False)
 
-            except Exception as e:
+            except (ResourceGoneError, InvalidContainerError) as e:
                 add_event(name=AGENT_NAME,
                           version=CURRENT_VERSION,
                           op=WALAEventOperation.HostPlugin,
                           is_success=False,
                           message=ustr(e),
                           log_event=False)
-                raise e
+                raise
 
         except Exception:
             raise

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -1038,6 +1038,12 @@ class WireClient(object):
                   "ContainerId: {0}, role config file: {1}. Fetching new goal state and retrying the call." \
                   "Error: {2}".format(old_container_id, old_role_config_name, ustr(e))
             logger.info(msg)
+            add_event(name=AGENT_NAME,
+                      version=CURRENT_VERSION,
+                      op=WALAEventOperation.HostPlugin,
+                      is_success=False,
+                      message=msg,
+                      log_event=False)
 
             self.update_goal_state(forced=True)
 
@@ -1071,6 +1077,12 @@ class WireClient(object):
                 raise
 
         logger.info("Request succeeded using the host plugin channel.")
+        add_event(name=AGENT_NAME,
+                  version=CURRENT_VERSION,
+                  op=WALAEventOperation.HostPlugin,
+                  is_success=True,
+                  message="Request succeeded using the host plugin channel.",
+                  log_event=False)
 
         if not HostPluginProtocol.is_default_channel():
             logger.info("Setting host plugin as default channel from now on. "

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -1070,9 +1070,6 @@ class WireClient(object):
                           log_event=False)
                 raise
 
-        except Exception:
-            raise
-
         logger.info("Request succeeded using the host plugin channel.")
 
         if not HostPluginProtocol.is_default_channel():

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 # Requires Python 2.6+ and Openssl 1.0+
+
 import datetime
 import json
 import os
@@ -25,13 +26,17 @@ import xml.sax.saxutils as saxutils
 from datetime import datetime
 
 import azurelinuxagent.common.conf as conf
+from azurelinuxagent.common.datacontract import validate_param, set_properties
 from azurelinuxagent.common.event import add_event, WALAEventOperation
 import azurelinuxagent.common.utils.textutil as textutil
 from azurelinuxagent.common.exception import ProtocolNotFoundError, \
-    ResourceGoneError, ExtensionDownloadError, InvalidContainerError
+    ResourceGoneError, ExtensionDownloadError, InvalidContainerError, ProtocolError, HttpError
 from azurelinuxagent.common.future import httpclient, bytebuffer
+import azurelinuxagent.common.logger as logger
+from azurelinuxagent.common.utils import fileutil, restutil
 from azurelinuxagent.common.protocol.hostplugin import HostPluginProtocol
 from azurelinuxagent.common.protocol.restapi import *
+from azurelinuxagent.common.telemetryevent import TelemetryEventList
 from azurelinuxagent.common.utils.archive import StateFlusher
 from azurelinuxagent.common.utils.cryptutil import CryptUtil
 from azurelinuxagent.common.utils.textutil import parse_doc, findall, find, \

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -1068,11 +1068,15 @@ class WireClient(object):
                               log_event=False)
 
             except (ResourceGoneError, InvalidContainerError) as e:
+                msg = "Request failed using the host plugin channel after goal state refresh." \
+                      "ContainerId changed from {0} to {1}, role config file changed from {2} to {3}." \
+                      "Exception type: {4}.".format(old_container_id, new_container_id, old_role_config_name,
+                                                    new_role_config_name, type(e).__name__)
                 add_event(name=AGENT_NAME,
                           version=CURRENT_VERSION,
                           op=WALAEventOperation.HostPlugin,
                           is_success=False,
-                          message=ustr(e),
+                          message=msg,
                           log_event=False)
                 raise
 

--- a/azurelinuxagent/common/telemetryevent.py
+++ b/azurelinuxagent/common/telemetryevent.py
@@ -1,0 +1,38 @@
+# Microsoft Azure Linux Agent
+#
+# Copyright 2019 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Requires Python 2.6+ and Openssl 1.0+
+#
+
+from azurelinuxagent.common.datacontract import DataContract, DataContractList
+
+
+class TelemetryEventParam(DataContract):
+    def __init__(self, name=None, value=None):
+        self.name = name
+        self.value = value
+
+
+class TelemetryEvent(DataContract):
+    def __init__(self, eventId=None, providerId=None):
+        self.eventId = eventId
+        self.providerId = providerId
+        self.parameters = DataContractList(TelemetryEventParam)
+
+
+class TelemetryEventList(DataContract):
+    def __init__(self):
+        self.events = DataContractList(TelemetryEvent)

--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -38,6 +38,7 @@ import azurelinuxagent.common.logger as logger
 import azurelinuxagent.common.utils.fileutil as fileutil
 import azurelinuxagent.common.version as version
 from azurelinuxagent.common.cgroupconfigurator import CGroupConfigurator
+from azurelinuxagent.common.datacontract import get_properties, set_properties
 from azurelinuxagent.common.errorstate import ErrorState, ERROR_STATE_DELTA_INSTALL
 from azurelinuxagent.common.event import add_event, WALAEventOperation, elapsed_milliseconds, report_event
 from azurelinuxagent.common.exception import ExtensionError, ProtocolError, ProtocolNotFoundError, \
@@ -47,9 +48,7 @@ from azurelinuxagent.common.protocol import get_protocol_util
 from azurelinuxagent.common.protocol.restapi import ExtHandlerStatus, \
     ExtensionStatus, \
     ExtensionSubStatus, \
-    VMStatus, ExtHandler, \
-    get_properties, \
-    set_properties
+    VMStatus, ExtHandler
 from azurelinuxagent.common.utils.flexible_version import FlexibleVersion
 from azurelinuxagent.common.utils.processutil import read_output
 from azurelinuxagent.common.version import AGENT_NAME, CURRENT_VERSION, GOAL_STATE_AGENT_VERSION, \

--- a/azurelinuxagent/ga/monitor.py
+++ b/azurelinuxagent/ga/monitor.py
@@ -36,8 +36,8 @@ from azurelinuxagent.common.osutil import get_osutil
 from azurelinuxagent.common.protocol import get_protocol_util
 from azurelinuxagent.common.protocol.healthservice import HealthService
 from azurelinuxagent.common.protocol.imds import get_imds_client
-from azurelinuxagent.common.protocol.restapi import TelemetryEventParam, \
-    TelemetryEventList, TelemetryEvent, set_properties
+from azurelinuxagent.common.telemetryevent import TelemetryEvent, TelemetryEventParam, TelemetryEventList
+from azurelinuxagent.common.datacontract import set_properties
 from azurelinuxagent.common.utils.restutil import IOErrorCounter
 from azurelinuxagent.common.utils.textutil import parse_doc, findall, find, getattrib, hash_strings
 from azurelinuxagent.common.version import DISTRO_NAME, DISTRO_VERSION, \

--- a/azurelinuxagent/ga/remoteaccess.py
+++ b/azurelinuxagent/ga/remoteaccess.py
@@ -18,45 +18,19 @@
 #
 
 import datetime
-import glob
-import json
-import operator
 import os
 import os.path
-import pwd
-import random
-import re
-import shutil
-import stat
-import subprocess
-import textwrap
-import time
 import traceback
-import zipfile
 
 import azurelinuxagent.common.conf as conf
 import azurelinuxagent.common.logger as logger
-import azurelinuxagent.common.utils.fileutil as fileutil
-import azurelinuxagent.common.version as version
-import azurelinuxagent.common.protocol.wire
-import azurelinuxagent.common.protocol.metadata as metadata
 
 from datetime import datetime, timedelta
-from pwd import getpwall
-from azurelinuxagent.common.errorstate import ErrorState
 
-from azurelinuxagent.common.event import add_event, WALAEventOperation, elapsed_milliseconds
-from azurelinuxagent.common.exception import ExtensionError, ProtocolError, RemoteAccessError
+from azurelinuxagent.common.event import add_event, WALAEventOperation
+from azurelinuxagent.common.exception import RemoteAccessError
 from azurelinuxagent.common.future import ustr
-from azurelinuxagent.common.protocol.restapi import ExtHandlerStatus, \
-                                                    ExtensionStatus, \
-                                                    ExtensionSubStatus, \
-                                                    VMStatus, ExtHandler, \
-                                                    get_properties, \
-                                                    set_properties
-from azurelinuxagent.common.protocol.metadata import MetadataProtocol
 from azurelinuxagent.common.utils.cryptutil import CryptUtil
-from azurelinuxagent.common.utils.flexible_version import FlexibleVersion
 from azurelinuxagent.common.protocol import get_protocol_util
 from azurelinuxagent.common.version import AGENT_NAME, CURRENT_VERSION
 from azurelinuxagent.common.osutil import get_osutil
@@ -68,8 +42,10 @@ REMOTE_ACCESS_ACCOUNT_COMMENT = "JIT_Account"
 MAX_TRY_ATTEMPT = 5
 FAILED_ATTEMPT_THROTTLE = 1
 
+
 def get_remote_access_handler():
     return RemoteAccessHandler()
+
 
 class RemoteAccessHandler(object):
     def __init__(self):

--- a/tests/ga/test_extension.py
+++ b/tests/ga/test_extension.py
@@ -27,6 +27,12 @@ from azurelinuxagent.common.protocol.restapi import Extension
 from azurelinuxagent.ga.exthandlers import *
 from azurelinuxagent.common.protocol.wire import WireProtocol, InVMArtifactsProfile
 
+SLEEP = time.sleep
+
+
+def mock_sleep(sec=0.01):
+    SLEEP(sec)
+
 
 def do_not_run_test():
     return True
@@ -294,6 +300,7 @@ class ExtensionTestCase(AgentTestCase):
             CGroupConfigurator.get_instance().disable()
 
 
+@patch('time.sleep', side_effect=lambda _: mock_sleep(0.001))
 @patch("azurelinuxagent.common.protocol.wire.CryptUtil")
 @patch("azurelinuxagent.common.utils.restutil.http_get")
 class TestExtension(ExtensionTestCase):
@@ -320,7 +327,7 @@ class TestExtension(ExtensionTestCase):
         self.assertEquals(0, len(vm_status.vmAgent.extensionHandlers))
         return
 
-    def _create_mock(self, test_data, mock_http_get, MockCryptUtil):
+    def _create_mock(self, test_data, mock_http_get, MockCryptUtil, *args):
         """Test enable/disable/uninstall of an extension"""
         handler = get_exthandlers_handler()
 

--- a/tests/ga/test_extension.py
+++ b/tests/ga/test_extension.py
@@ -27,6 +27,7 @@ from azurelinuxagent.common.protocol.restapi import Extension
 from azurelinuxagent.ga.exthandlers import *
 from azurelinuxagent.common.protocol.wire import WireProtocol, InVMArtifactsProfile
 
+# Mocking the original sleep to reduce test execution time
 SLEEP = time.sleep
 
 

--- a/tests/ga/test_monitor.py
+++ b/tests/ga/test_monitor.py
@@ -20,7 +20,7 @@ from datetime import timedelta
 
 from azurelinuxagent.common.cgroup import CGroup
 from azurelinuxagent.common.event import EventLogger
-from azurelinuxagent.common.protocol.restapi import get_properties
+from azurelinuxagent.common.datacontract import get_properties
 from azurelinuxagent.common.protocol.wire import WireProtocol
 from azurelinuxagent.common.utils import restutil
 from azurelinuxagent.ga.monitor import *

--- a/tests/protocol/test_datacontract.py
+++ b/tests/protocol/test_datacontract.py
@@ -15,18 +15,16 @@
 # Requires Python 2.6+ and Openssl 1.0+
 #
 
-from tests.tools import *
-import uuid
 import unittest
-import os
-import shutil
-import time
+from azurelinuxagent.common.datacontract import get_properties, set_properties
 from azurelinuxagent.common.protocol.restapi import *
+
 
 class SampleDataContract(DataContract):
     def __init__(self):
         self.foo = None
         self.bar = DataContractList(int)
+
 
 class TestDataContract(unittest.TestCase):
     def test_get_properties(self):
@@ -45,6 +43,7 @@ class TestDataContract(unittest.TestCase):
         }
         set_properties('sample', obj, data)
         self.assertFalse(hasattr(obj, 'baz'))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/protocol/test_image_info_matcher.py
+++ b/tests/protocol/test_image_info_matcher.py
@@ -1,13 +1,23 @@
-# Copyright (c) Microsoft Corporation. All rights reserved.
+# Microsoft Azure Linux Agent
+#
+# Copyright 2018 Microsoft Corporation
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
-import json
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Requires Python 2.6+ and Openssl 1.0+
 
-from azurelinuxagent.common.exception import HttpError
-from azurelinuxagent.common.protocol.imds import ComputeInfo, ImdsClient, IMDS_IMAGE_ORIGIN_CUSTOM, \
-    IMDS_IMAGE_ORIGIN_ENDORSED, IMDS_IMAGE_ORIGIN_PLATFORM, ImageInfoMatcher
-from azurelinuxagent.common.protocol.restapi import set_properties
-from azurelinuxagent.common.utils import restutil
-from tests.ga.test_update import ResponseMock
+from azurelinuxagent.common.datacontract import set_properties
+from azurelinuxagent.common.protocol.imds import ImageInfoMatcher
 from tests.tools import *
 
 

--- a/tests/protocol/test_imds.py
+++ b/tests/protocol/test_imds.py
@@ -1,12 +1,28 @@
-# Copyright (c) Microsoft Corporation. All rights reserved.
+# Microsoft Azure Linux Agent
+#
+# Copyright 2018 Microsoft Corporation
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Requires Python 2.6+ and Openssl 1.0+
+
 import json
 
 import azurelinuxagent.common.protocol.imds as imds
 
+from azurelinuxagent.common.datacontract import set_properties
 from azurelinuxagent.common.exception import HttpError
 from azurelinuxagent.common.future import ustr
-from azurelinuxagent.common.protocol.restapi import set_properties
 from azurelinuxagent.common.utils import restutil
 from tests.ga.test_update import ResponseMock
 from tests.tools import *

--- a/tests/protocol/test_metadata.py
+++ b/tests/protocol/test_metadata.py
@@ -15,16 +15,16 @@
 # Requires Python 2.6+ and Openssl 1.0+
 #
 
-import json
-
-from azurelinuxagent.common.future import ustr
-
-from azurelinuxagent.common.utils.restutil import httpclient
+from azurelinuxagent.common.datacontract import get_properties, set_properties
+from azurelinuxagent.common.exception import ProtocolError
 from azurelinuxagent.common.protocol.metadata import *
 from azurelinuxagent.common.protocol.restapi import *
+from azurelinuxagent.common.telemetryevent import TelemetryEventList, TelemetryEvent
+from azurelinuxagent.common.utils import restutil
 
 from tests.protocol.mockmetadata import *
 from tests.tools import *
+
 
 class TestMetadataProtocolGetters(AgentTestCase):
     def load_json(self, path):
@@ -48,7 +48,6 @@ class TestMetadataProtocolGetters(AgentTestCase):
     def test_getters_no(self, *args):
         test_data = MetadataProtocolData(DATA_FILE_NO_EXT)
         self._test_getters(test_data, *args)
-
 
     @patch("azurelinuxagent.common.protocol.metadata.MetadataProtocol.update_goal_state")
     @patch("azurelinuxagent.common.protocol.metadata.MetadataProtocol._get_data")

--- a/tests/protocol/test_wire.py
+++ b/tests/protocol/test_wire.py
@@ -18,6 +18,7 @@
 
 import zipfile
 
+from azurelinuxagent.common.telemetryevent import TelemetryEvent, TelemetryEventParam
 from azurelinuxagent.common.protocol.wire import *
 from azurelinuxagent.common.utils.shellutil import run_get_output
 from tests.ga.test_monitor import random_generator


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

We want to emit telemetry whenever we invoke the HostGAPlugin retry logic and log the success or failure of the calls (first or second try). For that, `WireProtocol` needed to use the `add_event` method, which introduced circular dependencies.

Imports are fixed with the following changes:
- Extract the `DataContract` object(s) and related methods to a common module outside of `restapi`.
- Extract the `TelemetryEvent` object(s) to a common module outside of `restapi`.
- Update all imports referencing these objects and methods.

Also, added sleep mocking in `test_extension` module to reduce unit test execution time from 7+ minutes to ~2.5 minutes.

<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/walinuxagent/1632)
<!-- Reviewable:end -->
