### PR TITLE
Fix flaky test for missing header

### DIFF
--- a/tests/protocol/test_hostplugin.py
+++ b/tests/protocol/test_hostplugin.py
@@ -473,29 +473,41 @@ class TestHostPlugin(AgentTestCase):
 
         exp_method = 'PUT'
         exp_url = hostplugin_status_url
-        exp_data = self._hostplugin_data(
-            status_blob.get_block_blob_headers(len(faux_status)),
-            bytearray(faux_status, encoding='utf-8'))
 
-        with patch.object(restutil, "http_request") as patch_http:
-            patch_http.return_value = Mock(status=httpclient.OK)
+        original_strftime = time.strftime
 
-            with patch.object(wire.HostPluginProtocol,
-                              "get_api_versions") as patch_get:
-                patch_get.return_value = api_versions
-                host_client.put_vm_status(status_blob, sas_url)
+        def mock_strftime(old_formatting, timestamp):
+            # Remove seconds from timestamp for the purpose of this test; it was failing intermittently if it took
+            # longer than 1 second between populating the expected data and comparing it to the actual data because
+            # we are using a strict string comparison
+            new_formatting = "%Y-%m-%dT%H:%M"
+            return original_strftime(new_formatting, timestamp)
 
-                self.assertTrue(patch_http.call_count == 2)
+        with patch("time.strftime", side_effect=mock_strftime):
+            exp_data = self._hostplugin_data(
+                status_blob.get_block_blob_headers(len(faux_status)),
+                bytearray(faux_status, encoding='utf-8'))
 
-                # first call is to host plugin
-                self._validate_hostplugin_args(
-                    patch_http.call_args_list[0],
-                    test_goal_state,
-                    exp_method, exp_url, exp_data)
+        with patch("time.strftime", side_effect=mock_strftime):
+            with patch.object(restutil, "http_request") as patch_http:
+                patch_http.return_value = Mock(status=httpclient.OK)
 
-                # second call is to health service
-                self.assertEqual('POST', patch_http.call_args_list[1][0][0])
-                self.assertEqual(health_service_url, patch_http.call_args_list[1][0][1])
+                with patch.object(wire.HostPluginProtocol,
+                                  "get_api_versions") as patch_get:
+                    patch_get.return_value = api_versions
+                    host_client.put_vm_status(status_blob, sas_url)
+
+                    self.assertTrue(patch_http.call_count == 2)
+    
+                    # first call is to host plugin
+                    self._validate_hostplugin_args(
+                        patch_http.call_args_list[0],
+                        test_goal_state,
+                        exp_method, exp_url, exp_data)
+
+                    # second call is to health service
+                    self.assertEqual('POST', patch_http.call_args_list[1][0][0])
+                    self.assertEqual(health_service_url, patch_http.call_args_list[1][0][1])
 
     def test_validate_page_blobs(self):
         """Validate correct set of data is sent for page blobs"""


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

The elusive test came up again in this Travis run: https://travis-ci.org/Azure/WALinuxAgent/jobs/587997214

It intermittently fails because we compare two header values which contain an exact timestamp to the second. The mitigation is to remove the seconds from the timestamp (only in the scope of this test) to make the test more robust.

<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/walinuxagent/1643)
<!-- Reviewable:end -->
