### PR TITLE
Enable SWAP on Resource Disk as Application Certification Support suggested

### DIFF
--- a/config/freebsd/waagent.conf
+++ b/config/freebsd/waagent.conf
@@ -48,10 +48,10 @@ ResourceDisk.Filesystem=ufs
 ResourceDisk.MountPoint=/mnt/resource
 
 # Create and use swapfile on resource disk.
-ResourceDisk.EnableSwap=n
+ResourceDisk.EnableSwap=y
 
 # Size of the swapfile.
-ResourceDisk.SwapSizeMB=0
+ResourceDisk.SwapSizeMB=16384
 
 # Comma-seperated list of mount options. See man(8) for valid options.
 ResourceDisk.MountOptions=None


### PR DESCRIPTION
…gested

<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Issue # <!-- if any -->
The FreeBSD image on Azure used to have a swap partition allocated, as Application Certification Support suggested, moving it to Resource Disk is the better choice.

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/walinuxagent/1762)
<!-- Reviewable:end -->
