### PR TITLE
Remove ssh host key thumbprint in report ready

### DIFF
--- a/azurelinuxagent/pa/provision/cloudinit.py
+++ b/azurelinuxagent/pa/provision/cloudinit.py
@@ -53,6 +53,7 @@ class CloudInitProvisionHandler(ProvisionHandler):
             self.protocol_util.get_protocol()
             self.report_not_ready("Provisioning", "Starting")
 
+            thumbprint = self.wait_for_ssh_host_key()
             self.write_provisioned()
             logger.info("Finished provisioning")
 
@@ -96,6 +97,34 @@ class CloudInitProvisionHandler(ProvisionHandler):
                     time.sleep(sleep_time)
         raise ProvisionError("Giving up, ovf-env.xml was not copied to {0} "
                              "after {1}s".format(ovf_file_path,
+                                                 max_retry * sleep_time))
+
+    def wait_for_ssh_host_key(self, max_retry=1800, sleep_time=1):
+        """
+        Wait for cloud-init to generate ssh host key
+        """
+        keypair_type = conf.get_ssh_host_keypair_type()
+        path = conf.get_ssh_key_public_path()
+        for retry in range(0, max_retry):
+            if os.path.isfile(path):
+                logger.info("ssh host key found at: {0}".format(path))
+                try:
+                    thumbprint = self.get_ssh_host_key_thumbprint(chk_err=False)
+                    logger.info("Thumbprint obtained from : {0}".format(path))
+                    return thumbprint
+                except ProvisionError:
+                    logger.warn("Could not get thumbprint from {0}".format(path))
+            if retry < max_retry - 1:
+                logger.info("Waiting for ssh host key be generated at {0} "
+                            "[{1} attempts remaining, "
+                            "sleeping {2}s]".format(path,
+                                                    max_retry - retry,
+                                                    sleep_time))
+                if not self.validate_cloud_init():
+                    logger.warn("cloud-init does not appear to be running")
+                time.sleep(sleep_time)
+        raise ProvisionError("Giving up, ssh host key was not found at {0} "
+                             "after {1}s".format(path,
                                                  max_retry * sleep_time))
 
 def _cloud_init_is_enabled_systemd():

--- a/azurelinuxagent/pa/provision/default.py
+++ b/azurelinuxagent/pa/provision/default.py
@@ -94,7 +94,7 @@ class ProvisionHandler(object):
 
             self.handle_provision_guest_agent(ovf_env.provision_guest_agent)
 
-            self.report_ready(thumbprint)
+            self.report_ready()
             logger.info("Provisioning complete")
 
         except (ProtocolError, ProvisionError) as e:
@@ -308,9 +308,8 @@ class ProvisionHandler(object):
             logger.error("Reporting NotReady failed: {0}", e)
             self.report_event(ustr(e))
 
-    def report_ready(self, thumbprint=None):
+    def report_ready(self):
         status = ProvisionStatus(status="Ready")
-        status.properties.certificateThumbprint = thumbprint
         try:
             protocol = self.protocol_util.get_protocol()
             protocol.report_provision_status(status)


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Issue #1783 

Reporting the ssh host key thumbprint is from the old portal experience and is not currently being used. This PR removes this from the call to report ready.

---

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).