### PR TITLE
Refactoring reset_logger to reset every 12 hours

### DIFF
--- a/azurelinuxagent/common/cgroupstelemetry.py
+++ b/azurelinuxagent/common/cgroupstelemetry.py
@@ -108,8 +108,6 @@ class CGroupsTelemetry(object):
                     CGroupsTelemetry._cgroup_metrics[key].marked_for_delete]:
             del CGroupsTelemetry._cgroup_metrics[key]
 
-        logger.reset_periodic()
-
         return collected_metrics
 
     @staticmethod

--- a/azurelinuxagent/common/logger.py
+++ b/azurelinuxagent/common/logger.py
@@ -200,18 +200,34 @@ def set_prefix(prefix):
 
 
 def periodic_info(delta, msg_format, *args):
+    """
+    The hash-map maintaining the state of the logs gets reset here -
+    azurelinuxagent.ga.monitor.MonitorHandler.reset_loggers. The current time period is defined by RESET_LOGGERS_PERIOD.
+    """
     DEFAULT_LOGGER.periodic_info(delta, msg_format, *args)
 
 
 def periodic_verbose(delta, msg_format, *args):
+    """
+    The hash-map maintaining the state of the logs gets reset here -
+    azurelinuxagent.ga.monitor.MonitorHandler.reset_loggers. The current time period is defined by RESET_LOGGERS_PERIOD.
+    """
     DEFAULT_LOGGER.periodic_verbose(delta, msg_format, *args)
 
 
 def periodic_error(delta, msg_format, *args):
+    """
+    The hash-map maintaining the state of the logs gets reset here -
+    azurelinuxagent.ga.monitor.MonitorHandler.reset_loggers. The current time period is defined by RESET_LOGGERS_PERIOD.
+    """
     DEFAULT_LOGGER.periodic_error(delta, msg_format, *args)
 
 
 def periodic_warn(delta, msg_format, *args):
+    """
+    The hash-map maintaining the state of the logs gets reset here -
+    azurelinuxagent.ga.monitor.MonitorHandler.reset_loggers. The current time period is defined by RESET_LOGGERS_PERIOD.
+    """
     DEFAULT_LOGGER.periodic_warn(delta, msg_format, *args)
 
 

--- a/azurelinuxagent/ga/monitor.py
+++ b/azurelinuxagent/ga/monitor.py
@@ -114,12 +114,16 @@ class MonitorHandler(object):
     IMDS_HEARTBEAT_PERIOD = datetime.timedelta(minutes=1)
     IMDS_HEALTH_PERIOD = datetime.timedelta(minutes=3)
 
+    # Resetting loggers period
+    RESET_LOGGERS_PERIOD = datetime.timedelta(hours=12)
+
     def __init__(self):
         self.osutil = get_osutil()
         self.protocol_util = get_protocol_util()
         self.imds_client = get_imds_client()
 
         self.event_thread = None
+        self.last_reset_loggers_time = None
         self.last_event_collection = None
         self.last_telemetry_heartbeat = None
         self.last_cgroup_polling_telemetry = None
@@ -277,7 +281,24 @@ class MonitorHandler(object):
             self.send_host_plugin_heartbeat()
             self.send_imds_heartbeat()
             self.log_altered_network_configuration()
+            self.reset_loggers()
             time.sleep(min_delta)
+
+    def reset_loggers(self):
+        """
+        The loggers maintain hash-tables in memory and they need to be cleaned up from time to time.
+        For reference, please check azurelinuxagent.common.logger.Logger and
+        azurelinuxagent.common.event.EventLogger classes
+        """
+        time_now = datetime.datetime.utcnow()
+        if not self.last_reset_loggers_time:
+            self.last_reset_loggers_time = time_now
+
+        if time_now >= (self.last_reset_loggers_time +
+                        MonitorHandler.RESET_LOGGERS_PERIOD):
+            logger.reset_periodic()
+
+            self.last_reset_loggers_time = time_now
 
     def add_sysinfo(self, event):
         sysinfo_names = [v.name for v in self.sysinfo]

--- a/azurelinuxagent/ga/monitor.py
+++ b/azurelinuxagent/ga/monitor.py
@@ -296,9 +296,10 @@ class MonitorHandler(object):
 
         if time_now >= (self.last_reset_loggers_time +
                         MonitorHandler.RESET_LOGGERS_PERIOD):
-            logger.reset_periodic()
-
-            self.last_reset_loggers_time = time_now
+            try:
+                logger.reset_periodic()
+            finally:
+                self.last_reset_loggers_time = time_now
 
     def add_sysinfo(self, event):
         sysinfo_names = [v.name for v in self.sysinfo]

--- a/tests/common/test_logger.py
+++ b/tests/common/test_logger.py
@@ -64,24 +64,38 @@ class TestLogger(AgentTestCase):
     def test_periodic_does_not_emit_if_previously_sent(self, mock_info, mock_error, mock_warn, mock_verbose):
         # The count does not increase from 1 - the first time it sends the data.
         logger.periodic_info(logger.EVERY_DAY, _MSG_INFO, *_DATA)
+        self.assertIn(hash(_MSG_INFO), logger.DEFAULT_LOGGER.periodic_messages)
         self.assertEqual(1, mock_info.call_count)
+
         logger.periodic_info(logger.EVERY_DAY, _MSG_INFO, *_DATA)
+        self.assertIn(hash(_MSG_INFO), logger.DEFAULT_LOGGER.periodic_messages)
         self.assertEqual(1, mock_info.call_count)
 
         logger.periodic_warn(logger.EVERY_DAY, _MSG_WARN, *_DATA)
+        self.assertIn(hash(_MSG_WARN), logger.DEFAULT_LOGGER.periodic_messages)
         self.assertEqual(1, mock_warn.call_count)
+
         logger.periodic_warn(logger.EVERY_DAY, _MSG_WARN, *_DATA)
+        self.assertIn(hash(_MSG_WARN), logger.DEFAULT_LOGGER.periodic_messages)
         self.assertEqual(1, mock_warn.call_count)
 
         logger.periodic_error(logger.EVERY_DAY, _MSG_ERROR, *_DATA)
+        self.assertIn(hash(_MSG_ERROR), logger.DEFAULT_LOGGER.periodic_messages)
         self.assertEqual(1, mock_error.call_count)
+
         logger.periodic_error(logger.EVERY_DAY, _MSG_ERROR, *_DATA)
+        self.assertIn(hash(_MSG_ERROR), logger.DEFAULT_LOGGER.periodic_messages)
         self.assertEqual(1, mock_error.call_count)
 
         logger.periodic_verbose(logger.EVERY_DAY, _MSG_VERBOSE, *_DATA)
+        self.assertIn(hash(_MSG_VERBOSE), logger.DEFAULT_LOGGER.periodic_messages)
         self.assertEqual(1, mock_verbose.call_count)
+
         logger.periodic_verbose(logger.EVERY_DAY, _MSG_VERBOSE, *_DATA)
+        self.assertIn(hash(_MSG_VERBOSE), logger.DEFAULT_LOGGER.periodic_messages)
         self.assertEqual(1, mock_verbose.call_count)
+
+        self.assertEqual(4, len(logger.DEFAULT_LOGGER.periodic_messages))
 
     @patch('azurelinuxagent.common.logger.Logger.verbose')
     @patch('azurelinuxagent.common.logger.Logger.warn')

--- a/tests/ga/test_monitor.py
+++ b/tests/ga/test_monitor.py
@@ -18,16 +18,14 @@ import random
 import string
 from datetime import timedelta
 
+from nose.plugins.attrib import attr
+
 from azurelinuxagent.common.cgroup import CGroup
-from azurelinuxagent.common.event import EventLogger
 from azurelinuxagent.common.datacontract import get_properties
-from azurelinuxagent.common.logger import DEFAULT_LOGGER
-from azurelinuxagent.common.protocol.imds import ComputeInfo, IMDS_IMAGE_ORIGIN_ENDORSED
-from azurelinuxagent.common.protocol.restapi import VMInfo
+from azurelinuxagent.common.event import EventLogger
 from azurelinuxagent.common.protocol.wire import WireProtocol
 from azurelinuxagent.common.utils import restutil
 from azurelinuxagent.ga.monitor import *
-from nose.plugins.attrib import attr
 from tests.common.test_cgroupstelemetry import make_new_cgroup, consume_cpu_time, consume_memory
 from tests.protocol.mockwiredata import WireProtocolData, DATA_FILE
 from tests.tools import *

--- a/tests/ga/test_monitor.py
+++ b/tests/ga/test_monitor.py
@@ -309,6 +309,24 @@ class TestMonitor(AgentTestCase):
 
         monitor_handler.stop()
 
+    @patch("azurelinuxagent.common.logger.reset_periodic", side_effect=Exception())
+    def test_reset_loggers_ensuring_timestamp_gets_updated(self, *args):
+        # Resetting the logger time states.
+        monitor_handler = get_monitor_handler()
+        initial_time = datetime.datetime.utcnow() - timedelta(hours=1)
+        monitor_handler.last_reset_loggers_time = initial_time
+        MonitorHandler.RESET_LOGGERS_PERIOD = timedelta(milliseconds=100)
+
+        # noinspection PyBroadException
+        try:
+            monitor_handler.reset_loggers()
+        except:
+            pass
+
+        # The hash map got cleaned up by the reset_loggers method
+        self.assertGreater(monitor_handler.last_reset_loggers_time, initial_time)
+        monitor_handler.stop()
+
 
 @patch('azurelinuxagent.common.event.EventLogger.add_event')
 @patch('azurelinuxagent.common.osutil.get_osutil')

--- a/tests/ga/test_monitor.py
+++ b/tests/ga/test_monitor.py
@@ -22,9 +22,8 @@ from azurelinuxagent.common.cgroup import CGroup
 from azurelinuxagent.common.event import EventLogger
 from azurelinuxagent.common.datacontract import get_properties
 from azurelinuxagent.common.logger import DEFAULT_LOGGER
-from azurelinuxagent.common.protocol.restapi import get_properties
 from azurelinuxagent.common.protocol.imds import ComputeInfo, IMDS_IMAGE_ORIGIN_ENDORSED
-from azurelinuxagent.common.protocol.restapi import get_properties, VMInfo
+from azurelinuxagent.common.protocol.restapi import VMInfo
 from azurelinuxagent.common.protocol.wire import WireProtocol
 from azurelinuxagent.common.utils import restutil
 from azurelinuxagent.ga.monitor import *
@@ -32,13 +31,6 @@ from nose.plugins.attrib import attr
 from tests.common.test_cgroupstelemetry import make_new_cgroup, consume_cpu_time, consume_memory
 from tests.protocol.mockwiredata import WireProtocolData, DATA_FILE
 from tests.tools import *
-
-
-_MSG_INFO = "This is our test info logging message {0} {1}"
-_MSG_WARN = "This is our test warn logging message {0} {1}"
-_MSG_ERROR = "This is our test error logging message {0} {1}"
-_MSG_VERBOSE = "This is our test verbose logging message {0} {1}"
-_DATA = ["arg1", "arg2"]
 
 
 class ResponseMock(Mock):


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
Refactoring the reset loggers to bring it to the MonitorHandler level. The logger now resets every 12 hours.

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/walinuxagent/1666)
<!-- Reviewable:end -->
