### PR TITLE
Merge mock_http_request into mock_wire_protocol

### DIFF
--- a/tests/data/wire/ext_conf_in_vm_artifacts_profile.xml
+++ b/tests/data/wire/ext_conf_in_vm_artifacts_profile.xml
@@ -1,0 +1,28 @@
+<Extensions version="1.0.0.0" goalStateIncarnation="9">
+  <GuestAgentExtension xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+    <GAFamilies>
+      <GAFamily>
+        <Name>Prod</Name>
+        <Uris>
+            <Uri>http://mock-goal-state/manifest_of_ga.xml</Uri>
+        </Uris>
+      </GAFamily>
+      <GAFamily>
+        <Name>Test</Name>
+        <Uris>
+            <Uri>http://mock-goal-state/manifest_of_ga.xml</Uri>
+          </Uris>
+      </GAFamily>
+    </GAFamilies>
+  </GuestAgentExtension>
+  <Plugins>
+    <Plugin name="OSTCExtensions.ExampleHandlerLinux" version="1.0.0" location="http://mock-goal-state/rdfepirv2hknprdstr03.blob.core.windows.net/b01058962be54ceca550a390fa5ff064/Microsoft.OSTCExtensions_ExampleHandlerLinux_asiaeast_manifest.xml" config="" state="enabled" autoUpgrade="false" failoverlocation="http://mock-goal-state/rdfepirv2hknprdstr04.blob.core.windows.net/b01058962be54ceca550a390fa5ff064/Microsoft.OSTCExtensions_ExampleHandlerLinux_asiaeast_manifest.xml" runAsStartupTask="false" isJson="true" />
+  </Plugins>
+  <PluginSettings>
+    <Plugin name="OSTCExtensions.ExampleHandlerLinux" version="1.0.0">
+      <RuntimeSettings seqNo="0">{"runtimeSettings":[{"handlerSettings":{"protectedSettingsCertThumbprint":"4037FBF5F1F3014F99B5D6C7799E9B20E6871CB3","protectedSettings":"MIICWgYJK","publicSettings":{"foo":"bar"}}}]}</RuntimeSettings>
+    </Plugin>
+  </PluginSettings>
+  <StatusUploadBlob statusBlobType="BlockBlob">https://test.blob.core.windows.net/vhds/test-cs12.test-cs12.test-cs12.status?sr=b&amp;sp=rw&amp;se=9999-01-01&amp;sk=key1&amp;sv=2014-02-14&amp;sig=hfRh7gzUE7sUtYwke78IOlZOrTRCYvkec4hGZ9zZzXo</StatusUploadBlob>
+  <InVMArtifactsProfileBlob statusBlobType="BlockBlob">https://mock-goal-state/test.blob.core.windows.net/$system/test-cs12.test-cs12.test-cs12.vmSettings?sv=2016-05-31&amp;sr=b&amp;sk=system-1&amp;sig=saskey;se=9999-01-01T00%3a00%3a00Z&amp;sp=r</InVMArtifactsProfileBlob>
+</Extensions>

--- a/tests/data/wire/in_vm_artifacts_profile.json
+++ b/tests/data/wire/in_vm_artifacts_profile.json
@@ -1,0 +1,1 @@
+{ "onHold": true }

--- a/tests/protocol/mocks.py
+++ b/tests/protocol/mocks.py
@@ -19,124 +19,169 @@ import re
 from azurelinuxagent.common.protocol.wire import WireProtocol
 from azurelinuxagent.common.utils import restutil
 from tests.tools import patch
-from tests.protocol.mockwiredata import WireProtocolData
+from tests.protocol import mockwiredata
+
+# regex used to determine whether to use the mock wireserver data
+_USE_MOCK_WIRE_DATA_RE = re.compile(
+    r'https?://(mock-goal-state|{0}).*'.format(restutil.KNOWN_WIRESERVER_IP.replace(r'.', r'\.')), re.IGNORECASE)
 
 
 @contextlib.contextmanager
-def mock_wire_protocol(mock_wire_data_file):
+def mock_wire_protocol(mock_wire_data_file, http_get_handler=None, http_post_handler=None, http_put_handler=None, fail_on_unknown_request=True):
     """
-    Creates a mock WireProtocol object that will return the data specified by 'mock_wire_data_file' (which must
-    follow the structure of the data files defined in tests/protocol/mockwiredata.py).
+    Creates a WireProtocol object that handles requests to the WireServer and the Host GA Plugin (i.e requests on the WireServer endpoint), plus
+    some requests to storage (requests on the fake server 'mock-goal-state').
 
-    NOTE: This function creates mocks for azurelinuxagent.common.utils.restutil.http_request and
-          azurelinuxagent.common.protocol.wire.CryptUtil. These mocks can be stopped using the
-          methods stop_mock_http_get() and stop_mock_crypt_util().
+    The data returned by those requests is read from the files specified by 'mock_wire_data_file' (which must follow the structure of the data
+    files defined in tests/protocol/mockwiredata.py).
 
-    The return value is an instance of WireProtocol augmented with these properties/methods:
+    The caller can also provide handler functions for specific HTTP methods using the http_*_handler arguments. The return value of the handler
+    function is interpreted similarly to the "return_value" argument of patch(): if it is an exception the exception is raised or, if it is
+    any object other than None, the value is returned by the mock. If the handler function returns None the call is handled using the mock
+    wireserver data or passed to the original to restutil.http_request.
+
+    The returned protocol object maintains a list of "tracked" urls. When a handler function returns a value than is not None the url for the
+    request is automatically added to the tracked list. The handler function can add other items to this list using the track_url() method on
+    the mock.
+
+    The return value of this function is an instance of WireProtocol augmented with these properties/methods:
 
         * mock_wire_data - the WireProtocolData constructed from the mock_wire_data_file parameter.
-        * stop_mock_http_request() - stops the mock for restutil.http_request
-        * stop_mock_crypt_util() - stops the mock for CrypUtil
-        * stop() - stops both mocks
-    """
-    def stop_mock_http_request():
-        if stop_mock_http_request.mock is not None:
-            stop_mock_http_request.mock.stop()
-            stop_mock_http_request.mock = None
-    stop_mock_http_request.mock = None
-
-    def stop_mock_crypt_util():
-        if stop_mock_crypt_util.mock is not None:
-            stop_mock_crypt_util.mock.stop()
-            stop_mock_crypt_util.mock = None
-    stop_mock_crypt_util.mock = None
-
-    def stop():
-        stop_mock_crypt_util()
-        stop_mock_http_request()
-
-    protocol = WireProtocol(restutil.KNOWN_WIRESERVER_IP)
-    protocol.mock_wire_data = WireProtocolData(mock_wire_data_file)
-    protocol.stop_mock_http_request = stop_mock_http_request
-    protocol.stop_mock_crypt_util = stop_mock_crypt_util
-    protocol.stop = stop
-
-    try:
-        # To minimize the impact of mocking restutil.http_request we only use the mock data for requests
-        # to the wireserver or requests starting with "mock-goal-state"
-        mock_data_re = re.compile(r'https?://(mock-goal-state|{0}).*'.format(restutil.KNOWN_WIRESERVER_IP.replace(r'.', r'\.')), re.IGNORECASE)
-
-        original_http_request = restutil.http_request
-
-        def http_request(method, url, data, **kwargs):
-            if method == 'GET' and mock_data_re.match(url) is not None:
-                return protocol.mock_wire_data.mock_http_get(url, **kwargs)
-            elif method == 'POST':
-                return protocol.mock_wire_data.mock_http_post(url, data, **kwargs)
-            return original_http_request(method, url, data, **kwargs)
-
-        patched = patch("azurelinuxagent.common.utils.restutil.http_request", side_effect=http_request)
-        patched.start()
-        stop_mock_http_request.mock = patched
-
-        patched = patch("azurelinuxagent.common.protocol.wire.CryptUtil", side_effect=protocol.mock_wire_data.mock_crypt_util)
-        patched.start()
-        stop_mock_crypt_util.mock = patched
-
-        protocol.detect()
-
-        yield protocol
-
-    finally:
-        protocol.stop()
-
-
-@contextlib.contextmanager
-def mock_http_request(http_get_handler=None, http_post_handler=None, http_put_handler=None):
-    """
-    Creates a Mock of restutil.http_request that executes the handler given for the corresponding HTTP method.
-
-    The return value of the handler function is interpreted similarly to the "return_value" argument of patch(): if it
-    is an exception the exception is raised or, if it is any object other than None, the value is returned by the mock.
-
-    If the handler function returns None the call is passed to the original restutil.http_request.
-
-    The patch maintains a list of "tracked" urls. When the handler function returns a value than is not None the url
-    for the request is automatically added to the tracked list. The handler function can add other items to this list
-    using the track_url() method on the mock.
-
-    The returned Mock is augmented with these 2 methods:
-
+        * start() - starts the patchers for http_request and CryptUtil
+        * stop() - stops the patchers
         * track_url(url) - adds the given item to the list of tracked urls.
         * get_tracked_urls() - returns the list of tracked urls.
+
+    NOTE: This function patches common.utils.restutil.http_request and common.protocol.wire.CryptUtil; you need to be aware of this if your
+          tests patch those methods or others in the call stack (e.g. restutil.get, resutil._http_request, etc)
+
     """
     tracked_urls = []
+
+    # use a helper function to keep the HTTP handlers (they need to be modified by set_http_handlers() and
+    # Python 2.* does not support nonlocal declarations)
+    def http_handlers(get, post, put):
+        http_handlers.get = get
+        http_handlers.post = post
+        http_handlers.put = put
+        del tracked_urls[:]
+    http_handlers(get=http_get_handler, post=http_post_handler, put=http_put_handler)
+
+    #
+    # function used to patch restutil.http_request
+    #
     original_http_request = restutil.http_request
 
-    def http_request(method, url, *args, **kwargs):
+    def http_request(method, url, data, **kwargs):
+        # if there is a handler for the request, use it
         handler = None
         if method == 'GET':
-            handler = http_get_handler
+            handler = http_handlers.get
         elif method == 'POST':
-            handler = http_post_handler
+            handler = http_handlers.post
         elif method == 'PUT':
-            handler = http_put_handler
+            handler = http_handlers.put
 
         if handler is not None:
-            return_value = handler(url, *args, **kwargs)
+            if method == 'GET':
+                return_value = handler(url, **kwargs)
+            else:
+                return_value = handler(url, data, **kwargs)
             if return_value is not None:
                 tracked_urls.append(url)
                 if isinstance(return_value, Exception):
                     raise return_value
                 return return_value
 
-        return original_http_request(method, url, *args, **kwargs)
+        # if the request was not handled try to use the mock wireserver data
+        if _USE_MOCK_WIRE_DATA_RE.match(url) is not None:
+            if method == 'GET':
+                return protocol.mock_wire_data.mock_http_get(url, **kwargs)
+            if method == 'POST':
+                return protocol.mock_wire_data.mock_http_post(url, data, **kwargs)
 
-    patched = patch("azurelinuxagent.common.utils.restutil.http_request", side_effect=http_request)
-    patched.track_url = lambda url: tracked_urls.append(url)
-    patched.get_tracked_urls = lambda: tracked_urls
-    patched.start()
+        # the request was not handled; fail or call the original resutil.http_request
+        if fail_on_unknown_request:
+            raise ValueError('Unknown HTTP request: {0} [{1}]'.format(url, method))
+        return original_http_request(method, url, data, **kwargs)
+
+    #
+    # functions to start/stop the mocks
+    #
+    def start():
+        patched = patch("azurelinuxagent.common.utils.restutil.http_request", side_effect=http_request)
+        patched.start()
+        start.http_request_patch = patched
+
+        patched = patch("azurelinuxagent.common.protocol.wire.CryptUtil", side_effect=protocol.mock_wire_data.mock_crypt_util)
+        patched.start()
+        start.crypt_util_patch = patched
+    start.http_request_patch = None
+    start.crypt_util_patch = None
+
+    def stop():
+        if start.crypt_util_patch is not None:
+            start.crypt_util_patch.stop()
+        if start.http_request_patch is not None:
+            start.http_request_patch.stop()
+
+    #
+    # create the protocol object
+    #
+    protocol = WireProtocol(restutil.KNOWN_WIRESERVER_IP)
+    protocol.mock_wire_data = mockwiredata.WireProtocolData(mock_wire_data_file)
+    protocol.start = start
+    protocol.stop = stop
+    protocol.track_url = lambda url: tracked_urls.append(url)
+    protocol.get_tracked_urls = lambda: tracked_urls
+    protocol.set_http_handlers = lambda http_get_handler=None, http_post_handler=None, http_put_handler=None:\
+        http_handlers(get=http_get_handler, post=http_post_handler, put=http_put_handler)
+
+    # go do it
     try:
-        yield patched
+        protocol.start()
+        protocol.detect()
+        yield protocol
     finally:
-        patched.stop()
+        protocol.stop()
+
+
+class HttpRequestPredicates(object):
+    """
+    Utility functions to check the urls used by tests
+    """
+    @staticmethod
+    def is_goal_state_request(url):
+        return url.lower() == 'http://{0}/machine/?comp=goalstate'.format(restutil.KNOWN_WIRESERVER_IP)
+
+    @staticmethod
+    def is_in_vm_artifacts_profile_request(url):
+        return re.match(r'https://.+\.blob\.core\.windows\.net/\$system/.+\.(vmSettings|settings)\?.+', url) is not None
+
+    @staticmethod
+    def _get_host_plugin_request_artifact_location(url, request_kwargs):
+        if 'headers' not in request_kwargs:
+            raise ValueError('Host plugin request is missing HTTP headers ({0})'.format(url))
+        headers = request_kwargs['headers']
+        if 'x-ms-artifact-location' not in headers:
+            raise ValueError('Host plugin request is missing the x-ms-artifact-location header ({0})'.format(url))
+        return headers['x-ms-artifact-location']
+
+    @staticmethod
+    def is_host_plugin_extension_artifact_request(url):
+        return url.lower() == 'http://{0}:{1}/extensionartifact'.format(restutil.KNOWN_WIRESERVER_IP, restutil.HOST_PLUGIN_PORT)
+
+    @staticmethod
+    def is_host_plugin_extension_request(request_url, request_kwargs, extension_url):
+        if not HttpRequestPredicates.is_host_plugin_extension_artifact_request(request_url):
+            return False
+        artifact_location = HttpRequestPredicates._get_host_plugin_request_artifact_location(request_url, request_kwargs)
+        return artifact_location == extension_url
+
+    @staticmethod
+    def is_host_plugin_in_vm_artifacts_profile_request(url, request_kwargs):
+        if not HttpRequestPredicates.is_host_plugin_extension_artifact_request(url):
+            return False
+        artifact_location = HttpRequestPredicates._get_host_plugin_request_artifact_location(url, request_kwargs)
+        return HttpRequestPredicates.is_in_vm_artifacts_profile_request(artifact_location)
+

--- a/tests/protocol/mockwiredata.py
+++ b/tests/protocol/mockwiredata.py
@@ -34,8 +34,13 @@ DATA_FILE = {
         "trans_prv": "wire/trans_prv",
         "trans_cert": "wire/trans_cert",
         "test_ext": "ext/sample_ext-1.3.0.zip",
-        "remote_access": None
+        "remote_access": None,
+        "in_vm_artifacts_profile": None
 }
+
+DATA_FILE_IN_VM_ARTIFACTS_PROFILE = DATA_FILE.copy()
+DATA_FILE_IN_VM_ARTIFACTS_PROFILE["ext_conf"] = "wire/ext_conf_in_vm_artifacts_profile.xml"
+DATA_FILE_IN_VM_ARTIFACTS_PROFILE["in_vm_artifacts_profile"] = "wire/in_vm_artifacts_profile.json"
 
 DATA_FILE_NO_EXT = DATA_FILE.copy()
 DATA_FILE_NO_EXT["goal_state"] = "wire/goal_state_no_ext.xml"
@@ -96,7 +101,8 @@ class WireProtocolData(object):
             "extensionArtifact": 0,
             "manifest.xml": 0,
             "manifest_of_ga.xml": 0,
-            "ExampleHandlerLinux": 0
+            "ExampleHandlerLinux": 0,
+            "in_vm_artifacts_profile": 0
         }
         self.data_files = data_files
         self.version_info = None
@@ -111,6 +117,7 @@ class WireProtocolData(object):
         self.trans_cert = None
         self.ext = None
         self.remote_access = None
+        self.in_vm_artifacts_profile = None
 
         self.reload()
 
@@ -126,9 +133,14 @@ class WireProtocolData(object):
         self.trans_prv = load_data(self.data_files.get("trans_prv"))
         self.trans_cert = load_data(self.data_files.get("trans_cert"))
         self.ext = load_bin_data(self.data_files.get("test_ext"))
+
         remote_access_data_file = self.data_files.get("remote_access")
         if remote_access_data_file is not None:
             self.remote_access = load_data(remote_access_data_file)
+
+        in_vm_artifacts_profile_file = self.data_files.get("in_vm_artifacts_profile")
+        if in_vm_artifacts_profile_file is not None:
+            self.in_vm_artifacts_profile = load_data(in_vm_artifacts_profile_file)
 
     def mock_http_get(self, url, *args, **kwargs):
         content = None
@@ -160,6 +172,9 @@ class WireProtocolData(object):
         elif "remoteaccessinfouri" in url:
             content = self.remote_access
             self.call_counts["remoteaccessinfouri"] += 1
+        elif ".vmSettings" in url or ".settings" in url:
+            content = self.in_vm_artifacts_profile
+            self.call_counts["in_vm_artifacts_profile"] += 1
 
         else:
             # A stale GoalState results in a 400 from the HostPlugin
@@ -176,10 +191,10 @@ class WireProtocolData(object):
             # via the x-ms-artifact-location header
             if "extensionArtifact" in url:
                 self.call_counts["extensionArtifact"] += 1
-                if "headers" not in kwargs or \
-                    "x-ms-artifact-location" not in kwargs["headers"]:
-                    raise Exception("Bad HEADERS passed to HostPlugin: {0}",
-                            kwargs)
+                if "headers" not in kwargs:
+                    raise ValueError("HostPlugin request is missing the HTTP headers: {0}", kwargs)
+                if "x-ms-artifact-location" not in kwargs["headers"]:
+                    raise ValueError("HostPlugin request is missing the x-ms-artifact-location header: {0}", kwargs)
                 url = kwargs["headers"]["x-ms-artifact-location"]
 
             if "manifest.xml" in url:
@@ -193,6 +208,9 @@ class WireProtocolData(object):
                 self.call_counts["ExampleHandlerLinux"] += 1
                 resp.read = Mock(return_value=content)
                 return resp
+            elif ".vmSettings" in url or ".settings" in url:
+                content = self.in_vm_artifacts_profile
+                self.call_counts["in_vm_artifacts_profile"] += 1
             else:
                 raise Exception("Bad url {0}".format(url))
 


### PR DESCRIPTION
Merged mock_http_request into mock_wire_protocol; this obviates the need for nested mocks and simplifies tests that need to mock http requests.

Also, created HttpRequestPredicates, which replaces some of the tests for URLs I was doing before. Eliminates code duplication, allows for stronger assertions and serves as documentation for those requests.

Lastly, several unit tests for the in-vm artifacts profile broke due to this refactoring. I rewrote those and added support for in-vm artifacts profile in mockwiredata.

I'll anotate the PR with comments to help with the review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/walinuxagent/1810)
<!-- Reviewable:end -->
