### PR TITLE
Do not use --unit with systemd-cgls

### DIFF
--- a/azurelinuxagent/common/cgroupapi.py
+++ b/azurelinuxagent/common/cgroupapi.py
@@ -628,19 +628,19 @@ After=system-{1}.slice""".format(extension_name, EXTENSIONS_ROOT_CGROUP_NAME)
         return self._agent_unit_name
 
     @staticmethod
-    def get_processes_in_cgroup(unit_name):
+    def get_processes_in_cgroup(cgroup_path):
         """
         Returns an array of tuples with the PID and command line of the processes that are currently
-        within the cgroup for the given unit.
+        within the cgroup for the given path (which must be within the cgroup filesystem).
         """
         #
         # The output of the command is similar to
         #
-        #     Unit walinuxagent.service (/system.slice/walinuxagent.service):
+        #     Directory /sys/fs/cgroup/cpu/system.slice/walinuxagent.service:
         #     ├─27519 /usr/bin/python3 -u /usr/sbin/waagent -daemon
         #     └─27547 python3 -u bin/WALinuxAgent-2.2.48.1-py2.7.egg -run-exthandlers
         #
-        output = shellutil.run_command(['systemd-cgls', '--unit', unit_name])
+        output = shellutil.run_command(['systemd-cgls', cgroup_path])
 
         processes = []
 

--- a/azurelinuxagent/common/utils/shellutil.py
+++ b/azurelinuxagent/common/utils/shellutil.py
@@ -120,14 +120,14 @@ class CommandError(Exception):
     Exception raised by run_command when the command returns an error
     """
     @staticmethod
-    def _get_message(command, returncode):
+    def _get_message(command, return_code, stderr):
         command_name = command[0] if isinstance(command, list) and len(command) > 0 else command
-        return "'{0}' failed: {1}".format(command_name, returncode)
+        return "'{0}' failed: {1} ({2})".format(command_name, return_code, stderr.rstrip())
 
-    def __init__(self, command, returncode, stdout, stderr):
-        super(Exception, self).__init__(CommandError._get_message(command, returncode))
+    def __init__(self, command, return_code, stdout, stderr):
+        super(Exception, self).__init__(CommandError._get_message(command, return_code, stderr))
         self.command = command
-        self.returncode = returncode
+        self.returncode = return_code
         self.stdout = stdout
         self.stderr = stderr
 
@@ -169,7 +169,7 @@ def run_command(command, log_error=False, cmd_input=None):
                 returncode,
                 encoded_stdout,
                 encoded_stderr)
-        raise CommandError(command=command, returncode=returncode, stdout=encoded_stdout, stderr=encoded_stderr)
+        raise CommandError(command=command, return_code=returncode, stdout=encoded_stdout, stderr=encoded_stderr)
 
     return _encode_command_output(stdout)
 

--- a/azurelinuxagent/ga/monitor.py
+++ b/azurelinuxagent/ga/monitor.py
@@ -71,17 +71,16 @@ class PollResourceUsageOperation(PeriodicOperation):
 
                 if len(unexpected_processes) > 0:
                     unexpected_processes.sort()
-                    processes_check_error = ustr(unexpected_processes)
+                    processes_check_error = "The agent's cgroup includes unexpected processes: {0}".format(ustr(unexpected_processes))
         except Exception as e:
-            processes_check_error = ustr(e)
+            processes_check_error = "Failed to check the processes in the agent's cgroup: {0}".format(ustr(e))
 
         # Report a small sample of errors
         if processes_check_error != self._last_error and self._error_count < 5:
             self._error_count += 1
             self._last_error = processes_check_error
-            message = "The agent's cgroup includes unexpected processes: {0}".format(processes_check_error)
-            logger.info(message)
-            add_event(op=WALAEventOperation.CGroupsDebug, message=message)
+            logger.info(processes_check_error)
+            add_event(op=WALAEventOperation.CGroupsDebug, message=processes_check_error)
 
         #
         # Report metrics

--- a/tests/common/mock_cgroup_commands.py
+++ b/tests/common/mock_cgroup_commands.py
@@ -67,9 +67,9 @@ Running scope as unit: TEST_UNIT.scope
 Thu 28 May 2020 07:25:55 AM PDT
 '''),
 
-    (r"^systemd-cgls --unit walinuxagent.service$",
+    (r"^systemd-cgls.+/walinuxagent.service$",
 '''
-Unit walinuxagent.service (/system.slice/walinuxagent.service):
+Directory /sys/fs/cgroup/cpu/system.slice/walinuxagent.service:
 ├─27519 /usr/bin/python3 -u /usr/sbin/waagent -daemon
 └─27547 python3 -u bin/WALinuxAgent-2.2.48.1-py2.7.egg -run-exthandlers
 '''),

--- a/tests/common/test_cgroupapi.py
+++ b/tests/common/test_cgroupapi.py
@@ -526,7 +526,7 @@ class SystemdCgroupsApiTestCase(AgentTestCase):
 
     def test_get_processes_in_cgroup_should_return_the_processes_within_the_cgroup(self):
         with mock_cgroup_commands():
-            processes = SystemdCgroupsApi.get_processes_in_cgroup("walinuxagent.service")
+            processes = SystemdCgroupsApi.get_processes_in_cgroup("/sys/fs/cgroup/cpu/system.slice/walinuxagent.service")
 
             self.assertTrue(len(processes) >= 2,
                 "The cgroup should contain at least 2 procceses (daemon and extension handler): [{0}]".format(processes))

--- a/tests/ga/test_monitor.py
+++ b/tests/ga/test_monitor.py
@@ -519,11 +519,12 @@ class PollResourceUsageOperationTestCase(AgentTestCase):
 
     def test_it_should_report_processes_that_do_not_belong_to_the_agent_cgroup(self):
         with mock_cgroup_commands() as mock_commands:
-            mock_commands.add_command(r'^systemd-cgls --unit walinuxagent.service$',
+            mock_commands.add_command(r'^systemd-cgls.+/walinuxagent.service$',
 '''
-Unit walinuxagent.service (/system.slice/walinuxagent.service):
+Directory /sys/fs/cgroup/cpu/system.slice/walinuxagent.service:
 ├─27519 /usr/bin/python3 -u /usr/sbin/waagent -daemon
 ├─27547 python3 -u bin/WALinuxAgent-2.2.48.1-py2.7.egg -run-exthandlers
+├─6200 systemd-cgls /sys/fs/cgroup/cpu,cpuacct/system.slice/walinuxagent.service
 ├─5821 pidof systemd-networkd
 ├─5822 iptables --version
 ├─5823 iptables -w -t security -D OUTPUT -d 168.63.129.16 -p tcp -m conntrack --ctstate INVALID,NEW -j ACCEPT

--- a/tests/utils/test_shell_util.py
+++ b/tests/utils/test_shell_util.py
@@ -15,7 +15,6 @@
 #
 # Requires Python 2.6+ and Openssl 1.0+
 #
-
 from tests.tools import AgentTestCase, patch
 import unittest
 import azurelinuxagent.common.utils.shellutil as shellutil
@@ -140,7 +139,8 @@ class RunCommandTestCase(AgentTestCase):
             shellutil.run_command(command)
 
         exception = context_manager.exception
-        self.assertEquals(str(exception), "'ls' failed: 2")
+        self.assertIn("'ls' failed: 2", str(exception))
+        self.assertIn("No such file or directory", str(exception))
         self.assertEquals(exception.stdout, "/etc\n")
         self.assertIn("No such file or directory", exception.stderr)
         self.assertEquals(exception.returncode, 2)


### PR DESCRIPTION
systemd-cgls doesn't support --unit on ubuntu 16; using the cgroup path instead.

also, improved error handling and reporting.