### PR TITLE
Fix upgrade sequence when update command fails

### DIFF
--- a/tests/ga/test_extension.py
+++ b/tests/ga/test_extension.py
@@ -1487,9 +1487,10 @@ class TestExtension(ExtensionTestCase):
 
         with patch('azurelinuxagent.common.cgroupapi.subprocess.Popen', side_effect=mock_popen):
             exthandlers_handler.run()
-            update_command_count = len(filter(lambda call: patch_get_update_command.return_value in call,
-                                               extension_calls))
-            enable_command_count = len(filter(lambda call: "-enable" in call, extension_calls))
+            update_command_count = len([extension_call for extension_call in extension_calls
+                                        if patch_get_update_command.return_value in extension_call])
+            enable_command_count = len([extension_call for extension_call in extension_calls
+                                        if "-enable" in extension_call])
             
             self.assertEquals(1, update_command_count)
             self.assertEquals(0, enable_command_count)
@@ -1502,9 +1503,10 @@ class TestExtension(ExtensionTestCase):
             for x in range(loop_run):
                 exthandlers_handler.run()
 
-            update_command_count = len(filter(lambda call: patch_get_update_command.return_value in call,
-                                              extension_calls))
-            enable_command_count = len(filter(lambda call: "-enable" in call, extension_calls))
+            update_command_count = len([extension_call for extension_call in extension_calls
+                                        if patch_get_update_command.return_value in extension_call])
+            enable_command_count = len([extension_call for extension_call in extension_calls
+                                        if "-enable" in extension_call])
             self.assertEquals(1, update_command_count)
             self.assertEquals(0, enable_command_count)
 
@@ -1513,9 +1515,10 @@ class TestExtension(ExtensionTestCase):
             test_data.goal_state = test_data.goal_state.replace("<Incarnation>2<", "<Incarnation>3<")
             exthandlers_handler.run()
 
-            update_command_count = len(filter(lambda call: patch_get_update_command.return_value in call,
-                                              extension_calls))
-            enable_command_count = len(filter(lambda call: "-enable" in call, extension_calls))
+            update_command_count = len([extension_call for extension_call in extension_calls
+                                        if patch_get_update_command.return_value in extension_call])
+            enable_command_count = len([extension_call for extension_call in extension_calls
+                                        if "-enable" in extension_call])
             self.assertEquals(2, update_command_count)
             self.assertEquals(0, enable_command_count)
 

--- a/tests/ga/test_extension.py
+++ b/tests/ga/test_extension.py
@@ -1464,24 +1464,45 @@ class TestExtension(ExtensionTestCase):
         self._assert_no_handler_status(protocol.report_vm_status)
 
     @patch('azurelinuxagent.ga.exthandlers.HandlerManifest.get_update_command')
-    def test_upgrade_failure(self, patch_get_update_command, *args):
+    def test_extension_upgrade_failure_when_new_version_update_fails(self, patch_get_update_command, *args):
         """
-        Extension upgrade failure should not be retried
+        When the update command of the new extension fails, it should result in the new extension removed and the
+        old extension disabled. On the next goal state, the entire upgrade scenario should be retried (once),
+        meaning the download, initialize and update are called on the new extension.
+        Note: we don't re-download the zip since it wasn't cleaned up in the previous goal state (we only clean up
+        NotInstalled handlers), so we just re-use the existing zip.
         """
         test_data, exthandlers_handler, protocol = self._set_up_update_test_and_update_gs(patch_get_update_command,
                                                                                           *args)
 
-        exthandlers_handler.run()
-        self.assertEqual(1, patch_get_update_command.call_count)
+        with patch('azurelinuxagent.ga.exthandlers.HandlerManifest.get_enable_command') as patch_get_enable_command:
+            exthandlers_handler.run()
+            self.assertEqual(1, patch_get_update_command.call_count)
+            self.assertEqual(0, patch_get_enable_command.call_count)
 
-        # On the next iteration, update should not be retried
-        exthandlers_handler.run()
-        self.assertEqual(1, patch_get_update_command.call_count)
+            # We report the failure of the new extension version
+            self._assert_handler_status(protocol.report_vm_status, "NotReady", expected_ext_count=1, version="1.0.1")
 
-        self._assert_handler_status(protocol.report_vm_status, "NotReady", expected_ext_count=1, version="1.0.1")
+            # Ensure we are processing the same goal state only once
+            loop_run = 5
+            for x in range(loop_run):
+                exthandlers_handler.run()
+
+            self.assertEqual(1, patch_get_update_command.call_count)
+            self.assertEqual(0, patch_get_enable_command.call_count)
+
+            # If the incarnation number changes (there's a new goal state), ensure we go through the entire upgrade
+            # process again.
+            test_data.goal_state = test_data.goal_state.replace("<Incarnation>2<", "<Incarnation>3<")
+            exthandlers_handler.run()
+            self.assertEqual(2, patch_get_update_command.call_count)
+            self.assertEqual(0, patch_get_enable_command.call_count)
+
+            # We report the failure of the new extension version
+            self._assert_handler_status(protocol.report_vm_status, "NotReady", expected_ext_count=1, version="1.0.1")
 
     @patch('azurelinuxagent.ga.exthandlers.HandlerManifest.get_disable_command')
-    def test__extension_upgrade_failure_when_prev_version_disable_fails(self, patch_get_disable_command, *args):
+    def test_extension_upgrade_failure_when_prev_version_disable_fails(self, patch_get_disable_command, *args):
         test_data, exthandlers_handler, protocol = self._set_up_update_test_and_update_gs(patch_get_disable_command,
                                                                                           *args)
 
@@ -1503,7 +1524,7 @@ class TestExtension(ExtensionTestCase):
             self.assertEqual(0, patch_get_enable_command.call_count)
 
     @patch('azurelinuxagent.ga.exthandlers.HandlerManifest.get_disable_command')
-    def test__extension_upgrade_failure_when_prev_version_disable_fails_and_recovers_on_next_incarnation(self, patch_get_disable_command,
+    def test_extension_upgrade_failure_when_prev_version_disable_fails_and_recovers_on_next_incarnation(self, patch_get_disable_command,
                                                                                                          *args):
         test_data, exthandlers_handler, protocol = self._set_up_update_test_and_update_gs(patch_get_disable_command,
                                                                                           *args)
@@ -1536,7 +1557,7 @@ class TestExtension(ExtensionTestCase):
                 self._assert_handler_status(protocol.report_vm_status, "Ready", expected_ext_count=1, version="1.0.1")
 
     @patch('azurelinuxagent.ga.exthandlers.HandlerManifest.get_disable_command')
-    def test__extension_upgrade_failure_when_prev_version_disable_fails_incorrect_zip(self, patch_get_disable_command,
+    def test_extension_upgrade_failure_when_prev_version_disable_fails_incorrect_zip(self, patch_get_disable_command,
                                                                                       *args):
         test_data, exthandlers_handler, protocol = self._set_up_update_test_and_update_gs(patch_get_disable_command,
                                                                                           *args)
@@ -1564,7 +1585,7 @@ class TestExtension(ExtensionTestCase):
                     self.assertEqual(0, patch_get_enable_command.call_count)
 
     @patch('azurelinuxagent.ga.exthandlers.HandlerManifest.get_disable_command')
-    def test__old_handler_reports_failure_on_disable_fail_on_update(self, patch_get_disable_command, *args):
+    def test_old_handler_reports_failure_on_disable_fail_on_update(self, patch_get_disable_command, *args):
         old_version, new_version = "1.0.0", "1.0.1"
         test_data, exthandlers_handler, protocol = self._set_up_update_test_and_update_gs(patch_get_disable_command,
                                                                                           *args)


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Today, during an extension upgrade, if the update command of the new extension fails, the new extension will be marked as Failed and on the next goal state we would directly call enable on the new version instead of calling download, initialize, and update beforehand due to [this check](https://github.com/Azure/WALinuxAgent/blob/develop/azurelinuxagent/ga/exthandlers.py#L487). This PR fixes the condition by including the `FailedUpgrade` state, ensuring we don't skip any steps in the upgrade scenario in subsequent goal states.

We need to keep the failed (new) version on disk in order to keep reporting its failed status. Since we don't clean up the failed extension, this means that we won't re-download it on the next goal state, but re-use the existing zip on disk. The old extension is also present on disk and disabled. When uninstall is called, the old version is uninstalled and removed. The new version's zip still persists (and is in a failed state). Improvements on this clean up logic can be addressed in a separate PR.

<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/walinuxagent/1731)
<!-- Reviewable:end -->
