### PR TITLE
Change ovf-env.xml to agent-agnostic directory

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,7 +8,7 @@
 # The Azure Linux Provisioning team is interested in getting notifications
 # when there are requests for changes in the provisioning agent. For any
 # questions, please feel free to reach out to thstring@microsoft.com.
-/azurelinuxagent/pa/ @trstringer @anhvoms
+/azurelinuxagent/pa/ @trstringer @anhvoms @johnsonshi
 
 #
 # RDMA

--- a/azurelinuxagent/common/conf.py
+++ b/azurelinuxagent/common/conf.py
@@ -116,6 +116,7 @@ __SWITCH_OPTIONS__ = {
 
 __STRING_OPTIONS__ = {
     "Lib.Dir": "/var/lib/waagent",
+    "AzureProvisioning.Dir": "/var/lib/azure-provisioning",
     "DVD.MountPoint": "/mnt/cdrom/secure",
     "Pid.File": "/var/run/waagent.pid",
     "Extension.LogDir": "/var/log/azure",
@@ -188,6 +189,10 @@ def get_logs_console(conf=__conf__):
 
 def get_lib_dir(conf=__conf__):
     return conf.get("Lib.Dir", "/var/lib/waagent")
+
+
+def get_azprov_dir(conf=__conf__):
+    return conf.get("AzureProvisioning.Dir", "/var/lib/azure-provisioning")
 
 
 def get_published_hostname(conf=__conf__):

--- a/azurelinuxagent/common/protocol/util.py
+++ b/azurelinuxagent/common/protocol/util.py
@@ -87,7 +87,7 @@ class ProtocolUtil(SingletonPerThread):
         dvd_mount_point = conf.get_dvd_mount_point()
         ovf_file_path_on_dvd = os.path.join(dvd_mount_point, OVF_FILE_NAME)
         tag_file_path_on_dvd = os.path.join(dvd_mount_point, TAG_FILE_NAME)
-        ovf_file_path = os.path.join(conf.get_lib_dir(), OVF_FILE_NAME)
+        ovf_file_path = os.path.join(conf.get_azprov_dir(), OVF_FILE_NAME)
         tag_file_path = self._get_tag_file_path()
 
         try:
@@ -138,7 +138,7 @@ class ProtocolUtil(SingletonPerThread):
         """
         Load saved ovf-env.xml
         """
-        ovf_file_path = os.path.join(conf.get_lib_dir(), OVF_FILE_NAME)
+        ovf_file_path = os.path.join(conf.get_azprov_dir(), OVF_FILE_NAME)
         if os.path.isfile(ovf_file_path):
             xml_text = fileutil.read_file(ovf_file_path)
             return OvfEnv(xml_text)

--- a/azurelinuxagent/pa/provision/cloudinit.py
+++ b/azurelinuxagent/pa/provision/cloudinit.py
@@ -73,7 +73,7 @@ class CloudInitProvisionHandler(ProvisionHandler):
         """
         Wait for cloud-init to copy ovf-env.xml file from provision ISO
         """
-        ovf_file_path = os.path.join(conf.get_lib_dir(), OVF_FILE_NAME)
+        ovf_file_path = os.path.join(conf.get_azprov_dir(), OVF_FILE_NAME)
         for retry in range(0, max_retry):
             if os.path.isfile(ovf_file_path):
                 try:

--- a/config/arch/waagent.conf
+++ b/config/arch/waagent.conf
@@ -87,6 +87,9 @@ OS.SshDir=/etc/ssh
 # Lib.Dir=/var/lib/waagent
 
 #
+# AzureProvisioning.Dir=/var/lib/azure-provisioning
+
+#
 # DVD.MountPoint=/mnt/cdrom/secure
 
 #

--- a/config/bigip/waagent.conf
+++ b/config/bigip/waagent.conf
@@ -77,6 +77,9 @@ OS.SshDir=/etc/ssh
 # Specify location of waagent lib dir on BIG-IP
 Lib.Dir=/shared/vadc/azure/waagent/
 
+#
+# AzureProvisioning.Dir=/var/lib/azure-provisioning
+
 # Specify location of sshd config file on BIG-IP
 OS.SshdConfigPath=/config/ssh/sshd_config
 

--- a/config/coreos/waagent.conf
+++ b/config/coreos/waagent.conf
@@ -91,6 +91,9 @@ OS.OpensslPath=None
 # Lib.Dir=/var/lib/waagent
 
 #
+# AzureProvisioning.Dir=/var/lib/azure-provisioning
+
+#
 # DVD.MountPoint=/mnt/cdrom/secure
 
 #

--- a/config/freebsd/waagent.conf
+++ b/config/freebsd/waagent.conf
@@ -89,6 +89,9 @@ OS.SudoersDir=/usr/local/etc/sudoers.d
 # Lib.Dir=/var/lib/waagent
 
 #
+# AzureProvisioning.Dir=/var/lib/azure-provisioning
+
+#
 # DVD.MountPoint=/mnt/cdrom/secure
 
 #

--- a/config/gaia/waagent.conf
+++ b/config/gaia/waagent.conf
@@ -88,6 +88,9 @@ OS.SshDir=/etc/ssh
 # Lib.Dir=/var/lib/waagent
 
 #
+# AzureProvisioning.Dir=/var/lib/azure-provisioning
+
+#
 # DVD.MountPoint=/mnt/cdrom/secure
 
 #

--- a/config/iosxe/waagent.conf
+++ b/config/iosxe/waagent.conf
@@ -87,6 +87,9 @@ OS.SshDir=/etc/ssh
 # Lib.Dir=/var/lib/waagent
 
 #
+# AzureProvisioning.Dir=/var/lib/azure-provisioning
+
+#
 # DVD.MountPoint=/mnt/cdrom/secure
 
 #

--- a/config/nsbsd/waagent.conf
+++ b/config/nsbsd/waagent.conf
@@ -85,6 +85,9 @@ OS.SudoersDir=/usr/local/etc/sudoers.d
 Lib.Dir=/usr/Firewall/var/waagent
 
 #
+# AzureProvisioning.Dir=/var/lib/azure-provisioning
+
+#
 # DVD.MountPoint=/mnt/cdrom/secure
 
 #

--- a/config/openbsd/waagent.conf
+++ b/config/openbsd/waagent.conf
@@ -83,6 +83,9 @@ OS.PasswordPath=/etc/master.passwd
 # Lib.Dir=/var/lib/waagent
 
 #
+# AzureProvisioning.Dir=/var/lib/azure-provisioning
+
+#
 # DVD.MountPoint=/mnt/cdrom/secure
 
 #

--- a/config/suse/waagent.conf
+++ b/config/suse/waagent.conf
@@ -91,6 +91,9 @@ OS.SshDir=/etc/ssh
 # Lib.Dir=/var/lib/waagent
 
 #
+# AzureProvisioning.Dir=/var/lib/azure-provisioning
+
+#
 # DVD.MountPoint=/mnt/cdrom/secure
 
 #

--- a/config/waagent.conf
+++ b/config/waagent.conf
@@ -91,6 +91,9 @@ OS.SshDir=/etc/ssh
 # Lib.Dir=/var/lib/waagent
 
 #
+# AzureProvisioning.Dir=/var/lib/azure-provisioning
+
+#
 # DVD.MountPoint=/mnt/cdrom/secure
 
 #

--- a/tests/common/test_conf.py
+++ b/tests/common/test_conf.py
@@ -55,6 +55,7 @@ class TestConf(AgentTestCase):
         "HttpProxy.Port": None,
         "DetectScvmmEnv": False,
         "Lib.Dir": "/var/lib/waagent",
+        "AzureProvisioning.Dir": "/var/lib/azure-provisioning",
         "DVD.MountPoint": "/mnt/cdrom/secure",
         "Pid.File": "/var/run/waagent.pid",
         "Extension.LogDir": "/var/log/azure",

--- a/tests/data/test_waagent.conf
+++ b/tests/data/test_waagent.conf
@@ -93,6 +93,9 @@ OS.SshDir=/notareal/path
 # Lib.Dir=/var/lib/waagent
 
 #
+# AzureProvisioning.Dir=/var/lib/azure-provisioning
+
+#
 # DVD.MountPoint=/mnt/cdrom/secure
 
 #

--- a/tests/ga/test_update.py
+++ b/tests/ga/test_update.py
@@ -775,7 +775,7 @@ class TestUpdate(UpdateTestCase):
             os.path.join(conf.get_lib_dir(), "faux_certificate.p7m"),
             os.path.join(conf.get_lib_dir(), "faux_certificate.pem"),
             os.path.join(conf.get_lib_dir(), "faux_certificate.prv"),
-            os.path.join(conf.get_lib_dir(), "ovf-env.xml")
+            os.path.join(conf.get_azprov_dir(), "ovf-env.xml")
         ]
         for path in test_files:
             fileutil.write_file(path, "Faux content")

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -36,6 +36,7 @@ Extensions.Enabled = True
 HttpProxy.Host = None
 HttpProxy.Port = None
 Lib.Dir = /var/lib/waagent
+AzureProvisioning.Dir = /var/lib/azure-provisioning
 Logs.Console = True
 Logs.Verbose = False
 OS.AllowHTTP = False


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Issue #1812

The ovf-env.xml file should be in an agent-agnostic directory so that cloud-init can be decoupled from waagent.

---

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes in the description.
- [x] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [x] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/walinuxagent/1813)
<!-- Reviewable:end -->
