### PR TITLE
Remove issue assignees

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,6 @@
 name: Bug report
 about: Create a report to help us improve
 title: "[BUG] Bug Title"
-assignees: narrieta, pgombar, vrdmr, larohra
 
 ---
 


### PR DESCRIPTION
The current list is assignees is not useful, since there is no clear owner.  Also, when the issue should not be assigned to any of the people in the current list one needs to remove them manually, creating friction.

We can assign an owner when we triage the issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/walinuxagent/1734)
<!-- Reviewable:end -->
