### PR TITLE
Move AutoUpdate reporting to HeartBeat event

### DIFF
--- a/azurelinuxagent/common/event.py
+++ b/azurelinuxagent/common/event.py
@@ -70,7 +70,6 @@ class WALAEventOperation:
     AgentBlacklisted = "AgentBlacklisted"
     AgentEnabled = "AgentEnabled"
     ArtifactsProfileBlob = "ArtifactsProfileBlob"
-    AutoUpdate = "AutoUpdate"
     CGroupsCleanUp = "CGroupsCleanUp"
     CGroupsDebug = "CGroupsDebug"
     CGroupsInfo = "CGroupsInfo"
@@ -180,7 +179,6 @@ class EventStatus(object):
 
 __event_status__ = EventStatus()
 __event_status_operations__ = [
-        WALAEventOperation.AutoUpdate,
         WALAEventOperation.ReportStatus
     ]
 

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -259,6 +259,7 @@ class UpdateHandler(object):
             protocol.update_goal_state()
 
             initialize_event_logger_vminfo_common_parameters(protocol)
+            self._send_heartbeat_telemetry(protocol)
 
             # Log OS-specific info.
             os_info_msg = u"Distro: {0}-{1}; OSUtil: {2}; AgentService: {3}; Python: {4}.{5}.{6}".format(
@@ -266,7 +267,7 @@ class UpdateHandler(object):
                 PY_VERSION_MINOR, PY_VERSION_MICRO)
             logger.info(os_info_msg)
             add_event(AGENT_NAME, op=WALAEventOperation.OSInfo, message=os_info_msg)
-
+            
             # Launch monitoring threads
             from azurelinuxagent.ga.monitor import get_monitor_handler
             monitor_thread = get_monitor_handler()
@@ -348,8 +349,6 @@ class UpdateHandler(object):
                             op=WALAEventOperation.ProcessGoalState,
                             duration=duration,
                             message="Incarnation {0}".format(exthandlers_handler.last_etag))
-
-                self._send_heartbeat_telemetry(protocol)
 
                 time.sleep(goal_state_interval)
 
@@ -445,11 +444,6 @@ class UpdateHandler(object):
                 message = "lib dir is in an unexpected location: {0}".format(conf.get_lib_dir())
                 logger.info(message)
                 add_event(AGENT_NAME, op=WALAEventOperation.ConfigurationChange, message=message)
-
-            # Always report the value of AutoUpdate
-            auto_update_enabled = conf.get_autoupdate_enabled()
-            logger.info("AutoUpdate.Enabled: {0}}", auto_update_enabled)
-            add_event(op=WALAEventOperation.AutoUpdate, is_success=auto_update_enabled, log_event=False)
 
         except Exception as e:
             logger.warn("Failed to log changes in configuration: {0}", ustr(e))
@@ -756,9 +750,12 @@ class UpdateHandler(object):
 
         if datetime.utcnow() >= (self._last_telemetry_heartbeat + UpdateHandler.TELEMETRY_HEARTBEAT_PERIOD):
             dropped_packets = self.osutil.get_firewall_dropped_packets(protocol.get_endpoint())
-            msg = "{0};{1};{2};{3}".format(self._heartbeat_counter, self._heartbeat_id, dropped_packets, self._heartbeat_update_goal_state_error_count)
+            auto_update_enabled = 1 if conf.get_autoupdate_enabled() else 0
+            msg = "{0};{1};{2};{3};{4}".format(self._heartbeat_counter, self._heartbeat_id, dropped_packets,
+                                               self._heartbeat_update_goal_state_error_count, auto_update_enabled)
 
-            add_event(name=AGENT_NAME, version=CURRENT_VERSION, op=WALAEventOperation.HeartBeat, is_success=True, message=msg, log_event=False)
+            add_event(name=AGENT_NAME, version=CURRENT_VERSION, op=WALAEventOperation.HeartBeat, is_success=True,
+                      message=msg, log_event=False)
             self._heartbeat_counter += 1
             self._heartbeat_update_goal_state_error_count = 0
 

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -259,7 +259,6 @@ class UpdateHandler(object):
             protocol.update_goal_state()
 
             initialize_event_logger_vminfo_common_parameters(protocol)
-            self._send_heartbeat_telemetry(protocol)
 
             # Log OS-specific info.
             os_info_msg = u"Distro: {0}-{1}; OSUtil: {2}; AgentService: {3}; Python: {4}.{5}.{6}".format(

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -666,7 +666,6 @@ class UpdateHandler(object):
     def _upgrade_available(self, protocol, base_version=CURRENT_VERSION):
         # Ignore new agents if updating is disabled
         if not conf.get_autoupdate_enabled():
-            logger.warn(u"Agent auto-update is disabled.")
             return False
 
         now = time.time()
@@ -751,15 +750,20 @@ class UpdateHandler(object):
         if datetime.utcnow() >= (self._last_telemetry_heartbeat + UpdateHandler.TELEMETRY_HEARTBEAT_PERIOD):
             dropped_packets = self.osutil.get_firewall_dropped_packets(protocol.get_endpoint())
             auto_update_enabled = 1 if conf.get_autoupdate_enabled() else 0
-            msg = "{0};{1};{2};{3};{4}".format(self._heartbeat_counter, self._heartbeat_id, dropped_packets,
-                                               self._heartbeat_update_goal_state_error_count, auto_update_enabled)
+            telemetry_msg = "{0};{1};{2};{3};{4}".format(self._heartbeat_counter, self._heartbeat_id, dropped_packets,
+                                                         self._heartbeat_update_goal_state_error_count, auto_update_enabled)
 
             add_event(name=AGENT_NAME, version=CURRENT_VERSION, op=WALAEventOperation.HeartBeat, is_success=True,
-                      message=msg, log_event=False)
+                      message=telemetry_msg, log_event=False)
             self._heartbeat_counter += 1
             self._heartbeat_update_goal_state_error_count = 0
 
-            logger.info(u"[HEARTBEAT] Agent {0} is running as the goal state agent", CURRENT_AGENT)
+            debug_log_msg = "[DEBUG HeartbeatCounter: {0};HeartbeatId: {1};DroppedPackets: {2};" \
+                            "UpdateGSErrors: {3};AutoUpdate: {4}]".format(self._heartbeat_counter,
+                                                                          self._heartbeat_id, dropped_packets,
+                                                                          self._heartbeat_update_goal_state_error_count,
+                                                                          auto_update_enabled)
+            logger.info(u"[HEARTBEAT] Agent {0} is running as the goal state agent {1}", CURRENT_AGENT, debug_log_msg)
             self._last_telemetry_heartbeat = datetime.utcnow()
 
 

--- a/tests/ga/test_update.py
+++ b/tests/ga/test_update.py
@@ -1476,10 +1476,8 @@ class TestUpdate(UpdateTestCase):
         update_handler.last_telemetry_heartbeat = datetime.utcnow() - timedelta(hours=1)
         update_handler._send_heartbeat_telemetry(mock_protocol)
         self.assertEqual(1, patch_add_event.call_count)
-        self.assertTrue(
-            any(call_args[0] == "[HEARTBEAT] Agent {0} is running as the goal state agent" for call_args in patch_info.call_args),
-            "The heartbeat was not written to the agent's log"
-        )
+        self.assertTrue(any(call_args[0] == "[HEARTBEAT] Agent {0} is running as the goal state agent {1}"
+                            for call_args in patch_info.call_args), "The heartbeat was not written to the agent's log")
 
 
 class MonitorThreadTest(AgentTestCase):


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

1. AutoUpdate needs to be reported more frequently than just on system startup (#1907) in order to know how many VMs in our fleet are not updating due to potential issues or due to AutoUpdate being set to false.
2. Move AutoUpdate reporting to HeartBeat event which is emitted and logged locally every half an hour.
3. Emit HeartBeat in the beginning of the exthandlers thread.

Local log message:
`2020-06-25T21:01:19.140669Z INFO ExtHandler ExtHandler [HEARTBEAT] Agent WALinuxAgent-2.2.48.1 is running as the goal state agent [DEBUG HeartbeatCounter: 1;HeartbeatId: BC244091-DA90-476D-A49D-6184F6A4125D;DroppedPackets: 0;UpdateGSErrors: 0;AutoUpdate: 1]`


<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).