### PR TITLE
Allow for more fine tune provisioning options

### DIFF
--- a/azurelinuxagent/common/conf.py
+++ b/azurelinuxagent/common/conf.py
@@ -103,7 +103,10 @@ __SWITCH_OPTIONS__ = {
     "Provisioning.DeleteRootPassword": False,
     "Provisioning.DecodeCustomData": False,
     "Provisioning.ExecuteCustomData": False,
+    "Provisioning.SaveCustomData": True,
     "Provisioning.MonitorHostName": False,
+    "Provisioning.SetHostName": True,
+    "Provisioning.UserAccounts": True,
     "DetectScvmmEnv": False,
     "ResourceDisk.Format": False,
     "ResourceDisk.EnableSwap": False,
@@ -291,6 +294,10 @@ def get_decode_customdata(conf=__conf__):
     return conf.get_switch("Provisioning.DecodeCustomData", False)
 
 
+def get_save_customdata(conf=__conf__):
+    return conf.get_switch("Provisioning.SaveCustomData", True)
+
+
 def get_execute_customdata(conf=__conf__):
     return conf.get_switch("Provisioning.ExecuteCustomData", False)
 
@@ -320,6 +327,14 @@ def get_password_crypt_salt_len(conf=__conf__):
 
 def get_monitor_hostname(conf=__conf__):
     return conf.get_switch("Provisioning.MonitorHostName", False)
+
+
+def get_provisioning_hostname_set(conf=__conf__):
+    return conf.get_switch("Provisioning.SetHostName", True)
+
+
+def get_provisioning_user_account_set(conf=__conf__):
+    return conf.get_switch("Provisioning.UserAccounts", True)
 
 
 def get_httpproxy_host(conf=__conf__):

--- a/config/debian/waagent.conf
+++ b/config/debian/waagent.conf
@@ -28,8 +28,18 @@ Provisioning.MonitorHostName=y
 # Decode CustomData from Base64.
 Provisioning.DecodeCustomData=n
 
-# Execute CustomData after provisioning.
+# Execute CustomData after provisioning. If Provisioning.SaveCustomData is False
+# the following option is ignored.
 Provisioning.ExecuteCustomData=n
+
+# Save custom data for provisioning
+Provisioning.SaveCustomData=y
+
+# Set hostname of host by WAAgent on host provisioning
+Provisioning.SetHostName=y
+
+# Allow WAAgent to provision useraccounts
+Provisioning.UserAccounts=y
 
 # Algorithm used by crypt when generating password hash.
 #Provisioning.PasswordCryptId=6


### PR DESCRIPTION
Allow a user to better control what WAAgent provisions during a
Provisioning event. Allow the user to control if, useraccounts, hostname
and custom data be set.

<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).