### PR TITLE
Set message for cgroup exceptions

### DIFF
--- a/azurelinuxagent/common/exception.py
+++ b/azurelinuxagent/common/exception.py
@@ -52,14 +52,9 @@ class AgentNetworkError(AgentError):
 
 
 class CGroupsException(AgentError):
+    def __init__(self, msg=None, inner=None):
+        super(CGroupsException, self).__init__(msg, inner)
 
-    def __init__(self, msg, inner=None):
-        super(AgentError, self).__init__(msg, inner)
-        # TODO: AgentError should set the message - investigate whether doing it there would break anything
-        self.message = msg
-
-    def __str__(self):
-        return self.message
 
 class ExtensionError(AgentError):
     """

--- a/tests/common/test_cgroupapi.py
+++ b/tests/common/test_cgroupapi.py
@@ -634,7 +634,7 @@ class SystemdCgroupsApiMockedFileSystemTestCase(_MockedFileSystemTestCase):
                 with self.assertRaises(CGroupsException) as context_manager:
                     SystemdCgroupsApi().cleanup_legacy_cgroups()
 
-        self.assertEquals(context_manager.exception.message, "The daemon's PID ({0}) was already added to the legacy cgroup; this invalidates resource usage data.".format(daemon_pid))
+        self.assertEquals(context_manager.exception.message, "[CGroupsException] The daemon's PID ({0}) was already added to the legacy cgroup; this invalidates resource usage data.".format(daemon_pid))
 
         # The method should have deleted the legacy cgroups
         self.assertFalse(os.path.exists(legacy_cpu_cgroup))

--- a/tests/common/test_cgroupapi.py
+++ b/tests/common/test_cgroupapi.py
@@ -634,7 +634,7 @@ class SystemdCgroupsApiMockedFileSystemTestCase(_MockedFileSystemTestCase):
                 with self.assertRaises(CGroupsException) as context_manager:
                     SystemdCgroupsApi().cleanup_legacy_cgroups()
 
-        self.assertEquals(context_manager.exception.message, "[CGroupsException] The daemon's PID ({0}) was already added to the legacy cgroup; this invalidates resource usage data.".format(daemon_pid))
+        self.assertEquals(str(context_manager.exception), "[CGroupsException] The daemon's PID ({0}) was already added to the legacy cgroup; this invalidates resource usage data.".format(daemon_pid))
 
         # The method should have deleted the legacy cgroups
         self.assertFalse(os.path.exists(legacy_cpu_cgroup))

--- a/tests/common/test_cgroupconfigurator.py
+++ b/tests/common/test_cgroupconfigurator.py
@@ -289,7 +289,7 @@ class CGroupConfiguratorTestCase(AgentTestCase):
         self.assertFalse(kwargs['is_success'])
         self.assertEquals(
             kwargs['message'],
-            "Failed to process legacy cgroups. Collection of resource usage data will be disabled. The daemon's PID ({0}) was already added to the legacy cgroup; this invalidates resource usage data.".format(daemon_pid))
+            "Failed to process legacy cgroups. Collection of resource usage data will be disabled. [CGroupsException] The daemon's PID ({0}) was already added to the legacy cgroup; this invalidates resource usage data.".format(daemon_pid))
 
         self.assertFalse(cgroup_configurator.enabled())
         self.assertEquals(len(CGroupsTelemetry._tracked), 0)

--- a/tests/common/test_exception.py
+++ b/tests/common/test_exception.py
@@ -1,0 +1,44 @@
+# Copyright 2019 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Requires Python 2.6+ and Openssl 1.0+
+#
+
+import sys, inspect
+from azurelinuxagent.common.exception import AgentError
+from tests.tools import *
+
+
+class TestAgentError(AgentTestCase):
+    @classmethod
+    def setUpClass(cls):
+        AgentTestCase.setUpClass()
+
+        cls.agent_exceptions = inspect.getmembers(
+            sys.modules["azurelinuxagent.common.exception"],
+            lambda member: inspect.isclass(member) and issubclass(member, AgentError))
+
+    def test_agent_exceptions_should_set_their_error_message(self):
+        for exception_name, exception_class in TestAgentError.agent_exceptions:
+            exception_instance = exception_class("A test Message")
+
+            self.assertEqual(exception_instance.message, "[{0}] A test Message".format(exception_name))
+
+    def test_agent_exceptions_should_include_the_inner_exception_in_their_error_message(self):
+        inner_exception = Exception("The inner exception")
+
+        for exception_name, exception_class in TestAgentError.agent_exceptions:
+            exception_instance = exception_class("A test Message", inner_exception)
+
+            self.assertEqual(exception_instance.message, "[{0}] A test Message\nInner error: The inner exception".format(exception_name))

--- a/tests/common/test_exception.py
+++ b/tests/common/test_exception.py
@@ -33,7 +33,7 @@ class TestAgentError(AgentTestCase):
         for exception_name, exception_class in TestAgentError.agent_exceptions:
             exception_instance = exception_class("A test Message")
 
-            self.assertEqual(exception_instance.message, "[{0}] A test Message".format(exception_name))
+            self.assertEqual(str(exception_instance), "[{0}] A test Message".format(exception_name))
 
     def test_agent_exceptions_should_include_the_inner_exception_in_their_error_message(self):
         inner_exception = Exception("The inner exception")
@@ -41,4 +41,4 @@ class TestAgentError(AgentTestCase):
         for exception_name, exception_class in TestAgentError.agent_exceptions:
             exception_instance = exception_class("A test Message", inner_exception)
 
-            self.assertEqual(exception_instance.message, "[{0}] A test Message\nInner error: The inner exception".format(exception_name))
+            self.assertEqual(str(exception_instance), "[{0}] A test Message\nInner error: The inner exception".format(exception_name))

--- a/tests/common/test_exception.py
+++ b/tests/common/test_exception.py
@@ -17,7 +17,7 @@
 
 import sys, inspect
 from azurelinuxagent.common.exception import AgentError
-from tests.tools import *
+from tests.tools import AgentTestCase
 
 
 class TestAgentError(AgentTestCase):


### PR DESCRIPTION
While working on #1688 I realized the message was not set correctly for CGroupsException, but I could not figure out why so I added a temporary workaround.

Turns out the problem was that CGroupsException was invoking super with AgentError instead of itself. This PR undoes the workaround, fixes the original issue, and adds unit tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/walinuxagent/1700)
<!-- Reviewable:end -->
