### PR TITLE
Removed is_snappy function

### DIFF
--- a/azurelinuxagent/common/version.py
+++ b/azurelinuxagent/common/version.py
@@ -211,19 +211,3 @@ GOAL_STATE_AGENT_VERSION = set_goal_state_agent()
 
 def is_current_agent_installed():
     return CURRENT_AGENT == AGENT_LONG_VERSION
-
-
-def is_snappy():
-    """
-    Add this workaround for detecting Snappy Ubuntu Core temporarily,
-    until ubuntu fixed this bug: https://bugs.launchpad.net/snappy/+bug/1481086
-    """
-    if os.path.exists("/etc/motd"):
-        motd = fileutil.read_file("/etc/motd")
-        if "snappy" in motd:
-            return True
-    return False
-
-
-if is_snappy():
-    DISTRO_FULL_NAME = "Snappy Ubuntu Core"


### PR DESCRIPTION
Removed is_snappy function from version.py as Snappy Ubuntu core has its own /etc/os-release file now which is recognised by python's platform.dist() that we use to determine the OS of a VM

<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/walinuxagent/1774)
<!-- Reviewable:end -->
