### PR TITLE
Add container id for extension telemetry events

### DIFF
--- a/azurelinuxagent/common/event.py
+++ b/azurelinuxagent/common/event.py
@@ -39,6 +39,7 @@ TELEMETRY_EVENT_PROVIDER_ID = "69B669B9-4AF8-4C50-BDC4-6006FA76E975"
 # Store the last retrieved container id as an environment variable to be shared between threads for telemetry purposes
 CONTAINER_ID_ENV_VARIABLE = "AZURE_GUEST_AGENT_CONTAINER_ID"
 
+
 class WALAEventOperation:
     ActivateResourceDisk = "ActivateResourceDisk"
     AgentBlacklisted = "AgentBlacklisted"

--- a/azurelinuxagent/common/telemetryevent.py
+++ b/azurelinuxagent/common/telemetryevent.py
@@ -25,6 +25,9 @@ class TelemetryEventParam(DataContract):
         self.name = name
         self.value = value
 
+    def __eq__(self, other):
+        return isinstance(other, TelemetryEventParam) and other.name == self.name and other.value == self.value
+
 
 class TelemetryEvent(DataContract):
     def __init__(self, eventId=None, providerId=None):

--- a/azurelinuxagent/ga/monitor.py
+++ b/azurelinuxagent/ga/monitor.py
@@ -230,7 +230,7 @@ class MonitorHandler(object):
         Periodically read, parse, and send events located in the events folder. Currently, this is done every minute.
         Any .tld file dropped in the events folder will be emitted. These event files can be created either by the
         agent or the extensions. We don't have control over extension's events parameters, but we will override
-        any values they might have set for sys_info parameters:
+        any values they might have set for sys_info parameters.
         """
         if self.last_event_collection is None:
             self.last_event_collection = datetime.datetime.utcnow() - MonitorHandler.EVENT_COLLECTION_PERIOD
@@ -310,7 +310,7 @@ class MonitorHandler(object):
         This method is called after parsing the event file in the events folder and before emitting it. This means
         all events, either coming from the agent or from the extensions, are passed through this method. The purpose
         is to add a static list of sys_info parameters such as VMName, Region, RAM, etc. If the sys_info parameters
-        are already populated in the event, they are not overwritten.
+        are already populated in the event, they will be overwritten by the sys_info values obtained from the agent.
         Since the ContainerId parameter is only populated on the fly for the agent events because it is not a static
         sys_info parameter, an event coming from an extension will not have it, so we explicitly add it.
         :param event: Event to be enriched with sys_info parameters

--- a/azurelinuxagent/ga/monitor.py
+++ b/azurelinuxagent/ga/monitor.py
@@ -29,7 +29,7 @@ import azurelinuxagent.common.utils.networkutil as networkutil
 
 from azurelinuxagent.common.cgroupstelemetry import CGroupsTelemetry
 from azurelinuxagent.common.errorstate import ErrorState
-from azurelinuxagent.common.event import add_event, WALAEventOperation
+from azurelinuxagent.common.event import add_event, WALAEventOperation, CONTAINER_ID_ENV_VARIABLE
 from azurelinuxagent.common.exception import EventError, ProtocolError, OSUtilError, HttpError
 from azurelinuxagent.common.future import ustr
 from azurelinuxagent.common.osutil import get_osutil
@@ -226,6 +226,12 @@ class MonitorHandler(object):
             raise EventError(msg)
 
     def collect_and_send_events(self):
+        """
+        Periodically read, parse, and send events located in the events folder. Currently, this is done every minute.
+        Any .tld file dropped in the events folder will be emitted. These event files can be created either by the
+        agent or the extensions. We don't have control over extension's events parameters, but we will override
+        any values they might have set for sys_info parameters:
+        """
         if self.last_event_collection is None:
             self.last_event_collection = datetime.datetime.utcnow() - MonitorHandler.EVENT_COLLECTION_PERIOD
 
@@ -300,15 +306,35 @@ class MonitorHandler(object):
                 self.last_reset_loggers_time = time_now
 
     def add_sysinfo(self, event):
+        """
+        This method is called after parsing the event file in the events folder and before emitting it. This means
+        all events, either coming from the agent or from the extensions, are passed through this method. The purpose
+        is to add a static list of sys_info parameters such as VMName, Region, RAM, etc. If the sys_info parameters
+        are already populated in the event, they are not overwritten.
+        Since the ContainerId parameter is only populated on the fly for the agent events because it is not a static
+        sys_info parameter, an event coming from an extension will not have it, so we explicitly add it.
+        :param event: Event to be enriched with sys_info parameters
+        :return: Event with all parameters added, ready to be reported
+        """
         sysinfo_names = [v.name for v in self.sysinfo]
-        copy_param = []
+        final_parameters = []
 
         for param in event.parameters:
-            if param.name not in sysinfo_names:
-                copy_param.append(param)
+            # Discard any sys_info parameters already in the event, since they will be overwritten
+            if param.name in sysinfo_names:
+                continue
 
-        copy_param.extend(self.sysinfo)
-        event.parameters = copy_param
+            final_parameters.append(param)
+
+        # Add sys_info params populated by the agent
+        final_parameters.extend(self.sysinfo)
+
+        # Container id is populated for agent events on the fly, but not for extension events. Add it if it's missing.
+        if "ContainerId" not in [param.name for param in event.parameters]:
+            final_parameters.append(
+                TelemetryEventParam("ContainerId", os.environ.get(CONTAINER_ID_ENV_VARIABLE, "UNINITIALIZED")))
+
+        event.parameters = final_parameters
 
     def send_imds_heartbeat(self):
         """

--- a/tests/data/ext/dsc_event.json
+++ b/tests/data/ext/dsc_event.json
@@ -1,0 +1,38 @@
+{
+   "eventId":"1",
+   "parameters":[
+      {
+         "name":"Name",
+         "value":"Microsoft.Azure.GuestConfiguration.DSCAgent"
+      },
+      {
+         "name":"Version",
+         "value":"1.18.0"
+      },
+      {
+         "name":"IsInternal",
+         "value":true
+      },
+      {
+         "name":"Operation",
+         "value":"GuestConfigAgent.Scenario"
+      },
+      {
+         "name":"OperationSuccess",
+         "value":true
+      },
+      {
+         "name":"Message",
+         "value":"<DSCLOG>[2019-11-05 10:06:52.688] [PID 11487] [TID 11513] [Timer Manager] [INFO] [89f9cf47-c02d-4774-b21a-abdf2beb3cd9] Run pull refresh for timer 'dsc_refresh_timer'</DSCLOG>\n"
+      },
+      {
+         "name":"Duration",
+         "value":0
+      },
+      {
+         "name":"ExtentionType",
+         "value":""
+      }
+   ],
+   "providerId":"69B669B9-4AF8-4C50-BDC4-6006FA76E975"
+}

--- a/tests/data/ext/event.json
+++ b/tests/data/ext/event.json
@@ -1,0 +1,38 @@
+{
+   "eventId":1,
+   "providerId":"69B669B9-4AF8-4C50-BDC4-6006FA76E975",
+   "parameters":[
+      {
+         "name":"Name",
+         "value":"CustomScript"
+      },
+      {
+         "name":"Version",
+         "value":"1.4.1.0"
+      },
+      {
+         "name":"IsInternal",
+         "value":false
+      },
+      {
+         "name":"Operation",
+         "value":"RunScript"
+      },
+      {
+         "name":"OperationSuccess",
+         "value":true
+      },
+      {
+         "name":"Message",
+         "value":"(01302)Script is finished.&#10;---stdout---&#10;hello&#10;&#10;---errout---&#10;&#10;"
+      },
+      {
+         "name":"Duration",
+         "value":0
+      },
+      {
+         "name":"ExtensionType",
+         "value":""
+      }
+   ]
+}

--- a/tests/data/ext/event.xml
+++ b/tests/data/ext/event.xml
@@ -1,1 +1,24 @@
-<Data><Provider id="69B669B9-4AF8-4C50-BDC4-6006FA76E975"/><Event id="1"/><Param Name="OperationSuccess" Value="True" T="mt:bool" /><Param Name="Processors" Value="0" T="mt:uint64" /><Param Name="OpcodeName" Value="" T="mt:wstr" /><Param Name="Version" Value="1.4.1.0" T="mt:wstr" /><Param Name="RoleName" Value="" T="mt:wstr" /><Param Name="IsInternal" Value="False" T="mt:bool" /><Param Name="RAM" Value="0" T="mt:uint64" /><Param Name="ExecutionMode" Value="IAAS" T="mt:wstr" /><Param Name="RoleInstanceName" Value="" T="mt:wstr" /><Param Name="Name" Value="CustomScript" T="mt:wstr" /><Param Name="Message" Value="(01302)Script is finished.&#10;---stdout---&#10;hello&#10;&#10;---errout---&#10;&#10;" T="mt:wstr" /><Param Name="KeywordName" Value="" T="mt:wstr" /><Param Name="TaskName" Value="" T="mt:wstr" /><Param Name="OSVersion" Value="" T="mt:wstr" /><Param Name="Operation" Value="RunScript" T="mt:wstr" /><Param Name="ContainerId" Value="" T="mt:wstr" /><Param Name="GAVersion" Value="" T="mt:wstr" /><Param Name="TenantName" Value="" T="mt:wstr" /><Param Name="Duration" Value="0" T="mt:uint64" /><Param Name="ExtensionType" Value="" T="mt:wstr" /></Data>
+<Data>
+    <Provider id="69B669B9-4AF8-4C50-BDC4-6006FA76E975"/>
+    <Event id="1"/>
+    <Param Name="OperationSuccess" Value="True" T="mt:bool"/>
+    <Param Name="Processors" Value="0" T="mt:uint64"/>
+    <Param Name="OpcodeName" Value="" T="mt:wstr"/>
+    <Param Name="Version" Value="1.4.1.0" T="mt:wstr"/>
+    <Param Name="RoleName" Value="" T="mt:wstr"/>
+    <Param Name="IsInternal" Value="False" T="mt:bool"/>
+    <Param Name="RAM" Value="0" T="mt:uint64"/>
+    <Param Name="ExecutionMode" Value="IAAS" T="mt:wstr"/>
+    <Param Name="RoleInstanceName" Value="" T="mt:wstr"/>
+    <Param Name="Name" Value="CustomScript" T="mt:wstr"/>
+    <Param Name="Message" Value="(01302)Script is finished.&#10;---stdout---&#10;hello&#10;&#10;---errout---&#10;&#10;"
+           T="mt:wstr"/>
+    <Param Name="KeywordName" Value="" T="mt:wstr"/>
+    <Param Name="TaskName" Value="" T="mt:wstr"/>
+    <Param Name="OSVersion" Value="" T="mt:wstr"/>
+    <Param Name="Operation" Value="RunScript" T="mt:wstr"/>
+    <Param Name="GAVersion" Value="" T="mt:wstr"/>
+    <Param Name="TenantName" Value="" T="mt:wstr"/>
+    <Param Name="Duration" Value="0" T="mt:uint64"/>
+    <Param Name="ExtensionType" Value="" T="mt:wstr"/>
+</Data>


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

PR #1628 introduced the logic of populating `ContainerId` values for telemetry event parameters on the fly, as the events were getting created, instead of once per service startup in `init_sysinfo`. 

The same telemetry pipeline is used by extension events too. Those events are dropped by extensions in the events folder, where the agent picks them up, parses them, adds sysinfo parameters and emits them. However, by having moved the `ContainerId` generation logic away from `init_sysinfo`, which was called for any event generated, now the `ContainerId` parameter is never generated for extension events.

This PR adds the `ContainerId` value from the designated environment variable, if the parameter is not already present, when adding the rest of sysinfo parameters and just before reporting the event, ensuring all emitted events have a `ContainerId` set.

<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/walinuxagent/1696)
<!-- Reviewable:end -->
