### PR TITLE
Set env variable to return code for failure

### DIFF
--- a/azurelinuxagent/common/cgroupapi.py
+++ b/azurelinuxagent/common/cgroupapi.py
@@ -516,7 +516,7 @@ After=system-{1}.slice""".format(extension_name, EXTENSIONS_ROOT_CGROUP_NAME)
             else:
                 # There was an issue with systemd-run. We need to log it and retry the extension without systemd.
                 err_msg = 'Systemd process exited with code %s and output %s' % (e.exit_code, process_output) \
-                    if isinstance(e, ExtensionOperationError) else "Systemd Timed-out, output: %s" % process_output
+                    if isinstance(e, ExtensionOperationError) else "Systemd timed-out, output: %s" % process_output
                 add_event(AGENT_NAME,
                           version=CURRENT_VERSION,
                           op=WALAEventOperation.InvokeCommandUsingSystemd,

--- a/azurelinuxagent/common/cgroupapi.py
+++ b/azurelinuxagent/common/cgroupapi.py
@@ -515,15 +515,14 @@ After=system-{1}.slice""".format(extension_name, EXTENSIONS_ROOT_CGROUP_NAME)
                 raise
             else:
                 # There was an issue with systemd-run. We need to log it and retry the extension without systemd.
-                exit_code = e.exit_code if isinstance(e, ExtensionOperationError) else e.code
+                err_msg = 'Systemd process exited with code %s and output %s' % (e.exit_code, process_output) \
+                    if isinstance(e, ExtensionOperationError) else "Systemd Timed-out, output: %s" % process_output
                 add_event(AGENT_NAME,
                           version=CURRENT_VERSION,
                           op=WALAEventOperation.InvokeCommandUsingSystemd,
                           is_success=False,
-                          message='Failed to run systemd-run for unit {0}.scope. '
-                                  'Process exited with code {1} and output {2}'.format(scope_name,
-                                                                                       exit_code,
-                                                                                       process_output))
+                          message='Failed to run systemd-run for unit {0}.scope. {1}'
+                                  .format(scope_name, err_msg))
                 # Reset the stdout and stderr
                 stdout.truncate(0)
                 stderr.truncate(0)

--- a/azurelinuxagent/common/cgroupapi.py
+++ b/azurelinuxagent/common/cgroupapi.py
@@ -25,11 +25,11 @@ from azurelinuxagent.common.cgroup import CGroup
 from azurelinuxagent.common.cgroupstelemetry import CGroupsTelemetry
 from azurelinuxagent.common.conf import get_agent_pid_file_path
 from azurelinuxagent.common.event import add_event, WALAEventOperation
-from azurelinuxagent.common.exception import CGroupsException, ExtensionError, ExtensionErrorCodes
+from azurelinuxagent.common.exception import CGroupsException, ExtensionErrorCodes, ExtensionError, \
+    ExtensionOperationError
 from azurelinuxagent.common.future import ustr
 from azurelinuxagent.common.utils import fileutil, shellutil
-from azurelinuxagent.common.utils.extensionprocessutil import read_output, handle_process_completion, \
-                                                     wait_for_process_completion_or_timeout
+from azurelinuxagent.common.utils.extensionprocessutil import handle_process_completion, read_output
 from azurelinuxagent.common.version import AGENT_NAME, CURRENT_VERSION
 
 CGROUPS_FILE_SYSTEM_ROOT = '/sys/fs/cgroup'
@@ -497,36 +497,32 @@ After=system-{1}.slice""".format(extension_name, EXTENSIONS_ROOT_CGROUP_NAME)
         self.track_cgroups(extension_cgroups)
 
         # Wait for process completion or timeout
-        timed_out, return_code = wait_for_process_completion_or_timeout(process, timeout)
-        process_output = read_output(stdout, stderr)
-
-        if return_code == 0:
-            # The process terminated in time and successfully
-            return extension_cgroups, process_output
-        else:
+        try:
+            process_output = handle_process_completion(process=process,
+                                                       command=command,
+                                                       timeout=timeout,
+                                                       stdout=stdout,
+                                                       stderr=stderr,
+                                                       error_code=error_code)
+        except ExtensionError as e:
             # The extension didn't terminate successfully. Determine whether it was due to systemd errors or
             # extension errors.
+            process_output = read_output(stdout, stderr)
             systemd_failure = self._is_systemd_failure(scope_name, process_output)
 
             if not systemd_failure:
-                # There was an extension error; it either timed out or returned a non-zero exit code.
-                if timed_out:
-                    raise ExtensionError("Timeout({0}): {1}\n{2}".format(timeout, command, process_output),
-                                         code=ExtensionErrorCodes.PluginHandlerScriptTimedout)
-                else:
-                    raise ExtensionError("Non-zero exit code: {0}, {1}\n{2}".format(return_code,
-                                                                                    command,
-                                                                                    process_output),
-                                         code=error_code)
+                # There was an extension error; it either timed out or returned a non-zero exit code. Re-raise the error
+                raise
             else:
                 # There was an issue with systemd-run. We need to log it and retry the extension without systemd.
+                exit_code = e.exit_code if isinstance(e, ExtensionOperationError) else e.code
                 add_event(AGENT_NAME,
                           version=CURRENT_VERSION,
                           op=WALAEventOperation.InvokeCommandUsingSystemd,
                           is_success=False,
                           message='Failed to run systemd-run for unit {0}.scope. '
                                   'Process exited with code {1} and output {2}'.format(scope_name,
-                                                                                       return_code,
+                                                                                       exit_code,
                                                                                        process_output))
                 # Reset the stdout and stderr
                 stdout.truncate(0)
@@ -549,6 +545,9 @@ After=system-{1}.slice""".format(extension_name, EXTENSIONS_ROOT_CGROUP_NAME)
                                                            error_code=error_code)
 
                 return [], process_output
+
+        # The process terminated in time and successfully
+        return extension_cgroups, process_output
 
     def cleanup_old_cgroups(self):
         # No cleanup needed from the old daemon in the systemd case.

--- a/azurelinuxagent/common/exception.py
+++ b/azurelinuxagent/common/exception.py
@@ -69,7 +69,7 @@ class ExtensionError(AgentError):
 
 class LaunchCommandError(ExtensionError):
     """
-    When failed to execute an extension
+    When the command times out or returns with a non-zero exit_code
     """
 
     def __init__(self, msg=None, inner=None, code=-1, exit_code=-1):

--- a/azurelinuxagent/common/exception.py
+++ b/azurelinuxagent/common/exception.py
@@ -67,6 +67,17 @@ class ExtensionError(AgentError):
         self.code = code
 
 
+class LaunchCommandError(ExtensionError):
+    """
+    When failed to execute an extension
+    """
+
+    def __init__(self, msg=None, inner=None, code=-1, exit_code=-1):
+        super(LaunchCommandError, self).__init__(msg, inner)
+        self.code = code
+        self.exit_code = exit_code
+
+
 class ExtensionUpdateError(ExtensionError):
     """
     When failed to update an extension

--- a/azurelinuxagent/common/exception.py
+++ b/azurelinuxagent/common/exception.py
@@ -67,13 +67,13 @@ class ExtensionError(AgentError):
         self.code = code
 
 
-class LaunchCommandError(ExtensionError):
+class ExtensionOperationError(ExtensionError):
     """
     When the command times out or returns with a non-zero exit_code
     """
 
     def __init__(self, msg=None, inner=None, code=-1, exit_code=-1):
-        super(LaunchCommandError, self).__init__(msg, inner)
+        super(ExtensionOperationError, self).__init__(msg, inner)
         self.code = code
         self.exit_code = exit_code
 
@@ -94,15 +94,6 @@ class ExtensionDownloadError(ExtensionError):
 
     def __init__(self, msg=None, inner=None, code=-1):
         super(ExtensionDownloadError, self).__init__(msg, inner, code)
-
-
-class ExtensionOperationError(ExtensionError):
-    """
-    When failed to execute an extension
-    """
-
-    def __init__(self, msg=None, inner=None, code=-1):
-        super(ExtensionOperationError, self).__init__(msg, inner, code)
 
 
 class ProvisionError(AgentError):

--- a/azurelinuxagent/common/utils/extensionprocessutil.py
+++ b/azurelinuxagent/common/utils/extensionprocessutil.py
@@ -17,7 +17,7 @@
 # Requires Python 2.6+ and Openssl 1.0+
 #
 
-from azurelinuxagent.common.exception import ExtensionError, ExtensionErrorCodes
+from azurelinuxagent.common.exception import ExtensionErrorCodes, LaunchCommandError
 from azurelinuxagent.common.future import ustr
 import os
 import signal
@@ -68,12 +68,13 @@ def handle_process_completion(process, command, timeout, stdout, stderr, error_c
     process_output = read_output(stdout, stderr)
 
     if timed_out:
-        raise ExtensionError("Timeout({0}): {1}\n{2}".format(timeout, command, process_output),
-                             code=ExtensionErrorCodes.PluginHandlerScriptTimedout)
+        raise LaunchCommandError("Timeout({0}): {1}\n{2}".format(timeout, command, process_output),
+                                 code=ExtensionErrorCodes.PluginHandlerScriptTimedout,
+                                 exit_code=ExtensionErrorCodes.PluginHandlerScriptTimedout)
 
     if return_code != 0:
-        raise ExtensionError("Non-zero exit code: {0}, {1}\n{2}".format(return_code, command, process_output),
-                             code=error_code)
+        raise LaunchCommandError("Non-zero exit code: {0}, {1}\n{2}".format(return_code, command, process_output),
+                                 code=error_code, exit_code=return_code)
 
     return process_output
 

--- a/azurelinuxagent/common/utils/extensionprocessutil.py
+++ b/azurelinuxagent/common/utils/extensionprocessutil.py
@@ -17,7 +17,7 @@
 # Requires Python 2.6+ and Openssl 1.0+
 #
 
-from azurelinuxagent.common.exception import ExtensionErrorCodes, LaunchCommandError
+from azurelinuxagent.common.exception import ExtensionErrorCodes, ExtensionOperationError, ExtensionError
 from azurelinuxagent.common.future import ustr
 import os
 import signal
@@ -68,13 +68,12 @@ def handle_process_completion(process, command, timeout, stdout, stderr, error_c
     process_output = read_output(stdout, stderr)
 
     if timed_out:
-        raise LaunchCommandError("Timeout({0}): {1}\n{2}".format(timeout, command, process_output),
-                                 code=ExtensionErrorCodes.PluginHandlerScriptTimedout,
-                                 exit_code=ExtensionErrorCodes.PluginHandlerScriptTimedout)
+        raise ExtensionError("Timeout({0}): {1}\n{2}".format(timeout, command, process_output),
+                             code=ExtensionErrorCodes.PluginHandlerScriptTimedout)
 
     if return_code != 0:
-        raise LaunchCommandError("Non-zero exit code: {0}, {1}\n{2}".format(return_code, command, process_output),
-                                 code=error_code, exit_code=return_code)
+        raise ExtensionOperationError("Non-zero exit code: {0}, {1}\n{2}".format(return_code, command, process_output),
+                                      code=error_code, exit_code=return_code)
 
     return process_output
 

--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -1205,6 +1205,7 @@ class ExtHandlerInstance(object):
     def launch_command(self, cmd, timeout=300, extension_error_code=ExtensionErrorCodes.PluginProcessingError,
                        env=None):
         begin_utc = datetime.datetime.utcnow()
+        self.logger.verbose("Launch command: [{0}]", cmd)
 
         base_dir = self.get_base_dir()
 
@@ -1222,13 +1223,6 @@ class ExtHandlerInstance(object):
                     # Some extensions erroneously begin cmd with a slash; don't interpret those
                     # as root-relative. (Issue #1170)
                     full_path = os.path.join(base_dir, cmd.lstrip(os.path.sep))
-
-                    self.report_event(
-                        message="Launching command : '%s' with timeout of : %s sec.\nAgent Environment Variables= %s" %
-                                (full_path, timeout, ' , '.join(["%s:%s" % (key, env[key]) for key in env.keys() if
-                                                                key.startswith(ExtCommandEnvVariable.Prefix) or
-                                                                key == ExtCommandEnvVariable.ExtensionSeqNumber])),
-                        is_success=True, log_event=True)
 
                     process_output = CGroupConfigurator.get_instance().start_extension_command(
                         extension_name=self.get_full_name(),

--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -87,6 +87,7 @@ class ExtCommandEnvVariable(object):
     ExtensionVersion = "%s_EXTENSION_VERSION" % Prefix
     ExtensionSeqNumber = "ConfigSequenceNumber"  # At par with Windows Guest Agent
     UpdatingFromVersion = "%s_UPDATING_FROM_VERSION" % Prefix
+    CurrentAgentVersion = "%s_CURRENT_VERSION" % Prefix
 
 
 def get_traceback(e):
@@ -1223,6 +1224,7 @@ class ExtHandlerInstance(object):
                 # Always add Extension Path and version to the current launch_command (Ask from publishers)
                 env.update({ExtCommandEnvVariable.ExtensionPath: base_dir,
                             ExtCommandEnvVariable.ExtensionVersion: self.ext_handler.properties.version,
+                            ExtCommandEnvVariable.CurrentAgentVersion: GOAL_STATE_AGENT_VERSION,
                             ExtCommandEnvVariable.ExtensionSeqNumber: str(self.get_seq_no())})
 
                 try:

--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -1223,7 +1223,7 @@ class ExtHandlerInstance(object):
                 env.update(os.environ)
                 # Always add Extension Path and version to the current launch_command (Ask from publishers)
                 env.update({ExtCommandEnvVariable.ExtensionPath: base_dir,
-                            ExtCommandEnvVariable.ExtensionVersion: self.ext_handler.properties.version,
+                            ExtCommandEnvVariable.ExtensionVersion: str(self.ext_handler.properties.version),
                             ExtCommandEnvVariable.CurrentAgentVersion: str(GOAL_STATE_AGENT_VERSION),
                             ExtCommandEnvVariable.ExtensionSeqNumber: str(self.get_seq_no())})
 

--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -1224,7 +1224,7 @@ class ExtHandlerInstance(object):
                 # Always add Extension Path and version to the current launch_command (Ask from publishers)
                 env.update({ExtCommandEnvVariable.ExtensionPath: base_dir,
                             ExtCommandEnvVariable.ExtensionVersion: self.ext_handler.properties.version,
-                            ExtCommandEnvVariable.CurrentAgentVersion: GOAL_STATE_AGENT_VERSION,
+                            ExtCommandEnvVariable.CurrentAgentVersion: str(GOAL_STATE_AGENT_VERSION),
                             ExtCommandEnvVariable.ExtensionSeqNumber: str(self.get_seq_no())})
 
                 try:

--- a/tests/common/test_cgroupapi.py
+++ b/tests/common/test_cgroupapi.py
@@ -183,7 +183,7 @@ class FileSystemCgroupsApiTestCase(AgentTestCase):
 
         AgentTestCase.tearDown(self)
 
-    @patch('time.sleep', side_effect=lambda _: mock_sleep)
+    @patch('time.sleep', side_effect=lambda _: mock_sleep())
     def test_cleanup_old_cgroups_should_move_daemon_pid_on_all_controllers(self, _):
         # Set up the mock /var/run/waagent.pid file
         daemon_pid = "42"
@@ -298,7 +298,7 @@ class FileSystemCgroupsApiTestCase(AgentTestCase):
         for cgroup in created:
             self.assertTrue(any(retrieved_cgroup.path == cgroup.path for retrieved_cgroup in retrieved))
 
-    @patch('time.sleep', side_effect=lambda _: mock_sleep)
+    @patch('time.sleep', side_effect=lambda _: mock_sleep())
     def test_start_extension_command_should_add_the_child_process_to_the_extension_cgroup(self, _):
         api = FileSystemCgroupsApi()
         api.create_extension_cgroups_root()
@@ -416,7 +416,7 @@ class SystemdCgroupsApiTestCase(AgentTestCase):
         self.assertTrue(cpu_found, 'start_extension_command did not return a cpu cgroup')
         self.assertTrue(memory_found, 'start_extension_command did not return a memory cgroup')
 
-    @patch('time.sleep', side_effect=lambda _: mock_sleep)
+    @patch('time.sleep', side_effect=lambda _: mock_sleep())
     def test_start_extension_command_should_create_extension_scopes(self, _):
         original_popen = subprocess.Popen
 
@@ -547,7 +547,7 @@ class SystemdCgroupsApiTestCase(AgentTestCase):
 
     @attr('requires_sudo')
     @patch("azurelinuxagent.common.cgroupapi.add_event")
-    @patch('time.sleep', side_effect=lambda _: mock_sleep)
+    @patch('time.sleep', side_effect=lambda _: mock_sleep())
     def test_start_extension_command_should_not_use_fallback_option_if_extension_fails(self, *args):
         self.assertTrue(i_am_root(), "Test does not run when non-root")
 
@@ -600,7 +600,7 @@ class SystemdCgroupsApiTestCase(AgentTestCase):
                                           ExtensionErrorCodes.PluginHandlerScriptTimedout)
                         self.assertIn("Timeout", ustr(context_manager.exception))
 
-    @patch('time.sleep', side_effect=lambda _: mock_sleep)
+    @patch('time.sleep', side_effect=lambda _: mock_sleep())
     def test_start_extension_command_should_capture_only_the_last_subprocess_output(self, _):
         original_popen = subprocess.Popen
 

--- a/tests/common/test_cgroupapi.py
+++ b/tests/common/test_cgroupapi.py
@@ -183,7 +183,7 @@ class FileSystemCgroupsApiTestCase(AgentTestCase):
 
         AgentTestCase.tearDown(self)
 
-    @patch('time.sleep', side_effect=lambda _: mock_sleep(0.001))
+    @patch('time.sleep', side_effect=lambda _: mock_sleep)
     def test_cleanup_old_cgroups_should_move_daemon_pid_on_all_controllers(self, _):
         # Set up the mock /var/run/waagent.pid file
         daemon_pid = "42"
@@ -298,7 +298,7 @@ class FileSystemCgroupsApiTestCase(AgentTestCase):
         for cgroup in created:
             self.assertTrue(any(retrieved_cgroup.path == cgroup.path for retrieved_cgroup in retrieved))
 
-    @patch('time.sleep', side_effect=lambda _: mock_sleep(0.001))
+    @patch('time.sleep', side_effect=lambda _: mock_sleep)
     def test_start_extension_command_should_add_the_child_process_to_the_extension_cgroup(self, _):
         api = FileSystemCgroupsApi()
         api.create_extension_cgroups_root()
@@ -416,7 +416,7 @@ class SystemdCgroupsApiTestCase(AgentTestCase):
         self.assertTrue(cpu_found, 'start_extension_command did not return a cpu cgroup')
         self.assertTrue(memory_found, 'start_extension_command did not return a memory cgroup')
 
-    @patch('time.sleep', side_effect=lambda _: mock_sleep(0.001))
+    @patch('time.sleep', side_effect=lambda _: mock_sleep)
     def test_start_extension_command_should_create_extension_scopes(self, _):
         original_popen = subprocess.Popen
 
@@ -439,7 +439,7 @@ class SystemdCgroupsApiTestCase(AgentTestCase):
             self.assert_cgroups_created(extension_cgroups)
 
     @attr('requires_sudo')
-    @patch('time.sleep', side_effect=lambda _: mock_sleep(0.001))
+    @patch('time.sleep', side_effect=lambda _: mock_sleep)
     def test_start_extension_command_should_use_systemd_and_not_the_fallback_option_if_successful(self, _):
         self.assertTrue(i_am_root(), "Test does not run when non-root")
 
@@ -465,7 +465,7 @@ class SystemdCgroupsApiTestCase(AgentTestCase):
 
                     self.assert_cgroups_created(extension_cgroups)
 
-    @patch('time.sleep', side_effect=lambda _: mock_sleep(0.001))
+    @patch('time.sleep', side_effect=lambda _: mock_sleep(0.2))
     def test_start_extension_command_should_use_fallback_option_if_systemd_fails(self, _):
         original_popen = subprocess.Popen
 
@@ -510,7 +510,7 @@ class SystemdCgroupsApiTestCase(AgentTestCase):
                         # No cgroups should have been created
                         self.assertEquals(extension_cgroups, [])
 
-    @patch('time.sleep', side_effect=lambda _: mock_sleep(0.001))
+    @patch('time.sleep', side_effect=lambda _: mock_sleep)
     def test_start_extension_command_should_use_fallback_option_if_systemd_times_out(self, _):
         from azurelinuxagent.common.utils.extensionprocessutil import wait_for_process_completion_or_timeout
         # Mock systemd timeout and make sure the failure is only attributed to the extension if the command fails
@@ -558,7 +558,7 @@ class SystemdCgroupsApiTestCase(AgentTestCase):
 
     @attr('requires_sudo')
     @patch("azurelinuxagent.common.cgroupapi.add_event")
-    @patch('time.sleep', side_effect=lambda _: mock_sleep(0.001))
+    @patch('time.sleep', side_effect=lambda _: mock_sleep)
     def test_start_extension_command_should_not_use_fallback_option_if_extension_fails(self, *args):
         self.assertTrue(i_am_root(), "Test does not run when non-root")
 
@@ -611,7 +611,7 @@ class SystemdCgroupsApiTestCase(AgentTestCase):
                                           ExtensionErrorCodes.PluginHandlerScriptTimedout)
                         self.assertIn("Timeout", ustr(context_manager.exception))
 
-    @patch('time.sleep', side_effect=lambda _: mock_sleep(0.001))
+    @patch('time.sleep', side_effect=lambda _: mock_sleep)
     def test_start_extension_command_should_capture_only_the_last_subprocess_output(self, _):
         original_popen = subprocess.Popen
 

--- a/tests/common/test_cgroupapi.py
+++ b/tests/common/test_cgroupapi.py
@@ -439,7 +439,7 @@ class SystemdCgroupsApiTestCase(AgentTestCase):
             self.assert_cgroups_created(extension_cgroups)
 
     @attr('requires_sudo')
-    @patch('time.sleep', side_effect=lambda _: mock_sleep)
+    @patch('time.sleep', side_effect=lambda _: mock_sleep(0.2))
     def test_start_extension_command_should_use_systemd_and_not_the_fallback_option_if_successful(self, _):
         self.assertTrue(i_am_root(), "Test does not run when non-root")
 

--- a/tests/common/test_cgroupapi.py
+++ b/tests/common/test_cgroupapi.py
@@ -183,7 +183,8 @@ class FileSystemCgroupsApiTestCase(AgentTestCase):
 
         AgentTestCase.tearDown(self)
 
-    def test_cleanup_old_cgroups_should_move_daemon_pid_on_all_controllers(self):
+    @patch('time.sleep', side_effect=lambda _: mock_sleep(0.001))
+    def test_cleanup_old_cgroups_should_move_daemon_pid_on_all_controllers(self, _):
         # Set up the mock /var/run/waagent.pid file
         daemon_pid = "42"
         daemon_pid_file_tmp = os.path.join(self.tmp_dir, "waagent.pid")
@@ -297,7 +298,8 @@ class FileSystemCgroupsApiTestCase(AgentTestCase):
         for cgroup in created:
             self.assertTrue(any(retrieved_cgroup.path == cgroup.path for retrieved_cgroup in retrieved))
 
-    def test_start_extension_command_should_add_the_child_process_to_the_extension_cgroup(self):
+    @patch('time.sleep', side_effect=lambda _: mock_sleep(0.001))
+    def test_start_extension_command_should_add_the_child_process_to_the_extension_cgroup(self, _):
         api = FileSystemCgroupsApi()
         api.create_extension_cgroups_root()
 
@@ -414,7 +416,8 @@ class SystemdCgroupsApiTestCase(AgentTestCase):
         self.assertTrue(cpu_found, 'start_extension_command did not return a cpu cgroup')
         self.assertTrue(memory_found, 'start_extension_command did not return a memory cgroup')
 
-    def test_start_extension_command_should_create_extension_scopes(self):
+    @patch('time.sleep', side_effect=lambda _: mock_sleep(0.001))
+    def test_start_extension_command_should_create_extension_scopes(self, _):
         original_popen = subprocess.Popen
 
         def mock_popen(*args, **kwargs):
@@ -436,7 +439,8 @@ class SystemdCgroupsApiTestCase(AgentTestCase):
             self.assert_cgroups_created(extension_cgroups)
 
     @attr('requires_sudo')
-    def test_start_extension_command_should_use_systemd_and_not_the_fallback_option_if_successful(self):
+    @patch('time.sleep', side_effect=lambda _: mock_sleep(0.001))
+    def test_start_extension_command_should_use_systemd_and_not_the_fallback_option_if_successful(self, _):
         self.assertTrue(i_am_root(), "Test does not run when non-root")
 
         with tempfile.TemporaryFile(dir=self.tmp_dir, mode="w+b") as stdout:
@@ -461,7 +465,8 @@ class SystemdCgroupsApiTestCase(AgentTestCase):
 
                     self.assert_cgroups_created(extension_cgroups)
 
-    def test_start_extension_command_should_use_fallback_option_if_systemd_fails(self):
+    @patch('time.sleep', side_effect=lambda _: mock_sleep(0.001))
+    def test_start_extension_command_should_use_fallback_option_if_systemd_fails(self, _):
         original_popen = subprocess.Popen
 
         def mock_popen(*args, **kwargs):
@@ -505,11 +510,21 @@ class SystemdCgroupsApiTestCase(AgentTestCase):
                         # No cgroups should have been created
                         self.assertEquals(extension_cgroups, [])
 
-    @patch("azurelinuxagent.common.cgroupapi.add_event")
-    def test_start_extension_command_should_use_fallback_option_if_systemd_times_out(self, *args):
+    @patch('time.sleep', side_effect=lambda _: mock_sleep(0.001))
+    def test_start_extension_command_should_use_fallback_option_if_systemd_times_out(self, _):
+        from azurelinuxagent.common.utils.extensionprocessutil import wait_for_process_completion_or_timeout
         # Mock systemd timeout and make sure the failure is only attributed to the extension if the command fails
         # using the fallback option
         original_popen = subprocess.Popen
+        mock_counter = Mock()
+        original_wait_for_completion = wait_for_process_completion_or_timeout
+
+        def mock_wait_for_process_completion(mock_counter, *args):
+            # Mock the first call and run the original function 2nd time to get the output of the command gracefully
+            mock_counter.call_count += 1
+            if mock_counter.call_count == 2:
+                return original_wait_for_completion(*args)
+            return [True, None]
 
         def mock_popen(*args, **kwargs):
             # Inject a syntax error to the call
@@ -523,8 +538,9 @@ class SystemdCgroupsApiTestCase(AgentTestCase):
         with tempfile.TemporaryFile(dir=self.tmp_dir, mode="w+b") as stdout:
             with tempfile.TemporaryFile(dir=self.tmp_dir, mode="w+b") as stderr:
                 with patch("azurelinuxagent.common.cgroupapi.subprocess.Popen", side_effect=mock_popen):
-                    with patch("azurelinuxagent.common.cgroupapi.wait_for_process_completion_or_timeout",
-                               return_value=[True, None]):
+                    with patch(
+                            "azurelinuxagent.common.utils.extensionprocessutil.wait_for_process_completion_or_timeout",
+                            side_effect=lambda *_: mock_wait_for_process_completion(mock_counter, *_)):
                         with patch("azurelinuxagent.common.cgroupapi.SystemdCgroupsApi._is_systemd_failure",
                                    return_value=True):
                             extension_cgroups, process_output = SystemdCgroupsApi().start_extension_command(
@@ -542,6 +558,7 @@ class SystemdCgroupsApiTestCase(AgentTestCase):
 
     @attr('requires_sudo')
     @patch("azurelinuxagent.common.cgroupapi.add_event")
+    @patch('time.sleep', side_effect=lambda _: mock_sleep(0.001))
     def test_start_extension_command_should_not_use_fallback_option_if_extension_fails(self, *args):
         self.assertTrue(i_am_root(), "Test does not run when non-root")
 
@@ -575,7 +592,7 @@ class SystemdCgroupsApiTestCase(AgentTestCase):
 
         with tempfile.TemporaryFile(dir=self.tmp_dir, mode="w+b") as stdout:
             with tempfile.TemporaryFile(dir=self.tmp_dir, mode="w+b") as stderr:
-                with patch("azurelinuxagent.common.cgroupapi.wait_for_process_completion_or_timeout",
+                with patch("azurelinuxagent.common.utils.extensionprocessutil.wait_for_process_completion_or_timeout",
                            return_value=[True, None]):
                     with patch("azurelinuxagent.common.cgroupapi.SystemdCgroupsApi._is_systemd_failure",
                                return_value=False):
@@ -594,7 +611,8 @@ class SystemdCgroupsApiTestCase(AgentTestCase):
                                           ExtensionErrorCodes.PluginHandlerScriptTimedout)
                         self.assertIn("Timeout", ustr(context_manager.exception))
 
-    def test_start_extension_command_should_capture_only_the_last_subprocess_output(self):
+    @patch('time.sleep', side_effect=lambda _: mock_sleep(0.001))
+    def test_start_extension_command_should_capture_only_the_last_subprocess_output(self, _):
         original_popen = subprocess.Popen
 
         def mock_popen(*args, **kwargs):

--- a/tests/ga/test_extension.py
+++ b/tests/ga/test_extension.py
@@ -711,7 +711,6 @@ class TestExtension(ExtensionTestCase):
 
         mock_error_state.return_value = True
         exthandlers_handler.run()
-        clean_mocked_event_call_arg_list_as_per_kwargs_msg(mock_add_event)
         self.assertEquals(5, mock_add_event.call_count)
         args, kw = mock_add_event.call_args
         self.assertEquals(False, kw['is_success'])
@@ -725,7 +724,6 @@ class TestExtension(ExtensionTestCase):
         protocol.report_vm_status = Mock(side_effect=ResourceGoneError)
 
         exthandlers_handler.run()
-        clean_mocked_event_call_arg_list_as_per_kwargs_msg(mock_add_event)
         self.assertEquals(4, mock_add_event.call_count)
         args, kw = mock_add_event.call_args
         self.assertEquals(False, kw['is_success'])
@@ -1698,7 +1696,6 @@ class TestExtension(ExtensionTestCase):
         with patch.object(ExtHandlerInstance, "load_manifest", return_value=manifest):
             with patch.object(ExtHandlerInstance, 'report_event') as mock_report_event:
                 exthandlers_handler.run()
-                clean_mocked_event_call_arg_list_as_per_kwargs_msg(mock_report_event)
 
                 for _, kwargs in mock_report_event.call_args_list:
                     # The output is of the format - 'testfile.sh\n[stdout]ConfigSequenceNumber=N\n[stderr]'
@@ -1718,7 +1715,6 @@ class TestExtension(ExtensionTestCase):
 
             with patch.object(ExtHandlerInstance, 'report_event') as mock_report_event:
                 exthandlers_handler.run()
-                clean_mocked_event_call_arg_list_as_per_kwargs_msg(mock_report_event)
 
                 for _, kwargs in mock_report_event.call_args_list:
                     # The output is of the format - 'testfile.sh\n[stdout]ConfigSequenceNumber=N\n[stderr]'
@@ -1763,8 +1759,6 @@ class TestExtension(ExtensionTestCase):
         with patch("azurelinuxagent.ga.exthandlers.ExtHandlerInstance.load_manifest", return_value=manifest):
             with patch.object(ExtHandlerInstance, 'report_event') as mock_report_event:
                 exthandlers_handler.run()
-
-                clean_mocked_event_call_arg_list_as_per_kwargs_msg(mock_report_event)
 
                 _, disable_kwargs = mock_report_event.call_args_list[1]
                 _, update_kwargs = mock_report_event.call_args_list[2]
@@ -2114,7 +2108,6 @@ class TestExtensionWithCGroupsEnabled(AgentTestCase):
 
         # Test enable scenario.
         exthandlers_handler.run()
-        clean_mocked_event_call_arg_list_as_per_kwargs_msg(patch_add_event)
         self._assert_handler_status(protocol.report_vm_status, "Ready", 1, "1.0.0")
         self._assert_ext_status(protocol.report_ext_status, "success", 0)
 
@@ -2368,7 +2361,6 @@ class TestExtensionUpdateOnFailure(ExtensionTestCase):
             # For update and install we're running the script above to print all the env variables starting with AZURE_
             # and verify accordingly if the corresponding env variables are set properly or not
             ExtHandlersHandler._update_extension_handler_and_return_if_failed(old_handler_i, new_handler_i)
-            clean_mocked_event_call_arg_list_as_per_kwargs_msg(mock_report)
 
             _, update_kwargs = mock_report.call_args_list[0]
             _, install_kwargs = mock_report.call_args_list[1]
@@ -2455,7 +2447,6 @@ class TestExtensionUpdateOnFailure(ExtensionTestCase):
         with patch.object(new_handler_i, 'report_event', autospec=True) as mock_report:
             uninstall_rc = ExtHandlersHandler._update_extension_handler_and_return_if_failed(old_handler_i,
                                                                                              new_handler_i)
-            clean_mocked_event_call_arg_list_as_per_kwargs_msg(mock_report)
             _, update_kwargs = mock_report.call_args_list[0]
             _, install_kwargs = mock_report.call_args_list[1]
 
@@ -2498,7 +2489,6 @@ class TestExtensionUpdateOnFailure(ExtensionTestCase):
         with patch.object(new_handler_i, 'report_event', autospec=True) as mock_report:
             uninstall_rc = ExtHandlersHandler._update_extension_handler_and_return_if_failed(old_handler_i,
                                                                                              new_handler_i)
-            clean_mocked_event_call_arg_list_as_per_kwargs_msg(mock_report)
             _, update_kwargs = mock_report.call_args_list[0]
             _, install_kwargs = mock_report.call_args_list[1]
 

--- a/tests/ga/test_extension.py
+++ b/tests/ga/test_extension.py
@@ -1712,7 +1712,7 @@ class TestExtension(ExtensionTestCase):
                     self.assertIn("{0}={1}".format(ExtCommandEnvVariable.ExtensionSeqNumber, expected_seq_no),
                                   kwargs['message'])
 
-    def test_correct_exit_code_should_set_on_uninstall_cmd_failure(self, *args):
+    def test_correct_exit_code_should_be_set_on_uninstall_cmd_failure(self, *args):
         test_file_name = "testfile.sh"
         test_error_file_name = "error.sh"
         handler_json = {

--- a/tests/ga/test_extension.py
+++ b/tests/ga/test_extension.py
@@ -27,13 +27,6 @@ from azurelinuxagent.common.protocol.restapi import Extension, ExtHandlerPropert
 from azurelinuxagent.ga.exthandlers import *
 from azurelinuxagent.common.protocol.wire import WireProtocol, InVMArtifactsProfile
 
-# Mock sleep to reduce test execution time
-SLEEP = time.sleep
-
-
-def mock_sleep(sec=0.01):
-    SLEEP(sec)
-
 
 def do_not_run_test():
     return True
@@ -690,14 +683,11 @@ class TestExtension(ExtensionTestCase):
     def test_ext_handler_download_failure_transient(self, mock_add_event, *args):
         original_sleep = time.sleep
 
-        def mock_sleep(*args, **kwargs):
-            return original_sleep(0.1)
-
         test_data = WireProtocolData(DATA_FILE)
         exthandlers_handler, protocol = self._create_mock(test_data, *args)
         protocol.download_ext_handler_pkg = Mock(side_effect=ProtocolError)
 
-        with patch("time.sleep", side_effect=mock_sleep):
+        with patch("time.sleep", side_effect=mock_sleep(0.1)):
             exthandlers_handler.run()
 
         self.assertEquals(0, mock_add_event.call_count)
@@ -1610,10 +1600,10 @@ class TestExtension(ExtensionTestCase):
             # Ensure the new run didn't have Disable Return Code env variable
             self.assertNotIn(ExtCommandEnvVariable.DisableReturnCode, new_enable_kwargs['env'])
 
-            # Ensure the new run had Uninstall Return Code env variable == NotRun
+            # Ensure the new run had Uninstall Return Code env variable == NOT_RUN
             self.assertIn(ExtCommandEnvVariable.UninstallReturnCode, new_enable_kwargs['env'])
             self.assertTrue(
-                new_enable_kwargs['env'][ExtCommandEnvVariable.UninstallReturnCode] == ExtCommandEnvVariable.NotRun)
+                new_enable_kwargs['env'][ExtCommandEnvVariable.UninstallReturnCode] == NOT_RUN)
 
         # Ensure the handler status and ext_status is successful
         self._assert_handler_status(protocol.report_vm_status, "Ready", expected_ext_count=1, version="1.0.1")

--- a/tests/ga/test_extension.py
+++ b/tests/ga/test_extension.py
@@ -27,6 +27,8 @@ from azurelinuxagent.common.protocol.restapi import Extension, ExtHandlerPropert
 from azurelinuxagent.ga.exthandlers import *
 from azurelinuxagent.common.protocol.wire import WireProtocol, InVMArtifactsProfile
 
+from tests.tools import mock_sleep
+
 
 def do_not_run_test():
     return True

--- a/tests/ga/test_extension.py
+++ b/tests/ga/test_extension.py
@@ -27,7 +27,7 @@ from azurelinuxagent.common.protocol.restapi import Extension, ExtHandlerPropert
 from azurelinuxagent.ga.exthandlers import *
 from azurelinuxagent.common.protocol.wire import WireProtocol, InVMArtifactsProfile
 
-from tests.tools import mock_sleep
+from tests.tools import *
 
 
 def do_not_run_test():

--- a/tests/ga/test_extension.py
+++ b/tests/ga/test_extension.py
@@ -711,6 +711,7 @@ class TestExtension(ExtensionTestCase):
 
         mock_error_state.return_value = True
         exthandlers_handler.run()
+        clean_mocked_event_call_arg_list_as_per_kwargs_msg(mock_add_event)
         self.assertEquals(5, mock_add_event.call_count)
         args, kw = mock_add_event.call_args
         self.assertEquals(False, kw['is_success'])
@@ -724,6 +725,7 @@ class TestExtension(ExtensionTestCase):
         protocol.report_vm_status = Mock(side_effect=ResourceGoneError)
 
         exthandlers_handler.run()
+        clean_mocked_event_call_arg_list_as_per_kwargs_msg(mock_add_event)
         self.assertEquals(4, mock_add_event.call_count)
         args, kw = mock_add_event.call_args
         self.assertEquals(False, kw['is_success'])
@@ -931,7 +933,7 @@ class TestExtension(ExtensionTestCase):
         exthandler.properties.extensions.append(extension)
 
         # Override the timeout value to minimize the test duration
-        wait_until = datetime.datetime.utcnow() + datetime.timedelta(seconds=5)
+        wait_until = datetime.datetime.utcnow() + datetime.timedelta(seconds=0.1)
         return exthandlers_handler.wait_for_handler_successful_completion(exthandler, wait_until)
 
     def test_wait_for_handler_successful_completion_no_status(self, *args):
@@ -1443,8 +1445,6 @@ class TestExtension(ExtensionTestCase):
                                                                                           *args)
 
         with patch.object(ExtHandlerInstance, "report_event", autospec=True) as patch_report_event:
-            # Disable of the old extn fails
-            patch_get_disable_command.return_value = "exit 1"
             exthandlers_handler.run()  # Download the new update the first time, and then we patch the download method.
             self.assertEqual(1, patch_get_disable_command.call_count)
 
@@ -1464,7 +1464,7 @@ class TestExtension(ExtensionTestCase):
 
             self.assertFalse(old_version_kwargs['is_success'], "The last call to report event should be for a failure")
 
-            self.assertTrue(old_version_kwargs['message'].startswith('[ExtensionError]'), "No error reported")
+            self.assertTrue('Error' in old_version_kwargs['message'], "No error reported")
 
             # This is ensuring that the error status is being written to the new version
         self._assert_handler_status(protocol.report_vm_status, "NotReady", expected_ext_count=0, version=new_version)
@@ -1574,7 +1574,7 @@ class TestExtension(ExtensionTestCase):
         self._assert_handler_status(protocol.report_vm_status, "NotReady", expected_ext_count=1, version="1.0.1")
 
     @patch('azurelinuxagent.ga.exthandlers.HandlerManifest.is_continue_on_update_failure', return_value=True)
-    def test_both_env_var_should_clear_before_every_call_to_exthandler_run(
+    def test_uninstall_rc_env_var_should_report_not_run_for_non_update_calls_to_exthandler_run(
             self, patch_continue_on_update, *args):
         test_data, exthandlers_handler, protocol = self._set_up_update_test_and_update_gs(Mock(), *args)
 
@@ -1586,16 +1586,22 @@ class TestExtension(ExtensionTestCase):
             _, install_kwargs = patch_start_cmd.call_args_list[3]
             _, enable_kwargs = patch_start_cmd.call_args_list[4]
 
-            # Ensure that the env variables were present in the first run when failures were thrown
+            # Ensure that the env variables were present in the first run when failures were thrown for update
             self.assertEqual(2, patch_continue_on_update.call_count)
-            self.assertTrue('-update' in update_kwargs['command'] and ExtCommandEnvVariable.DisableFailed in update_kwargs['env'],
-                            "The update command call should have Disable Failed in env variable")
-            self.assertTrue('-install' in install_kwargs['command'] and ExtCommandEnvVariable.DisableFailed not in install_kwargs['env'],
-                            "The Disable Failed env variable should be removed from install command")
-            self.assertTrue('-install' in install_kwargs['command'] and ExtCommandEnvVariable.UninstallFailed in install_kwargs['env'],
-                            "The install command call should have Uninstall Failed in env variable")
-            self.assertTrue('-enable' in enable_kwargs['command'] and ExtCommandEnvVariable.UninstallFailed in enable_kwargs['env'],
-                            "The enable command call should have Uninstall Failed in env variable")
+            self.assertTrue(
+                '-update' in update_kwargs['command'] and ExtCommandEnvVariable.DisableReturnCode in update_kwargs['env'],
+                "The update command call should have Disable Failed in env variable")
+            self.assertTrue(
+                '-install' in install_kwargs['command'] and ExtCommandEnvVariable.DisableReturnCode not in install_kwargs[
+                    'env'],
+                "The Disable Failed env variable should be removed from install command")
+            self.assertTrue(
+                '-install' in install_kwargs['command'] and ExtCommandEnvVariable.UninstallReturnCode in install_kwargs[
+                    'env'],
+                "The install command call should have Uninstall Failed in env variable")
+            self.assertTrue(
+                '-enable' in enable_kwargs['command'] and ExtCommandEnvVariable.UninstallReturnCode in enable_kwargs['env'],
+                "The enable command call should have Uninstall Failed in env variable")
 
             # Initiating another run which shouldn't have any failed env variables in it if no failures
             # Updating Incarnation
@@ -1603,9 +1609,13 @@ class TestExtension(ExtensionTestCase):
             exthandlers_handler.run()
             _, new_enable_kwargs = patch_start_cmd.call_args
 
-            # Ensure the new run didn't have any failed env variables
-            self.assertNotIn(ExtCommandEnvVariable.DisableFailed, new_enable_kwargs['env'])
-            self.assertNotIn(ExtCommandEnvVariable.UninstallFailed, new_enable_kwargs['env'])
+            # Ensure the new run didn't have Disable Return Code env variable
+            self.assertNotIn(ExtCommandEnvVariable.DisableReturnCode, new_enable_kwargs['env'])
+
+            # Ensure the new run had Uninstall Return Code env variable == NotRun
+            self.assertIn(ExtCommandEnvVariable.UninstallReturnCode, new_enable_kwargs['env'])
+            self.assertTrue(
+                new_enable_kwargs['env'][ExtCommandEnvVariable.UninstallReturnCode] == ExtCommandEnvVariable.NotRun)
 
         # Ensure the handler status and ext_status is successful
         self._assert_handler_status(protocol.report_vm_status, "Ready", expected_ext_count=1, version="1.0.1")
@@ -1621,7 +1631,8 @@ class TestExtension(ExtensionTestCase):
             # Extension Path and Version should be set for all launch_command calls
             for args, kwargs in patch_start_cmd.call_args_list:
                 self.assertIn(ExtCommandEnvVariable.ExtensionPath, kwargs['env'])
-                self.assertIn('OSTCExtensions.ExampleHandlerLinux-1.0.0', kwargs['env'][ExtCommandEnvVariable.ExtensionPath])
+                self.assertIn('OSTCExtensions.ExampleHandlerLinux-1.0.0',
+                              kwargs['env'][ExtCommandEnvVariable.ExtensionPath])
                 self.assertIn(ExtCommandEnvVariable.ExtensionVersion, kwargs['env'])
                 self.assertEqual("1.0.0", kwargs['env'][ExtCommandEnvVariable.ExtensionVersion])
 
@@ -1659,12 +1670,6 @@ class TestExtension(ExtensionTestCase):
 
     def test_ext_sequence_no_should_be_set_from_within_extension(self, *args):
 
-        def create_test_dir_and_script(base_dir, test_file_name, test_file):
-            if not os.path.exists(base_dir):
-                os.mkdir(base_dir)
-            self.create_script(file_name=test_file_name, contents=test_file,
-                               file_path=os.path.join(base_dir, test_file_name))
-
         test_file_name = "testfile.sh"
         handler_json = {
             "installCommand": test_file_name,
@@ -1683,8 +1688,8 @@ class TestExtension(ExtensionTestCase):
                 printenv | grep ConfigSequenceNumber
                 """
 
-        base_dir = os.path.join(conf.get_lib_dir(), 'OSTCExtensions.ExampleHandlerLinux-1.0.0')
-        create_test_dir_and_script(base_dir, test_file_name, test_file)
+        base_dir = os.path.join(conf.get_lib_dir(), 'OSTCExtensions.ExampleHandlerLinux-1.0.0', test_file_name)
+        self.create_script(test_file_name, test_file, base_dir)
 
         test_data = WireProtocolData(DATA_FILE_EXT_SINGLE)
         exthandlers_handler, protocol = self._create_mock(test_data, *args)
@@ -1693,6 +1698,7 @@ class TestExtension(ExtensionTestCase):
         with patch.object(ExtHandlerInstance, "load_manifest", return_value=manifest):
             with patch.object(ExtHandlerInstance, 'report_event') as mock_report_event:
                 exthandlers_handler.run()
+                clean_mocked_event_call_arg_list_as_per_kwargs_msg(mock_report_event)
 
                 for _, kwargs in mock_report_event.call_args_list:
                     # The output is of the format - 'testfile.sh\n[stdout]ConfigSequenceNumber=N\n[stderr]'
@@ -1707,11 +1713,12 @@ class TestExtension(ExtensionTestCase):
             test_data.ext_conf = test_data.ext_conf.replace('seqNo="0"', 'seqNo="1"')
             test_data.manifest = test_data.manifest.replace('1.0.0', '1.0.1')
             expected_seq_no = 1
-            base_dir = os.path.join(conf.get_lib_dir(), 'OSTCExtensions.ExampleHandlerLinux-1.0.1')
-            create_test_dir_and_script(base_dir, test_file_name, test_file)
+            base_dir = os.path.join(conf.get_lib_dir(), 'OSTCExtensions.ExampleHandlerLinux-1.0.1', test_file_name)
+            self.create_script(test_file_name, test_file, base_dir)
 
             with patch.object(ExtHandlerInstance, 'report_event') as mock_report_event:
                 exthandlers_handler.run()
+                clean_mocked_event_call_arg_list_as_per_kwargs_msg(mock_report_event)
 
                 for _, kwargs in mock_report_event.call_args_list:
                     # The output is of the format - 'testfile.sh\n[stdout]ConfigSequenceNumber=N\n[stderr]'
@@ -1719,6 +1726,55 @@ class TestExtension(ExtensionTestCase):
                         continue
                     self.assertIn("{0}={1}".format(ExtCommandEnvVariable.ExtensionSeqNumber, expected_seq_no),
                                   kwargs['message'])
+
+    def test_correct_exit_code_should_set_on_uninstall_cmd_failure(self, *args):
+        test_file_name = "testfile.sh"
+        test_error_file_name = "error.sh"
+        handler_json = {
+            "installCommand": test_file_name + " -install",
+            "uninstallCommand": test_error_file_name,
+            "updateCommand": test_file_name + " -update",
+            "enableCommand": test_file_name + " -enable",
+            "disableCommand": test_error_file_name,
+            "rebootAfterInstall": False,
+            "reportHeartbeat": False,
+            "continueOnUpdateFailure": True
+        }
+        manifest = HandlerManifest({'handlerManifest': handler_json})
+
+        # Script prints env variables passed to this process and prints all starting with ConfigSequenceNumber
+        test_file = """
+            printenv | grep AZURE_
+        """
+
+        exit_code = 151
+        test_error_content = """
+            exit %s
+        """ % exit_code
+
+        error_dir = os.path.join(conf.get_lib_dir(), 'OSTCExtensions.ExampleHandlerLinux-1.0.0', test_error_file_name)
+        self.create_script(test_error_file_name, test_error_content, error_dir)
+
+        test_data, exthandlers_handler, protocol = self._set_up_update_test_and_update_gs(Mock(), *args)
+
+        base_dir = os.path.join(conf.get_lib_dir(), 'OSTCExtensions.ExampleHandlerLinux-1.0.1', test_file_name)
+        self.create_script(test_file_name, test_file, base_dir)
+
+        with patch("azurelinuxagent.ga.exthandlers.ExtHandlerInstance.load_manifest", return_value=manifest):
+            with patch.object(ExtHandlerInstance, 'report_event') as mock_report_event:
+                exthandlers_handler.run()
+
+                clean_mocked_event_call_arg_list_as_per_kwargs_msg(mock_report_event)
+
+                _, disable_kwargs = mock_report_event.call_args_list[1]
+                _, update_kwargs = mock_report_event.call_args_list[2]
+                _, uninstall_kwargs = mock_report_event.call_args_list[3]
+                _, install_kwargs = mock_report_event.call_args_list[4]
+                _, enable_kwargs = mock_report_event.call_args_list[5]
+
+                self.assertIn("%s=%s" % (ExtCommandEnvVariable.DisableReturnCode, exit_code), update_kwargs['message'])
+                self.assertIn("%s=%s" % (ExtCommandEnvVariable.UninstallReturnCode, exit_code), install_kwargs['message'])
+                self.assertIn("%s=%s" % (ExtCommandEnvVariable.UninstallReturnCode, exit_code), enable_kwargs['message'])
 
 
 @patch("azurelinuxagent.common.protocol.wire.CryptUtil")
@@ -2058,6 +2114,7 @@ class TestExtensionWithCGroupsEnabled(AgentTestCase):
 
         # Test enable scenario.
         exthandlers_handler.run()
+        clean_mocked_event_call_arg_list_as_per_kwargs_msg(patch_add_event)
         self._assert_handler_status(protocol.report_vm_status, "Ready", 1, "1.0.0")
         self._assert_ext_status(protocol.report_ext_status, "success", 0)
 
@@ -2188,7 +2245,7 @@ class TestExtensionUpdateOnFailure(ExtensionTestCase):
 
             args, kwargs = patch_start_cmd.call_args
 
-            self.assertTrue('-update' in kwargs['command'] and ExtCommandEnvVariable.DisableFailed in kwargs['env'],
+            self.assertTrue('-update' in kwargs['command'] and ExtCommandEnvVariable.DisableReturnCode in kwargs['env'],
                             "The update command should have Disable Failed in env variable")
 
     def test_uninstall_failed_env_variable_should_set_for_install_when_continue_on_update_failure_is_true(
@@ -2203,7 +2260,7 @@ class TestExtensionUpdateOnFailure(ExtensionTestCase):
 
             args, kwargs = patch_start_cmd.call_args
 
-            self.assertTrue('-install' in kwargs['command'] and ExtCommandEnvVariable.UninstallFailed in kwargs['env'],
+            self.assertTrue('-install' in kwargs['command'] and ExtCommandEnvVariable.UninstallReturnCode in kwargs['env'],
                             "The install command should have Uninstall Failed in env variable")
 
     def test_extension_error_should_be_raised_when_continue_on_update_failure_is_false_on_disable_failure(self, *args):
@@ -2278,10 +2335,6 @@ class TestExtensionUpdateOnFailure(ExtensionTestCase):
 
                 self.assertEqual(2, patch_launch_command.call_count, "Launch command should be called 2 times for "
                                                                      "Disable->Update")
-                for args, kwargs in patch_launch_command.call_args_list:
-                    # Disable wont have any env variables, and Update would have only 'Version' in env param
-                    self.assertTrue(('env' not in kwargs and '-disable' in args[0]) or
-                                    ('-update' in args[0] and ExtCommandEnvVariable.DisableFailed not in kwargs['env']))
 
     @patch('time.sleep', side_effect=lambda _: mock_sleep(0.001))
     def test_failed_env_variables_should_be_set_from_within_extension_commands(self, *args):
@@ -2308,34 +2361,152 @@ class TestExtensionUpdateOnFailure(ExtensionTestCase):
         self.create_script(file_name=test_file_name, contents=test_file,
                            file_path=os.path.join(new_handler_i.get_base_dir(), test_file_name))
 
-        with patch.object(new_handler_i.logger, 'verbose', autospec=True) as mock_verbose:
+        with patch.object(new_handler_i, 'report_event', autospec=True) as mock_report:
             # Since we're not mocking the azurelinuxagent.common.cgroupconfigurator..handle_process_completion,
             # both disable.cmd and uninstall.cmd would raise ExtensionError exceptions and set the
-            # ExtCommandEnvVariable.DisableFailed and ExtCommandEnvVariable.UninstallFailed env variables.
+            # ExtCommandEnvVariable.DisableReturnCode and ExtCommandEnvVariable.UninstallReturnCode env variables.
             # For update and install we're running the script above to print all the env variables starting with AZURE_
             # and verify accordingly if the corresponding env variables are set properly or not
             ExtHandlersHandler._update_extension_handler_and_return_if_failed(old_handler_i, new_handler_i)
+            clean_mocked_event_call_arg_list_as_per_kwargs_msg(mock_report)
 
-            # Mocking the verbose logger as we log the output of the command in the verbose logs
-            # (We also send out a telemetry event for it and log it as info logs too)
-            update_command_args = mock_verbose.call_args_list[0][0]
-            update_args = mock_verbose.call_args_list[1][0]
-            install_command_args = mock_verbose.call_args_list[2][0]
-            install_args = mock_verbose.call_args_list[3][0]
+            _, update_kwargs = mock_report.call_args_list[0]
+            _, install_kwargs = mock_report.call_args_list[1]
 
             # Ensure we're checking variables for update scenario
-            self.assertEqual(update_file_name, update_command_args[1])
-            self.assertIn(ExtCommandEnvVariable.DisableFailed, update_args[0])
-            self.assertTrue(ExtCommandEnvVariable.ExtensionPath in update_args[0] and
-                            ExtCommandEnvVariable.ExtensionVersion in update_args[0])
-            self.assertNotIn(ExtCommandEnvVariable.UninstallFailed, update_args[0])
+            self.assertIn(update_file_name, update_kwargs['message'])
+            self.assertIn(ExtCommandEnvVariable.DisableReturnCode, update_kwargs['message'])
+            self.assertTrue(ExtCommandEnvVariable.ExtensionPath in update_kwargs['message'] and
+                            ExtCommandEnvVariable.ExtensionVersion in update_kwargs['message'])
+            self.assertNotIn(ExtCommandEnvVariable.UninstallReturnCode, update_kwargs['message'])
 
             # Ensure we're checking variables for install scenario
-            self.assertEqual(install_file_name, install_command_args[1])
-            self.assertIn(ExtCommandEnvVariable.UninstallFailed, install_args[0])
-            self.assertTrue(ExtCommandEnvVariable.ExtensionPath in install_args[0] and
-                            ExtCommandEnvVariable.ExtensionVersion in install_args[0])
-            self.assertNotIn(ExtCommandEnvVariable.DisableFailed, install_args[0])
+            self.assertIn(install_file_name, install_kwargs['message'])
+            self.assertIn(ExtCommandEnvVariable.UninstallReturnCode, install_kwargs['message'])
+            self.assertTrue(ExtCommandEnvVariable.ExtensionPath in install_kwargs['message'] and
+                            ExtCommandEnvVariable.ExtensionVersion in install_kwargs['message'])
+            self.assertNotIn(ExtCommandEnvVariable.DisableReturnCode, install_kwargs['message'])
+
+    @patch('time.sleep', side_effect=lambda _: mock_sleep(0.001))
+    def test_correct_exit_code_should_set_on_disable_cmd_failure(self, _):
+        test_env_file_name = "test_env.sh"
+        test_failure_file_name = "test_fail.sh"
+        # update_file_name = test_env_file_name + " -update"
+        old_handler_i = TestExtensionUpdateOnFailure._get_ext_handler_instance('foo', '1.0.0', handler={
+            "disableCommand": test_failure_file_name,
+            "uninstallCommand": test_failure_file_name})
+        new_handler_i = TestExtensionUpdateOnFailure._get_ext_handler_instance(
+            'foo', '1.0.1',
+            handler={"updateCommand": test_env_file_name,
+                     "updateMode": "UpdateWithoutInstall"},
+            continue_on_update_failure=True
+        )
+
+        exit_code = 150
+        error_test_file = """
+                    exit %s
+                    """ % exit_code
+
+        test_env_file = """
+            printenv | grep AZURE_
+            """
+
+        self.create_script(file_name=test_env_file_name, contents=test_env_file,
+                           file_path=os.path.join(new_handler_i.get_base_dir(), test_env_file_name))
+        self.create_script(file_name=test_failure_file_name, contents=error_test_file,
+                           file_path=os.path.join(old_handler_i.get_base_dir(), test_failure_file_name))
+
+        with patch.object(new_handler_i, 'report_event', autospec=True) as mock_report:
+
+            uninstall_rc = ExtHandlersHandler._update_extension_handler_and_return_if_failed(old_handler_i, new_handler_i)
+            _, kwargs = mock_report.call_args
+
+            self.assertEqual(exit_code, uninstall_rc)
+            self.assertIn("%s=%s" % (ExtCommandEnvVariable.DisableReturnCode, exit_code), kwargs['message'])
+
+    @patch('time.sleep', side_effect=lambda _: mock_sleep(0.0001))
+    def test_timeout_code_should_set_on_cmd_timeout(self, _):
+        test_env_file_name = "test_env.sh"
+        test_failure_file_name = "test_fail.sh"
+        old_handler_i = TestExtensionUpdateOnFailure._get_ext_handler_instance('foo', '1.0.0', handler={
+            "disableCommand": test_failure_file_name,
+            "uninstallCommand": test_failure_file_name})
+        new_handler_i = TestExtensionUpdateOnFailure._get_ext_handler_instance(
+            'foo', '1.0.1',
+            handler={"updateCommand": test_env_file_name + " -u", "installCommand": test_env_file_name + " -i"},
+            continue_on_update_failure=True
+        )
+
+        exit_code = 156
+        error_test_file = """
+            sleep 1m
+            exit %s
+        """ % exit_code
+
+        test_env_file = """
+            printenv | grep AZURE_
+        """
+
+        self.create_script(file_name=test_env_file_name, contents=test_env_file,
+                           file_path=os.path.join(new_handler_i.get_base_dir(), test_env_file_name))
+        self.create_script(file_name=test_failure_file_name, contents=error_test_file,
+                           file_path=os.path.join(old_handler_i.get_base_dir(), test_failure_file_name))
+
+        with patch.object(new_handler_i, 'report_event', autospec=True) as mock_report:
+            uninstall_rc = ExtHandlersHandler._update_extension_handler_and_return_if_failed(old_handler_i,
+                                                                                             new_handler_i)
+            clean_mocked_event_call_arg_list_as_per_kwargs_msg(mock_report)
+            _, update_kwargs = mock_report.call_args_list[0]
+            _, install_kwargs = mock_report.call_args_list[1]
+
+            self.assertNotEqual(exit_code, uninstall_rc)
+            self.assertEqual(ExtensionErrorCodes.PluginHandlerScriptTimedout, uninstall_rc)
+            self.assertTrue(test_env_file_name + " -i" in install_kwargs['message'] and "%s=%s" % (
+                ExtCommandEnvVariable.UninstallReturnCode, ExtensionErrorCodes.PluginHandlerScriptTimedout) in
+                            install_kwargs['message'])
+            self.assertTrue(test_env_file_name + " -u" in update_kwargs['message'] and "%s=%s" % (
+                ExtCommandEnvVariable.DisableReturnCode, ExtensionErrorCodes.PluginHandlerScriptTimedout) in
+                            update_kwargs['message'])
+
+    @patch('time.sleep', side_effect=lambda _: mock_sleep(0.0001))
+    def test_success_code_should_set_in_env_variables_on_cmd_success(self, _):
+        test_env_file_name = "test_env.sh"
+        test_success_file_name = "test_success.sh"
+        old_handler_i = TestExtensionUpdateOnFailure._get_ext_handler_instance('foo', '1.0.0', handler={
+            "disableCommand": test_success_file_name,
+            "uninstallCommand": test_success_file_name})
+        new_handler_i = TestExtensionUpdateOnFailure._get_ext_handler_instance(
+            'foo', '1.0.1',
+            handler={"updateCommand": test_env_file_name + " -u", "installCommand": test_env_file_name + " -i"},
+            continue_on_update_failure=False
+        )
+
+        exit_code = 0
+        success_test_file = """
+                exit %s
+            """ % exit_code
+
+        test_env_file = """
+                printenv | grep AZURE_
+            """
+
+        self.create_script(file_name=test_env_file_name, contents=test_env_file,
+                           file_path=os.path.join(new_handler_i.get_base_dir(), test_env_file_name))
+        self.create_script(file_name=test_success_file_name, contents=success_test_file,
+                           file_path=os.path.join(old_handler_i.get_base_dir(), test_success_file_name))
+
+        with patch.object(new_handler_i, 'report_event', autospec=True) as mock_report:
+            uninstall_rc = ExtHandlersHandler._update_extension_handler_and_return_if_failed(old_handler_i,
+                                                                                             new_handler_i)
+            clean_mocked_event_call_arg_list_as_per_kwargs_msg(mock_report)
+            _, update_kwargs = mock_report.call_args_list[0]
+            _, install_kwargs = mock_report.call_args_list[1]
+
+            self.assertEqual(exit_code, uninstall_rc)
+            self.assertTrue(test_env_file_name + " -i" in install_kwargs['message'] and "%s=%s" % (
+                ExtCommandEnvVariable.UninstallReturnCode, exit_code) in install_kwargs['message'])
+            self.assertTrue(test_env_file_name + " -u" in update_kwargs['message'] and "%s=%s" % (
+                ExtCommandEnvVariable.DisableReturnCode, exit_code) in update_kwargs['message'])
 
 
 if __name__ == '__main__':

--- a/tests/ga/test_extension.py
+++ b/tests/ga/test_extension.py
@@ -27,8 +27,6 @@ from azurelinuxagent.common.protocol.restapi import Extension, ExtHandlerPropert
 from azurelinuxagent.ga.exthandlers import *
 from azurelinuxagent.common.protocol.wire import WireProtocol, InVMArtifactsProfile
 
-from tests.tools import *
-
 
 def do_not_run_test():
     return True
@@ -689,8 +687,7 @@ class TestExtension(ExtensionTestCase):
         exthandlers_handler, protocol = self._create_mock(test_data, *args)
         protocol.download_ext_handler_pkg = Mock(side_effect=ProtocolError)
 
-        with patch("time.sleep", side_effect=mock_sleep(0.1)):
-            exthandlers_handler.run()
+        exthandlers_handler.run()
 
         self.assertEquals(0, mock_add_event.call_count)
 

--- a/tests/ga/test_exthandlers.py
+++ b/tests/ga/test_exthandlers.py
@@ -580,3 +580,14 @@ sys.stderr.write("STDERR")
             output = self.ext_handler_instance.launch_command(command)
 
         self.assertIn("[stderr]\nCannot read stdout/stderr:", output)
+
+    def test_it_should_report_command_details_before_launching(self):
+        command = self.create_script("hello.sh", '''
+        echo 'Hello'
+        ''')
+
+        with patch.object(self.ext_handler_instance, 'report_event') as mock_report:
+            output = self.ext_handler_instance.launch_command(command)
+            self.assertEqual(2, mock_report.call_count)
+            self.assertIn("Launching command : ", mock_report.call_args_list[0].kwargs['message'])
+            self.assertRegex(output, LaunchCommandTestCase._output_regex("Hello", ""))

--- a/tests/ga/test_exthandlers.py
+++ b/tests/ga/test_exthandlers.py
@@ -580,14 +580,3 @@ sys.stderr.write("STDERR")
             output = self.ext_handler_instance.launch_command(command)
 
         self.assertIn("[stderr]\nCannot read stdout/stderr:", output)
-
-    def test_it_should_report_command_details_before_launching(self):
-        command = self.create_script("hello.sh", '''
-        echo 'Hello'
-        ''')
-
-        with patch.object(self.ext_handler_instance, 'report_event') as mock_report:
-            output = self.ext_handler_instance.launch_command(command)
-            self.assertEqual(2, mock_report.call_count)
-            self.assertIn("Launching command : ", mock_report.call_args_list[0].kwargs['message'])
-            self.assertRegex(output, LaunchCommandTestCase._output_regex("Hello", ""))

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -64,6 +64,17 @@ _MAX_LENGTH = 120
 
 _MAX_LENGTH_SAFE_REPR = 80
 
+# Mock sleep to reduce test execution time
+_SLEEP = time.sleep
+
+
+def mock_sleep(sec=0.01):
+    """
+    Mocks the time.sleep method to reduce unit test time
+    :param sec: Time to replace the sleep call with, default = 0.01sec
+    """
+    _SLEEP(sec)
+
 
 def safe_repr(obj, short=False):
     try:

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -533,16 +533,3 @@ def distros(distro_name=".*", distro_version=".*", distro_full_name=".*"):
     return decorator
 
 
-def clean_mocked_event_call_arg_list_as_per_kwargs_msg(mock_obj, remove_string="Launching command : "):
-    """
-    This function removes all call objects from the mock_obj.call_args_list by filtering out the remove_string from the
-    kwargs['message'] parameter. It also modifies the call count of the mock object
-    :param mock_obj: The mock object to clean
-    :param remove_string: The string to remove
-    """
-
-    mock_obj.call_args_list = [obj for obj in mock_obj.call_args_list if
-                               remove_string not in obj.kwargs['message']]
-    mock_obj.call_count = len(mock_obj.call_args_list)
-
-

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -450,6 +450,10 @@ class AgentTestCase(unittest.TestCase):
         if not file_path:
             file_path = os.path.join(self.tmp_dir, file_name)
 
+        directory = os.path.dirname(file_path)
+        if not os.path.exists(directory):
+            os.mkdir(directory)
+
         with open(file_path, "w") as script:
             if file_name.endswith(".py"):
                 script.write("#!/usr/bin/env python3\n")
@@ -527,5 +531,18 @@ def distros(distro_name=".*", distro_version=".*", distro_full_name=".*"):
                     self.setUp()
         return wrapper
     return decorator
+
+
+def clean_mocked_event_call_arg_list_as_per_kwargs_msg(mock_obj, remove_string="Launching command : "):
+    """
+    This function removes all call objects from the mock_obj.call_args_list by filtering out the remove_string from the
+    kwargs['message'] parameter. It also modifies the call count of the mock object
+    :param mock_obj: The mock object to clean
+    :param remove_string: The string to remove
+    """
+
+    mock_obj.call_args_list = [obj for obj in mock_obj.call_args_list if
+                               remove_string not in obj.kwargs['message']]
+    mock_obj.call_count = len(mock_obj.call_args_list)
 
 


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
Currently during extension update if there is any problem in the Disable/Uninstall command of the prev version we include a boolean Environment variable to indicate the fact that there was an error. This PR adds the feature that instead of setting a boolean, we would now be setting the value of the environment variable to the exit code of the command.

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/walinuxagent/1646)
<!-- Reviewable:end -->
