### PR TITLE
Do not update goal state when refreshing the host plugin

### DIFF
--- a/azurelinuxagent/common/protocol/metadata.py
+++ b/azurelinuxagent/common/protocol/metadata.py
@@ -170,7 +170,7 @@ class MetadataProtocol(Protocol):
                                 "{0}.crt".format(thumbprint))
         shutil.copyfile(trans_prv_file, prv_file)
         shutil.copyfile(trans_cert_file, crt_file)
-        self.update_goal_state(forced=True)
+        self.update_goal_state()
 
     def get_vminfo(self):
         vminfo = VMInfo()
@@ -330,7 +330,7 @@ class MetadataProtocol(Protocol):
         certificates = self.get_certs()
         return certificates.cert_list
 
-    def update_goal_state(self, forced=False, max_retry=3):
+    def update_goal_state(self, max_retry=3):
         # Start updating goalstate, retry on 410
         for retry in range(0, max_retry):
             try:

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -760,8 +760,8 @@ class WireClient(object):
         self.ext_conf = ExtensionsConfig(xml_text)
 
     # Type of update performed by _update_from_goal_state()
-    class UpdateType(object):
-        # Update the Host GA Plugin client (Contained ID and RoleConfigName)
+    class _UpdateType(object):
+        # Update the Host GA Plugin client (Container ID and RoleConfigName)
         HostPlugin = 0
         # Update the full goal state only if the incarnation has changed
         GoalState = 1
@@ -772,13 +772,13 @@ class WireClient(object):
         """
         Fetches a new goal state and updates the Container ID and Role Config Name of the host plugin client
         """
-        self._update_from_goal_state(WireClient.UpdateType.HostPlugin)
+        self._update_from_goal_state(WireClient._UpdateType.HostPlugin)
 
     def update_goal_state(self, forced=False):
         """
         Updates the goal state if the incarnation changed or if 'forced' is True
         """
-        self._update_from_goal_state(WireClient.UpdateType.GoalStateForced if forced else WireClient.UpdateType.GoalState)
+        self._update_from_goal_state(WireClient._UpdateType.GoalStateForced if forced else WireClient._UpdateType.GoalState)
 
     def _update_from_goal_state(self, refresh_type):
         """
@@ -799,7 +799,7 @@ class WireClient(object):
                         self.host_plugin.container_id = new_goal_state.container_id
                         self.host_plugin.role_config_name = new_goal_state.role_config_name
 
-                if refresh_type == WireClient.UpdateType.HostPlugin:
+                if refresh_type == WireClient._UpdateType.HostPlugin:
                     update_host_plugin()
                     return
 
@@ -809,7 +809,7 @@ class WireClient(object):
                         last_incarnation = fileutil.read_file(incarnation_file)
                     return last_incarnation is None or last_incarnation != new_goal_state.incarnation
 
-                if refresh_type == WireClient.UpdateType.GoalStateForced or incarnation_changed() or self.goal_state is None:
+                if refresh_type == WireClient._UpdateType.GoalStateForced or incarnation_changed() or self.goal_state is None:
                     def save_goal_state(incarnation, xml_text):
                         file_name = GOAL_STATE_FILE_NAME.format(incarnation)
                         goal_state_file = os.path.join(conf.get_lib_dir(), file_name)

--- a/azurelinuxagent/daemon/main.py
+++ b/azurelinuxagent/daemon/main.py
@@ -31,7 +31,7 @@ from azurelinuxagent.common.event import add_event, WALAEventOperation
 from azurelinuxagent.common.future import ustr
 from azurelinuxagent.common.osutil import get_osutil
 from azurelinuxagent.common.protocol import get_protocol_util
-from azurelinuxagent.common.protocol.wire import WireClient
+from azurelinuxagent.common.protocol.wire import WireProtocol
 from azurelinuxagent.common.rdma import setup_rdma_device
 from azurelinuxagent.common.version import AGENT_NAME, AGENT_LONG_NAME, \
     AGENT_VERSION, \
@@ -150,10 +150,9 @@ class DaemonHandler(object):
                 #   incarnation number. A forced update ensures the most
                 #   current values.
                 protocol = self.protocol_util.get_protocol()
-                client = protocol.client
-                if client is None or type(client) is not WireClient:
+                if type(protocol) is not WireProtocol:
                     raise Exception("Attempt to setup RDMA without Wireserver")
-                client.update_goal_state(forced=True)
+                protocol.client.update_goal_state(forced=True)
 
                 setup_rdma_device(nd_version)
             except Exception as e:

--- a/tests/ga/test_update.py
+++ b/tests/ga/test_update.py
@@ -1716,7 +1716,7 @@ class ProtocolMock(object):
             raise ResourceGoneError()
         return self.agent_packages
 
-    def update_goal_state(self, full_goal_state=False, max_retry=3):
+    def update_goal_state(self, forced=False):
         self.call_counts["update_goal_state"] += 1
 
 

--- a/tests/ga/test_update.py
+++ b/tests/ga/test_update.py
@@ -1667,7 +1667,6 @@ class ProtocolMock(object):
             "update_goal_state" : 0
         }
         self.goal_state_is_stale = False
-        self.goal_state_forced = False
         self.etag = etag
         self.versions = versions if versions is not None else []
         self.create_manifests()
@@ -1717,9 +1716,8 @@ class ProtocolMock(object):
             raise ResourceGoneError()
         return self.agent_packages
 
-    def update_goal_state(self, forced=False, max_retry=3):
+    def update_goal_state(self, full_goal_state=False, max_retry=3):
         self.call_counts["update_goal_state"] += 1
-        self.goal_state_forced = self.goal_state_forced or forced
 
 
 class ResponseMock(Mock):

--- a/tests/protocol/mockwiredata.py
+++ b/tests/protocol/mockwiredata.py
@@ -207,10 +207,10 @@ class WireProtocolData(object):
     # For the use of "(?<=" "(?=" see 7.2.1 in https://docs.python.org/3.1/library/re.html
     # For the use of "\g<1>" see backreferences in https://docs.python.org/3.1/library/re.html#re.sub
     #
-    # Note that these regular expressions are not enough to _parse all valid XML documents (e.g. they do
+    # Note that these regular expressions are not enough to parse all valid XML documents (e.g. they do
     # not account for metacharacters like < or > in the values) but they are good enough for the test
-    # data. There are some basic checks, but the functions could could not match valid XML or produce
-    # invalid XML if their input is too complex.
+    # data. There are some basic checks, but the functions may not match valid XML or produce invalid
+    # XML if their input is too complex.
     #
     @staticmethod
     def replace_xml_element_value(xml_document, element_name, element_value):

--- a/tests/protocol/test_wire.py
+++ b/tests/protocol/test_wire.py
@@ -1086,7 +1086,7 @@ class GoalStateTestCase(AgentTestCase):
 
 class UpdateGoalStateTestCase(GoalStateTestCase):
     """
-    Tests for WireClient.update_host_plugin_from_goal_state()
+    Tests for WireClient.update_goal_state()
     """
     def test_it_should_update_the_goal_state_and_the_host_plugin_when_the_incarnation_changes(self):
         # if the incarnation changes the behavior is the same for forced and non-forced updates

--- a/tests/protocol/test_wire.py
+++ b/tests/protocol/test_wire.py
@@ -21,10 +21,10 @@ import os
 import stat
 import tempfile
 import time
+import uuid
 import unittest
 import zipfile
 
-from azurelinuxagent.common import conf
 from azurelinuxagent.common.exception import InvalidContainerError, ResourceGoneError, ProtocolError, \
     ExtensionDownloadError
 from azurelinuxagent.common.future import httpclient
@@ -38,6 +38,7 @@ from azurelinuxagent.common.utils.shellutil import run_get_output
 from azurelinuxagent.common.version import CURRENT_VERSION, DISTRO_NAME, DISTRO_VERSION
 from tests.ga.test_monitor import random_generator
 from tests.protocol import mockwiredata
+from tests.protocol.mockwiredata import WireProtocolData
 from tests.tools import ANY, MagicMock, Mock, patch, AgentTestCase, skip_if_predicate_true, running_under_travis
 
 data_with_bom = b'\xef\xbb\xbfhehe'
@@ -140,7 +141,7 @@ class TestWireProtocol(AgentTestCase):
         # -- Tracking calls to retrieve GoalState is problematic since it is
         #    fetched often; however, the dependent documents, such as the
         #    HostingEnvironmentConfig, will be retrieved the expected number
-        self.assertEqual(2, test_data.call_counts["hostingenvuri"])
+        self.assertEqual(1, test_data.call_counts["hostingenvuri"])
         self.assertEqual(1, patch_report.call_count)
 
     def test_call_storage_kwargs(self, *args):
@@ -610,73 +611,6 @@ class TestWireClient(AgentTestCase):
         self.assertEqual("BlockBlob", ext_conf.status_upload_blob_type)
         self.assertEqual(None, ext_conf.artifacts_profile_blob)
 
-    def test_save_or_update_goal_state_should_save_new_goal_state_file(self):
-        # Assert the file didn't exist before
-        incarnation = 42
-        goal_state_file = os.path.join(conf.get_lib_dir(), "GoalState.{0}.xml".format(incarnation))
-        self.assertFalse(os.path.exists(goal_state_file))
-
-        xml_text = mockwiredata.WireProtocolData(mockwiredata.DATA_FILE).goal_state
-        client = WireClient(WIRESERVER_URL)
-        client.save_or_update_goal_state_file(incarnation, xml_text)
-
-        # Assert the file exists and its contents
-        self.assertTrue(os.path.exists(goal_state_file))
-        with open(goal_state_file, "r") as f:
-            contents = f.readlines()
-            self.assertEquals("".join(contents), xml_text)
-
-    def test_save_or_update_goal_state_should_update_existing_goal_state_file(self):
-        incarnation = 42
-        goal_state_file = os.path.join(conf.get_lib_dir(), "GoalState.{0}.xml".format(incarnation))
-        xml_text = mockwiredata.WireProtocolData(mockwiredata.DATA_FILE).goal_state
-
-        with open(goal_state_file, "w") as f:
-            f.write(xml_text)
-
-        # Assert the file exists and its contents
-        self.assertTrue(os.path.exists(goal_state_file))
-        with open(goal_state_file, "r") as f:
-            contents = f.readlines()
-            self.assertEquals("".join(contents), xml_text)
-
-        # Update the container id
-        new_goal_state = mockwiredata.WireProtocolData(mockwiredata.DATA_FILE).goal_state.replace("c6d5526c-5ac2-4200-b6e2-56f2b70c5ab2",
-                                                                        "z6d5526c-5ac2-4200-b6e2-56f2b70c5ab2")
-        client = WireClient(WIRESERVER_URL)
-        client.save_or_update_goal_state_file(incarnation, new_goal_state)
-
-        # Assert the file exists and its contents
-        self.assertTrue(os.path.exists(goal_state_file))
-        with open(goal_state_file, "r") as f:
-            contents = f.readlines()
-            self.assertEquals("".join(contents), new_goal_state)
-
-    def test_save_or_update_goal_state_should_update_goal_state_and_container_id_when_not_forced(self):
-        incarnation = "1"  # Match the incarnation number from dummy goal state file
-        incarnation_file = os.path.join(conf.get_lib_dir(), INCARNATION_FILE_NAME)
-        with open(incarnation_file, "w") as f:
-            f.write(incarnation)
-
-        xml_text = mockwiredata.WireProtocolData(mockwiredata.DATA_FILE).goal_state
-        goal_state_file = os.path.join(conf.get_lib_dir(), "GoalState.{0}.xml".format(incarnation))
-
-        with open(goal_state_file, "w") as f:
-            f.write(xml_text)
-
-        client = WireClient(WIRESERVER_URL)
-        host = client.get_host_plugin()
-        old_container_id = host.container_id
-
-        # Update the container id
-        new_goal_state = mockwiredata.WireProtocolData(mockwiredata.DATA_FILE).goal_state.replace("c6d5526c-5ac2-4200-b6e2-56f2b70c5ab2",
-                                                                        "z6d5526c-5ac2-4200-b6e2-56f2b70c5ab2")
-        with patch("azurelinuxagent.common.protocol.wire.WireClient.fetch_config", return_value=new_goal_state):
-            client.update_goal_state(forced=False)
-
-        self.assertNotEqual(old_container_id, host.container_id)
-        self.assertEquals(host.container_id, "z6d5526c-5ac2-4200-b6e2-56f2b70c5ab2")
-
     @patch("azurelinuxagent.common.protocol.wire.WireClient.get_goal_state")
     @patch("azurelinuxagent.common.protocol.hostplugin.HostPluginProtocol.get_artifact_request")
     def test_download_ext_handler_pkg_should_not_invoke_host_channel_when_direct_channel_succeeds(self, mock_get_artifact_request, *args):
@@ -735,7 +669,7 @@ class TestWireClient(AgentTestCase):
 
     @patch("azurelinuxagent.common.protocol.wire.WireClient.get_goal_state")
     @patch("azurelinuxagent.common.protocol.hostplugin.HostPluginProtocol.get_artifact_request")
-    def test_download_ext_handler_pkg_should_retry_the_host_channel_after_reloading_goal_state(self, mock_get_artifact_request, *args):
+    def test_download_ext_handler_pkg_should_retry_the_host_channel_after_refreshing_host_plugin(self, mock_get_artifact_request, *args):
         mock_get_artifact_request.return_value = "dummy_url", "dummy_header"
         protocol = WireProtocol("foo.bar")
         HostPluginProtocol.set_default_channel(False)
@@ -748,7 +682,7 @@ class TestWireClient(AgentTestCase):
         # As a consequence, goal state should have been updated and host channel should have been set as default.
         with patch("azurelinuxagent.common.utils.restutil._http_request",
                    side_effect=[mock_failed_response, mock_failed_response, mock_successful_response]):
-            with patch("azurelinuxagent.common.protocol.wire.WireClient.update_goal_state") as mock_update_goal_state:
+            with patch("azurelinuxagent.common.protocol.wire.WireClient.update_host_plugin_from_goal_state") as mock_update_host_plugin_from_goal_state:
                 with patch("azurelinuxagent.common.protocol.wire.WireClient.stream", wraps=protocol.client.stream) \
                         as patch_direct:
                     with patch("azurelinuxagent.common.protocol.wire.WireProtocol.download_ext_handler_pkg_through_host",
@@ -759,13 +693,13 @@ class TestWireClient(AgentTestCase):
                         self.assertEquals(patch_host.call_count, 2)
                         # The host channel calls the direct function under the covers
                         self.assertEquals(patch_direct.call_count, 1 + patch_host.call_count)
-                        self.assertEquals(mock_update_goal_state.call_count, 1)
+                        self.assertEquals(mock_update_host_plugin_from_goal_state.call_count, 1)
 
                         self.assertEquals(HostPluginProtocol.is_default_channel(), True)
 
     @patch("azurelinuxagent.common.protocol.wire.WireClient.get_goal_state")
     @patch("azurelinuxagent.common.protocol.hostplugin.HostPluginProtocol.get_artifact_request")
-    def test_download_ext_handler_pkg_should_update_goal_state_and_not_change_default_channel_if_host_fails(self, mock_get_artifact_request, *args):
+    def test_download_ext_handler_pkg_should_not_change_default_channel_if_host_fails(self, mock_get_artifact_request, *args):
         mock_get_artifact_request.return_value = "dummy_url", "dummy_header"
         protocol = WireProtocol("foo.bar")
         HostPluginProtocol.set_default_channel(False)
@@ -775,7 +709,7 @@ class TestWireClient(AgentTestCase):
 
         # Everything fails. Goal state should have been updated and host channel should not have been set as default.
         with patch("azurelinuxagent.common.utils.restutil._http_request", return_value=mock_failed_response):
-            with patch("azurelinuxagent.common.protocol.wire.WireClient.update_goal_state") as mock_update_goal_state:
+            with patch("azurelinuxagent.common.protocol.wire.WireClient.update_host_plugin_from_goal_state") as mock_update_host_plugin_from_goal_state:
                 with patch("azurelinuxagent.common.protocol.wire.WireClient.stream", wraps=protocol.client.stream) \
                         as patch_direct:
                     with patch("azurelinuxagent.common.protocol.wire.WireProtocol.download_ext_handler_pkg_through_host",
@@ -786,7 +720,7 @@ class TestWireClient(AgentTestCase):
                         self.assertEquals(patch_host.call_count, 2)
                         # The host channel calls the direct function under the covers
                         self.assertEquals(patch_direct.call_count, 1 + patch_host.call_count)
-                        self.assertEquals(mock_update_goal_state.call_count, 1)
+                        self.assertEquals(mock_update_host_plugin_from_goal_state.call_count, 1)
 
                         self.assertEquals(HostPluginProtocol.is_default_channel(), False)
 
@@ -849,7 +783,7 @@ class TestWireClient(AgentTestCase):
 
     @patch("azurelinuxagent.common.protocol.wire.WireClient.get_goal_state")
     @patch("azurelinuxagent.common.protocol.hostplugin.HostPluginProtocol.get_artifact_request")
-    def test_fetch_manifest_should_retry_the_host_channel_after_reloading_goal_state(self, mock_get_artifact_request, *args):
+    def test_fetch_manifest_should_retry_the_host_channel_after_refreshing_the_host_plugin(self, mock_get_artifact_request, *args):
         mock_get_artifact_request.return_value = "dummy_url", "dummy_header"
         client = WireClient("foo.bar")
 
@@ -862,7 +796,7 @@ class TestWireClient(AgentTestCase):
         # As a consequence, goal state should have been updated and host channel should have been set as default.
         with patch("azurelinuxagent.common.utils.restutil._http_request",
                    side_effect=[mock_failed_response, mock_failed_response, mock_successful_response]):
-            with patch("azurelinuxagent.common.protocol.wire.WireClient.update_goal_state") as mock_update_goal_state:
+            with patch("azurelinuxagent.common.protocol.wire.WireClient.update_host_plugin_from_goal_state") as mock_update_host_plugin_from_goal_state:
                 with patch("azurelinuxagent.common.protocol.wire.WireClient.fetch", wraps=client.fetch) as patch_direct:
                     with patch("azurelinuxagent.common.protocol.wire.WireClient.fetch_manifest_through_host",
                                wraps=client.fetch_manifest_through_host) as patch_host:
@@ -872,7 +806,7 @@ class TestWireClient(AgentTestCase):
                         self.assertEquals(patch_host.call_count, 2)
                         # The host channel calls the direct function under the covers
                         self.assertEquals(patch_direct.call_count, 1 + patch_host.call_count)
-                        self.assertEquals(mock_update_goal_state.call_count, 1)
+                        self.assertEquals(mock_update_host_plugin_from_goal_state.call_count, 1)
 
                         self.assertEquals(HostPluginProtocol.is_default_channel(), True)
 
@@ -962,7 +896,7 @@ class TestWireClient(AgentTestCase):
 
     @patch("azurelinuxagent.common.protocol.wire.WireClient.get_goal_state")
     @patch("azurelinuxagent.common.protocol.hostplugin.HostPluginProtocol.get_artifact_request")
-    def test_get_artifacts_profile_should_retry_the_host_channel_after_reloading_goal_state(self, mock_get_artifact_request, *args):
+    def test_get_artifacts_profile_should_retry_the_host_channel_after_refreshing_the_host_plugin(self, mock_get_artifact_request, *args):
         mock_get_artifact_request.return_value = "dummy_url", "dummy_header"
         client = WireClient("foo.bar")
         client.ext_conf = ExtensionsConfig(None)
@@ -975,10 +909,10 @@ class TestWireClient(AgentTestCase):
         mock_successful_response = MockResponse(body=json_profile, status_code=200)
 
         # Direct channel fails, host channel fails due to stale goal state, host channel succeeds after refresh.
-        # As a consequence, goal state should have been updated and host channel should have been set as default.
+        # As a consequence, host plugin should have been updated and host channel should have been set as default.
         with patch("azurelinuxagent.common.utils.restutil._http_request",
                    side_effect=[mock_failed_response, mock_failed_response, mock_successful_response]):
-            with patch("azurelinuxagent.common.protocol.wire.WireClient.update_goal_state") as mock_update_goal_state:
+            with patch("azurelinuxagent.common.protocol.wire.WireClient.update_host_plugin_from_goal_state") as mock_update_host_plugin_from_goal_state:
                 with patch("azurelinuxagent.common.protocol.wire.WireClient.fetch", wraps=client.fetch) as patch_direct:
                     with patch("azurelinuxagent.common.protocol.wire.WireClient.get_artifacts_profile_through_host",
                                wraps=client.get_artifacts_profile_through_host) as patch_host:
@@ -988,13 +922,13 @@ class TestWireClient(AgentTestCase):
                         self.assertEquals(patch_host.call_count, 2)
                         # The host channel calls the direct function under the covers
                         self.assertEquals(patch_direct.call_count, 1 + patch_host.call_count)
-                        self.assertEquals(mock_update_goal_state.call_count, 1)
+                        self.assertEquals(mock_update_host_plugin_from_goal_state.call_count, 1)
 
                         self.assertEquals(HostPluginProtocol.is_default_channel(), True)
 
     @patch("azurelinuxagent.common.protocol.wire.WireClient.get_goal_state")
     @patch("azurelinuxagent.common.protocol.hostplugin.HostPluginProtocol.get_artifact_request")
-    def test_get_artifacts_profile_should_update_goal_state_and_not_change_default_channel_if_host_fails(self, mock_get_artifact_request, *args):
+    def test_get_artifacts_profile_should_refresh_the_host_plugin_and_not_change_default_channel_if_host_plugin_fails(self, mock_get_artifact_request, *args):
         mock_get_artifact_request.return_value = "dummy_url", "dummy_header"
         client = WireClient("foo.bar")
         client.ext_conf = ExtensionsConfig(None)
@@ -1007,7 +941,7 @@ class TestWireClient(AgentTestCase):
 
         # Everything fails. Goal state should have been updated and host channel should not have been set as default.
         with patch("azurelinuxagent.common.utils.restutil._http_request", return_value=mock_failed_response):
-            with patch("azurelinuxagent.common.protocol.wire.WireClient.update_goal_state") as mock_update_goal_state:
+            with patch("azurelinuxagent.common.protocol.wire.WireClient.update_host_plugin_from_goal_state") as mock_update_host_plugin_from_goal_state:
                 with patch("azurelinuxagent.common.protocol.wire.WireClient.fetch", wraps=client.fetch) as patch_direct:
                     with patch("azurelinuxagent.common.protocol.wire.WireClient.get_artifacts_profile_through_host",
                                wraps=client.get_artifacts_profile_through_host) as patch_host:
@@ -1017,7 +951,7 @@ class TestWireClient(AgentTestCase):
                         self.assertEquals(patch_host.call_count, 2)
                         # The host channel calls the direct function under the covers
                         self.assertEquals(patch_direct.call_count, 1 + patch_host.call_count)
-                        self.assertEquals(mock_update_goal_state.call_count, 1)
+                        self.assertEquals(mock_update_host_plugin_from_goal_state.call_count, 1)
 
                         self.assertEquals(HostPluginProtocol.is_default_channel(), False)
 
@@ -1114,13 +1048,168 @@ class TestWireClient(AgentTestCase):
 
         # Assert we've called both the direct channel function (once) and the host channel function (twice).
         # After the host channel succeeds, the host plugin should have been set as the default channel.
-        with patch('azurelinuxagent.common.protocol.wire.WireClient.update_goal_state') as mock_update_goal_state:
+        with patch('azurelinuxagent.common.protocol.wire.WireClient.update_host_plugin_from_goal_state') as mock_update_host_plugin_from_goal_state:
             ret = client.send_request_using_appropriate_channel(direct_func, host_func)
             self.assertEquals(42, ret)
             self.assertEquals(1, direct_func.counter)
             self.assertEquals(2, host_func.counter)
-            self.assertEquals(1, mock_update_goal_state.call_count)
+            self.assertEquals(1, mock_update_host_plugin_from_goal_state.call_count)
             self.assertEquals(True, client.get_host_plugin().is_default_channel())
+
+
+class GoalStateTestCase(AgentTestCase):
+    """
+    Base class for UpdateGoalStateTestCase and UpdateHostPluginFromGoalStateTestCase
+    """
+    def setUp(self):
+        AgentTestCase.setUp(self)
+
+        self.mock_data = mockwiredata.WireProtocolData(mockwiredata.DATA_FILE)
+        self.mock_http_get = patch("azurelinuxagent.common.utils.restutil.http_get", side_effect=self.mock_data.mock_http_get)
+        self.mock_crypt_util = patch("azurelinuxagent.common.protocol.wire.CryptUtil", side_effect=self.mock_data.mock_crypt_util)
+        self.mock_http_get.start()
+        self.mock_crypt_util.start()
+
+        # Use the WireProtocol to create a test WireClient.
+        # WireProtocol.detect() creates the transport certs needed to retrieve the goal state and also sets the initial goal state.
+        # WireClient.get_host_plugin() forces the host plugin to be instantiated
+        protocol = WireProtocol(WIRESERVER_URL)
+        protocol.detect()
+        self.wire_client = protocol.client
+        self.wire_client.get_host_plugin()
+
+    def tearDown(self):
+        self.mock_crypt_util.stop()
+        self.mock_http_get.stop()
+        AgentTestCase.tearDown(self)
+
+
+class UpdateGoalStateTestCase(GoalStateTestCase):
+    """
+    Tests for WireClient.update_host_plugin_from_goal_state()
+    """
+    def test_it_should_update_the_goal_state_and_the_host_plugin_when_the_incarnation_changes(self):
+        # if the incarnation changes the behavior is the same for forced and non-forced updates
+        for forced in [True, False]:
+            self.mock_data.reload()  # start each iteration of the test with fresh mock data
+
+            #
+            # Update the mock data with random values; include at least one field from each of the components
+            # in the goal state to ensure the entire state was updated. Note that numeric entities, e.g. incarnation, are
+            # actually represented as strings in the goal state.
+            #
+            # Note that the shared config is not parsed by the agent, so we modify the XML data directly. Also, the
+            # certificates are encrypted and it is hard to update a single field; instead, we update the entire list with
+            # empty.
+            #
+            new_incarnation = str(uuid.uuid4())
+            new_container_id = str(uuid.uuid4())
+            new_role_config_name = str(uuid.uuid4())
+            new_hosting_env_deployment_name = str(uuid.uuid4())
+            new_shared_conf = WireProtocolData.replace_xml_attribute_value(self.mock_data.shared_config, "Deployment", "name", str(uuid.uuid4()))
+            new_sequence_number = str(uuid.uuid4())
+
+            if '<Format>Pkcs7BlobWithPfxContents</Format>' not in self.mock_data.certs:
+                raise Exception('This test requires a non-empty certificate list')
+
+            self.mock_data.set_incarnation(new_incarnation)
+            self.mock_data.set_container_id(new_container_id)
+            self.mock_data.set_role_config_name(new_role_config_name)
+            self.mock_data.set_hosting_env_deployment_name(new_hosting_env_deployment_name)
+            self.mock_data.shared_config = new_shared_conf
+            self.mock_data.set_extensions_config_sequence_number(new_sequence_number)
+            self.mock_data.certs = r'''<?xml version="1.0" encoding="utf-8"?>
+                <CertificateFile><Version>2012-11-30</Version>
+                  <Incarnation>12</Incarnation>
+                  <Format>CertificatesNonPfxPackage</Format>
+                  <Data>NotPFXData</Data>
+                </CertificateFile>
+            '''
+
+            if forced:
+                self.wire_client.update_goal_state(forced=True)
+            else:
+                self.wire_client.update_goal_state()
+
+            sequence_number = self.wire_client.ext_conf.ext_handlers.extHandlers[0].properties.extensions[0].sequenceNumber
+
+            self.assertEqual(self.wire_client.goal_state.incarnation, new_incarnation)
+            self.assertEqual(self.wire_client.hosting_env.deployment_name, new_hosting_env_deployment_name)
+            self.assertEqual(self.wire_client.shared_conf.xml_text, new_shared_conf)
+            self.assertEqual(sequence_number, new_sequence_number)
+            self.assertEqual(len(self.wire_client.certs.cert_list.certificates), 0)
+
+            self.assertEqual(self.wire_client.host_plugin.container_id, new_container_id)
+            self.assertEqual(self.wire_client.host_plugin.role_config_name, new_role_config_name)
+
+    def test_non_forced_update_should_not_update_the_goal_state_nor_the_host_plugin_when_the_incarnation_does_not_change(self):
+        # The container id, role config name and shared config can change without the incarnation changing; capture the initial
+        # goal state and then change those fields.
+        goal_state = self.wire_client.goal_state.xml_text
+        shared_conf = self.wire_client.shared_conf.xml_text
+        container_id = self.wire_client.host_plugin.container_id
+        role_config_name = self.wire_client.host_plugin.role_config_name
+
+        self.mock_data.set_container_id(str(uuid.uuid4()))
+        self.mock_data.set_role_config_name(str(uuid.uuid4()))
+        self.mock_data.shared_config = WireProtocolData.replace_xml_attribute_value(self.mock_data.shared_config, "Deployment", "name", str(uuid.uuid4()))
+
+        self.wire_client.update_goal_state()
+
+        self.assertEqual(self.wire_client.goal_state.xml_text, goal_state)
+        self.assertEqual(self.wire_client.shared_conf.xml_text, shared_conf)
+
+        self.assertEqual(self.wire_client.host_plugin.container_id, container_id)
+        self.assertEqual(self.wire_client.host_plugin.role_config_name, role_config_name)
+
+    def test_forced_update_should_update_the_goal_state_and_the_host_plugin_when_the_incarnation_does_not_change(self):
+        # The container id, role config name and shared config can change without the incarnation changing
+        incarnation = self.wire_client.goal_state.incarnation
+        new_container_id = str(uuid.uuid4())
+        new_role_config_name = str(uuid.uuid4())
+        new_shared_conf = WireProtocolData.replace_xml_attribute_value(self.mock_data.shared_config, "Deployment", "name", str(uuid.uuid4()))
+
+        self.mock_data.set_container_id(new_container_id)
+        self.mock_data.set_role_config_name(new_role_config_name)
+        self.mock_data.shared_config = new_shared_conf
+
+        self.wire_client.update_goal_state(forced=True)
+
+        self.assertEqual(self.wire_client.goal_state.incarnation, incarnation)
+        self.assertEqual(self.wire_client.shared_conf.xml_text, new_shared_conf)
+
+        self.assertEqual(self.wire_client.host_plugin.container_id, new_container_id)
+        self.assertEqual(self.wire_client.host_plugin.role_config_name, new_role_config_name)
+
+
+class UpdateHostPluginFromGoalStateTestCase(GoalStateTestCase):
+    """
+    Tests for WireClient.update_host_plugin_from_goal_state()
+    """
+    def test_it_should_update_the_host_plugin_with_or_without_incarnation_changes(self):
+        # the behavior should be the same whether the incarnation changes or not
+        for incarnation_change in [True, False]:
+            self.mock_data.reload()  # start each iteration of the test with fresh mock data
+
+            new_container_id = str(uuid.uuid4())
+            new_role_config_name = str(uuid.uuid4())
+
+            goal_state = self.mock_data.goal_state
+            shared_conf = self.mock_data.shared_config
+            if incarnation_change:
+                self.mock_data.set_incarnation(str(uuid.uuid4()))
+            self.mock_data.set_container_id(new_container_id)
+            self.mock_data.set_role_config_name(new_role_config_name)
+            self.mock_data.shared_config = WireProtocolData.replace_xml_attribute_value(self.mock_data.shared_config, "Deployment", "name", str(uuid.uuid4()))
+
+            self.wire_client.update_host_plugin_from_goal_state()
+
+            self.assertEqual(self.wire_client.host_plugin.container_id, new_container_id)
+            self.assertEqual(self.wire_client.host_plugin.role_config_name, new_role_config_name)
+
+            # it should not update the goal state
+            self.assertEqual(self.wire_client.goal_state.xml_text, goal_state)
+            self.assertEqual(self.wire_client.shared_conf.xml_text, shared_conf)
 
 
 class MockResponse:


### PR DESCRIPTION
We are updating the goal state too frequently and that is part of the reason different components are getting out of sync. One of the reasons we were forcing updates of the goal state was to retry calls to the host plugin when the container id or the role config change. In this case updating the full goal state is not needed and it can actually introduce consistency issues.

The main change in this PR is to define an API specifically to update the host plugin without changing the goal state.

Other small changes are minor cleanup of the update goal state in the metadata protocol and the parse code of the goal state; I'll add comments in the PR to explain those changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/walinuxagent/1741)
<!-- Reviewable:end -->
