### PR TITLE
Update osutil for Ubuntu 18+

### DIFF
--- a/azurelinuxagent/common/osutil/factory.py
+++ b/azurelinuxagent/common/osutil/factory.py
@@ -65,7 +65,9 @@ def _get_osutil(distro_name, distro_code_name, distro_version, distro_full_name)
             return Ubuntu14OSUtil()
         elif Version(distro_version) in [Version('16.04'), Version('16.10'), Version('17.04')]:
             return Ubuntu16OSUtil()
-        elif Version(distro_version) >= Version('18.04'):
+        elif Version(distro_version) in [Version('18.04'), Version('18.10'),
+                                         Version('19.04'), Version('19.10'),
+                                         Version('20.04')]:
             return Ubuntu18OSUtil()
         elif distro_full_name == "Snappy Ubuntu Core":
             return UbuntuSnappyOSUtil()

--- a/azurelinuxagent/common/osutil/factory.py
+++ b/azurelinuxagent/common/osutil/factory.py
@@ -65,7 +65,7 @@ def _get_osutil(distro_name, distro_code_name, distro_version, distro_full_name)
             return Ubuntu14OSUtil()
         elif Version(distro_version) in [Version('16.04'), Version('16.10'), Version('17.04')]:
             return Ubuntu16OSUtil()
-        elif Version(distro_version) in [Version('18.04')]:
+        elif Version(distro_version) >= Version('18.04'):
             return Ubuntu18OSUtil()
         elif distro_full_name == "Snappy Ubuntu Core":
             return UbuntuSnappyOSUtil()

--- a/azurelinuxagent/common/osutil/ubuntu.py
+++ b/azurelinuxagent/common/osutil/ubuntu.py
@@ -89,7 +89,7 @@ class Ubuntu16OSUtil(Ubuntu14OSUtil):
 
 class Ubuntu18OSUtil(Ubuntu16OSUtil):
     """
-    Ubuntu 18.04+ (19.04, 20.04)
+    Ubuntu 18.04, 18.10, 19.04, 19.10, 20.04
     """
     def __init__(self):
         super(Ubuntu18OSUtil, self).__init__()

--- a/azurelinuxagent/common/osutil/ubuntu.py
+++ b/azurelinuxagent/common/osutil/ubuntu.py
@@ -89,7 +89,7 @@ class Ubuntu16OSUtil(Ubuntu14OSUtil):
 
 class Ubuntu18OSUtil(Ubuntu16OSUtil):
     """
-    Ubuntu 18.04
+    Ubuntu 18.04+ (19.04, 20.04)
     """
     def __init__(self):
         super(Ubuntu18OSUtil, self).__init__()

--- a/tests/common/osutil/test_factory.py
+++ b/tests/common/osutil/test_factory.py
@@ -83,8 +83,15 @@ class TestOsUtilFactory(AgentTestCase):
         self.assertEquals(ret.get_service_name(), "walinuxagent")
 
         ret = _get_osutil(distro_name="ubuntu",
-                          distro_code_name="",
+                          distro_code_name="bionic",
                           distro_version="18.04",
+                          distro_full_name="")
+        self.assertTrue(type(ret) == Ubuntu18OSUtil)
+        self.assertEquals(ret.get_service_name(), "walinuxagent")
+
+        ret = _get_osutil(distro_name="ubuntu",
+                          distro_code_name="focal",
+                          distro_version="20.04",
                           distro_full_name="")
         self.assertTrue(type(ret) == Ubuntu18OSUtil)
         self.assertEquals(ret.get_service_name(), "walinuxagent")


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Ubuntu images newer than 18.04 would default to using the default Ubuntu osutil, which doesn't support systemd. This PR makes sure that Ubuntu 18.04, 18.10, 19.04, 19.10, and 20.04 are using `Ubuntu18OSUtil` which supports systemd.

Fixes #1671.

<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).