### PR TITLE
Use controller mount point for extension cgroup path

### DIFF
--- a/azurelinuxagent/common/cgroupconfigurator.py
+++ b/azurelinuxagent/common/cgroupconfigurator.py
@@ -91,7 +91,7 @@ class CGroupConfigurator(object):
                 #
                 # check v1 controllers
                 #
-                cpu_controller_root, memory_controller_root = self._cgroups_api.get_cpu_and_memory_mount_points()
+                cpu_controller_root, memory_controller_root = self._cgroups_api.get_cgroup_mount_points()
 
                 if cpu_controller_root is not None:
                     logger.info("The CPU cgroup controller is mounted at {0}", cpu_controller_root)
@@ -114,7 +114,7 @@ class CGroupConfigurator(object):
                 # check the cgroups for the agent
                 #
                 agent_unit_name = get_osutil().get_service_name() + ".service"
-                cpu_cgroup_relative_path, memory_cgroup_relative_path = self._cgroups_api.get_cpu_and_memory_cgroup_relative_paths_for_process("self")
+                cpu_cgroup_relative_path, memory_cgroup_relative_path = self._cgroups_api.get_process_cgroup_relative_paths("self")
                 if cpu_cgroup_relative_path is None:
                     log_cgroup_warn("The agent's process is not within a CPU cgroup")
                 else:
@@ -143,6 +143,8 @@ class CGroupConfigurator(object):
                 else:
                     memory_cgroup_path = os.path.join(memory_controller_root, memory_cgroup_relative_path)
                     CGroupsTelemetry.track_cgroup(MemoryCgroup(agent_unit_name, memory_cgroup_path))
+
+                log_cgroup_info("Agent cgroups: CPU: {0} -- MEMORY: {1}", cpu_cgroup_path, memory_cgroup_path)
 
             except Exception as e:
                 message = "Error initializing cgroups: {0}".format(ustr(e))
@@ -239,15 +241,15 @@ class CGroupConfigurator(object):
                                                            stderr=stderr,
                                                            error_code=error_code)
             else:
-                extension_cgroups, process_output = self._cgroups_api.start_extension_command(extension_name,
-                                                                                              command,
-                                                                                              timeout,
-                                                                                              shell=shell,
-                                                                                              cwd=cwd,
-                                                                                              env=env,
-                                                                                              stdout=stdout,
-                                                                                              stderr=stderr,
-                                                                                              error_code=error_code)
+                process_output = self._cgroups_api.start_extension_command(extension_name,
+                                                                          command,
+                                                                          timeout,
+                                                                          shell=shell,
+                                                                          cwd=cwd,
+                                                                          env=env,
+                                                                          stdout=stdout,
+                                                                          stderr=stderr,
+                                                                          error_code=error_code)
 
             return process_output
 

--- a/tests/common/test_cgroupapi.py
+++ b/tests/common/test_cgroupapi.py
@@ -21,8 +21,9 @@ import os
 import re
 import subprocess
 import tempfile
-from azurelinuxagent.common.cgroupapi import CGroupsApi, FileSystemCgroupsApi, SystemdCgroupsApi, CGROUPS_FILE_SYSTEM_ROOT, VM_AGENT_CGROUP_NAME
-from azurelinuxagent.common.exception import CGroupsException, ExtensionError, ExtensionErrorCodes
+from azurelinuxagent.common.cgroupapi import CGroupsApi, FileSystemCgroupsApi, SystemdCgroupsApi, VM_AGENT_CGROUP_NAME
+from azurelinuxagent.common.cgroupstelemetry import CGroupsTelemetry
+from azurelinuxagent.common.exception import ExtensionError, ExtensionErrorCodes
 from azurelinuxagent.common.future import ustr
 from azurelinuxagent.common.utils import shellutil, fileutil
 from nose.plugins.attrib import attr
@@ -474,13 +475,13 @@ class SystemdCgroupsApiTestCase(AgentTestCase):
 
     def test_get_cpu_and_memory_mount_points_should_return_the_cgroup_mount_points(self):
         with mock_cgroup_commands():
-            cpu, memory = SystemdCgroupsApi.get_cpu_and_memory_mount_points()
+            cpu, memory = SystemdCgroupsApi().get_cgroup_mount_points()
             self.assertEquals(cpu, '/sys/fs/cgroup/cpu,cpuacct', "The mount point for the CPU controller is incorrect")
             self.assertEquals(memory, '/sys/fs/cgroup/memory', "The mount point for the memory controller is incorrect")
 
     def test_get_cpu_and_memory_cgroup_relative_paths_for_process_should_return_the_cgroup_relative_paths(self):
         with mock_cgroup_commands():
-            cpu, memory = SystemdCgroupsApi.get_cpu_and_memory_cgroup_relative_paths_for_process('self')
+            cpu, memory = SystemdCgroupsApi.get_process_cgroup_relative_paths('self')
             self.assertEquals(cpu, "system.slice/walinuxagent.service", "The relative path for the CPU cgroup is incorrect")
             self.assertEquals(memory, "system.slice/walinuxagent.service", "The relative memory for the CPU cgroup is incorrect")
 
@@ -567,18 +568,11 @@ class SystemdCgroupsApiTestCase(AgentTestCase):
         self.assertTrue(memory_found, 'start_extension_command did not return a memory cgroup')
 
     @patch('time.sleep', side_effect=lambda _: mock_sleep())
-    def test_start_extension_command_should_create_extension_scopes(self, _):
-        original_popen = subprocess.Popen
-
-        def mock_popen(*args, **kwargs):
-            return original_popen("date", **kwargs)
-
-        # we mock subprocess.Popen to execute a dummy command (date), so no actual cgroups are created; their paths
-        # should be computed properly, though
-        with patch("azurelinuxagent.common.cgroupapi.subprocess.Popen", mock_popen):
-            extension_cgroups, process_output = SystemdCgroupsApi().start_extension_command(
+    def test_start_extension_command_should_execute_the_command_in_a_cgroup(self, _):
+        with mock_cgroup_commands():
+            SystemdCgroupsApi().start_extension_command(
                 extension_name="Microsoft.Compute.TestExtension-1.2.3",
-                command="date",
+                command="test command",
                 shell=False,
                 timeout=300,
                 cwd=self.tmp_dir,
@@ -586,82 +580,79 @@ class SystemdCgroupsApiTestCase(AgentTestCase):
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE)
 
-            self.assert_cgroups_created(extension_cgroups)
+            tracked = CGroupsTelemetry._tracked
 
-    @attr('requires_sudo')
-    @patch('time.sleep', side_effect=lambda _: mock_sleep(0.2))
-    def test_start_extension_command_should_use_systemd_and_not_the_fallback_option_if_successful(self, _):
-        self.assertTrue(i_am_root(), "Test does not run when non-root")
+            self.assertTrue(
+                any(cg for cg in tracked if cg.name == 'Microsoft.Compute.TestExtension-1.2.3' and 'cpu' in cg.path),
+                "The extension's CPU is not being tracked")
+            self.assertTrue(
+                any(cg for cg in tracked if cg.name == 'Microsoft.Compute.TestExtension-1.2.3' and 'memory' in cg.path),
+                "The extension's memory is not being tracked")
 
-        with tempfile.TemporaryFile(dir=self.tmp_dir, mode="w+b") as stdout:
-            with tempfile.TemporaryFile(dir=self.tmp_dir, mode="w+b") as stderr:
-                with patch("azurelinuxagent.common.cgroupapi.subprocess.Popen", wraps=subprocess.Popen) \
-                        as patch_mock_popen:
-                    extension_cgroups, process_output = SystemdCgroupsApi().start_extension_command(
+    @patch('time.sleep', side_effect=lambda _: mock_sleep())
+    def test_start_extension_command_should_use_systemd_to_execute_the_command(self, _):
+        with mock_cgroup_commands():
+            with patch("azurelinuxagent.common.cgroupapi.subprocess.Popen", wraps=subprocess.Popen) as popen_patch:
+                SystemdCgroupsApi().start_extension_command(
+                    extension_name="Microsoft.Compute.TestExtension-1.2.3",
+                    command="the-test-extension-command",
+                    timeout=300,
+                    shell=True,
+                    cwd=self.tmp_dir,
+                    env={},
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE)
+
+                extension_calls = [args[0] for (args, _) in popen_patch.call_args_list if "the-test-extension-command" in args[0]]
+
+                self.assertEquals(1, len(extension_calls), "The extension should have been invoked exactly once")
+                self.assertIn("systemd-run --unit=Microsoft.Compute.TestExtension_1.2.3", extension_calls[0], "The extension should have been invoked using systemd")
+
+    @patch('time.sleep', side_effect=lambda _: mock_sleep())
+    def test_start_extension_command_should_invoke_the_command_directly_if_systemd_fails(self, _):
+        original_popen = subprocess.Popen
+
+        def mock_popen(command, *args, **kwargs):
+            if command.startswith('systemd-run'):
+                # Inject a syntax error to the call
+                command = command.replace('systemd-run', 'systemd-run syntax_error')
+            return original_popen(command, *args, **kwargs)
+
+        with tempfile.TemporaryFile(dir=self.tmp_dir, mode="w+b") as output_file:
+            with patch("azurelinuxagent.common.cgroupapi.add_event") as mock_add_event:
+                with patch("azurelinuxagent.common.cgroupapi.subprocess.Popen", side_effect=mock_popen) as popen_patch:
+                    CGroupsTelemetry.reset()
+
+                    process_output = SystemdCgroupsApi().start_extension_command(
                         extension_name="Microsoft.Compute.TestExtension-1.2.3",
                         command="date",
                         timeout=300,
                         shell=True,
                         cwd=self.tmp_dir,
                         env={},
-                        stdout=stdout,
-                        stderr=stderr)
+                        stdout=output_file,
+                        stderr=output_file)
 
-                    # We should have invoked the extension command only once and succeeded
-                    self.assertEquals(1, patch_mock_popen.call_count)
+                    args, kwargs = mock_add_event.call_args
+                    self.assertIn("Failed to run systemd-run for unit Microsoft.Compute.TestExtension_1.2.3",
+                                  kwargs['message'])
+                    self.assertIn("Failed to find executable syntax_error: No such file or directory",
+                                  kwargs['message'])
+                    self.assertEquals(False, kwargs['is_success'])
+                    self.assertEquals('InvokeCommandUsingSystemd', kwargs['op'])
 
-                    args = patch_mock_popen.call_args[0][0]
-                    self.assertIn("systemd-run --unit", args)
+                    extension_calls = [args[0] for (args, _) in popen_patch.call_args_list if "date" in args[0]]
 
-                    self.assert_cgroups_created(extension_cgroups)
+                    self.assertEquals(2, len(extension_calls), "The extension should have been invoked exactly twice")
+                    self.assertIn("systemd-run --unit=Microsoft.Compute.TestExtension_1.2.3", extension_calls[0],
+                        "The first call to the extension should have used systemd")
+                    self.assertEquals("date", extension_calls[1],
+                        "The second call to the extension should not have used systemd")
 
-    @patch('time.sleep', side_effect=lambda _: mock_sleep(0.2))
-    def test_start_extension_command_should_use_fallback_option_if_systemd_fails(self, _):
-        original_popen = subprocess.Popen
+                    self.assertEquals(len(CGroupsTelemetry._tracked), 0, "No cgroups should have been created")
 
-        def mock_popen(*args, **kwargs):
-            # Inject a syntax error to the call
-            systemd_command = args[0].replace('systemd-run', 'systemd-run syntax_error')
-            new_args = (systemd_command,)
-            return original_popen(new_args, **kwargs)
-
-        with tempfile.TemporaryFile(dir=self.tmp_dir, mode="w+b") as stdout:
-            with tempfile.TemporaryFile(dir=self.tmp_dir, mode="w+b") as stderr:
-                with patch("azurelinuxagent.common.cgroupapi.add_event") as mock_add_event:
-                    with patch("azurelinuxagent.common.cgroupapi.subprocess.Popen", side_effect=mock_popen) \
-                            as patch_mock_popen:
-                        # We expect this call to fail because of the syntax error
-                        extension_cgroups, process_output = SystemdCgroupsApi().start_extension_command(
-                            extension_name="Microsoft.Compute.TestExtension-1.2.3",
-                            command="date",
-                            timeout=300,
-                            shell=True,
-                            cwd=self.tmp_dir,
-                            env={},
-                            stdout=stdout,
-                            stderr=stderr)
-
-                        args, kwargs = mock_add_event.call_args
-                        self.assertIn("Failed to run systemd-run for unit Microsoft.Compute.TestExtension_1.2.3",
-                                      kwargs['message'])
-                        self.assertIn("Failed to find executable syntax_error: No such file or directory",
-                                      kwargs['message'])
-                        self.assertEquals(False, kwargs['is_success'])
-                        self.assertEquals('InvokeCommandUsingSystemd', kwargs['op'])
-
-                        # We expect two calls to Popen, first for the systemd-run call, second for the fallback option
-                        self.assertEquals(2, patch_mock_popen.call_count)
-
-                        first_call_args = patch_mock_popen.mock_calls[0][1][0]
-                        second_call_args = patch_mock_popen.mock_calls[1][1][0]
-                        self.assertIn("systemd-run --unit", first_call_args)
-                        self.assertNotIn("systemd-run --unit", second_call_args)
-
-                        # No cgroups should have been created
-                        self.assertEquals(extension_cgroups, [])
-
-    @patch('time.sleep', side_effect=lambda _: mock_sleep(0.001))
-    def test_start_extension_command_should_use_fallback_option_if_systemd_times_out(self, _):
+    @patch('time.sleep', side_effect=lambda _: mock_sleep())
+    def test_start_extension_command_should_invoke_the_command_directly_if_systemd_times_out(self, _):
         # Systemd has its own internal timeout which is shorter than what we define for extension operation timeout.
         # When systemd times out, it will write a message to stderr and exit with exit code 1.
         # In that case, we will internally recognize the failure due to the non-zero exit code, not as a timeout.
@@ -681,9 +672,10 @@ class SystemdCgroupsApiTestCase(AgentTestCase):
 
         with tempfile.TemporaryFile(dir=self.tmp_dir, mode="w+b") as stdout:
             with tempfile.TemporaryFile(dir=self.tmp_dir, mode="w+b") as stderr:
-                with patch("azurelinuxagent.common.cgroupapi.subprocess.Popen", side_effect=mock_popen) \
-                        as patch_mock_popen:
-                    extension_cgroups, process_output = SystemdCgroupsApi().start_extension_command(
+                with patch("azurelinuxagent.common.cgroupapi.subprocess.Popen", side_effect=mock_popen) as popen_patch:
+                    CGroupsTelemetry.reset()
+
+                    SystemdCgroupsApi().start_extension_command(
                         extension_name="Microsoft.Compute.TestExtension-1.2.3",
                         command="echo 'success'",
                         timeout=300,
@@ -693,16 +685,13 @@ class SystemdCgroupsApiTestCase(AgentTestCase):
                         stdout=stdout,
                         stderr=stderr)
 
-                    # We expect two calls to Popen, first for the systemd-run call, second for the fallback option
-                    self.assertEquals(2, patch_mock_popen.call_count)
+                    extension_calls = [args[0] for (args, _) in popen_patch.call_args_list if "echo 'success'" in args[0]]
 
-                    first_call_args = patch_mock_popen.mock_calls[0][1][0]
-                    second_call_args = patch_mock_popen.mock_calls[1][1][0]
-                    self.assertIn("systemd-run --unit", first_call_args)
-                    self.assertNotIn("systemd-run --unit", second_call_args)
+                    self.assertEquals(2, len(extension_calls), "The extension should have been invoked exactly twice")
+                    self.assertIn("systemd-run --unit=Microsoft.Compute.TestExtension_1.2.3", extension_calls[0], "The first call to the extension should have used systemd")
+                    self.assertEquals("echo 'success'", extension_calls[1], "The second call to the extension should not have used systemd")
 
-                    self.assertEquals(extension_cgroups, [])
-                    self.assertEquals(expected_output.format("success"), process_output)
+                    self.assertEquals(len(CGroupsTelemetry._tracked), 0, "No cgroups should have been created")
 
     @attr('requires_sudo')
     @patch("azurelinuxagent.common.cgroupapi.add_event")

--- a/tests/common/test_cgroupconfigurator.py
+++ b/tests/common/test_cgroupconfigurator.py
@@ -26,7 +26,7 @@ from azurelinuxagent.common.cgroupconfigurator import CGroupConfigurator
 from azurelinuxagent.common.cgroupstelemetry import CGroupsTelemetry
 from azurelinuxagent.common.exception import CGroupsException
 from tests.common.mock_cgroup_commands import mock_cgroup_commands
-from tests.tools import AgentTestCase, patch
+from tests.tools import AgentTestCase, patch, mock_sleep
 
 
 class CGroupConfiguratorSystemdTestCase(AgentTestCase):
@@ -130,7 +130,8 @@ class CGroupConfiguratorSystemdTestCase(AgentTestCase):
                     message = args[0]
                     self.assertIn("A TEST EXCEPTION", message)
 
-    def test_start_extension_command_should_not_use_systemd_when_groups_are_not_enabled(self):
+    @patch('time.sleep', side_effect=lambda _: mock_sleep())
+    def test_start_extension_command_should_not_use_systemd_when_groups_are_not_enabled(self, _):
         configurator = CGroupConfiguratorSystemdTestCase._get_new_cgroup_configurator_instance()
         configurator.disable()
 
@@ -150,45 +151,30 @@ class CGroupConfiguratorSystemdTestCase(AgentTestCase):
             self.assertNotIn("systemd-run", command_calls[0], "The command should not have been invoked using systemd")
             self.assertEqual(command_calls[0], "date", "The command line should not have been modified")
 
-    @staticmethod
-    @contextlib.contextmanager
-    def _create_mock_popen(command):
-        """
-         Creates a mock for subprocess.Popen that replaces the given command with a dummy command (date); this allows
-        the tests below to run  on environments where systemd-run is not available
-        """
-        original_popen = subprocess.Popen
+    @patch('time.sleep', side_effect=lambda _: mock_sleep())
+    def test_start_extension_command_should_use_systemd_run_when_groups_are_enabled(self, _):
+        with mock_cgroup_commands():
+            with patch("azurelinuxagent.common.cgroupapi.subprocess.Popen", wraps=subprocess.Popen) as popen_patch:
+                CGroupConfiguratorSystemdTestCase._get_new_cgroup_configurator_instance().start_extension_command(
+                    extension_name="Microsoft.Compute.TestExtension-1.2.3",
+                    command="the-test-extension-command",
+                    timeout=300,
+                    shell=False,
+                    cwd=self.tmp_dir,
+                    env={},
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE)
 
-        def mock_popen(command_arg, *args, **kwargs):
-            if command in command_arg:
-                return original_popen("date", *args, **kwargs)
-            else:
-                return original_popen(command_arg, *args, **kwargs)
+                command_calls = [args[0] for (args, _) in popen_patch.call_args_list if "the-test-extension-command" in args[0]]
 
-        with patch("azurelinuxagent.common.cgroupapi.subprocess.Popen", side_effect=mock_popen) as patcher:
-            patcher.get_command_calls = lambda: [args[0] for args, _ in patcher.call_args_list if len(args) > 0 and command in args[0]]
-            yield patcher
+                self.assertEqual(len(command_calls), 1, "The test command should have been called exactly once [{0}]".format(command_calls))
+                self.assertIn("systemd-run --unit=Microsoft.Compute.TestExtension_1.2.3", command_calls[0], "The extension should have been invoked using systemd")
 
-    def test_start_extension_command_should_use_systemd_run_when_groups_are_enabled(self):
-        with CGroupConfiguratorSystemdTestCase._create_mock_popen("test command") as patch_popen:
-            CGroupConfiguratorSystemdTestCase._get_new_cgroup_configurator_instance().start_extension_command(
-                extension_name="Microsoft.Compute.TestExtension-1.2.3",
-                command="test command",
-                timeout=300,
-                shell=False,
-                cwd=self.tmp_dir,
-                env={},
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE)
-
-            command_calls = patch_popen.get_command_calls()
-            self.assertEqual(len(command_calls), 1, "The test command should have been called exactly once [{0}]".format(command_calls))
-            self.assertTrue(command_calls[0].startswith("systemd-run"), "The command should have been invoked using systemd [{0}]".format(command_calls))
-
-    def test_start_extension_command_should_start_tracking_the_extension_cgroups(self):
+    @patch('time.sleep', side_effect=lambda _: mock_sleep())
+    def test_start_extension_command_should_start_tracking_the_extension_cgroups(self, _):
         # CPU usage is initialized when we begin tracking a CPU cgroup; since this test does not retrieve the
         # CPU usage, there is no need for initialization
-        with CGroupConfiguratorSystemdTestCase._create_mock_popen("test command") as patch_popen:
+        with mock_cgroup_commands():
             CGroupConfiguratorSystemdTestCase._get_new_cgroup_configurator_instance().start_extension_command(
                 extension_name="Microsoft.Compute.TestExtension-1.2.3",
                 command="test command",

--- a/tests/common/test_cgroupconfigurator.py
+++ b/tests/common/test_cgroupconfigurator.py
@@ -131,7 +131,7 @@ class CGroupConfiguratorSystemdTestCase(AgentTestCase):
                     self.assertIn("A TEST EXCEPTION", message)
 
     @patch('time.sleep', side_effect=lambda _: mock_sleep())
-    def test_start_extension_command_should_not_use_systemd_when_groups_are_not_enabled(self, _):
+    def test_start_extension_command_should_not_use_systemd_when_cgroups_are_not_enabled(self, _):
         configurator = CGroupConfiguratorSystemdTestCase._get_new_cgroup_configurator_instance()
         configurator.disable()
 
@@ -152,7 +152,7 @@ class CGroupConfiguratorSystemdTestCase(AgentTestCase):
             self.assertEqual(command_calls[0], "date", "The command line should not have been modified")
 
     @patch('time.sleep', side_effect=lambda _: mock_sleep())
-    def test_start_extension_command_should_use_systemd_run_when_groups_are_enabled(self, _):
+    def test_start_extension_command_should_use_systemd_run_when_cgroups_are_enabled(self, _):
         with mock_cgroup_commands():
             with patch("azurelinuxagent.common.cgroupapi.subprocess.Popen", wraps=subprocess.Popen) as popen_patch:
                 CGroupConfiguratorSystemdTestCase._get_new_cgroup_configurator_instance().start_extension_command(

--- a/tests/data/cgroups/proc_pid_cgroup
+++ b/tests/data/cgroups/proc_pid_cgroup
@@ -1,0 +1,13 @@
+12:devices:/system.slice/Microsoft.A.Sample.Extension_1.0.1_aeac05dc-8c24-4542-95f2-a0d6be1c5ba7.scope
+11:perf_event:/
+10:rdma:/
+9:blkio:/system.slice/Microsoft.A.Sample.Extension_1.0.1_aeac05dc-8c24-4542-95f2-a0d6be1c5ba7.scope
+8:net_cls,net_prio:/
+7:freezer:/
+6:hugetlb:/
+5:memory:/system.slice/Microsoft.A.Sample.Extension_1.0.1_aeac05dc-8c24-4542-95f2-a0d6be1c5ba7.scope
+4:cpuset:/
+3:cpu,cpuacct:/system.slice/Microsoft.A.Sample.Extension_1.0.1_aeac05dc-8c24-4542-95f2-a0d6be1c5ba7.scope
+2:pids:/system.slice/Microsoft.A.Sample.Extension_1.0.1_aeac05dc-8c24-4542-95f2-a0d6be1c5ba7.scope
+1:name=systemd:/system.slice/Microsoft.A.Sample.Extension_1.0.1_aeac05dc-8c24-4542-95f2-a0d6be1c5ba7.scope
+0::/system.slice/Microsoft.A.Sample.Extension_1.0.1_aeac05dc-8c24-4542-95f2-a0d6be1c5ba7.scope


### PR DESCRIPTION
A small change in how we create the path for extensions cgroups. Instead of a hardcoded path now we use the mount point for the controllers.

Also, some test updates.