### PR TITLE
Add telemetry event when cleaning up old cgroups

### DIFF
--- a/azurelinuxagent/common/cgroupapi.py
+++ b/azurelinuxagent/common/cgroupapi.py
@@ -132,9 +132,7 @@ class CGroupsApi(object):
         for controller in CGROUP_CONTROLLERS:
             try:
                 if controller not in mounted_controllers:
-                    msg = 'Cgroup controller "{0}" is not mounted. {1}'.format(controller, message)
-                    logger.warn(msg)
-                    errors.append(msg)
+                    logger.warn('Cgroup controller "{0}" is not mounted. {1}'.format(controller, message))
                 else:
                     operation(controller)
             except Exception as e:

--- a/azurelinuxagent/common/cgroupapi.py
+++ b/azurelinuxagent/common/cgroupapi.py
@@ -124,17 +124,24 @@ class CGroupsApi(object):
         """
         Executes the given operation on all controllers that need to be tracked; outputs 'message' if the controller
         is not mounted or if an error occurs in the operation
+        :return: Returns a list of error messages or an empty list if no errors occurred
         """
+        errors = []
         mounted_controllers = os.listdir(CGROUPS_FILE_SYSTEM_ROOT)
 
         for controller in CGROUP_CONTROLLERS:
             try:
                 if controller not in mounted_controllers:
-                    logger.warn('Cgroup controller "{0}" is not mounted. {1}'.format(controller, message))
+                    msg = 'Cgroup controller "{0}" is not mounted. {1}'.format(controller, message)
+                    logger.warn(msg)
+                    errors.append(msg)
                 else:
                     operation(controller)
             except Exception as e:
-                logger.warn('Error in cgroup controller "{0}": {1}. {2}'.format(controller, ustr(e), message))
+                msg = 'Error in cgroup controller "{0}": {1}. {2}'.format(controller, ustr(e), message)
+                logger.warn(msg)
+                errors.append(msg)
+        return errors
 
 
 class FileSystemCgroupsApi(CGroupsApi):
@@ -208,8 +215,20 @@ class FileSystemCgroupsApi(CGroupsApi):
                 fileutil.append_file(os.path.join(new_path, "cgroup.procs"), daemon_pid)
                 shutil.rmtree(old_path, ignore_errors=True)
 
-        self._foreach_controller(cleanup_old_controller, "Failed to update the tracking of the daemon; resource usage "
-                                                         "of the agent will not include the daemon process.")
+        errors = self._foreach_controller(cleanup_old_controller,
+                                          "Failed to update the tracking of the daemon; resource usage of the agent "
+                                          "will not include the daemon process.")
+
+        if len(errors) == 0:
+            msg = 'Successfully cleaned up old cgroups in WALinuxAgent/WALinuxAgent.'
+        else:
+            msg = 'Failed to clean up old cgroups in WALinuxAgent/WALinuxAgent. Errors: {0}'.format(errors)
+
+        add_event(AGENT_NAME,
+                  version=CURRENT_VERSION,
+                  op=WALAEventOperation.CGroupsCleanUp,
+                  is_success=len(errors) == 0,
+                  message=msg)
 
     def create_agent_cgroups(self):
         """

--- a/azurelinuxagent/common/event.py
+++ b/azurelinuxagent/common/event.py
@@ -45,6 +45,7 @@ class WALAEventOperation:
     ArtifactsProfileBlob = "ArtifactsProfileBlob"
     AutoUpdate = "AutoUpdate"
     CustomData = "CustomData"
+    CGroupsCleanUp = "CGroupsCleanUp"
     CGroupsLimitsCrossed = "CGroupsLimitsCrossed"
     ExtensionMetricsData = "ExtensionMetricsData"
     Deploy = "Deploy"

--- a/tests/common/test_cgroupapi.py
+++ b/tests/common/test_cgroupapi.py
@@ -229,7 +229,7 @@ class FileSystemCgroupsApiTestCase(AgentTestCase):
         self.assertEquals(kwargs['is_success'], True)
         self.assertEquals(kwargs['message'], 'Successfully cleaned up old cgroups in WALinuxAgent/WALinuxAgent.')
 
-    def test_cleanup_old_cgroups_should_fail_to_move_daemon_pid_on_all_controllers(self):
+    def test_cleanup_old_cgroups_should_report_errors_from_all_controllers_that_failed(self):
         # Set up the mock /var/run/waagent.pid file
         daemon_pid = "42"
         daemon_pid_file_tmp = os.path.join(self.tmp_dir, "waagent.pid")


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

Adding a permanent telemetry event for changes made in #1595.

<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/walinuxagent/1637)
<!-- Reviewable:end -->
