### PR TITLE
Disable should reset tracked cgroups

### DIFF
--- a/azurelinuxagent/common/cgroupconfigurator.py
+++ b/azurelinuxagent/common/cgroupconfigurator.py
@@ -78,6 +78,7 @@ class CGroupConfigurator(object):
 
         def disable(self):
             self._enabled = False
+            CGroupsTelemetry.reset()
 
         def _invoke_cgroup_operation(self, operation, error_message, on_error=None):
             """
@@ -119,7 +120,6 @@ class CGroupConfigurator(object):
 
             def disable_cgroups(exception):
                 self.disable()
-                CGroupsTelemetry.reset()
                 add_event(
                     AGENT_NAME,
                     version=CURRENT_VERSION,

--- a/tests/common/test_cgroupconfigurator.py
+++ b/tests/common/test_cgroupconfigurator.py
@@ -103,6 +103,18 @@ class CGroupConfiguratorTestCase(AgentTestCase):
                 CGroupConfigurator.get_instance().enable()
             self.assertIn("cgroups are not supported", str(context_manager.exception))
 
+    def test_disable_should_reset_tracked_cgroups(self):
+        configurator = CGroupConfigurator.get_instance()
+
+        # Start tracking a couple of dummy cgroups
+        CGroupsTelemetry.track_cgroup(CGroup("dummy", "/sys/fs/cgroup/memory/system.slice/dummy.service", "cpu"))
+        CGroupsTelemetry.track_cgroup(CGroup("dummy", "/sys/fs/cgroup/memory/system.slice/dummy.service", "memory"))
+
+        configurator.disable()
+
+        self.assertFalse(configurator.enabled())
+        self.assertEquals(len(CGroupsTelemetry._tracked), 0)
+
     def test_cgroup_operations_should_not_invoke_the_cgroup_api_when_cgroups_are_not_enabled(self):
         configurator = CGroupConfigurator.get_instance()
         configurator.disable()


### PR DESCRIPTION
Resetting the tracked cgroups should have been done in disable()

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/walinuxagent/1697)
<!-- Reviewable:end -->
