### PR TITLE
Remove upgrade extension loop for the same goal state

### DIFF
--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -817,7 +817,6 @@ class ExtHandlerInstance(object):
     def set_operation(self, op):
         self.operation = op
 
-
     def report_event(self, message="", is_success=True, duration=0, log_event=True):
         ext_handler_version = self.ext_handler.properties.version
         add_event(name=self.ext_handler.name, version=ext_handler_version, message=message,

--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -428,7 +428,7 @@ class ExtHandlersHandler(object):
                 return
 
             self.get_artifact_error_state.reset()
-            if not ext_handler_i.is_upgrade and self.last_etag == etag:
+            if self.last_etag == etag:
                 if self.log_etag:
                     ext_handler_i.logger.verbose("Version {0} is current for etag {1}",
                                                  ext_handler_i.pkg.version,
@@ -684,7 +684,6 @@ class ExtHandlerInstance(object):
         self.operation = None
         self.pkg = None
         self.pkg_file = None
-        self.is_upgrade = False
         self.logger = None
         self.set_logger()
 
@@ -744,12 +743,6 @@ class ExtHandlerInstance(object):
             self.pkg = selected_pkg
             if self.pkg is not None:
                 self.ext_handler.properties.version = str(selected_pkg.version)
-
-        # Note if the selected package is different than that installed
-        if installed_pkg is None \
-                or (
-                self.pkg is not None and FlexibleVersion(self.pkg.version) != FlexibleVersion(installed_pkg.version)):
-            self.is_upgrade = True
 
         if self.pkg is not None:
             self.logger.verbose("Use version: {0}", self.pkg.version)

--- a/tests/ga/test_extension.py
+++ b/tests/ga/test_extension.py
@@ -1481,45 +1481,22 @@ class TestExtension(ExtensionTestCase):
         test_data, exthandlers_handler, protocol = self._set_up_update_test_and_update_gs(patch_get_disable_command,
                                                                                           *args)
 
-        exthandlers_handler.run()  # Download the new update the first time, and then we patch the download method.
-
-        with patch('azurelinuxagent.common.protocol.restapi.Protocol.download_ext_handler_pkg') as patch_download:
-            loop_run = 5
-            for x in range(loop_run):
-                exthandlers_handler.run()
-
-            self.assertEqual(loop_run + 1, patch_get_disable_command.call_count)  # counting the earlier run done to
-            # download the new update
-            self.assertEqual(0, patch_download.call_count)  # The download should never be called.
-
-        # On the next iteration, update should not be retried
-        self._assert_handler_status(protocol.report_vm_status, "NotReady", expected_ext_count=0, version="1.0.1")
-
-    @patch('azurelinuxagent.ga.exthandlers.HandlerManifest.get_disable_command')
-    def test__extension_upgrade_failure_when_prev_version_disable_fails_and_recovers(self, patch_get_disable_command,
-                                                                                     *args):
-        test_data, exthandlers_handler, protocol = self._set_up_update_test_and_update_gs(patch_get_disable_command,
-                                                                                          *args)
-
-        exthandlers_handler.run()  # Download the new update the first time, and then we patch the download method.
-        self.assertEqual(1, patch_get_disable_command.call_count)
-
-        with patch('azurelinuxagent.ga.exthandlers.ExtHandlerInstance.launch_command') as patch_launch_command:
+        with patch('azurelinuxagent.ga.exthandlers.HandlerManifest.get_enable_command') as patch_get_enable_command:
             exthandlers_handler.run()
 
-        self.assertEqual(2, patch_get_disable_command.call_count)  # counting the earlier run done.
+            # When the previous version's disable fails, we expect the upgrade scenario to fail, so the enable
+            # for the new version is not called and the new version handler's status is reported as not ready.
+            self.assertEqual(1, patch_get_disable_command.call_count)
+            self.assertEqual(0, patch_get_enable_command.call_count)
+            self._assert_handler_status(protocol.report_vm_status, "NotReady", expected_ext_count=0, version="1.0.1")
 
-        with patch('azurelinuxagent.common.protocol.restapi.Protocol.download_ext_handler_pkg') as patch_download:
+            # Ensure we are processing the same goal state only once
             loop_run = 5
             for x in range(loop_run):
                 exthandlers_handler.run()
 
-            self.assertEqual(0, patch_download.call_count)  # The download should never be called.
-
-        self.assertEqual(2, patch_get_disable_command.call_count)  # Disable is not called again after it recovered
-
-        # The update recovered, and thus should be "Ready" now.
-        self._assert_handler_status(protocol.report_vm_status, "Ready", expected_ext_count=1, version="1.0.1")
+            self.assertEqual(1, patch_get_disable_command.call_count)
+            self.assertEqual(0, patch_get_enable_command.call_count)
 
     @patch('azurelinuxagent.ga.exthandlers.HandlerManifest.get_disable_command')
     def test__extension_upgrade_failure_when_prev_version_disable_fails_incorrect_zip(self, patch_get_disable_command,
@@ -1527,26 +1504,27 @@ class TestExtension(ExtensionTestCase):
         test_data, exthandlers_handler, protocol = self._set_up_update_test_and_update_gs(patch_get_disable_command,
                                                                                           *args)
 
-        with patch("time.sleep"):  # the download logic has retry logic that sleeps before each try - make sleep a no-op.
+        # The download logic has retry logic that sleeps before each try - make sleep a no-op.
+        with patch("time.sleep"):
             with patch("zipfile.ZipFile.extractall") as patch_zipfile_extractall:
-                patch_zipfile_extractall.side_effect = raise_ioerror
-                exthandlers_handler.run()  # Check if the zipfile was corrupt and re-download again in the next run.
+                with patch(
+                        'azurelinuxagent.ga.exthandlers.HandlerManifest.get_enable_command') as patch_get_enable_command:
+                    patch_zipfile_extractall.side_effect = raise_ioerror
+                    # The zipfile was corrupt and the upgrade sequence failed
+                    exthandlers_handler.run()
 
-        # Disable of the old extn fails
-        patch_get_disable_command.return_value = "exit 1"
-        exthandlers_handler.run()  # Download the new update the correctly, and then we patch the download method.
+                    # We never called the disable of the old version due to the failure when unzipping the new version,
+                    # nor the enable of the new version
+                    self.assertEqual(0, patch_get_disable_command.call_count)
+                    self.assertEqual(0, patch_get_enable_command.call_count)
 
-        with patch('azurelinuxagent.common.protocol.restapi.Protocol.download_ext_handler_pkg') as patch_download:
-            loop_run = 5
-            for x in range(loop_run):
-                exthandlers_handler.run()
+                    # Ensure we are processing the same goal state only once
+                    loop_run = 5
+                    for x in range(loop_run):
+                        exthandlers_handler.run()
 
-            # failed to download earlier, thus doesn't need to add +1, like in the earlier test case
-            self.assertEqual(loop_run + 1, patch_get_disable_command.call_count)
-            self.assertEqual(0, patch_download.call_count)  # The download should never be called.
-
-        # On the next iteration, update should not be retried
-        self._assert_handler_status(protocol.report_vm_status, "NotReady", expected_ext_count=0, version="1.0.1")
+                    self.assertEqual(0, patch_get_disable_command.call_count)
+                    self.assertEqual(0, patch_get_enable_command.call_count)
 
     @patch('azurelinuxagent.ga.exthandlers.HandlerManifest.get_disable_command')
     def test__old_handler_reports_failure_on_disable_fail_on_update(self, patch_get_disable_command, *args):


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Currently, if we're upgrading an extension and the upgrade fails, we will retry the entire upgrade sequence every three seconds. This is triggered in the main loop of the extension handler thread. 

Unfortunately, when one of the commands in the upgrade sequence keeps failing (e.g. the old extension's disable command) we are stuck in a never-ending loop of trying to upgrade the extension and failing.

This PR removes the retry logic for the upgrade scenario, meaning we will treat it as any other operation -- if the operation was already processed (either successfully or unsuccessfully) for the same goal state (same incarnation number), we will not process it again.


<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/walinuxagent/1686)
<!-- Reviewable:end -->
