### PR TITLE
Handle errors from update_goal_state

### DIFF
--- a/azurelinuxagent/common/event.py
+++ b/azurelinuxagent/common/event.py
@@ -78,6 +78,7 @@ class WALAEventOperation:
     Download = "Download"
     Enable = "Enable"
     ExtensionProcessing = "ExtensionProcessing"
+    FetchGoalState = "FetchGoalState"
     Firewall = "Firewall"
     GetArtifactExtended = "GetArtifactExtended"
     HealthCheck = "HealthCheck"

--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -240,14 +240,8 @@ class ExtHandlersHandler(object):
                           message="Failed to get extension artifact for over "
                                   "{0}: {1}".format(self.get_artifact_error_state.min_timedelta, msg))
                 self.get_artifact_error_state.reset()
-            else:
-                logger.warn(msg)
 
-            add_event(AGENT_NAME,
-                      version=CURRENT_VERSION,
-                      op=WALAEventOperation.ExtensionProcessing,
-                      is_success=False,
-                      message=detailed_msg)
+            add_event(AGENT_NAME, version=CURRENT_VERSION, op=WALAEventOperation.ExtensionProcessing, is_success=False, message=detailed_msg)
             return
 
         try:

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -317,7 +317,6 @@ class UpdateHandler(object):
                     goal_state_fetched = True
                 except Exception as e:
                     msg = u"Exception retrieving the goal state: {0}".format(ustr(traceback.format_exc()))
-                    logger.warn(msg)
                     add_event(AGENT_NAME, op=WALAEventOperation.FetchGoalState, version=CURRENT_VERSION, is_success=False, message=msg)
 
                 if goal_state_fetched:
@@ -701,15 +700,8 @@ class UpdateHandler(object):
                 or (len(self.agents) > 0 and self.agents[0].version > base_version)
 
         except Exception as e:
-            msg = u"Exception retrieving agent manifests: {0}".format(
-                        ustr(traceback.format_exc()))
-            logger.warn(msg)
-            add_event(
-                AGENT_NAME,
-                op=WALAEventOperation.Download,
-                version=CURRENT_VERSION,
-                is_success=False,
-                message=msg)
+            msg = u"Exception retrieving agent manifests: {0}".format(ustr(traceback.format_exc()))
+            add_event(AGENT_NAME, op=WALAEventOperation.Download, version=CURRENT_VERSION, is_success=False, message=msg)
             return False
 
     def _write_pid_file(self):

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -311,39 +311,47 @@ class UpdateHandler(object):
                 #
                 # Process the goal state
                 #
-                protocol.update_goal_state()
+                goal_state_fetched = False
+                try:
+                    protocol.update_goal_state()
+                    goal_state_fetched = True
+                except Exception as e:
+                    msg = u"Exception retrieving the goal state: {0}".format(ustr(traceback.format_exc()))
+                    logger.warn(msg)
+                    add_event(AGENT_NAME, op=WALAEventOperation.FetchGoalState, version=CURRENT_VERSION, is_success=False, message=msg)
 
-                if self._upgrade_available(protocol):
-                    available_agent = self.get_latest_agent()
-                    if available_agent is None:
-                        logger.info(
-                            "Agent {0} is reverting to the installed agent -- exiting",
-                            CURRENT_AGENT)
-                    else:
-                        logger.info(
-                            u"Agent {0} discovered update {1} -- exiting",
-                            CURRENT_AGENT,
-                            available_agent.name)
-                    break
+                if goal_state_fetched:
+                    if self._upgrade_available(protocol):
+                        available_agent = self.get_latest_agent()
+                        if available_agent is None:
+                            logger.info(
+                                "Agent {0} is reverting to the installed agent -- exiting",
+                                CURRENT_AGENT)
+                        else:
+                            logger.info(
+                                u"Agent {0} discovered update {1} -- exiting",
+                                CURRENT_AGENT,
+                                available_agent.name)
+                        break
 
-                utc_start = datetime.utcnow()
+                    utc_start = datetime.utcnow()
 
-                last_etag = exthandlers_handler.last_etag
-                exthandlers_handler.run()
+                    last_etag = exthandlers_handler.last_etag
+                    exthandlers_handler.run()
 
-                remote_access_handler.run()
+                    remote_access_handler.run()
 
-                if last_etag != exthandlers_handler.last_etag:
-                    self._ensure_readonly_files()
-                    duration = elapsed_milliseconds(utc_start)
-                    logger.info('ProcessGoalState completed [incarnation {0}; {1} ms]',
-                                exthandlers_handler.last_etag,
-                                duration)
-                    add_event(
-                        AGENT_NAME,
-                        op=WALAEventOperation.ProcessGoalState,
-                        duration=duration,
-                        message="Incarnation {0}".format(exthandlers_handler.last_etag))
+                    if last_etag != exthandlers_handler.last_etag:
+                        self._ensure_readonly_files()
+                        duration = elapsed_milliseconds(utc_start)
+                        logger.info('ProcessGoalState completed [incarnation {0}; {1} ms]',
+                                    exthandlers_handler.last_etag,
+                                    duration)
+                        add_event(
+                            AGENT_NAME,
+                            op=WALAEventOperation.ProcessGoalState,
+                            duration=duration,
+                            message="Incarnation {0}".format(exthandlers_handler.last_etag))
 
                 time.sleep(goal_state_interval)
 


### PR DESCRIPTION
When I moved the call to update_goal_state from get_vmagent_manifests/get_ext_handlers to the main loop I did not notice it does not handle exceptions.

The purpose of this PR is to handle exceptions mimicking what the original code did. 3 TODOs for subsequent PRs:
* other calls to update_goal_state should generate the same telemetry event
* the main loop should handle more exceptions
* the main loop needs some serious refactoring to make it amenable to unit tests

Verified the fix manually raising an exception from the debugger on a live agent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/walinuxagent/1758)
<!-- Reviewable:end -->
