### PR TITLE
Do not update goal state from main loop in monitor thread

### DIFF
--- a/azurelinuxagent/common/protocol/metadata.py
+++ b/azurelinuxagent/common/protocol/metadata.py
@@ -172,6 +172,10 @@ class MetadataProtocol(Protocol):
         shutil.copyfile(trans_cert_file, crt_file)
         self._update_certs_with_retry()
 
+    def update_host_plugin_from_goal_state(self):
+        # Metadata doesn't cache the goal state; nothing to do here...
+        pass
+
     def update_goal_state(self):
         # Metadata doesn't cache the goal state; nothing to do here...
         pass

--- a/azurelinuxagent/common/protocol/restapi.py
+++ b/azurelinuxagent/common/protocol/restapi.py
@@ -240,6 +240,9 @@ class Protocol(DataContract):
     def update_goal_state(self):
         raise NotImplementedError()
 
+    def update_host_plugin_from_goal_state(self):
+        raise NotImplementedError()
+
     def get_endpoint(self):
         raise NotImplementedError()
 

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -102,6 +102,9 @@ class WireProtocol(Protocol):
     def update_goal_state(self):
         self.client.update_goal_state()
 
+    def update_host_plugin_from_goal_state(self):
+        self.client.update_host_plugin_from_goal_state()
+
     def get_endpoint(self):
         return self.client.get_endpoint()
 

--- a/azurelinuxagent/ga/monitor.py
+++ b/azurelinuxagent/ga/monitor.py
@@ -285,8 +285,7 @@ class MonitorHandler(object):
                         MonitorHandler.HOST_PLUGIN_HEARTBEAT_PERIOD,
                         MonitorHandler.IMDS_HEARTBEAT_PERIOD).seconds
         while self.should_run:
-            # Updating the goal_state periodically for the monitor thread to keep the WireClient object upto-date always
-            self.protocol.update_goal_state()
+            self.protocol.update_host_plugin_from_goal_state()
             self.send_telemetry_heartbeat()
             self.poll_telemetry_metrics()
             self.send_telemetry_metrics()   # This will be removed in favor of poll_telemetry_metrics() and it'll directly send the perf data for each cgroup.


### PR DESCRIPTION
The monitor thread and the extension handler thread may try to update the certificates from the goal state concurrently, which can produce sporadic failures.

The main loop in monitor actually does not need to update the full goal state; the only data it needs are the container id and role config name to keep the host ga plugin up to date (to send the plugin's hearbeat).

There is a small chance of a race condition during initialization: MonitorHandler.init_protocols calls update_goal_state. I will address that issue on a separate PR.

Verified the fix manually using the debugger on a live VM.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/walinuxagent/1767)
<!-- Reviewable:end -->
