### PR TITLE
Upgrade unit test to be compatible with Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ matrix:
     - python: 3.4
     - python: 3.6
     - python: 3.7
+    - python: 3.8
       env:
         - >-
           NOSEOPTS="--verbose --with-coverage --with-timer --cover-inclusive

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,12 +23,6 @@ matrix:
     - python: 3.6
     - python: 3.7
     - python: 3.8
-      env:
-        - >-
-          NOSEOPTS="--verbose --with-coverage --with-timer --cover-inclusive
-          --cover-min-percentage=60 --cover-branches
-          --cover-package=azurelinuxagent --cover-xml"
-          SETUPOPTS=""
 
 install:
   - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,12 @@ matrix:
     - python: 3.6
     - python: 3.7
     - python: 3.8
+      env:
+        - >-
+          NOSEOPTS="--verbose --with-coverage --with-timer --cover-inclusive
+          --cover-min-percentage=60 --cover-branches
+          --cover-package=azurelinuxagent --cover-xml"
+          SETUPOPTS=""
 
 install:
   - pip install -r requirements.txt

--- a/azurelinuxagent/common/osutil/bigip.py
+++ b/azurelinuxagent/common/osutil/bigip.py
@@ -67,7 +67,7 @@ class BigIpOSUtil(DefaultOSUtil):
                 break
             time.sleep(30)
 
-        if rc is 0:
+        if rc == 0:
             return True
 
         raise OSUtilError(

--- a/azurelinuxagent/common/version.py
+++ b/azurelinuxagent/common/version.py
@@ -87,7 +87,7 @@ def get_distro():
         osinfo = ['nsbsd', release, '', 'nsbsd']
     else:
         try:
-            # dist() removed in Python 3.7
+            # dist() removed in Python 3.8
             osinfo = list(platform.dist()) + ['']
         except:
             osinfo = ['UNKNOWN', 'FFFF', '', '']

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-distro; python_version >= '3.8'
+distro; python_version >= '3.7'
 pyasn1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-distro; python_version >= '3.7'
+distro; python_version >= '3.8'
 pyasn1

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,6 +4,6 @@ flake8; python_version >= '2.7'
 mock==2.0.0; python_version == '2.6'
 mock==3.0.5; python_version >= '2.7' and python_version <= '3.5'
 mock==4.0.2; python_version >= '3.6'
-distro; python_version >= '3.7'
+distro; python_version >= '3.8'
 nose
 nose-timer; python_version >= '2.7'

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,5 +4,6 @@ flake8; python_version >= '2.7'
 mock==2.0.0; python_version == '2.6'
 mock==3.0.5; python_version >= '2.7' and python_version <= '3.5'
 mock==4.0.2; python_version >= '3.6'
+distro; python_version >= '3.7'
 nose
 nose-timer; python_version >= '2.7'

--- a/tests/common/test_version.py
+++ b/tests/common/test_version.py
@@ -26,7 +26,7 @@ from azurelinuxagent.common.event import EVENTS_DIRECTORY
 from azurelinuxagent.common.version import set_current_agent, \
     AGENT_LONG_VERSION, AGENT_VERSION, AGENT_NAME, AGENT_NAME_PATTERN, \
     get_f5_platform, get_distro, PY_VERSION_MAJOR, PY_VERSION_MINOR
-from tests.tools import AgentTestCase, open_patch, patch, skip_if_predicate_false
+from tests.tools import AgentTestCase, open_patch, patch
 
 
 def freebsd_system():
@@ -57,7 +57,7 @@ def default_system_exception():
     raise Exception
 
 
-def is_platform_supported():
+def is_platform_dist_supported():
     # platform.dist() and platform.linux_distribution() is deprecated from Python 3.7+
     if PY_VERSION_MAJOR == 3 and PY_VERSION_MINOR >= 7:
         return False
@@ -85,21 +85,33 @@ class TestAgentVersion(AgentTestCase):
         self.assertListEqual(openbsd_list, osinfo)
         return
 
-    @skip_if_predicate_false(is_platform_supported, "platform.dist() is deprecated in Python 3.7+")
     @mock.patch('platform.system', side_effect=default_system)
-    @mock.patch('platform.dist', side_effect=default_system_no_linux_distro)
-    def test_distro_is_correct_format_when_default_case(self, platform_system_name, default_system_no_linux):
-        osinfo = get_distro()
+    def test_distro_is_correct_format_when_default_case(self, *args):
         default_list = ['', '', '', '']
-        self.assertListEqual(default_list, osinfo)
+        unknown_list = ['unknown', 'FFFF', '', '']
+
+        if is_platform_dist_supported():
+            with patch('platform.dist', side_effect=default_system_no_linux_distro):
+                osinfo = get_distro()
+                self.assertListEqual(default_list, osinfo)
+        else:
+            # platform.dist() is deprecated in Python 3.7+ and would throw, resulting in unknown distro
+            osinfo = get_distro()
+            self.assertListEqual(unknown_list, osinfo)
         return
 
-    @skip_if_predicate_false(is_platform_supported, "platform.dist() is deprecated in Python 3.7+")
     @mock.patch('platform.system', side_effect=default_system)
-    @mock.patch('platform.dist', side_effect=default_system_exception)
-    def test_distro_is_correct_for_exception_case(self, platform_system_name, default_system_no_linux):
-        osinfo = get_distro()
+    def test_distro_is_correct_for_exception_case(self, *args):
         default_list = ['unknown', 'FFFF', '', '']
+
+        if is_platform_dist_supported():
+            with patch('platform.dist', side_effect=default_system_exception):
+                osinfo = get_distro()
+        else:
+            # platform.dist() is deprecated in Python 3.7+ so we can't patch it, but it would throw
+            # as well, resulting in the same unknown distro
+            osinfo = get_distro()
+
         self.assertListEqual(default_list, osinfo)
         return
 

--- a/tests/common/test_version.py
+++ b/tests/common/test_version.py
@@ -58,8 +58,8 @@ def default_system_exception():
 
 
 def is_platform_dist_supported():
-    # platform.dist() and platform.linux_distribution() is deprecated from Python 3.7+
-    if PY_VERSION_MAJOR == 3 and PY_VERSION_MINOR >= 7:
+    # platform.dist() and platform.linux_distribution() is deprecated from Python 3.8+
+    if PY_VERSION_MAJOR == 3 and PY_VERSION_MINOR >= 8:
         return False
     else:
         return True

--- a/tests/protocol/test_protocol_util.py
+++ b/tests/protocol/test_protocol_util.py
@@ -281,11 +281,10 @@ class TestProtocolUtil(AgentTestCase):
         with open(os.path.join(dir, ENDPOINT_FILE_NAME), 'r') as f:
             self.assertEquals(f.read(), KNOWN_WIRESERVER_IP)
 
-    @patch("azurelinuxagent.common.utils.fileutil")
+    @patch("azurelinuxagent.common.protocol.util.fileutil")
     @patch("azurelinuxagent.common.conf.get_lib_dir")
     def test_endpoint_file_states(self, mock_get_lib_dir, mock_fileutil, _):
         mock_get_lib_dir.return_value = self.tmp_dir
-        mock_fileutil = MagicMock()
 
         protocol_util = get_protocol_util()
         endpoint_file = protocol_util._get_wireserver_endpoint_file_path()
@@ -312,7 +311,7 @@ class TestProtocolUtil(AgentTestCase):
         mock_fileutil.write_file.side_effect = IOError()
 
         ep = protocol_util.get_wireserver_endpoint()
-        self.assertRaises(OSUtilError, protocol_util._set_wireserver_endpoint('abc'))
+        self.assertRaises(OSUtilError, protocol_util._set_wireserver_endpoint, 'abc')
 
         # Test clear endpoint for io error
         with open(endpoint_file, "w+") as ep_fd:


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

- Fixed tests that were failing in Python 3.8
- Removed coverage output in Travis runs since the output was getting in the way of readability for unit test runs (codecov still runs on PRs and commits)
- Disabled tests that rely on mocking `platform.dist`. These tests and the method they are testing need to be updated once we figure out a good strategy to support `distro` and get away from `platform`.

Related to #1859.

<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).