### PR TITLE
Add anhvoms as code owner for pa

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,7 +8,7 @@
 # The Azure Linux Provisioning team is interested in getting notifications
 # when there are requests for changes in the provisioning agent. For any
 # questions, please feel free to reach out to thstring@microsoft.com.
-/azurelinuxagent/pa @trstringer
+/azurelinuxagent/pa/ @trstringer @anhvoms
 
 # Guest Agent team
 * @narrieta @vrdmr @pgombar @larohra


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

This PR would add @anhvoms as a code owner for the provisioning agent.

---

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [x] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/walinuxagent/1661)
<!-- Reviewable:end -->
