### PR TITLE
Remove marking the extension as Failed

### DIFF
--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -203,7 +203,6 @@ class ExtHandlerState(object):
     NotInstalled = "NotInstalled"
     Installed = "Installed"
     Enabled = "Enabled"
-    Failed = "Failed"
 
 
 def get_exthandlers_handler():
@@ -1023,19 +1022,14 @@ class ExtHandlerInstance(object):
         env = {'VERSION': version, ExtCommandEnvVariable.DisableReturnCode: disable_exit_code,
                ExtCommandEnvVariable.UpdatingFromVersion: updating_from_version}
 
-        try:
-            self.set_operation(WALAEventOperation.Update)
-            man = self.load_manifest()
-            update_cmd = man.get_update_command()
-            self.logger.info("Update extension [{0}]".format(update_cmd))
-            self.launch_command(update_cmd,
-                                timeout=900,
-                                extension_error_code=ExtensionErrorCodes.PluginUpdateProcessingFailed,
-                                env=env)
-        except ExtensionError:
-            # prevent the handler update from being retried
-            self.set_handler_state(ExtHandlerState.Failed)
-            raise
+        self.set_operation(WALAEventOperation.Update)
+        man = self.load_manifest()
+        update_cmd = man.get_update_command()
+        self.logger.info("Update extension [{0}]".format(update_cmd))
+        self.launch_command(update_cmd,
+                            timeout=900,
+                            extension_error_code=ExtensionErrorCodes.PluginUpdateProcessingFailed,
+                            env=env)
 
     def update_with_install(self, uninstall_exit_code=None):
         man = self.load_manifest()


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Today, during an extension upgrade, if the update command of the new extension fails, the new extension will be marked as Failed. This is the only usage of that extension handler state.

However, this means that, when a new goal state comes in, since the new extension is marked as Failed, agent will try to call enable on the new extension, skipping update, because the extension handler's state is not equal to [NotInstalled](https://github.com/Azure/WALinuxAgent/blob/develop/azurelinuxagent/ga/exthandlers.py#L487).

This PR ensures that the entire upgrade scenario is called even if the previous goal state resulted in a failed update step. This is done by removing the Failed state as an option and, as a result, when the update command fails, the new extension will be removed, so when the new goal state comes in, it will be treated as a new - not previously installed - extension and the entire upgrade scenario will be exercised.

<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/walinuxagent/1726)
<!-- Reviewable:end -->
