### PR TITLE
Fetch goal state before sending telemetry

### DIFF
--- a/azurelinuxagent/daemon/main.py
+++ b/azurelinuxagent/daemon/main.py
@@ -61,8 +61,9 @@ class DaemonHandler(object):
 
     def run(self, child_args=None):
         #
-        # The Container ID in telemetry events requires information retrieved from the goal state (e.g. Container ID).
-        # We can fetch the goal state only after protocol detection, which is done during provisioning.
+        # The Container ID in telemetry events is retrieved from the goal state. We can fetch the goal state
+        # only after protocol detection, which is done during provisioning.
+        #
         # Be aware that telemetry events emitted before that will not include the Container ID.
         #
         logger.info("{0} Version:{1}", AGENT_LONG_NAME, AGENT_VERSION)

--- a/azurelinuxagent/daemon/main.py
+++ b/azurelinuxagent/daemon/main.py
@@ -60,15 +60,17 @@ class DaemonHandler(object):
         self.osutil = get_osutil()
 
     def run(self, child_args=None):
+        #
+        # The Container ID in telemetry events requires information retrieved from the goal state (e.g. Container ID).
+        # We can fetch the goal state only after protocol detection, which is done during provisioning.
+        # Be aware that telemetry events emitted before that will not include the Container ID.
+        #
         logger.info("{0} Version:{1}", AGENT_LONG_NAME, AGENT_VERSION)
         logger.info("OS: {0} {1}", DISTRO_NAME, DISTRO_VERSION)
-        logger.info("Python: {0}.{1}.{2}", PY_VERSION_MAJOR, PY_VERSION_MINOR,
-                    PY_VERSION_MICRO)
+        logger.info("Python: {0}.{1}.{2}", PY_VERSION_MAJOR, PY_VERSION_MINOR, PY_VERSION_MICRO)
 
         self.check_pid()
         self.initialize_environment()
-
-        CGroupConfigurator.get_instance().create_agent_cgroups(track_cgroups=False)
 
         # If FIPS is enabled, set the OpenSSL environment variable
         # Note:
@@ -137,6 +139,9 @@ class DaemonHandler(object):
         self.protocol_util.clear_protocol()
 
         self.provision_handler.run()
+
+        # Initialize the agent cgroup
+        CGroupConfigurator.get_instance().create_agent_cgroups(track_cgroups=False)
 
         # Enable RDMA, continue in errors
         if conf.enable_rdma():


### PR DESCRIPTION
Some of the code that emits telemetry is relying on something else initializing the container ID (which comes from the goal state). 

I made an explicit call to fetch the goal state in the extension handler. 

For the daemon, provisioning must be completed before being able to fetch the goal state, so I moved some initialization code (whose telemetry we are interested in) after provisioning. As a result of this, resource usage would not be monitored/enforced for provisioning on non-systemd distros, but I think that is OK (in fact, I am considering whether enforcement should include provisioning on systemd distros).

There is still one telemetry event without a container ID. It is emitted at the end of provisioning; I am hesitant to touch that code at this point so I will leave it alone for now.

I verified this change using the telemetry emitted by DCR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/walinuxagent/1751)
<!-- Reviewable:end -->
