### PR TITLE
Passing sequence number to all Extension Commands

### DIFF
--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -1393,9 +1393,10 @@ class ExtHandlerInstance(object):
 
     def get_seq_no(self):
         runtime_settings = self.ext_handler.properties.extensions
-        # If no runtime_settings available for this ext_handler, then return the largest {x}.settings number
+        # If no runtime_settings available for this ext_handler, then return 0 (this is the behavior we follow
+        # for update_settings)
         if not runtime_settings or len(runtime_settings) == 0:
-            return self.get_largest_seq_no()
+            return "0"
         # Currently for every runtime settings we use the same sequence number
         # (Check : def parse_plugin_settings(self, ext_handler, plugin_settings) in wire.py)
         # Will have to revisit once the feature to enable multiple runtime settings is rolled out by CRP

--- a/tests/ga/test_extension.py
+++ b/tests/ga/test_extension.py
@@ -2083,7 +2083,6 @@ class TestExtensionWithCGroupsEnabled(AgentTestCase):
         self._assert_no_handler_status(protocol.report_vm_status)
 
 
-@patch('azurelinuxagent.ga.exthandlers.ExtHandlerInstance.get_seq_no', return_value="12")
 class TestExtensionUpdateOnFailure(ExtensionTestCase):
 
     @staticmethod

--- a/tests/ga/test_extension.py
+++ b/tests/ga/test_extension.py
@@ -1627,7 +1627,7 @@ class TestExtension(ExtensionTestCase):
 
         self._assert_handler_status(protocol.report_vm_status, "Ready", expected_ext_count=1, version="1.0.0")
 
-    def test_ext_sequence_no_should_set_for_ever_command_call(self, *args):
+    def test_ext_sequence_no_should_be_set_for_every_command_call(self, *args):
         test_data = WireProtocolData(DATA_FILE_MULTIPLE_EXT)
         exthandlers_handler, protocol = self._create_mock(test_data, *args)
 

--- a/tests/ga/test_exthandlers.py
+++ b/tests/ga/test_exthandlers.py
@@ -231,9 +231,6 @@ class LaunchCommandTestCase(AgentTestCase):
         self.mock_get_log_dir = patch("azurelinuxagent.ga.exthandlers.ExtHandlerInstance.get_log_dir", lambda *_: self.log_dir)
         self.mock_get_log_dir.start()
 
-        self.mock_get_seq_no = patch("azurelinuxagent.ga.exthandlers.ExtHandlerInstance.get_seq_no")
-        self.mock_get_seq_no.start()
-
         mock_sleep = time.sleep
         self.mock_sleep = patch("time.sleep", lambda *_: mock_sleep(0.01))
         self.mock_sleep.start()
@@ -249,7 +246,6 @@ class LaunchCommandTestCase(AgentTestCase):
 
         self.mock_get_log_dir.stop()
         self.mock_get_base_dir.stop()
-        self.mock_get_seq_no.stop()
         self.mock_sleep.stop()
 
         AgentTestCase.tearDown(self)

--- a/tests/ga/test_exthandlers.py
+++ b/tests/ga/test_exthandlers.py
@@ -249,6 +249,8 @@ class LaunchCommandTestCase(AgentTestCase):
 
         self.mock_get_log_dir.stop()
         self.mock_get_base_dir.stop()
+        self.mock_get_seq_no.stop()
+        self.mock_sleep.stop()
 
         AgentTestCase.tearDown(self)
 

--- a/tests/ga/test_exthandlers.py
+++ b/tests/ga/test_exthandlers.py
@@ -231,6 +231,13 @@ class LaunchCommandTestCase(AgentTestCase):
         self.mock_get_log_dir = patch("azurelinuxagent.ga.exthandlers.ExtHandlerInstance.get_log_dir", lambda *_: self.log_dir)
         self.mock_get_log_dir.start()
 
+        self.mock_get_seq_no = patch("azurelinuxagent.ga.exthandlers.ExtHandlerInstance.get_seq_no")
+        self.mock_get_seq_no.start()
+
+        mock_sleep = time.sleep
+        self.mock_sleep = patch("time.sleep", lambda *_: mock_sleep(0.01))
+        self.mock_sleep.start()
+
         self.cgroups_enabled = CGroupConfigurator.get_instance().enabled()
         CGroupConfigurator.get_instance().disable()
 


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
This PR is to address the behavior where the Guest Agent is supposed to pass the latest Sequence number from the goalstate to all extension commands

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/walinuxagent/1640)
<!-- Reviewable:end -->
