### PR TITLE
Fix typo in unit test

### DIFF
--- a/tests/common/test_cgroupconfigurator.py
+++ b/tests/common/test_cgroupconfigurator.py
@@ -257,7 +257,7 @@ class CGroupConfiguratorTestCase(AgentTestCase):
         def mock_append_file(filepath, contents, **kwargs):
             if re.match(r'/.*/cpu/.*/cgroup.procs', filepath):
                 raise OSError(errno.ENOSPC, os.strerror(errno.ENOSPC))
-            fileutil.append_file(filepath, controller, **kwargs)
+            fileutil.append_file(filepath, contents, **kwargs)
 
         # Start tracking a couple of dummy cgroups
         CGroupsTelemetry.track_cgroup(CGroup("dummy", "/sys/fs/cgroup/memory/system.slice/dummy.service", "cpu"))


### PR DESCRIPTION
The test references 'controller' instead of 'contents'.

Currently none of the tested code invokes append_file with a path other thatn cgroup.procs, so that line is not exercised.

Thanks @pgombar for pointing this out.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/walinuxagent/1773)
<!-- Reviewable:end -->
