### PR TITLE
Add thread name to log

### DIFF
--- a/azurelinuxagent/common/logger.py
+++ b/azurelinuxagent/common/logger.py
@@ -19,6 +19,7 @@ Log utils
 """
 import sys
 from datetime import datetime, timedelta
+from threading import currentThread
 
 from azurelinuxagent.common.future import ustr
 
@@ -129,11 +130,11 @@ class Logger(object):
             # This format is based on ISO-8601, Z represents UTC (Zero offset)
         time = datetime.utcnow().strftime(u'%Y-%m-%dT%H:%M:%S.%fZ')
         level_str = LogLevel.STRINGS[level]
+        thread_name = currentThread().getName()
         if self.prefix is not None:
-            log_item = u"{0} {1} {2} {3}\n".format(time, level_str, self.prefix,
-                                                   msg)
+            log_item = u"{0} {1} {2} {3} {4}\n".format(time, level_str, thread_name, self.prefix, msg)
         else:
-            log_item = u"{0} {1} {2}\n".format(time, level_str, msg)
+            log_item = u"{0} {1} {2} {3}\n".format(time, level_str, thread_name, msg)
 
         log_item = ustr(log_item.encode('ascii', "backslashreplace"), 
                         encoding="ascii")

--- a/tests/common/test_logger.py
+++ b/tests/common/test_logger.py
@@ -546,14 +546,14 @@ class TestAppender(AgentTestCase):
         with open(self.log_file) as logfile:
             logcontent = logfile.readlines()
             self.assertEqual(1, len(logcontent))
-            self.assertRegex(logcontent[0], r"(.*WARNING\s*test-warn.*)")
+            self.assertRegex(logcontent[0], r"(.*WARNING\s\w+\s*test-warn.*)")
 
         logger.error("test-error")
         with open(self.log_file) as logfile:
             logcontent = logfile.readlines()
             # Levels are honored and Info, Verbose should not be written.
             self.assertEqual(1, len(logcontent))
-            self.assertRegex(logcontent[0], r"(.*ERROR\s*test-error.*)")
+            self.assertRegex(logcontent[0], r"(.*ERROR\s\w+\s*test-error.*)")
 
     def test_file_appender(self):
         logger.add_logger_appender(logger.AppenderType.FILE, logger.LogLevel.INFO, path=self.log_file)
@@ -566,9 +566,9 @@ class TestAppender(AgentTestCase):
             logcontent = logfile.readlines()
             # Levels are honored and Verbose should not be written.
             self.assertEqual(3, len(logcontent))
-            self.assertRegex(logcontent[0], r"(.*INFO\s*test-info.*)")
-            self.assertRegex(logcontent[1], r"(.*WARNING\s*test-warn.*)")
-            self.assertRegex(logcontent[2], r"(.*ERROR\s*test-error.*)")
+            self.assertRegex(logcontent[0], r"(.*INFO\s\w+\s*test-info.*)")
+            self.assertRegex(logcontent[1], r"(.*WARNING\s\w+\s*test-warn.*)")
+            self.assertRegex(logcontent[2], r"(.*ERROR\s\w+\s*test-error.*)")
 
     @patch("azurelinuxagent.common.event.send_logs_to_telemetry", return_value=True)
     @patch("azurelinuxagent.common.event.EventLogger.add_log_event")


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
Added the current thread name to the logs. New log line will look something like this - 
```log
2020-02-03T21:16:55.483285Z INFO MonitorHandler ExtHandler Set block dev timeout: sda with timeout: 300
2020-02-03T21:16:55.620273Z INFO ExtHandler ExtHandler ProcessGoalState completed [incarnation 1; 90 ms]
```

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/walinuxagent/1778)
<!-- Reviewable:end -->
