### PR TITLE
Fetch goal state when creating HostPluginProtocol

### DIFF
--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -1129,7 +1129,7 @@ class WireClient(object):
 
     def get_host_plugin(self):
         if self._host_plugin is None:
-            goal_state = self.get_goal_state()
+            goal_state = GoalState.fetch_goal_state(self)
             self._set_host_plugin(HostPluginProtocol(self.get_endpoint(),
                                                      goal_state.container_id,
                                                      goal_state.role_config_name))


### PR DESCRIPTION
Now we fetch the goal state explicitly instead of relying on somebody else initializing the instance in WireClient.

Also, the GoalState instance in WireClient will be removed as part of the next round of refactoring of the Protocol interface.