### PR TITLE
Fix issue with GPT disk mounting with guessing filesystem type

### DIFF
--- a/azurelinuxagent/daemon/resourcedisk/default.py
+++ b/azurelinuxagent/daemon/resourcedisk/default.py
@@ -249,14 +249,20 @@ class ResourceDiskHandler(object):
 
         return err_code, output
 
-    @staticmethod
-    def get_mount_string(mount_options, partition, mount_point):
+    def get_mount_string(self, mount_options, partition, mount_point):
         if mount_options is not None:
-            return 'mount -o {0} {1} {2}'.format(mount_options,
-                                                 partition,
-                                                 mount_point)
+            return 'mount -t {0} -o {1} {2} {3}'.format(
+                self.fs,
+                mount_options,
+                partition,
+                mount_point
+            )
         else:
-            return 'mount {0} {1}'.format(partition, mount_point)
+            return 'mount -t {0} {1} {2}'.format(
+                self.fs,
+                partition,
+                mount_point
+            )
 
     @staticmethod
     def check_existing_swap_file(swapfile, swaplist, size):

--- a/tests/daemon/test_resourcedisk.py
+++ b/tests/daemon/test_resourcedisk.py
@@ -25,7 +25,7 @@ class TestResourceDisk(AgentTestCase):
         partition = '/dev/sdb1'
         mountpoint = '/mnt/resource'
         options = None
-        expected = 'mount /dev/sdb1 /mnt/resource'
+        expected = 'mount -t ext3 /dev/sdb1 /mnt/resource'
         rdh = ResourceDiskHandler()
         mount_string = rdh.get_mount_string(options, partition, mountpoint)
         self.assertEqual(expected, mount_string)
@@ -34,7 +34,7 @@ class TestResourceDisk(AgentTestCase):
         partition = '/dev/sdb1'
         mountpoint = '/mnt/resource'
         options = 'noexec,noguid,nodev'
-        expected = 'mount -o noexec,noguid,nodev /dev/sdb1 /mnt/resource'
+        expected = 'mount -t ext3 -o noexec,noguid,nodev /dev/sdb1 /mnt/resource'
         rdh = ResourceDiskHandler()
         mount_string = rdh.get_mount_string(options, partition, mountpoint)
         self.assertEqual(expected, mount_string)


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

When we activate the resource disk, if the resource disk is a GPT disk with a single partition then we will try to mount the disk without formatting it. Because the resource disks are originally ntfs filesystem, if the machine has the ntfs driver then it will mount with that filesystem, completely disregarding the configuration `ResourceDisk.Filesystem`.

The fix is to explicitly specify the filesystem type with `-t` and passing in the configuration value so that we ensure that the user gets the resource disk in the desired filesystem. This should not be an ntfs-first approach.

// @anhvoms 

---

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [x] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/walinuxagent/1706)
<!-- Reviewable:end -->
