### PR TITLE
Use run_command to execute iptables

### DIFF
--- a/azurelinuxagent/common/osutil/default.py
+++ b/azurelinuxagent/common/osutil/default.py
@@ -89,10 +89,6 @@ def _get_firewall_packets_command(wait):
     return _add_wait(wait, ["iptables", "-t", "security", "-L", "OUTPUT", "--zero", "OUTPUT", "-nxv"])
 
 
-def _get_firewall_flush_command(wait):
-    return _add_wait(wait, ["iptables", "-t", "security", "-flush"])
-
-
 # Precisely delete the rules created by the agent.
 # this rule was used <= 2.2.25.  This rule helped to validate our change, and determine impact.
 def _get_firewall_delete_conntrack_accept_command(wait, destination):
@@ -162,7 +158,7 @@ class DefaultOSUtil(object):
                     # Transient error  that we ignore.  This code fires every loop
                     # of the daemon (60m), so we will get the value eventually.
                     return 0
-                logger.error("Failed to get firewall packets: {0}", ustr(e))
+                logger.warn("Failed to get firewall packets: {0}", ustr(e))
                 return -1
 
             return 0

--- a/azurelinuxagent/common/osutil/default.py
+++ b/azurelinuxagent/common/osutil/default.py
@@ -56,25 +56,54 @@ for all distros. Each concrete distro classes could overwrite default behavior
 if needed.
 """
 
-IPTABLES_VERSION_PATTERN = re.compile("^[^\d\.]*([\d\.]+).*$")
-IPTABLES_VERSION = "iptables --version"
-IPTABLES_LOCKING_VERSION = FlexibleVersion('1.4.21')
+_IPTABLES_VERSION_PATTERN = re.compile("^[^\d\.]*([\d\.]+).*$")
+_IPTABLES_LOCKING_VERSION = FlexibleVersion('1.4.21')
 
-FIREWALL_ACCEPT = "iptables {0} -t security -{1} OUTPUT -d {2} -p tcp -m owner --uid-owner {3} -j ACCEPT"
-# Note:
-# -- Initially "flight" the change to ACCEPT packets and develop a metric baseline
-#    A subsequent release will convert the ACCEPT to DROP
-# FIREWALL_DROP = "iptables {0} -t security -{1} OUTPUT -d {2} -p tcp -m conntrack --ctstate INVALID,NEW -j ACCEPT"
-FIREWALL_DROP = "iptables {0} -t security -{1} OUTPUT -d {2} -p tcp -m conntrack --ctstate INVALID,NEW -j DROP"
-FIREWALL_LIST = "iptables {0} -t security -L -nxv"
-FIREWALL_PACKETS = "iptables {0} -t security -L OUTPUT --zero OUTPUT -nxv"
-FIREWALL_FLUSH = "iptables {0} -t security --flush"
+
+def _get_iptables_version_command():
+    return ["iptables", "--version"]
+
+
+def _add_wait(wait, command):
+    """
+    If 'wait' is True, adds the wait option (w) to the given iptables command line
+    """
+    if wait:
+        command.insert(1, "-w")
+    return command
+
+
+def _get_firewall_accept_command(wait, command, destination, owner_uid):
+    return _add_wait(wait, ["iptables", "-t", "security", command, "OUTPUT", "-d", destination, "-p", "tcp", "-m", "owner", "--uid-owner", owner_uid, "-j" "ACCEPT"])
+
+
+def _get_firewall_drop_command(wait, command, destination):
+    return _add_wait(wait, ["iptables", "-t", "security", command, "OUTPUT", "-d", destination, "-p",  "tcp",  "-m", "conntrack", "--ctstate", "INVALID,NEW", "-j", "DROP"])
+
+
+def _get_firewall_list_command(wait):
+    return _add_wait(wait, ["iptables", "-t", "security", "-L", "-nxv"])
+
+
+def _get_firewall_packets_command(wait):
+    return _add_wait(wait, ["iptables", "-t", "security", "-L", "OUTPUT", "--zero", "OUTPUT", "-nxv"])
+
+
+def _get_firewall_flush_command(wait):
+    return _add_wait(wait, ["iptables", "-t", "security", "-flush"])
+
 
 # Precisely delete the rules created by the agent.
 # this rule was used <= 2.2.25.  This rule helped to validate our change, and determine impact.
-FIREWALL_DELETE_CONNTRACK_ACCEPT = "iptables {0} -t security -D OUTPUT -d {1} -p tcp -m conntrack --ctstate INVALID,NEW -j ACCEPT"
-FIREWALL_DELETE_OWNER_ACCEPT = "iptables {0} -t security -D OUTPUT -d {1} -p tcp -m owner --uid-owner {2} -j ACCEPT"
-FIREWALL_DELETE_CONNTRACK_DROP = "iptables {0} -t security -D OUTPUT -d {1} -p tcp -m conntrack --ctstate INVALID,NEW -j DROP"
+def _get_firewall_delete_conntrack_accept_command(wait, destination):
+    return _add_wait(wait, ["iptables", "-t", "security", "-D", "OUTPUT", "-d",  destination, "-p", "tcp", "-m", "conntrack", "--ctstate", "INVALID,NEW", "-j", "ACCEPT"])
+
+
+def _get_firewall_delete_owner_accept_command(wait, destination, owner_uid):
+    return _add_wait(wait, ["iptables", "-t", "security", "-D", "OUTPUT", "-d", destination, "-p", "tcp", "-m", "owner", "--uid-owner", owner_uid, "-j", "ACCEPT"])
+
+def _get_firewall_delete_conntrack_drop_command(wait, destination):
+    return _add_wait(wait, ["iptables", "-t", "security", "-D", "OUTPUT", "-d", destination, "-p", "tcp", "-m", "conntrack", "--ctstate", "INVALID,NEW", "-j", "DROP"])
 
 PACKET_PATTERN = "^\s*(\d+)\s+(\d+)\s+DROP\s+.*{0}[^\d]*$"
 ALL_CPUS_REGEX = re.compile('^cpu .*')
@@ -119,21 +148,22 @@ class DefaultOSUtil(object):
         try:
             wait = self.get_firewall_will_wait()
 
-            rc, output = shellutil.run_get_output(FIREWALL_PACKETS.format(wait), log_cmd=False, expected_errors=[3])
-            if rc == 3:
-                # Transient error  that we ignore.  This code fires every loop
-                # of the daemon (60m), so we will get the value eventually.
-                return 0
+            try:
+                output = shellutil.run_command(_get_firewall_packets_command(wait))
 
-            if rc != 0:
+                pattern = re.compile(PACKET_PATTERN.format(dst_ip))
+                for line in output.split('\n'):
+                    m = pattern.match(line)
+                    if m is not None:
+                        return int(m.group(1))
+
+            except Exception as e:
+                if isinstance(e, CommandError) and e.returncode == 3:
+                    # Transient error  that we ignore.  This code fires every loop
+                    # of the daemon (60m), so we will get the value eventually.
+                    return 0
                 return -1
 
-            pattern = re.compile(PACKET_PATTERN.format(dst_ip))
-            for line in output.split('\n'):
-                m = pattern.match(line)
-                if m is not None:
-                    return int(m.group(1))
-            
             return 0
 
         except Exception as e:
@@ -144,20 +174,21 @@ class DefaultOSUtil(object):
 
     def get_firewall_will_wait(self):
         # Determine if iptables will serialize access
-        rc, output = shellutil.run_get_output(IPTABLES_VERSION)
-        if rc != 0:
-            msg = "Unable to determine version of iptables"
+        try:
+            output = shellutil.run_command(_get_iptables_version_command())
+        except Exception as e:
+            msg = "Unable to determine version of iptables: {0}".format(ustr(e))
             logger.warn(msg)
             raise Exception(msg)
 
-        m = IPTABLES_VERSION_PATTERN.match(output)
+        m = _IPTABLES_VERSION_PATTERN.match(output)
         if m is None:
-            msg = "iptables did not return version information"
+            msg = "iptables did not return version information: {0}".format(output)
             logger.warn(msg)
             raise Exception(msg)
 
         wait = "-w" \
-                if FlexibleVersion(m.group(1)) >= IPTABLES_LOCKING_VERSION \
+                if FlexibleVersion(m.group(1)) >= _IPTABLES_LOCKING_VERSION \
                 else ""
         return wait
 
@@ -167,11 +198,13 @@ class DefaultOSUtil(object):
         code is non-zero or the limit has been reached.
         """
         for i in range(1, 100):
-            rc = shellutil.run(rule, chk_err=False)
-            if rc == 1:
-                return
-            elif rc == 2:
-                raise Exception("invalid firewall deletion rule '{0}'".format(rule))
+            try:
+                rc = shellutil.run_command(rule)
+            except CommandError as e:
+                if e.returncode == 1:
+                    return
+                if e.returncode == 2:
+                    raise Exception("invalid firewall deletion rule '{0}'".format(rule))
 
     def remove_firewall(self, dst_ip=None, uid=None):
         # If a previous attempt failed, do not retry
@@ -189,10 +222,9 @@ class DefaultOSUtil(object):
 
             # This rule was <= 2.2.25 only, and may still exist on some VMs.  Until 2.2.25
             # has aged out, keep this cleanup in place.
-            self._delete_rule(FIREWALL_DELETE_CONNTRACK_ACCEPT.format(wait, dst_ip))
-
-            self._delete_rule(FIREWALL_DELETE_OWNER_ACCEPT.format(wait, dst_ip, uid))
-            self._delete_rule(FIREWALL_DELETE_CONNTRACK_DROP.format(wait, dst_ip))
+            self._delete_rule(_get_firewall_delete_conntrack_accept_command(wait, dst_ip))
+            self._delete_rule(_get_firewall_delete_owner_accept_command(wait, dst_ip, uid))
+            self._delete_rule(_get_firewall_delete_conntrack_drop_command(wait, dst_ip))
 
             return True
 
@@ -203,55 +235,56 @@ class DefaultOSUtil(object):
                         "{0}".format(ustr(e)))
             return False
 
-    def enable_firewall(self, dst_ip=None, uid=None):
+    def enable_firewall(self, dst_ip, uid):
         # If a previous attempt failed, do not retry
         global _enable_firewall
         if not _enable_firewall:
             return False
 
         try:
-            if dst_ip is None or uid is None:
-                msg = "Missing arguments to enable_firewall"
-                logger.warn(msg)
-                raise Exception(msg)
-
             wait = self.get_firewall_will_wait()
 
             # If the DROP rule exists, make no changes
-            drop_rule = FIREWALL_DROP.format(wait, "C", dst_ip)
-            rc = shellutil.run(drop_rule, chk_err=False)
-            if rc == 0:
+            firewall_established = False
+            try:
+                drop_rule = _get_firewall_drop_command(wait, "-C", dst_ip)
+                shellutil.run_command(drop_rule)
+                firewall_established = True
+            except Exception as e:
+                if isinstance(e, CommandError) and e.returncode == 2:
+                    self.remove_firewall(dst_ip, uid)
+                    msg = "please upgrade iptables to a version that supports the -C option"
+                    logger.warn(msg)
+                    raise Exception(msg)
+
+            if firewall_established:
                 logger.verbose("Firewall appears established")
                 return True
-            elif rc == 2:
-                self.remove_firewall(dst_ip, uid)
-                msg = "please upgrade iptables to a version that supports the -C option"
-                logger.warn(msg)
-                raise Exception(msg)
 
             # Otherwise, append both rules
-            accept_rule = FIREWALL_ACCEPT.format(wait, "A", dst_ip, uid)
-            drop_rule = FIREWALL_DROP.format(wait, "A", dst_ip)
-
-            if shellutil.run(accept_rule) != 0:
-                msg = "Unable to add ACCEPT firewall rule '{0}'".format(
-                    accept_rule)
+            try:
+                accept_rule = _get_firewall_accept_command(wait, "-A", dst_ip, uid)
+                shellutil.run_command(accept_rule)
+            except Exception as e:
+                msg = "Unable to add ACCEPT firewall rule '{0}' - {1}".format(accept_rule, ustr(e))
                 logger.warn(msg)
                 raise Exception(msg)
 
-            if shellutil.run(drop_rule) != 0:
-                msg = "Unable to add DROP firewall rule '{0}'".format(
-                    drop_rule)
+            try:
+                drop_rule = _get_firewall_drop_command(wait, "-A", dst_ip)
+                shellutil.run_command(drop_rule)
+            except Exception as e:
+                msg = "Unable to add DROP firewall rule '{0}' - {1}".format(drop_rule, ustr(e))
                 logger.warn(msg)
                 raise Exception(msg)
 
             logger.info("Successfully added Azure fabric firewall rules")
 
-            rc, output = shellutil.run_get_output(FIREWALL_LIST.format(wait))
-            if rc == 0:
+            try:
+                output = shellutil.run_command(_get_firewall_list_command(wait))
                 logger.info("Firewall rules:\n{0}".format(output))
-            else:
-                logger.warn("Listing firewall rules failed: {0}".format(output))
+            except Exception as e:
+                logger.warn("Listing firewall rules failed: {0}".format(ustr(e)))
 
             return True
 

--- a/tests/common/osutil/test_default.py
+++ b/tests/common/osutil/test_default.py
@@ -733,7 +733,7 @@ Chain OUTPUT (policy ACCEPT 104 packets, 43628 bytes)
       32     1920 DROP       tcp  --  any    any     anywhere             168.63.129.16
 
 ''')
-            self.assertEqual(32, osutil.DefaultOSUtil().get_firewall_dropped_packets('168.63.129.16'))
+            self.assertEqual(32, osutil.DefaultOSUtil().get_firewall_dropped_packets(destination))
 
 
     def test_enable_firewall_should_set_up_the_firewall(self):
@@ -871,7 +871,9 @@ Chain OUTPUT (policy ACCEPT 104 packets, 43628 bytes)
         osutil._enable_firewall = True
 
         with TestOSUtil._mock_iptables() as mock_iptables:
-            delete_conntrack_accept_command = mock_iptables.set_command(osutil._get_firewall_delete_conntrack_accept_command(mock_iptables.wait, mock_iptables.destination), exit_code=2)
+            command = osutil._get_firewall_delete_conntrack_accept_command(mock_iptables.wait, mock_iptables.destination)
+            # Note that the command is actually a valid rule, but we use the mock to report it as invalid (exit code 2)
+            delete_conntrack_accept_command = mock_iptables.set_command(command, exit_code=2)
 
             success = osutil.DefaultOSUtil().remove_firewall(mock_iptables.destination, mock_iptables.uid)
 


### PR DESCRIPTION
iptables was using the deprecated run/run_get_output functions