### PR TITLE
Explicitly remove swap for single file instead of all

### DIFF
--- a/azurelinuxagent/daemon/resourcedisk/default.py
+++ b/azurelinuxagent/daemon/resourcedisk/default.py
@@ -292,7 +292,7 @@ class ResourceDiskHandler(object):
 
         if os.path.isfile(swapfile) and os.path.getsize(swapfile) != size:
             logger.info("Remove old swap file")
-            shellutil.run("swapoff -a", chk_err=False)
+            shellutil.run("swapoff {0}".format(swapfile), chk_err=False)
             os.remove(swapfile)
 
         if not os.path.isfile(swapfile):

--- a/azurelinuxagent/daemon/resourcedisk/freebsd.py
+++ b/azurelinuxagent/daemon/resourcedisk/freebsd.py
@@ -154,7 +154,7 @@ class FreeBSDResourceDiskHandler(ResourceDiskHandler):
 
         if os.path.isfile(swapfile) and os.path.getsize(swapfile) != size:
             logger.info("Remove old swap file")
-            shellutil.run("swapoff -a", chk_err=False)
+            shellutil.run("swapoff {0}".format(swapfile), chk_err=False)
             os.remove(swapfile)
 
         if not os.path.isfile(swapfile):

--- a/tests/daemon/test_resourcedisk.py
+++ b/tests/daemon/test_resourcedisk.py
@@ -17,7 +17,7 @@
 
 import unittest
 
-from tests.tools import AgentTestCase
+from tests.tools import AgentTestCase, patch, DEFAULT
 from azurelinuxagent.daemon.resourcedisk.default import ResourceDiskHandler
 
 
@@ -39,6 +39,47 @@ class TestResourceDisk(AgentTestCase):
         rdh = ResourceDiskHandler()
         mount_string = rdh.get_mount_string(options, partition, mountpoint)
         self.assertEqual(expected, mount_string)
+
+    @patch('azurelinuxagent.common.utils.shellutil.run_get_output')
+    @patch('azurelinuxagent.common.utils.shellutil.run')
+    @patch('azurelinuxagent.daemon.resourcedisk.default.ResourceDiskHandler.mkfile')
+    @patch('azurelinuxagent.daemon.resourcedisk.default.os.path.isfile', return_value=False)
+    @patch(
+        'azurelinuxagent.daemon.resourcedisk.default.ResourceDiskHandler.check_existing_swap_file',
+        return_value=False)
+    def test_create_swap_space(
+            self,
+            mock_check_existing_swap_file,
+            mock_isfile,
+            mock_mkfile,
+            mock_run,
+            mock_run_get_output):
+        mount_point = '/mnt/resource'
+        size_mb = 128
+
+        rdh = ResourceDiskHandler()
+
+        def rgo_side_effect(*args, **kwargs):
+            if args[0] == 'swapon -s':
+                return (0, 'Filename\t\t\t\tType\t\tSize\tUsed\tPriority\n/mnt/resource/swapfile                 \tfile    \t131068\t0\t-2\n')
+            return DEFAULT
+
+        def run_side_effect(*args, **kwargs):
+            # We have to change the default mock behavior to return a falsey value
+            # (instead of the default truthy of the mock), because we are testing
+            # really for the exit code of the the swapon command to return 0.
+            if 'swapon' in args[0]:
+                return 0
+            return None
+
+        mock_run_get_output.side_effect = rgo_side_effect
+        mock_run.side_effect = run_side_effect
+
+        rdh.create_swap_space(
+            mount_point=mount_point,
+            size_mb=size_mb
+        )
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Issue #1733 

Waagent shouldn't run `swapoff -a` (all) if there is a swapfile existing already. It should just disable swapping on the specified device.

---

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes in the description.
- [x] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [x] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/walinuxagent/1739)
<!-- Reviewable:end -->
