### PR TITLE
use alternate systemd detection

### DIFF
--- a/azurelinuxagent/common/utils/shellutil.py
+++ b/azurelinuxagent/common/utils/shellutil.py
@@ -89,13 +89,10 @@ def run_get_output(cmd, chk_err=True, log_cmd=True, expected_errors=[]):
         output = subprocess.check_output(cmd,
                                          stderr=subprocess.STDOUT,
                                          shell=True)
-        output = ustr(output,
-                      encoding='utf-8',
-                      errors="backslashreplace")
+        output = _encode_command_output(output)
     except subprocess.CalledProcessError as e:
-        output = ustr(e.output,
-                      encoding='utf-8',
-                      errors="backslashreplace")
+        output = _encode_command_output(e.output)
+
         if chk_err:
             msg = u"Command: [{0}], " \
                   u"return code: [{1}], " \

--- a/tests/common/test_cgroupapi.py
+++ b/tests/common/test_cgroupapi.py
@@ -58,7 +58,7 @@ class CGroupsApiTestCase(AgentTestCase):
         path_exists = os.path.exists
 
         def mock_path_exists(path):
-            if path in ("/run/systemd/system/", "/run/systemd/system"):
+            if path == "/run/systemd/system/":
                 mock_path_exists.path_tested = True
                 return True
             return path_exists(path)
@@ -76,9 +76,9 @@ class CGroupsApiTestCase(AgentTestCase):
         path_exists = os.path.exists
 
         def mock_path_exists(path):
-            if path in ("/run/systemd/system/", "/run/systemd/system"):
+            if path == "/run/systemd/system/":
                 mock_path_exists.path_tested = True
-                return True
+                return False
             return path_exists(path)
 
         mock_path_exists.path_tested = False
@@ -86,7 +86,7 @@ class CGroupsApiTestCase(AgentTestCase):
         with patch("azurelinuxagent.common.cgroupapi.os.path.exists", mock_path_exists):
             is_systemd = CGroupsApi._is_systemd()
 
-        self.assertTrue(is_systemd)
+        self.assertFalse(is_systemd)
 
         self.assertTrue(mock_path_exists.path_tested, 'The expected path was not tested; the implementation of CGroupsApi._is_systemd() may have changed.')
 

--- a/tests/common/test_cgroupstelemetry.py
+++ b/tests/common/test_cgroupstelemetry.py
@@ -579,21 +579,28 @@ class TestCGroupsTelemetry(AgentTestCase):
     def test_telemetry_with_tracked_cgroup(self):
         self.assertTrue(i_am_root(), "Test does not run when non-root")
 
-        max_num_polls = 30
-        time_to_wait = 3
-        extn_name = "foobar-1.0.0"
-        num_summarization_values = 7
+        # This test has some timing issues when systemd is managing cgroups, so we force the file system API
+        # by creating a new instance of the CGroupConfigurator
+        with patch("azurelinuxagent.common.cgroupapi.CGroupsApi._is_systemd", return_value=False):
+            cgroup_configurator_instance = CGroupConfigurator._instance
+            CGroupConfigurator._instance = None
 
-        cgs = make_new_cgroup(extn_name)
-        self.assertEqual(len(cgs), 2)
+            try:
+                max_num_polls = 30
+                time_to_wait = 3
+                extn_name = "foobar-1.0.0"
+                num_summarization_values = 7
 
-        ext_handler_properties = ExtHandlerProperties()
-        ext_handler_properties.version = "1.0.0"
-        self.ext_handler = ExtHandler(name='foobar')
-        self.ext_handler.properties = ext_handler_properties
-        self.ext_handler_instance = ExtHandlerInstance(ext_handler=self.ext_handler, protocol=None)
+                cgs = make_new_cgroup(extn_name)
+                self.assertEqual(len(cgs), 2)
 
-        command = self.create_script("keep_cpu_busy_and_consume_memory_for_5_seconds", '''
+                ext_handler_properties = ExtHandlerProperties()
+                ext_handler_properties.version = "1.0.0"
+                self.ext_handler = ExtHandler(name='foobar')
+                self.ext_handler.properties = ext_handler_properties
+                self.ext_handler_instance = ExtHandlerInstance(ext_handler=self.ext_handler, protocol=None)
+
+                command = self.create_script("keep_cpu_busy_and_consume_memory_for_5_seconds", '''
 nohup python -c "import time
 
 for i in range(5):
@@ -603,48 +610,59 @@ for i in range(5):
     print('Test loop')" &
 '''.format(time_to_wait))
 
-        self.log_dir = os.path.join(self.tmp_dir, "log")
+                self.log_dir = os.path.join(self.tmp_dir, "log")
 
-        with patch("azurelinuxagent.ga.exthandlers.ExtHandlerInstance.get_base_dir", lambda *_: self.tmp_dir) as \
-                patch_get_base_dir:
-            with patch("azurelinuxagent.ga.exthandlers.ExtHandlerInstance.get_log_dir", lambda *_: self.log_dir) as \
-                    patch_get_log_dir:
-                self.ext_handler_instance.launch_command(command)
+                with patch("azurelinuxagent.ga.exthandlers.ExtHandlerInstance.get_base_dir", lambda *_: self.tmp_dir) as \
+                        patch_get_base_dir:
+                    with patch("azurelinuxagent.ga.exthandlers.ExtHandlerInstance.get_log_dir", lambda *_: self.log_dir) as \
+                            patch_get_log_dir:
+                        self.ext_handler_instance.launch_command(command)
 
-        self.assertTrue(CGroupsTelemetry.is_tracked(os.path.join(
-            BASE_CGROUPS, "cpu", "walinuxagent.extensions", "foobar_1.0.0")))
-        self.assertTrue(CGroupsTelemetry.is_tracked(os.path.join(
-            BASE_CGROUPS, "memory", "walinuxagent.extensions", "foobar_1.0.0")))
+                #
+                # If the test is made to run using the systemd API, then the paths of the cgroups need to be checked differently:
+                #
+                #     self.assertEquals(len(CGroupsTelemetry._tracked), 2)
+                #     cpu = os.path.join(BASE_CGROUPS, "cpu", "system.slice", r"foobar_1.0.0_.*\.scope")
+                #     self.assertTrue(any(re.match(cpu, tracked.path) for tracked in CGroupsTelemetry._tracked))
+                #     memory = os.path.join(BASE_CGROUPS, "memory", "system.slice", r"foobar_1.0.0_.*\.scope")
+                #     self.assertTrue(any(re.match(memory, tracked.path) for tracked in CGroupsTelemetry._tracked))
+                #
+                self.assertTrue(CGroupsTelemetry.is_tracked(os.path.join(
+                    BASE_CGROUPS, "cpu", "walinuxagent.extensions", "foobar_1.0.0")))
+                self.assertTrue(CGroupsTelemetry.is_tracked(os.path.join(
+                    BASE_CGROUPS, "memory", "walinuxagent.extensions", "foobar_1.0.0")))
 
-        for i in range(max_num_polls):
-            CGroupsTelemetry.poll_all_tracked()
-            time.sleep(0.5)
+                for i in range(max_num_polls):
+                    CGroupsTelemetry.poll_all_tracked()
+                    time.sleep(0.5)
 
-        collected_metrics = CGroupsTelemetry.report_all_tracked()
+                collected_metrics = CGroupsTelemetry.report_all_tracked()
 
-        self.assertIn("memory", collected_metrics[extn_name])
-        self.assertIn("cur_mem", collected_metrics[extn_name]["memory"])
-        self.assertIn("max_mem", collected_metrics[extn_name]["memory"])
-        self.assertEqual(len(collected_metrics[extn_name]["memory"]["cur_mem"]), num_summarization_values)
-        self.assertEqual(len(collected_metrics[extn_name]["memory"]["max_mem"]), num_summarization_values)
+                self.assertIn("memory", collected_metrics[extn_name])
+                self.assertIn("cur_mem", collected_metrics[extn_name]["memory"])
+                self.assertIn("max_mem", collected_metrics[extn_name]["memory"])
+                self.assertEqual(len(collected_metrics[extn_name]["memory"]["cur_mem"]), num_summarization_values)
+                self.assertEqual(len(collected_metrics[extn_name]["memory"]["max_mem"]), num_summarization_values)
 
-        self.assertIsInstance(collected_metrics[extn_name]["memory"]["cur_mem"][5], str)
-        self.assertIsInstance(collected_metrics[extn_name]["memory"]["cur_mem"][6], str)
-        self.assertIsInstance(collected_metrics[extn_name]["memory"]["max_mem"][5], str)
-        self.assertIsInstance(collected_metrics[extn_name]["memory"]["max_mem"][6], str)
+                self.assertIsInstance(collected_metrics[extn_name]["memory"]["cur_mem"][5], str)
+                self.assertIsInstance(collected_metrics[extn_name]["memory"]["cur_mem"][6], str)
+                self.assertIsInstance(collected_metrics[extn_name]["memory"]["max_mem"][5], str)
+                self.assertIsInstance(collected_metrics[extn_name]["memory"]["max_mem"][6], str)
 
-        self.assertIn("cpu", collected_metrics[extn_name])
-        self.assertIn("cur_cpu", collected_metrics[extn_name]["cpu"])
-        self.assertEqual(len(collected_metrics[extn_name]["cpu"]["cur_cpu"]), num_summarization_values)
+                self.assertIn("cpu", collected_metrics[extn_name])
+                self.assertIn("cur_cpu", collected_metrics[extn_name]["cpu"])
+                self.assertEqual(len(collected_metrics[extn_name]["cpu"]["cur_cpu"]), num_summarization_values)
 
-        self.assertIsInstance(collected_metrics[extn_name]["cpu"]["cur_cpu"][5], str)
-        self.assertIsInstance(collected_metrics[extn_name]["cpu"]["cur_cpu"][6], str)
+                self.assertIsInstance(collected_metrics[extn_name]["cpu"]["cur_cpu"][5], str)
+                self.assertIsInstance(collected_metrics[extn_name]["cpu"]["cur_cpu"][6], str)
 
-        for i in range(5):
-            self.assertGreater(collected_metrics[extn_name]["memory"]["cur_mem"][i], 0)
-            self.assertGreater(collected_metrics[extn_name]["memory"]["max_mem"][i], 0)
-            self.assertGreaterEqual(collected_metrics[extn_name]["cpu"]["cur_cpu"][i], 0)
-            # Equal because CPU could be zero for minimum value.
+                for i in range(5):
+                    self.assertGreater(collected_metrics[extn_name]["memory"]["cur_mem"][i], 0)
+                    self.assertGreater(collected_metrics[extn_name]["memory"]["max_mem"][i], 0)
+                    self.assertGreaterEqual(collected_metrics[extn_name]["cpu"]["cur_cpu"][i], 0)
+                    # Equal because CPU could be zero for minimum value.
+            finally:
+                CGroupConfigurator._instance = cgroup_configurator_instance
 
 
 class TestMetric(AgentTestCase):


### PR DESCRIPTION
* Replacing run_get_output with run_command (errors were being ignored, since run_get_output does not throw)
* The new logic to detect systemd uses the same check as systemd itself (e.g. systemd-run).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/walinuxagent/1677)
<!-- Reviewable:end -->
