### PR TITLE
Add switch to turn redundant log file off

### DIFF
--- a/azurelinuxagent/agent.py
+++ b/azurelinuxagent/agent.py
@@ -62,11 +62,14 @@ class Agent(object):
         #Init log
         verbose = verbose or conf.get_logs_verbose()
         level = logger.LogLevel.VERBOSE if verbose else logger.LogLevel.INFO
-        logger.add_logger_appender(logger.AppenderType.FILE, level,
-                                 path="/var/log/waagent.log")
+
+        if conf.get_logs_file():
+            logger.add_logger_appender(logger.AppenderType.FILE, level,
+                                       path="/var/log/waagent.log")
+
         if conf.get_logs_console():
             logger.add_logger_appender(logger.AppenderType.CONSOLE, level,
-                    path="/dev/console")
+                                       path="/dev/console")
 
         if event.send_logs_to_telemetry():
             logger.add_logger_appender(logger.AppenderType.TELEMETRY,

--- a/azurelinuxagent/common/conf.py
+++ b/azurelinuxagent/common/conf.py
@@ -185,6 +185,8 @@ def get_logs_verbose(conf=__conf__):
 def get_logs_console(conf=__conf__):
     return conf.get_switch("Logs.Console", True)
 
+def get_logs_file(conf=__conf__):
+    return conf.get_switch("Logs.File", True)
 
 def get_lib_dir(conf=__conf__):
     return conf.get("Lib.Dir", "/var/lib/waagent")

--- a/config/alpine/waagent.conf
+++ b/config/alpine/waagent.conf
@@ -53,6 +53,9 @@ ResourceDisk.MountOptions=None
 # Respond to load balancer probes if requested by Windows Azure.
 LBProbeResponder=y
 
+# Enable File logging, default is y
+# Logs.File=y
+
 # Enable logging to serial console (y|n)
 # When stdout is not enough...
 # 'y' if not set

--- a/config/arch/waagent.conf
+++ b/config/arch/waagent.conf
@@ -61,6 +61,9 @@ LBProbeResponder=y
 # Enable verbose logging (y|n)
 Logs.Verbose=n
 
+# Enable File logging, default is y
+# Logs.File=y
+
 # Enable Console logging, default is y
 # Logs.Console=y
 

--- a/config/bigip/waagent.conf
+++ b/config/bigip/waagent.conf
@@ -59,6 +59,9 @@ LBProbeResponder=y
 # Enable verbose logging (y|n)
 Logs.Verbose=n
 
+# Enable File logging, default is y
+# Logs.File=y
+
 # Enable Console logging, default is y
 # Logs.Console=y
 

--- a/config/clearlinux/waagent.conf
+++ b/config/clearlinux/waagent.conf
@@ -60,6 +60,9 @@ ResourceDisk.SwapSizeMB=0
 # Enable verbose logging (y|n)
 Logs.Verbose=n
 
+# Enable File logging, default is y
+# Logs.File=y
+
 # Enable Console logging, default is y
 # Logs.Console=y
 

--- a/config/coreos/waagent.conf
+++ b/config/coreos/waagent.conf
@@ -65,6 +65,9 @@ LBProbeResponder=y
 # Enable verbose logging (y|n)
 Logs.Verbose=n
 
+# Enable File logging, default is y
+# Logs.File=y
+
 # Enable Console logging, default is y
 # Logs.Console=y
 

--- a/config/debian/waagent.conf
+++ b/config/debian/waagent.conf
@@ -62,6 +62,9 @@ ResourceDisk.MountOptions=None
 # Enable verbose logging (y|n)
 Logs.Verbose=n
 
+# Enable File logging, default is y
+# Logs.File=y
+
 # Enable Console logging, default is y
 # Logs.Console=y
 

--- a/config/freebsd/waagent.conf
+++ b/config/freebsd/waagent.conf
@@ -59,6 +59,9 @@ ResourceDisk.MountOptions=None
 # Enable verbose logging (y|n)
 Logs.Verbose=n
 
+# Enable File logging, default is y
+# Logs.File=y
+
 # Enable Console logging, default is y
 # Logs.Console=y
 

--- a/config/gaia/waagent.conf
+++ b/config/gaia/waagent.conf
@@ -62,6 +62,9 @@ ResourceDisk.MountOptions=None
 # Enable verbose logging (y|n)
 Logs.Verbose=n
 
+# Enable File logging, default is y
+# Logs.File=y
+
 # Enable Console logging, default is y
 # Logs.Console=y
 

--- a/config/iosxe/waagent.conf
+++ b/config/iosxe/waagent.conf
@@ -58,6 +58,9 @@ ResourceDisk.MountOptions=None
 # Enable verbose logging (y|n)
 Logs.Verbose=n
 
+# Enable File logging, default is y
+# Logs.File=y
+
 # Enable Console logging, default is y
 # Logs.Console=y
 

--- a/config/nsbsd/waagent.conf
+++ b/config/nsbsd/waagent.conf
@@ -55,6 +55,9 @@ ResourceDisk.MountOptions=None
 # Enable verbose logging (y|n)  TODO set n
 Logs.Verbose=n
 
+# Enable File logging, default is y
+# Logs.File=y
+
 # Enable Console logging, default is y
 # Logs.Console=y
 

--- a/config/openbsd/waagent.conf
+++ b/config/openbsd/waagent.conf
@@ -55,6 +55,9 @@ ResourceDisk.MountOptions=None
 # Enable verbose logging (y|n)
 Logs.Verbose=n
 
+# Enable File logging, default is y
+# Logs.File=y
+
 # Enable Console logging, default is y
 # Logs.Console=y
 

--- a/config/suse/waagent.conf
+++ b/config/suse/waagent.conf
@@ -65,6 +65,9 @@ LBProbeResponder=y
 # Enable verbose logging (y|n)
 Logs.Verbose=n
 
+# Enable File logging, default is y
+# Logs.File=y
+
 # Enable Console logging, default is y
 # Logs.Console=y
 

--- a/config/ubuntu/waagent.conf
+++ b/config/ubuntu/waagent.conf
@@ -65,6 +65,9 @@ LBProbeResponder=y
 # Enable verbose logging (y|n)
 Logs.Verbose=n
 
+# Enable File logging, default is y
+# Logs.File=y
+
 # Enable Console logging, default is y
 # Logs.Console=y
 

--- a/config/waagent.conf
+++ b/config/waagent.conf
@@ -62,6 +62,9 @@ ResourceDisk.MountOptions=None
 # Enable verbose logging (y|n)
 Logs.Verbose=n
 
+# Enable File logging, default is y
+# Logs.File=y
+
 # Enable Console logging, default is y
 # Logs.Console=y
 


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Issue #1817 (this adds on option for the last part, without actually changing the default behavior)

Currently there is no way to disable logging to /var/log/waagent.log, which is redundant with the proper system log in journald.

This PR adds a configuration switch so it's easy to turn off logging to a file, and only have logging in journald.

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).