### PR TITLE
added newsyslog rules for FreeBSD

### DIFF
--- a/config/freebsd/newsyslog/waagent.conf
+++ b/config/freebsd/newsyslog/waagent.conf
@@ -1,0 +1,1 @@
+/var/log/waagent.log			644  7	   *	@T00  J     /var/run/waagent.pid

--- a/setup.py
+++ b/setup.py
@@ -150,6 +150,8 @@ def get_data_files(name, version, fullname):
     elif name == 'freebsd':
         set_bin_files(data_files, dest="/usr/local/sbin")
         set_conf_files(data_files, src=["config/freebsd/waagent.conf"])
+        set_logrotate_files(data_files, dest="/etc/newsyslog.conf.d",
+                            src=["config/freebsd/newsyslog/waagent.conf"])
         set_freebsd_rc_files(data_files)
     elif name == 'openbsd':
         set_bin_files(data_files, dest="/usr/local/sbin")


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

waagent logs to /var/log/waagent.log. On FreeBSD, this logfile happens to grow. In contrast to Linux, there is no logrotate. Instead, every FreeBSD installation comes with newsyslog, which is similar to logrotate. The configuration of newsyslog is modular, i.e. the main configuration file /etc/newsyslog.conf also reads every file in the directory /etc/newsyslog.conf.d. My patch places a newsyslog config file for waagent in /etc/newsyslog.conf.d, which rotates the log file every midnight, and keeps up to 7 historical, compressed logfiles. setup.py was modified to copy over this configuration file on FreeBSD.

---

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [x] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).