### PR TITLE
Fix return value of start_extension_command

### DIFF
--- a/azurelinuxagent/common/cgroupapi.py
+++ b/azurelinuxagent/common/cgroupapi.py
@@ -747,7 +747,7 @@ After=system-{1}.slice""".format(extension_name, EXTENSIONS_ROOT_CGROUP_NAME)
                                                            stderr=stderr,
                                                            error_code=error_code)
 
-                return [], process_output
+                return process_output
 
         # The process terminated in time and successfully
         return process_output


### PR DESCRIPTION
#1899 changed the return value of start_extension_command, but did not update the retry path.

The test for retry did not check the return value, so the issue was undetected.

Updated code and existing test. Added new test for normal path (no retry)