### PR TITLE
Remove error message

### DIFF
--- a/azurelinuxagent/common/cgroup.py
+++ b/azurelinuxagent/common/cgroup.py
@@ -91,7 +91,6 @@ class CGroup(object):
             if isinstance(e, (IOError, OSError)) and e.errno == errno.ENOENT:
                 raise e
             parameter_filename = self._get_cgroup_file(parameter_name)
-            logger.error("Exception while attempting to read {0}: {1}".format(parameter_filename, ustr(e)))
             raise CGroupsException("Exception while attempting to read {0}".format(parameter_filename), e)
         return result
 


### PR DESCRIPTION
Failures in cgroup operations should be WARNINGs, not ERRORs.

In this case the exception is re-raised and the callers are already logging warnings, so I am removing the message altogether.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/walinuxagent/1644)
<!-- Reviewable:end -->
