### PR TITLE
Update 'Provisioning' options in default configs

### DIFF
--- a/config/alpine/waagent.conf
+++ b/config/alpine/waagent.conf
@@ -2,15 +2,13 @@
 # Windows Azure Linux Agent Configuration
 #
 
-# Enable instance creation
-Provisioning.Enabled=y
-
 # Enable extension handling. Do not disable this unless you do not need password reset,
 # backup, monitoring, or any extension handling whatsoever.
 Extensions.Enabled=y
 
-# Rely on cloud-init to provision
-Provisioning.UseCloudInit=n
+# Which provisioning agent to use. Supported values are "auto" (default), "waagent",
+# "cloud-init", or "disabled".
+Provisioning.Agent=auto
 
 # Password authentication for root account will be unavailable.
 Provisioning.DeleteRootPassword=y

--- a/config/arch/waagent.conf
+++ b/config/arch/waagent.conf
@@ -2,11 +2,9 @@
 # Microsoft Azure Linux Agent Configuration
 #
 
-# Enable instance creation
-Provisioning.Enabled=y
-
-# Rely on cloud-init to provision
-Provisioning.UseCloudInit=n
+# Which provisioning agent to use. Supported values are "auto" (default), "waagent",
+# "cloud-init", or "disabled".
+Provisioning.Agent=auto
 
 # Password authentication for root account will be unavailable.
 Provisioning.DeleteRootPassword=n

--- a/config/bigip/waagent.conf
+++ b/config/bigip/waagent.conf
@@ -13,15 +13,13 @@ Role.ConfigurationConsumer=None
 # Specified program is invoked with XML file argument specifying role topology.
 Role.TopologyConsumer=None
 
-# Enable instance creation
-Provisioning.Enabled=y
-
 # Enable extension handling. Do not disable this unless you do not need password reset,
 # backup, monitoring, or any extension handling whatsoever.
 Extensions.Enabled=y
 
-# Rely on cloud-init to provision
-Provisioning.UseCloudInit=n
+# Which provisioning agent to use. Supported values are "auto" (default), "waagent",
+# "cloud-init", or "disabled".
+Provisioning.Agent=auto
 
 # Password authentication for root account will be unavailable.
 Provisioning.DeleteRootPassword=y

--- a/config/clearlinux/waagent.conf
+++ b/config/clearlinux/waagent.conf
@@ -13,11 +13,9 @@ Role.ConfigurationConsumer=None
 # Specified program is invoked with XML file argument specifying role topology.
 Role.TopologyConsumer=None
 
-# Enable instance creation
-Provisioning.Enabled=y
-
-# Rely on cloud-init to provision
-Provisioning.UseCloudInit=n
+# Which provisioning agent to use. Supported values are "auto" (default), "waagent",
+# "cloud-init", or "disabled".
+Provisioning.Agent=auto
 
 # Password authentication for root account will be unavailable.
 Provisioning.DeleteRootPassword=y

--- a/config/coreos/waagent.conf
+++ b/config/coreos/waagent.conf
@@ -2,15 +2,13 @@
 # Microsoft Azure Linux Agent Configuration
 #
 
-# Enable instance creation
-Provisioning.Enabled=y
-
 # Enable extension handling. Do not disable this unless you do not need password reset,
 # backup, monitoring, or any extension handling whatsoever.
 Extensions.Enabled=y
 
-# Rely on cloud-init to provision
-Provisioning.UseCloudInit=n
+# Which provisioning agent to use. Supported values are "auto" (default), "waagent",
+# "cloud-init", or "disabled".
+Provisioning.Agent=auto
 
 # Password authentication for root account will be unavailable.
 Provisioning.DeleteRootPassword=n

--- a/config/debian/waagent.conf
+++ b/config/debian/waagent.conf
@@ -2,15 +2,13 @@
 # Microsoft Azure Linux Agent Configuration
 #
 
-# Enable instance creation
-Provisioning.Enabled=y
-
 # Enable extension handling. Do not disable this unless you do not need password reset,
 # backup, monitoring, or any extension handling whatsoever.
 Extensions.Enabled=y
 
-# Rely on cloud-init to provision
-Provisioning.UseCloudInit=n
+# Which provisioning agent to use. Supported values are "auto" (default), "waagent",
+# "cloud-init", or "disabled".
+Provisioning.Agent=auto
 
 # Password authentication for root account will be unavailable.
 Provisioning.DeleteRootPassword=y

--- a/config/freebsd/waagent.conf
+++ b/config/freebsd/waagent.conf
@@ -2,15 +2,13 @@
 # Microsoft Azure Linux Agent Configuration
 #
 
-# Enable instance creation
-Provisioning.Enabled=y
-
 # Enable extension handling. Do not disable this unless you do not need password reset,
 # backup, monitoring, or any extension handling whatsoever.
 Extensions.Enabled=y
 
-# Rely on cloud-init to provision
-Provisioning.UseCloudInit=n
+# Which provisioning agent to use. Supported values are "auto" (default), "waagent",
+# "cloud-init", or "disabled".
+Provisioning.Agent=auto
 
 # Password authentication for root account will be unavailable.
 Provisioning.DeleteRootPassword=y

--- a/config/gaia/waagent.conf
+++ b/config/gaia/waagent.conf
@@ -2,15 +2,13 @@
 # Microsoft Azure Linux Agent Configuration
 #
 
-# Enable instance creation
-Provisioning.Enabled=y
-
 # Enable extension handling. Do not disable this unless you do not need password reset,
 # backup, monitoring, or any extension handling whatsoever.
 Extensions.Enabled=y
 
-# Rely on cloud-init to provision
-Provisioning.UseCloudInit=n
+# Which provisioning agent to use. Supported values are "auto" (default), "waagent",
+# "cloud-init", or "disabled".
+Provisioning.Agent=auto
 
 # Password authentication for root account will be unavailable.
 Provisioning.DeleteRootPassword=n

--- a/config/iosxe/waagent.conf
+++ b/config/iosxe/waagent.conf
@@ -2,11 +2,9 @@
 # Microsoft Azure Linux Agent Configuration
 #
 
-# Enable instance creation
-Provisioning.Enabled=n
-
-# Rely on cloud-init to provision
-Provisioning.UseCloudInit=n
+# Which provisioning agent to use. Supported values are "auto" (default), "waagent",
+# "cloud-init", or "disabled".
+Provisioning.Agent=auto
 
 # Password authentication for root account will be unavailable.
 Provisioning.DeleteRootPassword=y

--- a/config/nsbsd/waagent.conf
+++ b/config/nsbsd/waagent.conf
@@ -2,11 +2,9 @@
 # Microsoft Azure Linux Agent Configuration
 #
 
-# Enable instance creation
-Provisioning.Enabled=y
-
-# Rely on cloud-init to provision
-Provisioning.UseCloudInit=n
+# Which provisioning agent to use. Supported values are "auto" (default), "waagent",
+# "cloud-init", or "disabled".
+Provisioning.Agent=auto
 
 # Password authentication for root account will be unavailable.
 Provisioning.DeleteRootPassword=n

--- a/config/openbsd/waagent.conf
+++ b/config/openbsd/waagent.conf
@@ -2,11 +2,9 @@
 # Microsoft Azure Linux Agent Configuration
 #
 
-# Enable instance creation
-Provisioning.Enabled=y
-
-# Rely on cloud-init to provision
-Provisioning.UseCloudInit=n
+# Which provisioning agent to use. Supported values are "auto" (default), "waagent",
+# "cloud-init", or "disabled".
+Provisioning.Agent=auto
 
 # Password authentication for root account will be unavailable.
 Provisioning.DeleteRootPassword=y

--- a/config/suse/waagent.conf
+++ b/config/suse/waagent.conf
@@ -2,15 +2,13 @@
 # Microsoft Azure Linux Agent Configuration
 #
 
-# Enable instance creation
-Provisioning.Enabled=y
-
 # Enable extension handling. Do not disable this unless you do not need password reset,
 # backup, monitoring, or any extension handling whatsoever.
 Extensions.Enabled=y
 
-# Rely on cloud-init to provision
-Provisioning.UseCloudInit=n
+# Which provisioning agent to use. Supported values are "auto" (default), "waagent",
+# "cloud-init", or "disabled".
+Provisioning.Agent=auto
 
 # Password authentication for root account will be unavailable.
 Provisioning.DeleteRootPassword=y

--- a/config/ubuntu/waagent.conf
+++ b/config/ubuntu/waagent.conf
@@ -2,15 +2,13 @@
 # Microsoft Azure Linux Agent Configuration
 #
 
-# Enable instance creation
-Provisioning.Enabled=n
-
 # Enable extension handling. Do not disable this unless you do not need password reset,
 # backup, monitoring, or any extension handling whatsoever.
 Extensions.Enabled=y
 
-# Rely on cloud-init to provision
-Provisioning.UseCloudInit=y
+# Which provisioning agent to use. Supported values are "auto" (default), "waagent",
+# "cloud-init", or "disabled".
+Provisioning.Agent=auto
 
 # Password authentication for root account will be unavailable.
 Provisioning.DeleteRootPassword=y

--- a/config/waagent.conf
+++ b/config/waagent.conf
@@ -2,15 +2,13 @@
 # Microsoft Azure Linux Agent Configuration
 #
 
-# Enable instance creation
-Provisioning.Enabled=y
-
 # Enable extension handling. Do not disable this unless you do not need password reset,
 # backup, monitoring, or any extension handling whatsoever.
 Extensions.Enabled=y
 
-# Rely on cloud-init to provision
-Provisioning.UseCloudInit=n
+# Which provisioning agent to use. Supported values are "auto" (default), "waagent",
+# "cloud-init", or "disabled".
+Provisioning.Agent=auto
 
 # Password authentication for root account will be unavailable.
 Provisioning.DeleteRootPassword=y


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

'Provisioning.Enabled' and 'Provisioning.UseCloudInit' parameters are
removed since v2.2.45 and replaced with 'Provisioning.Agent'. Update
distro specific configs accordingly.

Issue # <!-- if any -->
<!--
Semi-automatically remove now-unsupported 'Provisioning.Enabled' and
'Provisioning.UseCloudInit' options from all configs in config/ and add
'Provisioning.Agent=auto' there.
-->

---

### PR information
- [X ] The title of the PR is clear and informative.
- [X] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [X] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [-] If applicable, the PR references the bug/issue that it fixes in the description.
- [-] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [X] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/walinuxagent/1853)
<!-- Reviewable:end -->
