### PR TITLE
Remove remove_rules_files from Metadata Server Migration Utils

### DIFF
--- a/azurelinuxagent/common/protocol/metadata_server_migration_util.py
+++ b/azurelinuxagent/common/protocol/metadata_server_migration_util.py
@@ -60,7 +60,6 @@ def _reset_firewall_rules(osutil):
     Removes MetadataServer firewall rule so IMDS can be used. Enables
     WireServer firewall rule based on if firewall is configured to be on.
     """
-    osutil.remove_rules_files()
     osutil.remove_firewall(dst_ip=_KNOWN_METADATASERVER_IP, uid=os.getuid())
     if conf.enable_firewall():
         success = osutil.enable_firewall(dst_ip=KNOWN_WIRESERVER_IP, uid=os.getuid())

--- a/tests/protocol/test_metadata_server_migration_util.py
+++ b/tests/protocol/test_metadata_server_migration_util.py
@@ -80,7 +80,6 @@ class TestMetadataServerMigrationUtil(AgentTestCase):
         self.assertFalse(os.path.exists(metadata_server_p7b_file))
 
         # Assert Firewall rule calls
-        osutil.remove_rules_files.assert_called_once()
         osutil.remove_firewall.assert_called_once_with(dst_ip=_KNOWN_METADATASERVER_IP, uid=fixed_uid)
         osutil.enable_firewall.assert_called_once_with(dst_ip=KNOWN_WIRESERVER_IP, uid=fixed_uid)
 
@@ -113,7 +112,6 @@ class TestMetadataServerMigrationUtil(AgentTestCase):
         self.assertFalse(os.path.exists(metadata_server_p7b_file))
 
         # Assert Firewall rule calls
-        osutil.remove_rules_files.assert_called_once()
         osutil.remove_firewall.assert_called_once_with(dst_ip=_KNOWN_METADATASERVER_IP, uid=fixed_uid)
         osutil.enable_firewall.assert_not_called()
 

--- a/tests/protocol/test_protocol_util.py
+++ b/tests/protocol/test_protocol_util.py
@@ -184,7 +184,6 @@ class TestProtocolUtil(AgentTestCase):
             self.assertFalse(os.path.exists(mds_cert_path))
 
         # Check firewall rules was reset
-        protocol_util.osutil.remove_rules_files.assert_called_once()
         protocol_util.osutil.remove_firewall.assert_called_once()
         protocol_util.osutil.enable_firewall.assert_called_once()
 
@@ -230,7 +229,6 @@ class TestProtocolUtil(AgentTestCase):
             self.assertTrue(os.path.isfile(ws_cert_path))
 
         # Check firewall rules was reset
-        protocol_util.osutil.remove_rules_files.assert_called_once()
         protocol_util.osutil.remove_firewall.assert_called_once()
         protocol_util.osutil.enable_firewall.assert_called_once()
 
@@ -269,7 +267,6 @@ class TestProtocolUtil(AgentTestCase):
             self.assertTrue(os.path.isfile(ws_cert_path))
 
         # Check firewall rules were not reset
-        protocol_util.osutil.remove_rules_files.assert_not_called()
         protocol_util.osutil.remove_firewall.assert_not_called()
         protocol_util.osutil.enable_firewall.assert_not_called()
 


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
Removes clearing of 75-persistent-net-generator.rules and 70-persistent-net.rules. These files are not related to resetting firewall. I originally included this removal because env.py does this regularly. 

### PR information
- [x] Retest on AzureStack Environment

### Quality of Code and Contribution Guidelines
- [x] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/walinuxagent/1839)
<!-- Reviewable:end -->
