### PR TITLE
Do a single update_goal_state() in each iteration of the main loop

### DIFF
--- a/azurelinuxagent/common/protocol/restapi.py
+++ b/azurelinuxagent/common/protocol/restapi.py
@@ -237,6 +237,12 @@ class Protocol(DataContract):
     def detect(self):
         raise NotImplementedError()
 
+    def update_goal_state(self):
+        raise NotImplementedError()
+
+    def get_endpoint(self):
+        raise NotImplementedError()
+
     def get_vminfo(self):
         raise NotImplementedError()
 

--- a/azurelinuxagent/common/protocol/util.py
+++ b/azurelinuxagent/common/protocol/util.py
@@ -354,7 +354,7 @@ class ProtocolUtil(object):
                 protocols.append(prots.MetadataProtocol)
             protocol_name, protocol = self._detect_protocol(protocols)
 
-            IOErrorCounter.set_protocol_endpoint(endpoint=protocol.endpoint)
+            IOErrorCounter.set_protocol_endpoint(endpoint=protocol.get_endpoint())
             self._save_protocol(protocol_name)
 
             self.protocol = protocol

--- a/azurelinuxagent/ga/env.py
+++ b/azurelinuxagent/ga/env.py
@@ -110,10 +110,10 @@ class EnvHandler(object):
                 # to WireServer.  The previous rules allowed traffic.  Having both rules in
                 # place negated the fix in 2.2.26.
                 if not reset_firewall_fules:
-                    self.osutil.remove_firewall(dst_ip=protocol.endpoint, uid=os.getuid())
+                    self.osutil.remove_firewall(dst_ip=protocol.get_endpoint(), uid=os.getuid())
                     reset_firewall_fules = True
 
-                success = self.osutil.enable_firewall(dst_ip=protocol.endpoint, uid=os.getuid())
+                success = self.osutil.enable_firewall(dst_ip=protocol.get_endpoint(), uid=os.getuid())
 
                 add_periodic(
                     logger.EVERY_HOUR,

--- a/azurelinuxagent/ga/monitor.py
+++ b/azurelinuxagent/ga/monitor.py
@@ -153,7 +153,7 @@ class MonitorHandler(object):
 
     def init_protocols(self):
         self.protocol = self.protocol_util.get_protocol()
-        self.health_service = HealthService(self.protocol.endpoint)
+        self.health_service = HealthService(self.protocol.get_endpoint())
 
     def is_alive(self):
         return self.event_thread is not None and self.event_thread.is_alive()
@@ -419,7 +419,7 @@ class MonitorHandler(object):
         if datetime.datetime.utcnow() >= (self.last_telemetry_heartbeat + MonitorHandler.TELEMETRY_HEARTBEAT_PERIOD):
             try:
                 incarnation = self.protocol.get_incarnation()
-                dropped_packets = self.osutil.get_firewall_dropped_packets(self.protocol.endpoint)
+                dropped_packets = self.osutil.get_firewall_dropped_packets(self.protocol.get_endpoint())
                 msg = "{0};{1};{2};{3}".format(incarnation, self.counter, self.heartbeat_id, dropped_packets)
 
                 add_event(

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -307,7 +307,7 @@ class UpdateHandler(object):
                     break
 
                 #
-                # Check that all thread are still running
+                # Check that all the threads are still running
                 #
                 if not monitor_thread.is_alive():
                     logger.warn(u"Monitor thread died, restarting")

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -274,7 +274,9 @@ class UpdateHandler(object):
             env_thread.run()
 
             from azurelinuxagent.ga.exthandlers import get_exthandlers_handler, migrate_handler_state
-            exthandlers_handler = get_exthandlers_handler()
+            protocol = self.protocol_util.get_protocol()
+
+            exthandlers_handler = get_exthandlers_handler(protocol)
             migrate_handler_state()
 
             from azurelinuxagent.ga.remoteaccess import get_remote_access_handler
@@ -297,11 +299,16 @@ class UpdateHandler(object):
                 else GOAL_STATE_INTERVAL_DISABLED
 
             while self.running:
+                #
+                # Check that the parent process (the agent's daemon) is still running
+                #
                 if not debug and self._is_orphaned:
-                    logger.info("Agent {0} is an orphan -- exiting",
-                                CURRENT_AGENT)
+                    logger.info("Agent {0} is an orphan -- exiting", CURRENT_AGENT)
                     break
 
+                #
+                # Check that all thread are still running
+                #
                 if not monitor_thread.is_alive():
                     logger.warn(u"Monitor thread died, restarting")
                     monitor_thread.start()
@@ -310,7 +317,12 @@ class UpdateHandler(object):
                     logger.warn(u"Environment thread died, restarting")
                     env_thread.start()
 
-                if self._upgrade_available():
+                #
+                # Process the goal state
+                #
+                protocol.update_goal_state()
+
+                if self._upgrade_available(protocol):
                     available_agent = self.get_latest_agent()
                     if available_agent is None:
                         logger.info(
@@ -631,7 +643,7 @@ class UpdateHandler(object):
                 str(e))
         return
 
-    def _upgrade_available(self, base_version=CURRENT_VERSION):
+    def _upgrade_available(self, protocol, base_version=CURRENT_VERSION):
         # Emit an event expressing the state of AutoUpdate
         # Note:
         # - Duplicate events get suppressed; state transitions always emit
@@ -658,7 +670,6 @@ class UpdateHandler(object):
         logger.verbose("Checking for agent family {0} updates", family)
 
         self.last_attempt_time = now
-        protocol = self.protocol_util.get_protocol()
 
         try:
             manifest_list, etag = protocol.get_vmagent_manifests()

--- a/tests/ga/test_update.py
+++ b/tests/ga/test_update.py
@@ -1336,7 +1336,7 @@ class TestUpdate(UpdateTestCase):
         self.update_handler.protocol_util = protocol
         conf.get_autoupdate_gafamily = Mock(return_value=protocol.family)
 
-        return self.update_handler._upgrade_available(base_version=base_version)
+        return self.update_handler._upgrade_available(protocol, base_version=base_version)
 
     def test_upgrade_available_returns_true_on_first_use(self):
         self.assertTrue(self._test_upgrade_available())
@@ -1349,7 +1349,7 @@ class TestUpdate(UpdateTestCase):
         self.update_handler.protocol_util = protocol
         with patch('azurelinuxagent.common.logger.warn') as mock_logger:
             with patch('tests.ga.test_update.ProtocolMock.get_vmagent_pkgs', side_effect=ProtocolError):
-                self.assertFalse(self.update_handler._upgrade_available(base_version=CURRENT_VERSION))
+                self.assertFalse(self.update_handler._upgrade_available(protocol, base_version=CURRENT_VERSION))
                 self.assertEqual(0, mock_logger.call_count)
 
     def test_upgrade_available_includes_old_agents(self):
@@ -1716,7 +1716,7 @@ class ProtocolMock(object):
             raise ResourceGoneError()
         return self.agent_packages
 
-    def update_goal_state(self, forced=False):
+    def update_goal_state(self):
         self.call_counts["update_goal_state"] += 1
 
 

--- a/tests/protocol/mockwiredata.py
+++ b/tests/protocol/mockwiredata.py
@@ -230,7 +230,7 @@ class WireProtocolData(object):
         '''
         Sets the incarnation in the goal state, but not on its subcomponents (e.g. hosting env, shared config)
         '''
-        self.goal_state = WireProtocolData.replace_xml_element_value(self.goal_state, "Incarnation", incarnation)
+        self.goal_state = WireProtocolData.replace_xml_element_value(self.goal_state, "Incarnation", str(incarnation))
 
     def set_container_id(self, container_id):
         self.goal_state = WireProtocolData.replace_xml_element_value(self.goal_state, "ContainerId", container_id)
@@ -248,4 +248,22 @@ class WireProtocolData(object):
         '''
         Sets the sequence number for *all* extensions
         '''
-        self.ext_conf = WireProtocolData.replace_xml_attribute_value(self.ext_conf, "RuntimeSettings", "seqNo", sequence_number)
+        self.ext_conf = WireProtocolData.replace_xml_attribute_value(self.ext_conf, "RuntimeSettings", "seqNo", str(sequence_number))
+
+    def set_extensions_config_version(self, version):
+        '''
+        Sets the version for *all* extensions
+        '''
+        self.ext_conf = WireProtocolData.replace_xml_attribute_value(self.ext_conf, "Plugin", "version", version)
+
+    def set_extensions_config_state(self, state):
+        '''
+        Sets the state for *all* extensions
+        '''
+        self.ext_conf = WireProtocolData.replace_xml_attribute_value(self.ext_conf, "Plugin", "state", state)
+
+    def set_manifest_version(self, version):
+        '''
+        Sets the state for *all* extensions
+        '''
+        self.manifest = WireProtocolData.replace_xml_element_value(self.manifest, "Version", version)

--- a/tests/protocol/mockwiredata.py
+++ b/tests/protocol/mockwiredata.py
@@ -264,6 +264,6 @@ class WireProtocolData(object):
 
     def set_manifest_version(self, version):
         '''
-        Sets the state for *all* extensions
+        Sets the version of the extension manifest
         '''
         self.manifest = WireProtocolData.replace_xml_element_value(self.manifest, "Version", version)

--- a/tests/protocol/test_hostplugin.py
+++ b/tests/protocol/test_hostplugin.py
@@ -232,12 +232,15 @@ class TestHostPlugin(AgentTestCase):
         test_goal_state = wire.GoalState(WireProtocolData(DATA_FILE).goal_state)
         status = restapi.VMStatus(status="Ready", message="Guest Agent is running")
 
-        wire_protocol_client = wire.WireProtocol(wireserver_url).client
+        wire_protocol = wire.WireProtocol(wireserver_url)
+        wire_protocol_client = wire_protocol.client
         wire_protocol_client.get_goal_state = Mock(return_value=test_goal_state)
         wire_protocol_client.ext_conf = wire.ExtensionsConfig(None)
         wire_protocol_client.ext_conf.status_upload_blob = sas_url
         wire_protocol_client.ext_conf.status_upload_blob_type = page_blob_type
         wire_protocol_client.status_blob.set_vm_status(status)
+
+        wire_protocol.update_goal_state()
 
         # act
         wire_protocol_client.upload_status_blob()
@@ -272,12 +275,15 @@ class TestHostPlugin(AgentTestCase):
         test_goal_state = wire.GoalState(WireProtocolData(DATA_FILE).goal_state)
         status = restapi.VMStatus(status="Ready", message="Guest Agent is running")
 
-        wire_protocol_client = wire.WireProtocol(wireserver_url).client
+        wire_protocol = wire.WireProtocol(wireserver_url)
+        wire_protocol_client = wire_protocol.client
         wire_protocol_client.get_goal_state = Mock(return_value=test_goal_state)
         wire_protocol_client.ext_conf = wire.ExtensionsConfig(None)
         wire_protocol_client.ext_conf.status_upload_blob = sas_url
         wire_protocol_client.ext_conf.status_upload_blob_type = page_blob_type
         wire_protocol_client.status_blob.set_vm_status(status)
+
+        wire_protocol.update_goal_state()
 
         # act
         wire_protocol_client.upload_status_blob()
@@ -313,12 +319,15 @@ class TestHostPlugin(AgentTestCase):
         test_goal_state = wire.GoalState(WireProtocolData(DATA_FILE).goal_state)
         status = restapi.VMStatus(status="Ready", message="Guest Agent is running")
 
-        wire_protocol_client = wire.WireProtocol(wireserver_url).client
+        wire_protocol = wire.WireProtocol(wireserver_url)
+        wire_protocol_client = wire_protocol.client
         wire_protocol_client.get_goal_state = Mock(return_value=test_goal_state)
         wire_protocol_client.ext_conf = wire.ExtensionsConfig(None)
         wire_protocol_client.ext_conf.status_upload_blob = sas_url
         wire_protocol_client.ext_conf.status_upload_blob_type = page_blob_type
         wire_protocol_client.status_blob.set_vm_status(status)
+
+        wire_protocol.update_goal_state()
 
         # act
         wire_protocol_client.upload_status_blob()
@@ -354,12 +363,15 @@ class TestHostPlugin(AgentTestCase):
         test_goal_state = wire.GoalState(WireProtocolData(DATA_FILE).goal_state)
         status = restapi.VMStatus(status="Ready", message="Guest Agent is running")
 
-        wire_protocol_client = wire.WireProtocol(wireserver_url).client
+        wire_protocol = wire.WireProtocol(wireserver_url)
+        wire_protocol_client = wire_protocol.client
         wire_protocol_client.get_goal_state = Mock(return_value=test_goal_state)
         wire_protocol_client.ext_conf = wire.ExtensionsConfig(None)
         wire_protocol_client.ext_conf.status_upload_blob = sas_url
         wire_protocol_client.ext_conf.status_upload_blob_type = page_blob_type
         wire_protocol_client.status_blob.set_vm_status(status)
+
+        wire_protocol.update_goal_state()
 
         # act
         self.assertRaises(wire.ProtocolError, wire_protocol_client.upload_status_blob)

--- a/tests/protocol/test_metadata.py
+++ b/tests/protocol/test_metadata.py
@@ -47,7 +47,7 @@ class TestMetadataProtocolGetters(AgentTestCase):
         test_data = MetadataProtocolData(DATA_FILE_NO_EXT)
         self._test_getters(test_data, *args)
 
-    @patch("azurelinuxagent.common.protocol.metadata.MetadataProtocol.update_goal_state")
+    @patch("azurelinuxagent.common.protocol.metadata.MetadataProtocol._update_certs_with_retry")
     @patch("azurelinuxagent.common.protocol.metadata.MetadataProtocol._get_data")
     def test_get_vmagents_manifests(self, mock_get, mock_update):
         data = self.load_json("metadata/vmagent_manifests.json")
@@ -85,7 +85,7 @@ class TestMetadataProtocolGetters(AgentTestCase):
         mock_get.return_value = data, 43
         self.assertRaises(ProtocolError, protocol.get_vmagent_manifests)
 
-    @patch("azurelinuxagent.common.protocol.metadata.MetadataProtocol.update_goal_state")
+    @patch("azurelinuxagent.common.protocol.metadata.MetadataProtocol._update_certs_with_retry")
     @patch("azurelinuxagent.common.protocol.metadata.MetadataProtocol._get_data")
     def test_get_vmagents_manifests_raises(self, mock_get, mock_update):
         data = self.load_json("metadata/vmagent_manifests_invalid1.json")
@@ -98,7 +98,7 @@ class TestMetadataProtocolGetters(AgentTestCase):
         mock_get.return_value = data, 43
         self.assertRaises(ProtocolError, protocol.get_vmagent_manifests)
 
-    @patch("azurelinuxagent.common.protocol.metadata.MetadataProtocol.update_goal_state")
+    @patch("azurelinuxagent.common.protocol.metadata.MetadataProtocol._update_certs_with_retry")
     @patch("azurelinuxagent.common.protocol.metadata.MetadataProtocol._get_data")
     def test_get_vmagent_pkgs(self, mock_get, mock_update):
         data = self.load_json("metadata/vmagent_manifests.json")

--- a/tests/protocol/test_wire.py
+++ b/tests/protocol/test_wire.py
@@ -626,8 +626,8 @@ class TestWireClient(AgentTestCase):
             with patch("azurelinuxagent.common.protocol.wire.WireClient.update_goal_state") as mock_update_goal_state:
                 with patch("azurelinuxagent.common.protocol.wire.WireClient.stream", wraps=protocol.client.stream) \
                         as patch_direct:
-                    with patch("azurelinuxagent.common.protocol.wire.WireProtocol.download_ext_handler_pkg_through_host",
-                               wraps=protocol.download_ext_handler_pkg_through_host) as patch_host:
+                    with patch("azurelinuxagent.common.protocol.wire.WireProtocol._download_ext_handler_pkg_through_host",
+                               wraps=protocol._download_ext_handler_pkg_through_host) as patch_host:
                         ret = protocol.download_ext_handler_pkg("uri", destination)
                         self.assertEquals(ret, True)
 
@@ -655,8 +655,8 @@ class TestWireClient(AgentTestCase):
             with patch("azurelinuxagent.common.protocol.wire.WireClient.update_goal_state") as mock_update_goal_state:
                 with patch("azurelinuxagent.common.protocol.wire.WireClient.stream", wraps=protocol.client.stream) \
                         as patch_direct:
-                    with patch("azurelinuxagent.common.protocol.wire.WireProtocol.download_ext_handler_pkg_through_host",
-                               wraps=protocol.download_ext_handler_pkg_through_host) as patch_host:
+                    with patch("azurelinuxagent.common.protocol.wire.WireProtocol._download_ext_handler_pkg_through_host",
+                               wraps=protocol._download_ext_handler_pkg_through_host) as patch_host:
                         ret = protocol.download_ext_handler_pkg("uri", destination)
                         self.assertEquals(ret, True)
 
@@ -685,8 +685,8 @@ class TestWireClient(AgentTestCase):
             with patch("azurelinuxagent.common.protocol.wire.WireClient.update_host_plugin_from_goal_state") as mock_update_host_plugin_from_goal_state:
                 with patch("azurelinuxagent.common.protocol.wire.WireClient.stream", wraps=protocol.client.stream) \
                         as patch_direct:
-                    with patch("azurelinuxagent.common.protocol.wire.WireProtocol.download_ext_handler_pkg_through_host",
-                               wraps=protocol.download_ext_handler_pkg_through_host) as patch_host:
+                    with patch("azurelinuxagent.common.protocol.wire.WireProtocol._download_ext_handler_pkg_through_host",
+                               wraps=protocol._download_ext_handler_pkg_through_host) as patch_host:
                         ret = protocol.download_ext_handler_pkg("uri", destination)
                         self.assertEquals(ret, True)
 
@@ -712,8 +712,8 @@ class TestWireClient(AgentTestCase):
             with patch("azurelinuxagent.common.protocol.wire.WireClient.update_host_plugin_from_goal_state") as mock_update_host_plugin_from_goal_state:
                 with patch("azurelinuxagent.common.protocol.wire.WireClient.stream", wraps=protocol.client.stream) \
                         as patch_direct:
-                    with patch("azurelinuxagent.common.protocol.wire.WireProtocol.download_ext_handler_pkg_through_host",
-                               wraps=protocol.download_ext_handler_pkg_through_host) as patch_host:
+                    with patch("azurelinuxagent.common.protocol.wire.WireProtocol._download_ext_handler_pkg_through_host",
+                               wraps=protocol._download_ext_handler_pkg_through_host) as patch_host:
                         ret = protocol.download_ext_handler_pkg("uri", destination)
                         self.assertEquals(ret, False)
 

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,3 +1,5 @@
+from mock import Mock
+
 from tests.tools import AgentTestCase
 import azurelinuxagent.common.osutil as osutil
 import azurelinuxagent.common.dhcp as dhcp
@@ -25,5 +27,5 @@ class TestImportHandler(AgentTestCase):
         scvmm.get_scvmm_handler()
         monitor.get_monitor_handler()
         update.get_update_handler()
-        exthandlers.get_exthandlers_handler()
+        exthandlers.get_exthandlers_handler(Mock())
         remoteaccess.get_remote_access_handler()


### PR DESCRIPTION
Several methods in WireClient were triggering an update_goal_state. 

The implementation of WireClient was inconsistent in this respect, since some methods would update and others would assume the goal state was up-to-date. This inconsistency was captured in a TODO comment in wire.py

Of more concern, if the incarnation changes in-between the calls to those functions then we may end up  processing an inconsistent goal state.

This PR moves the call to update_goal_state to the main loop.

There is also some cleanup of the Protocol interface and the Metadata implementation. I will add comments in the PR pointing those out.

I am still running DCR. I will sync with @larohra to figure out how we will merge this PR and #1743

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/walinuxagent/1744)
<!-- Reviewable:end -->
