### PR TITLE
Don't log error on retryable mount attempt

### DIFF
--- a/azurelinuxagent/daemon/resourcedisk/default.py
+++ b/azurelinuxagent/daemon/resourcedisk/default.py
@@ -195,7 +195,7 @@ class ResourceDiskHandler(object):
 
             self.reread_partition_table(device)
 
-            ret, output = shellutil.run_get_output(mount_string)
+            ret, output = shellutil.run_get_output(mount_string, chk_err=False)
             if ret:
                 logger.warn("Failed to mount resource disk. "
                             "Attempting to format and retry mount. [{0}]",


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

If there is a retryable mount error then we shouldn't be logging the error. The only time `mount` should log an error is on the final attempt at mounting, where we would consider it a failure event on a non-zero exit status.

---

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [x] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/walinuxagent/1685)
<!-- Reviewable:end -->
