### PR TITLE
Fix DHCPCD --deprovision bug

### DIFF
--- a/azurelinuxagent/common/utils/fileutil.py
+++ b/azurelinuxagent/common/utils/fileutil.py
@@ -123,6 +123,14 @@ def chmod(path, mode):
         os.chmod(path, mode)
 
 
+def umount(*args):
+    for paths in args:
+        # find all possible mounts
+            for path in glob.glob(paths):
+                if os.path.ismount(path):
+                    os.unmount(path)
+
+
 def rm_files(*args):
     for paths in args:
         # find all possible file paths

--- a/azurelinuxagent/common/utils/fileutil.py
+++ b/azurelinuxagent/common/utils/fileutil.py
@@ -30,6 +30,7 @@ import shutil
 
 import azurelinuxagent.common.logger as logger
 import azurelinuxagent.common.utils.textutil as textutil
+import azurelinuxagent.common.utils.shellutil as shellutil
 
 from azurelinuxagent.common.future import ustr
 
@@ -128,7 +129,8 @@ def umount(*args):
         # find all possible mounts
             for path in glob.glob(paths):
                 if os.path.ismount(path):
-                    os.unmount(path)
+                    command=["umount",path]
+                    shellutil.run_command(command)
 
 
 def rm_files(*args):

--- a/azurelinuxagent/pa/deprovision/default.py
+++ b/azurelinuxagent/pa/deprovision/default.py
@@ -112,6 +112,9 @@ class DeprovisionHandler(object):
     def del_dhcp_lease(self, warnings, actions):
         warnings.append("WARNING! Cached DHCP leases will be deleted.")
 
+        # For Arch based systems. Kill DHCPCD service. Needed to clear cached leases.
+        shellutil.run("systemctl stop dhcpcd", chk_err=False)
+
         # For Arch based systems. Files mounted by DHCPCD can't be deleted whilst mounted, not even by root.
         dirs_to_umount = ["/var/lib/dhcpcd/run/systemd/journal", "/var/lib/dhcpcd/run/udev", "/var/lib/dhcpcd/sys", "/var/lib/dhcpcd/dev", "/var/lib/dhcpcd/proc"]
         actions.append(DeprovisionAction(fileutil.umount, dirs_to_umount))


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Issue #1890 <!-- if any -->
https://github.com/Azure/WALinuxAgent/issues/1890
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->
Fixes bug where `waagent --deprovision` would error/crash when trying to delete cached DHCPCD leases.


This error occurs because DHCPCD mounts files onto sub-directories of `/var/lib/dhcpcd`. These mounted DHCPCD files cannot be deleted whilst mounted (even with the all mighty power of `sudo rm`). This causes `waagent --deprovision` to crash when attempting to delete cached DHCPCD leases.


This PR adds the new method `umount(path)` to common/utils/fileutil.py. If the `path` argument does not pass os.path.ismount() then nothing happens. Otherwise the argument `path` is unmounted.


Right before we delete cached DHCPCD leases in the `del_dhcp_lease`, we call the method `fileutil.umount()` against paths of known DHCPCD mountpoints that cause this error. Because some mountpoints cannot be unmounted while DHCPCD is in use, we also first make sure that the DHCPCD service is not running. (pa/deprovision/default.py)

In doing so this PR address the crash/error and has been tested to work.

---

### PR information
- [ x ] The title of the PR is clear and informative.
- [ x ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ x ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [ x ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).

``` 
___      ___            __       ___      ___       __      
|"  |    |"  |          /""\     |"  \    /"  |     /""\     
||  |    ||  |         /    \     \   \  //   |    /    \    
|:  |    |:  |        /' /\  \    /\\  \/.    |   /' /\  \   
 \  |___  \  |___    //  __'  \  |: \.        |  //  __'  \  
( \_|:  \( \_|:  \  /   /  \\  \ |.  \    /:  | /   /  \\  \ 
 \_______)\_______)(___/    \___)|___|\__/|___|(___/    \___)                                                                                                                          
```