### PR TITLE
Fix deprecated-method warnings for "assertEquals"

### DIFF
--- a/2.7.pylintrc
+++ b/2.7.pylintrc
@@ -13,7 +13,6 @@
 # cell-var-from-loop<W0640>: (hi-pri) A variable used in a closure is defined in a loop. This will result in all closures using the same value for the closed-over variable.
 # cyclic-import<R0401>: (hi-pri) Used when a cyclic import between two or more modules is detected.
 # dangerous-default-value<W0102>: (hi-pri) Used when a mutable value as list or dictionary is detected in a default value for an argument.
-# deprecated-method<W1505>: (hi-pri) The method is marked as deprecated and will be removed in a future version of Python.
 # duplicate-key<W0109>: (hi-pri) Used when a dictionary expression binds the same key multiple times.
 # expression-not-assigned<W0106>: (hi-pri) Used when an expression that is not a function call is assigned to nothing.
 # duplicate-code<R0801>: (hi-pri) Indicates that a set of similar lines has been detected among multiple file. (also disabled globally)

--- a/3.6.pylintrc
+++ b/3.6.pylintrc
@@ -17,7 +17,6 @@
 # consider-using-in<R1714>: To check if a variable is equal to one of many values,combine the values into a tuple and check if the variable is contained "in" it instead of checking for equality against each of the values.
 # cyclic-import<R0401>: (hi-pri) Used when a cyclic import between two or more modules is detected.
 # dangerous-default-value<W0102>: (hi-pri) Used when a mutable value as list or dictionary is detected in a default value for an argument.
-# deprecated-method<W1505>: (hi-pri) The method is marked as deprecated and will be removed in a future version of Python
 # duplicate-key<W0109>: (hi-pri) Used when a dictionary expression binds the same key multiple times.
 # duplicate-code<R0801>: (hi-pri) Indicates that a set of similar lines has been detected among multiple file. (also disabled globally)
 # duplicate-string-formatting-argument<W1308>: (hi-pri) Used when we detect that a string formatting is repeating an argument instead of using named string arguments

--- a/test-run.sh
+++ b/test-run.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+for i in {1..10000}
+do
+    echo $i
+    nosetests tests/utils/test_extension_process_util.py:TestProcessUtils.test_handle_process_completion_should_raise_on_timeout || \
+    exit
+done

--- a/test-run.sh
+++ b/test-run.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-for i in {1..10000}
-do
-    echo $i
-    nosetests tests/utils/test_extension_process_util.py:TestProcessUtils.test_handle_process_completion_should_raise_on_timeout || \
-    exit
-done

--- a/test.out
+++ b/test.out
@@ -1,0 +1,2 @@
+1
+./test-run.sh: line 6: nosetests: command not found

--- a/test.out
+++ b/test.out
@@ -1,2 +1,0 @@
-1
-./test-run.sh: line 6: nosetests: command not found

--- a/tests/common/osutil/test_default.py
+++ b/tests/common/osutil/test_default.py
@@ -859,7 +859,7 @@ Chain OUTPUT (policy ACCEPT 104 packets, 43628 bytes)
                 delete_conntrack_drop_command = TestOSUtil._command_to_string(osutil._get_firewall_delete_conntrack_drop_command(mock_iptables.wait, mock_iptables.destination)) # pylint: disable=protected-access
 
                 self.assertTrue(success, "Removing the firewall should have succeeded")
-                self.assertEquals(len(delete_commands), 3, "Expected 3 delete commands: [{0}]".format(delete_commands)) # pylint: disable=deprecated-method
+                self.assertEqual(len(delete_commands), 3, "Expected 3 delete commands: [{0}]".format(delete_commands))
                 # delete rules < 2.2.26
                 self.assertIn(delete_conntrack_accept_command, delete_commands, "The delete conntrack accept command was not executed")
                 self.assertEqual(delete_commands[delete_conntrack_accept_command], 2, "The delete conntrack accept command should have been executed twice")

--- a/tests/common/osutil/test_default_osutil.py
+++ b/tests/common/osutil/test_default_osutil.py
@@ -21,4 +21,4 @@ from tests.tools import AgentTestCase, patch # pylint: disable=unused-import
 
 class DefaultOsUtilTestCase(AgentTestCase):
     def test_default_service_name(self):
-        self.assertEquals(DefaultOSUtil().get_service_name(), "waagent") # pylint: disable=deprecated-method
+        self.assertEqual(DefaultOSUtil().get_service_name(), "waagent")

--- a/tests/common/osutil/test_factory.py
+++ b/tests/common/osutil/test_factory.py
@@ -50,8 +50,8 @@ class TestOsUtilFactory(AgentTestCase):
                           distro_version="",
                           distro_full_name="")
         self.assertTrue(type(ret) == DefaultOSUtil) # pylint: disable=unidiomatic-typecheck
-        self.assertEquals(patch_logger.call_count, 1) # pylint: disable=deprecated-method
-        self.assertEquals(ret.get_service_name(), "waagent") # pylint: disable=deprecated-method
+        self.assertEqual(patch_logger.call_count, 1)
+        self.assertEqual(ret.get_service_name(), "waagent")
 
     def test_get_osutil_it_should_return_ubuntu(self):
         ret = _get_osutil(distro_name="ubuntu",
@@ -59,49 +59,49 @@ class TestOsUtilFactory(AgentTestCase):
                           distro_version="10.04",
                           distro_full_name="")
         self.assertTrue(type(ret) == UbuntuOSUtil) # pylint: disable=unidiomatic-typecheck
-        self.assertEquals(ret.get_service_name(), "walinuxagent") # pylint: disable=deprecated-method
+        self.assertEqual(ret.get_service_name(), "walinuxagent")
 
         ret = _get_osutil(distro_name="ubuntu",
                           distro_code_name="",
                           distro_version="12.04",
                           distro_full_name="")
         self.assertTrue(type(ret) == Ubuntu12OSUtil) # pylint: disable=unidiomatic-typecheck
-        self.assertEquals(ret.get_service_name(), "walinuxagent") # pylint: disable=deprecated-method
+        self.assertEqual(ret.get_service_name(), "walinuxagent")
 
         ret = _get_osutil(distro_name="ubuntu",
                           distro_code_name="trusty",
                           distro_version="14.04",
                           distro_full_name="")
         self.assertTrue(type(ret) == Ubuntu14OSUtil) # pylint: disable=unidiomatic-typecheck
-        self.assertEquals(ret.get_service_name(), "walinuxagent") # pylint: disable=deprecated-method
+        self.assertEqual(ret.get_service_name(), "walinuxagent")
 
         ret = _get_osutil(distro_name="ubuntu",
                           distro_code_name="xenial",
                           distro_version="16.04",
                           distro_full_name="")
         self.assertTrue(type(ret) == Ubuntu16OSUtil) # pylint: disable=unidiomatic-typecheck
-        self.assertEquals(ret.get_service_name(), "walinuxagent") # pylint: disable=deprecated-method
+        self.assertEqual(ret.get_service_name(), "walinuxagent")
 
         ret = _get_osutil(distro_name="ubuntu",
                           distro_code_name="bionic",
                           distro_version="18.04",
                           distro_full_name="")
         self.assertTrue(type(ret) == Ubuntu18OSUtil) # pylint: disable=unidiomatic-typecheck
-        self.assertEquals(ret.get_service_name(), "walinuxagent") # pylint: disable=deprecated-method
+        self.assertEqual(ret.get_service_name(), "walinuxagent")
 
         ret = _get_osutil(distro_name="ubuntu",
                           distro_code_name="focal",
                           distro_version="20.04",
                           distro_full_name="")
         self.assertTrue(type(ret) == Ubuntu18OSUtil) # pylint: disable=unidiomatic-typecheck
-        self.assertEquals(ret.get_service_name(), "walinuxagent") # pylint: disable=deprecated-method
+        self.assertEqual(ret.get_service_name(), "walinuxagent")
 
         ret = _get_osutil(distro_name="ubuntu",
                           distro_code_name="",
                           distro_version="10.04",
                           distro_full_name="Snappy Ubuntu Core")
         self.assertTrue(type(ret) == UbuntuSnappyOSUtil) # pylint: disable=unidiomatic-typecheck
-        self.assertEquals(ret.get_service_name(), "walinuxagent") # pylint: disable=deprecated-method
+        self.assertEqual(ret.get_service_name(), "walinuxagent")
 
     def test_get_osutil_it_should_return_arch(self):
         ret = _get_osutil(distro_name="arch",
@@ -109,7 +109,7 @@ class TestOsUtilFactory(AgentTestCase):
                           distro_version="",
                           distro_full_name="")
         self.assertTrue(type(ret) == ArchUtil) # pylint: disable=unidiomatic-typecheck
-        self.assertEquals(ret.get_service_name(), "waagent") # pylint: disable=deprecated-method
+        self.assertEqual(ret.get_service_name(), "waagent")
 
     def test_get_osutil_it_should_return_clear_linux(self):
         ret = _get_osutil(distro_name="clear linux",
@@ -117,7 +117,7 @@ class TestOsUtilFactory(AgentTestCase):
                           distro_version="",
                           distro_full_name="Clear Linux")
         self.assertTrue(type(ret) == ClearLinuxUtil) # pylint: disable=unidiomatic-typecheck
-        self.assertEquals(ret.get_service_name(), "waagent") # pylint: disable=deprecated-method
+        self.assertEqual(ret.get_service_name(), "waagent")
 
     def test_get_osutil_it_should_return_alpine(self):
         ret = _get_osutil(distro_name="alpine",
@@ -125,7 +125,7 @@ class TestOsUtilFactory(AgentTestCase):
                           distro_version="",
                           distro_full_name="")
         self.assertTrue(type(ret) == AlpineOSUtil) # pylint: disable=unidiomatic-typecheck
-        self.assertEquals(ret.get_service_name(), "waagent") # pylint: disable=deprecated-method
+        self.assertEqual(ret.get_service_name(), "waagent")
 
     def test_get_osutil_it_should_return_kali(self):
         ret = _get_osutil(distro_name="kali",
@@ -133,7 +133,7 @@ class TestOsUtilFactory(AgentTestCase):
                           distro_version="",
                           distro_full_name="")
         self.assertTrue(type(ret) == DebianOSBaseUtil) # pylint: disable=unidiomatic-typecheck
-        self.assertEquals(ret.get_service_name(), "waagent") # pylint: disable=deprecated-method
+        self.assertEqual(ret.get_service_name(), "waagent")
 
     def test_get_osutil_it_should_return_coreos(self):
         ret = _get_osutil(distro_name="coreos",
@@ -141,7 +141,7 @@ class TestOsUtilFactory(AgentTestCase):
                           distro_version="",
                           distro_full_name="")
         self.assertTrue(type(ret) == CoreOSUtil) # pylint: disable=unidiomatic-typecheck
-        self.assertEquals(ret.get_service_name(), "waagent") # pylint: disable=deprecated-method
+        self.assertEqual(ret.get_service_name(), "waagent")
 
     def test_get_osutil_it_should_return_suse(self):
         ret = _get_osutil(distro_name="suse",
@@ -149,21 +149,21 @@ class TestOsUtilFactory(AgentTestCase):
                           distro_version="10",
                           distro_full_name="")
         self.assertTrue(type(ret) == SUSEOSUtil) # pylint: disable=unidiomatic-typecheck
-        self.assertEquals(ret.get_service_name(), "waagent") # pylint: disable=deprecated-method
+        self.assertEqual(ret.get_service_name(), "waagent")
 
         ret = _get_osutil(distro_name="suse",
                           distro_code_name="",
                           distro_full_name="SUSE Linux Enterprise Server",
                           distro_version="11")
         self.assertTrue(type(ret) == SUSE11OSUtil) # pylint: disable=unidiomatic-typecheck
-        self.assertEquals(ret.get_service_name(), "waagent") # pylint: disable=deprecated-method
+        self.assertEqual(ret.get_service_name(), "waagent")
 
         ret = _get_osutil(distro_name="suse",
                           distro_code_name="",
                           distro_full_name="openSUSE",
                           distro_version="12")
         self.assertTrue(type(ret) == SUSE11OSUtil) # pylint: disable=unidiomatic-typecheck
-        self.assertEquals(ret.get_service_name(), "waagent") # pylint: disable=deprecated-method
+        self.assertEqual(ret.get_service_name(), "waagent")
 
     def test_get_osutil_it_should_return_debian(self):
         ret = _get_osutil(distro_name="debian",
@@ -171,14 +171,14 @@ class TestOsUtilFactory(AgentTestCase):
                           distro_full_name="",
                           distro_version="7")
         self.assertTrue(type(ret) == DebianOSBaseUtil) # pylint: disable=unidiomatic-typecheck
-        self.assertEquals(ret.get_service_name(), "waagent") # pylint: disable=deprecated-method
+        self.assertEqual(ret.get_service_name(), "waagent")
 
         ret = _get_osutil(distro_name="debian",
                           distro_code_name="",
                           distro_full_name="",
                           distro_version="8")
         self.assertTrue(type(ret) == DebianOSModernUtil) # pylint: disable=unidiomatic-typecheck
-        self.assertEquals(ret.get_service_name(), "walinuxagent") # pylint: disable=deprecated-method
+        self.assertEqual(ret.get_service_name(), "walinuxagent")
 
     def test_get_osutil_it_should_return_redhat(self):
         ret = _get_osutil(distro_name="redhat",
@@ -186,42 +186,42 @@ class TestOsUtilFactory(AgentTestCase):
                           distro_full_name="",
                           distro_version="6")
         self.assertTrue(type(ret) == Redhat6xOSUtil) # pylint: disable=unidiomatic-typecheck
-        self.assertEquals(ret.get_service_name(), "waagent") # pylint: disable=deprecated-method
+        self.assertEqual(ret.get_service_name(), "waagent")
 
         ret = _get_osutil(distro_name="centos",
                           distro_code_name="",
                           distro_full_name="",
                           distro_version="6")
         self.assertTrue(type(ret) == Redhat6xOSUtil) # pylint: disable=unidiomatic-typecheck
-        self.assertEquals(ret.get_service_name(), "waagent") # pylint: disable=deprecated-method
+        self.assertEqual(ret.get_service_name(), "waagent")
 
         ret = _get_osutil(distro_name="oracle",
                           distro_code_name="",
                           distro_full_name="",
                           distro_version="6")
         self.assertTrue(type(ret) == Redhat6xOSUtil) # pylint: disable=unidiomatic-typecheck
-        self.assertEquals(ret.get_service_name(), "waagent") # pylint: disable=deprecated-method
+        self.assertEqual(ret.get_service_name(), "waagent")
 
         ret = _get_osutil(distro_name="redhat",
                           distro_code_name="",
                           distro_full_name="",
                           distro_version="7")
         self.assertTrue(type(ret) == RedhatOSUtil) # pylint: disable=unidiomatic-typecheck
-        self.assertEquals(ret.get_service_name(), "waagent") # pylint: disable=deprecated-method
+        self.assertEqual(ret.get_service_name(), "waagent")
 
         ret = _get_osutil(distro_name="centos",
                           distro_code_name="",
                           distro_full_name="",
                           distro_version="7")
         self.assertTrue(type(ret) == RedhatOSUtil) # pylint: disable=unidiomatic-typecheck
-        self.assertEquals(ret.get_service_name(), "waagent") # pylint: disable=deprecated-method
+        self.assertEqual(ret.get_service_name(), "waagent")
 
         ret = _get_osutil(distro_name="oracle",
                           distro_code_name="",
                           distro_full_name="",
                           distro_version="7")
         self.assertTrue(type(ret) == RedhatOSUtil) # pylint: disable=unidiomatic-typecheck
-        self.assertEquals(ret.get_service_name(), "waagent") # pylint: disable=deprecated-method
+        self.assertEqual(ret.get_service_name(), "waagent")
 
     def test_get_osutil_it_should_return_euleros(self):
         ret = _get_osutil(distro_name="euleros",
@@ -229,7 +229,7 @@ class TestOsUtilFactory(AgentTestCase):
                           distro_version="",
                           distro_full_name="")
         self.assertTrue(type(ret) == RedhatOSUtil) # pylint: disable=unidiomatic-typecheck
-        self.assertEquals(ret.get_service_name(), "waagent") # pylint: disable=deprecated-method
+        self.assertEqual(ret.get_service_name(), "waagent")
 
     def test_get_osutil_it_should_return_freebsd(self):
         ret = _get_osutil(distro_name="freebsd",
@@ -237,7 +237,7 @@ class TestOsUtilFactory(AgentTestCase):
                           distro_version="",
                           distro_full_name="")
         self.assertTrue(type(ret) == FreeBSDOSUtil) # pylint: disable=unidiomatic-typecheck
-        self.assertEquals(ret.get_service_name(), "waagent") # pylint: disable=deprecated-method
+        self.assertEqual(ret.get_service_name(), "waagent")
 
     def test_get_osutil_it_should_return_openbsd(self):
         ret = _get_osutil(distro_name="openbsd",
@@ -245,7 +245,7 @@ class TestOsUtilFactory(AgentTestCase):
                           distro_version="",
                           distro_full_name="")
         self.assertTrue(type(ret) == OpenBSDOSUtil) # pylint: disable=unidiomatic-typecheck
-        self.assertEquals(ret.get_service_name(), "waagent") # pylint: disable=deprecated-method
+        self.assertEqual(ret.get_service_name(), "waagent")
 
     def test_get_osutil_it_should_return_bigip(self):
         ret = _get_osutil(distro_name="bigip",
@@ -253,7 +253,7 @@ class TestOsUtilFactory(AgentTestCase):
                           distro_version="",
                           distro_full_name="")
         self.assertTrue(type(ret) == BigIpOSUtil) # pylint: disable=unidiomatic-typecheck
-        self.assertEquals(ret.get_service_name(), "waagent") # pylint: disable=deprecated-method
+        self.assertEqual(ret.get_service_name(), "waagent")
 
     def test_get_osutil_it_should_return_gaia(self):
         ret = _get_osutil(distro_name="gaia",
@@ -261,7 +261,7 @@ class TestOsUtilFactory(AgentTestCase):
                           distro_version="",
                           distro_full_name="")
         self.assertTrue(type(ret) == GaiaOSUtil) # pylint: disable=unidiomatic-typecheck
-        self.assertEquals(ret.get_service_name(), "waagent") # pylint: disable=deprecated-method
+        self.assertEqual(ret.get_service_name(), "waagent")
 
     def test_get_osutil_it_should_return_iosxe(self):
         ret = _get_osutil(distro_name="iosxe",
@@ -269,7 +269,7 @@ class TestOsUtilFactory(AgentTestCase):
                           distro_version="",
                           distro_full_name="")
         self.assertTrue(type(ret) == IosxeOSUtil) # pylint: disable=unidiomatic-typecheck
-        self.assertEquals(ret.get_service_name(), "waagent") # pylint: disable=deprecated-method
+        self.assertEqual(ret.get_service_name(), "waagent")
 
     def test_get_osutil_it_should_return_openwrt(self):
         ret = _get_osutil(distro_name="openwrt",
@@ -277,4 +277,4 @@ class TestOsUtilFactory(AgentTestCase):
                           distro_version="",
                           distro_full_name="")
         self.assertTrue(type(ret) == OpenWRTOSUtil) # pylint: disable=unidiomatic-typecheck
-        self.assertEquals(ret.get_service_name(), "waagent") # pylint: disable=deprecated-method
+        self.assertEqual(ret.get_service_name(), "waagent")

--- a/tests/common/osutil/test_nsbsd.py
+++ b/tests/common/osutil/test_nsbsd.py
@@ -46,7 +46,7 @@ class TestNSBSDOSUtil(AgentTestCase):
                 with patch("azurelinuxagent.common.osutil.nsbsd.fileutil.read_file", mock_read_file):
                     pid_list = NSBSDOSUtil().get_dhcp_pid()
 
-            self.assertEquals(pid_list, [123]) # pylint: disable=deprecated-method
+            self.assertEqual(pid_list, [123])
 
     def test_get_dhcp_pid_should_return_an_empty_list_when_the_dhcp_client_is_not_running(self):
         with patch.object(NSBSDOSUtil, "resolver"):  # instantiating NSBSDOSUtil requires a resolver
@@ -61,7 +61,7 @@ class TestNSBSDOSUtil(AgentTestCase):
             with patch("os.path.isfile", mock_isfile):
                 pid_list = NSBSDOSUtil().get_dhcp_pid()
 
-            self.assertEquals(pid_list, []) # pylint: disable=deprecated-method
+            self.assertEqual(pid_list, [])
 
             #
             # PID file is empty
@@ -80,7 +80,7 @@ class TestNSBSDOSUtil(AgentTestCase):
                 with patch("azurelinuxagent.common.osutil.nsbsd.fileutil.read_file", mock_read_file):
                     pid_list = NSBSDOSUtil().get_dhcp_pid()
 
-            self.assertEquals(pid_list, []) # pylint: disable=deprecated-method
+            self.assertEqual(pid_list, [])
 
 
 if __name__ == '__main__':

--- a/tests/common/test_cgroupapi.py
+++ b/tests/common/test_cgroupapi.py
@@ -150,10 +150,10 @@ class CGroupsApiTestCase(_MockedFileSystemTestCase):
 
             args, kwargs = mock_logger_warn.call_args # pylint: disable=unused-variable
             (message_format, controller, error, message) = args
-            self.assertEquals(message_format, 'Error in cgroup controller "{0}": {1}. {2}') # pylint: disable=deprecated-method
-            self.assertEquals(controller, 'cpu') # pylint: disable=deprecated-method
-            self.assertEquals(error, 'A test exception') # pylint: disable=deprecated-method
-            self.assertEquals(message, 'A dummy message') # pylint: disable=deprecated-method
+            self.assertEqual(message_format, 'Error in cgroup controller "{0}": {1}. {2}')
+            self.assertEqual(controller, 'cpu')
+            self.assertEqual(error, 'A test exception')
+            self.assertEqual(message, 'A dummy message')
 
 
 class MountCgroupsTestCase(AgentTestCase):
@@ -313,7 +313,7 @@ class MountCgroupsTestCase(AgentTestCase):
             with patch("azurelinuxagent.common.osutil.default.os.symlink") as patch_symlink:
                 FileSystemCgroupsApi.mount_cgroups()
 
-                self.assertEquals(patch_symlink.call_count, 0, 'A symbolic link should not have been created') # pylint: disable=deprecated-method
+                self.assertEqual(patch_symlink.call_count, 0, 'A symbolic link should not have been created')
 
 
 class FileSystemCgroupsApiTestCase(_MockedFileSystemTestCase):
@@ -346,7 +346,7 @@ class FileSystemCgroupsApiTestCase(_MockedFileSystemTestCase):
         self.assertFalse(os.path.exists(legacy_memory_cgroup))
 
         # Assert the event parameters that were sent out
-        self.assertEquals(len(mock_add_event.call_args_list), 2) # pylint: disable=deprecated-method
+        self.assertEqual(len(mock_add_event.call_args_list), 2)
         self.assertTrue(all(kwargs['op'] == 'CGroupsCleanUp' for _, kwargs in mock_add_event.call_args_list))
         self.assertTrue(all(kwargs['is_success'] for _, kwargs in mock_add_event.call_args_list))
         self.assertTrue(any(
@@ -462,7 +462,7 @@ class FileSystemCgroupsApiTestCase(_MockedFileSystemTestCase):
                 contents = f.read()
             pid_from_cgroup = int(contents)
 
-            self.assertEquals(pid_from_output, pid_from_cgroup, # pylint: disable=deprecated-method
+            self.assertEqual(pid_from_output, pid_from_cgroup,
                               "The PID from the process output ({0}) does not match the PID found in the"
                               "process cgroup {1} ({2})".format(pid_from_output, cgroups_procs_path, pid_from_cgroup))
 
@@ -478,20 +478,20 @@ class SystemdCgroupsApiTestCase(AgentTestCase):
     def test_get_cpu_and_memory_mount_points_should_return_the_cgroup_mount_points(self):
         with mock_cgroup_commands():
             cpu, memory = SystemdCgroupsApi().get_cgroup_mount_points()
-            self.assertEquals(cpu, '/sys/fs/cgroup/cpu,cpuacct', "The mount point for the CPU controller is incorrect") # pylint: disable=deprecated-method
-            self.assertEquals(memory, '/sys/fs/cgroup/memory', "The mount point for the memory controller is incorrect") # pylint: disable=deprecated-method
+            self.assertEqual(cpu, '/sys/fs/cgroup/cpu,cpuacct', "The mount point for the CPU controller is incorrect")
+            self.assertEqual(memory, '/sys/fs/cgroup/memory', "The mount point for the memory controller is incorrect")
 
     def test_get_cpu_and_memory_cgroup_relative_paths_for_process_should_return_the_cgroup_relative_paths(self):
         with mock_cgroup_commands():
             cpu, memory = SystemdCgroupsApi.get_process_cgroup_relative_paths('self')
-            self.assertEquals(cpu, "system.slice/walinuxagent.service", "The relative path for the CPU cgroup is incorrect") # pylint: disable=deprecated-method
-            self.assertEquals(memory, "system.slice/walinuxagent.service", "The relative memory for the CPU cgroup is incorrect") # pylint: disable=deprecated-method
+            self.assertEqual(cpu, "system.slice/walinuxagent.service", "The relative path for the CPU cgroup is incorrect")
+            self.assertEqual(memory, "system.slice/walinuxagent.service", "The relative memory for the CPU cgroup is incorrect")
 
     def test_get_cgroup2_controllers_should_return_the_v2_cgroup_controllers(self):
         with mock_cgroup_commands():
             mount_point, controllers = SystemdCgroupsApi.get_cgroup2_controllers()
 
-            self.assertEquals(mount_point, "/sys/fs/cgroup/unified", "Invalid mount point for V2 cgroups") # pylint: disable=deprecated-method
+            self.assertEqual(mount_point, "/sys/fs/cgroup/unified", "Invalid mount point for V2 cgroups")
             self.assertIn("cpu", controllers, "The CPU controller is not in the list of V2 controllers")
             self.assertIn("memory", controllers, "The memory controller is not in the list of V2 controllers")
 
@@ -499,7 +499,7 @@ class SystemdCgroupsApiTestCase(AgentTestCase):
         with mock_cgroup_commands():
             cpu_accounting = SystemdCgroupsApi.get_unit_property("walinuxagent.service", "CPUAccounting")
 
-            self.assertEquals(cpu_accounting, "no", "Property {0} of {1} is incorrect".format("CPUAccounting", "walinuxagent.service")) # pylint: disable=deprecated-method
+            self.assertEqual(cpu_accounting, "no", "Property {0} of {1} is incorrect".format("CPUAccounting", "walinuxagent.service"))
 
     def test_get_extensions_slice_root_name_should_return_the_root_slice_for_extensions(self):
         root_slice_name = SystemdCgroupsApi()._get_extensions_slice_root_name() # pylint: disable=protected-access
@@ -644,7 +644,7 @@ class SystemdCgroupsApiTestCase(AgentTestCase):
 
                 extension_calls = [args[0] for (args, _) in popen_patch.call_args_list if "the-test-extension-command" in args[0]]
 
-                self.assertEquals(1, len(extension_calls), "The extension should have been invoked exactly once") # pylint: disable=deprecated-method
+                self.assertEqual(1, len(extension_calls), "The extension should have been invoked exactly once")
                 self.assertIn("systemd-run --unit=Microsoft.Compute.TestExtension_1.2.3", extension_calls[0], "The extension should have been invoked using systemd")
 
     @patch('time.sleep', side_effect=lambda _: mock_sleep())
@@ -679,18 +679,18 @@ class SystemdCgroupsApiTestCase(AgentTestCase):
                                   kwargs['message'])
                     self.assertIn("Failed to find executable syntax_error: No such file or directory",
                                   kwargs['message'])
-                    self.assertEquals(False, kwargs['is_success']) # pylint: disable=deprecated-method
-                    self.assertEquals('InvokeCommandUsingSystemd', kwargs['op']) # pylint: disable=deprecated-method
+                    self.assertEqual(False, kwargs['is_success'])
+                    self.assertEqual('InvokeCommandUsingSystemd', kwargs['op'])
 
                     extension_calls = [args[0] for (args, _) in popen_patch.call_args_list if command in args[0]]
 
-                    self.assertEquals(2, len(extension_calls), "The extension should have been invoked exactly twice") # pylint: disable=deprecated-method
+                    self.assertEqual(2, len(extension_calls), "The extension should have been invoked exactly twice")
                     self.assertIn("systemd-run --unit=Microsoft.Compute.TestExtension_1.2.3", extension_calls[0],
                                   "The first call to the extension should have used systemd")
-                    self.assertEquals(command, extension_calls[1], # pylint: disable=deprecated-method
+                    self.assertEqual(command, extension_calls[1],
                                       "The second call to the extension should not have used systemd")
 
-                    self.assertEquals(len(CGroupsTelemetry._tracked), 0, "No cgroups should have been created") # pylint: disable=deprecated-method,protected-access
+                    self.assertEqual(len(CGroupsTelemetry._tracked), 0, "No cgroups should have been created") # pylint: disable=protected-access
 
                     self.assertIn("TEST_OUTPUT\n", command_output, "The test output was not captured")
 
@@ -728,11 +728,11 @@ class SystemdCgroupsApiTestCase(AgentTestCase):
 
                     extension_calls = [args[0] for (args, _) in popen_patch.call_args_list if "echo 'success'" in args[0]]
 
-                    self.assertEquals(2, len(extension_calls), "The extension should have been invoked exactly twice") # pylint: disable=deprecated-method
+                    self.assertEqual(2, len(extension_calls), "The extension should have been invoked exactly twice")
                     self.assertIn("systemd-run --unit=Microsoft.Compute.TestExtension_1.2.3", extension_calls[0], "The first call to the extension should have used systemd")
-                    self.assertEquals("echo 'success'", extension_calls[1], "The second call to the extension should not have used systemd") # pylint: disable=deprecated-method
+                    self.assertEqual("echo 'success'", extension_calls[1], "The second call to the extension should not have used systemd")
 
-                    self.assertEquals(len(CGroupsTelemetry._tracked), 0, "No cgroups should have been created") # pylint: disable=deprecated-method,protected-access
+                    self.assertEqual(len(CGroupsTelemetry._tracked), 0, "No cgroups should have been created") # pylint: disable=protected-access
 
     @attr('requires_sudo')
     @patch("azurelinuxagent.common.cgroupapi.add_event")
@@ -757,11 +757,11 @@ class SystemdCgroupsApiTestCase(AgentTestCase):
 
                     extension_calls = [args[0] for (args, _) in popen_patch.call_args_list if command in args[0]]
 
-                    self.assertEquals(1, len(extension_calls), "The extension should have been invoked exactly once") # pylint: disable=deprecated-method
+                    self.assertEqual(1, len(extension_calls), "The extension should have been invoked exactly once")
                     self.assertIn("systemd-run --unit=Microsoft.Compute.TestExtension_1.2.3", extension_calls[0],
                                   "The first call to the extension should have used systemd")
 
-                    self.assertEquals(context_manager.exception.code, ExtensionErrorCodes.PluginUnknownFailure) # pylint: disable=deprecated-method
+                    self.assertEqual(context_manager.exception.code, ExtensionErrorCodes.PluginUnknownFailure)
                     self.assertIn("Non-zero exit code", ustr(context_manager.exception))
                     # The scope name should appear in the process output since systemd-run was invoked and stderr
                     # wasn't truncated.
@@ -793,11 +793,11 @@ class SystemdCgroupsApiTestCase(AgentTestCase):
 
                     extension_calls = [args[0] for (args, _) in popen_patch.call_args_list if long_stdout_stderr_command in args[0]]
 
-                    self.assertEquals(1, len(extension_calls), "The extension should have been invoked exactly once") # pylint: disable=deprecated-method
+                    self.assertEqual(1, len(extension_calls), "The extension should have been invoked exactly once")
                     self.assertIn("systemd-run --unit=Microsoft.Compute.TestExtension_1.2.3", extension_calls[0],
                                   "The first call to the extension should have used systemd")
 
-                    self.assertEquals(context_manager.exception.code, ExtensionErrorCodes.PluginUnknownFailure) # pylint: disable=deprecated-method
+                    self.assertEqual(context_manager.exception.code, ExtensionErrorCodes.PluginUnknownFailure)
                     self.assertIn("Non-zero exit code", ustr(context_manager.exception))
                     # stdout and stderr should have been truncated, so the scope name doesn't appear in stderr
                     # even though systemd-run ran
@@ -825,7 +825,7 @@ class SystemdCgroupsApiTestCase(AgentTestCase):
                                 stdout=stdout,
                                 stderr=stderr)
 
-                        self.assertEquals(context_manager.exception.code, # pylint: disable=deprecated-method
+                        self.assertEqual(context_manager.exception.code,
                                           ExtensionErrorCodes.PluginHandlerScriptTimedout)
                         self.assertIn("Timeout", ustr(context_manager.exception))
 
@@ -856,7 +856,7 @@ class SystemdCgroupsApiTestCase(AgentTestCase):
                             stdout=stdout,
                             stderr=stderr)
 
-                        self.assertEquals(expected_output.format("very specific test message"), process_output) # pylint: disable=deprecated-method
+                        self.assertEqual(expected_output.format("very specific test message"), process_output)
 
 
 class SystemdCgroupsApiMockedFileSystemTestCase(_MockedFileSystemTestCase):
@@ -873,6 +873,6 @@ class SystemdCgroupsApiMockedFileSystemTestCase(_MockedFileSystemTestCase):
             with patch("azurelinuxagent.common.cgroupapi.get_agent_pid_file_path", return_value=daemon_pid_file):
                 legacy_cgroups = SystemdCgroupsApi().cleanup_legacy_cgroups()
 
-        self.assertEquals(legacy_cgroups, 2, "cleanup_legacy_cgroups() did not find all the expected cgroups") # pylint: disable=deprecated-method
+        self.assertEqual(legacy_cgroups, 2, "cleanup_legacy_cgroups() did not find all the expected cgroups")
         self.assertFalse(os.path.exists(legacy_cpu_cgroup), "cleanup_legacy_cgroups() did not remove the CPU legacy cgroup")
         self.assertFalse(os.path.exists(legacy_memory_cgroup), "cleanup_legacy_cgroups() did not remove the memory legacy cgroup")

--- a/tests/common/test_cgroupconfigurator.py
+++ b/tests/common/test_cgroupconfigurator.py
@@ -82,7 +82,7 @@ class CGroupConfiguratorSystemdTestCase(AgentTestCase):
 
         CGroupConfiguratorSystemdTestCase._get_new_cgroup_configurator_instance().disable()
 
-        self.assertEquals(len(CGroupsTelemetry._tracked), 0) # pylint: disable=deprecated-method,protected-access
+        self.assertEqual(len(CGroupsTelemetry._tracked), 0) # pylint: disable=protected-access
 
     def test_cgroup_operations_should_not_invoke_the_cgroup_api_when_cgroups_are_not_enabled(self):
         configurator = CGroupConfiguratorSystemdTestCase._get_new_cgroup_configurator_instance()
@@ -121,7 +121,7 @@ class CGroupConfiguratorSystemdTestCase(AgentTestCase):
                     with patch(op[1], raise_exception):
                         op[0]()
 
-                    self.assertEquals(mock_logger_warn.call_count, 1) # pylint: disable=deprecated-method
+                    self.assertEqual(mock_logger_warn.call_count, 1)
 
                     args, kwargs = mock_logger_warn.call_args # pylint: disable=unused-variable
                     message = args[0]

--- a/tests/common/test_cgroups.py
+++ b/tests/common/test_cgroups.py
@@ -128,8 +128,8 @@ class TestCpuCgroup(AgentTestCase):
 
         cgroup.initialize_cpu_usage()
 
-        self.assertEquals(cgroup._current_cgroup_cpu, 63763) # pylint: disable=deprecated-method,protected-access
-        self.assertEquals(cgroup._current_system_cpu, 5496872) # pylint: disable=deprecated-method,protected-access
+        self.assertEqual(cgroup._current_cgroup_cpu, 63763) # pylint: disable=protected-access
+        self.assertEqual(cgroup._current_system_cpu, 5496872) # pylint: disable=protected-access
 
     def test_get_cpu_usage_should_return_the_cpu_usage_since_its_last_invocation(self):
         cgroup = CpuCgroup("test", "/sys/fs/cgroup/cpu/system.slice/test")
@@ -148,7 +148,7 @@ class TestCpuCgroup(AgentTestCase):
 
         cpu_usage = cgroup.get_cpu_usage()
 
-        self.assertEquals(cpu_usage, 0.031) # pylint: disable=deprecated-method
+        self.assertEqual(cpu_usage, 0.031)
 
         TestCpuCgroup.mock_read_file_map = {
             "/proc/stat": os.path.join(data_dir, "cgroups", "proc_stat_t2"),
@@ -157,7 +157,7 @@ class TestCpuCgroup(AgentTestCase):
 
         cpu_usage = cgroup.get_cpu_usage()
 
-        self.assertEquals(cpu_usage, 0.045) # pylint: disable=deprecated-method
+        self.assertEqual(cpu_usage, 0.045)
 
     def test_initialie_cpu_usage_should_set_the_cgroup_usage_to_0_when_the_cgroup_does_not_exist(self):
         cgroup = CpuCgroup("test", "/sys/fs/cgroup/cpu/system.slice/test")
@@ -172,8 +172,8 @@ class TestCpuCgroup(AgentTestCase):
 
         cgroup.initialize_cpu_usage()
 
-        self.assertEquals(cgroup._current_cgroup_cpu, 0) # pylint: disable=deprecated-method,protected-access
-        self.assertEquals(cgroup._current_system_cpu, 5496872)  # check the system usage just for test sanity # pylint: disable=deprecated-method,protected-access
+        self.assertEqual(cgroup._current_cgroup_cpu, 0) # pylint: disable=protected-access
+        self.assertEqual(cgroup._current_system_cpu, 5496872)  # check the system usage just for test sanity,protected-access
 
 
     def test_initialize_cpu_usage_should_raise_an_exception_when_called_more_than_once(self):

--- a/tests/common/test_cgroups.py
+++ b/tests/common/test_cgroups.py
@@ -173,7 +173,7 @@ class TestCpuCgroup(AgentTestCase):
         cgroup.initialize_cpu_usage()
 
         self.assertEqual(cgroup._current_cgroup_cpu, 0) # pylint: disable=protected-access
-        self.assertEqual(cgroup._current_system_cpu, 5496872)  # check the system usage just for test sanity,protected-access
+        self.assertEqual(cgroup._current_system_cpu, 5496872)  # check the system usage just for test sanity # pylint: disable=protected-access
 
 
     def test_initialize_cpu_usage_should_raise_an_exception_when_called_more_than_once(self):

--- a/tests/common/test_event.py
+++ b/tests/common/test_event.py
@@ -109,7 +109,7 @@ class TestEvent(HttpRequestPredicates, AgentTestCase): # pylint: disable=too-man
         def create_event_and_return_container_id(): # pylint: disable=inconsistent-return-statements
             event.add_event(name='Event')
             event_list = event.collect_events()
-            self.assertEquals(len(event_list.events), 1, "Could not find the event created by add_event") # pylint: disable=deprecated-method
+            self.assertEqual(len(event_list.events), 1, "Could not find the event created by add_event")
 
             for p in event_list.events[0].parameters: # pylint: disable=invalid-name
                 if p.name == CommonTelemetryEventSchema.ContainerId:
@@ -120,17 +120,17 @@ class TestEvent(HttpRequestPredicates, AgentTestCase): # pylint: disable=too-man
         with mock_wire_protocol(mockwiredata.DATA_FILE) as protocol:
             contained_id = create_event_and_return_container_id()
             # The expect value comes from DATA_FILE
-            self.assertEquals(contained_id, 'c6d5526c-5ac2-4200-b6e2-56f2b70c5ab2', "Incorrect container ID") # pylint: disable=deprecated-method
+            self.assertEqual(contained_id, 'c6d5526c-5ac2-4200-b6e2-56f2b70c5ab2', "Incorrect container ID")
 
             protocol.mock_wire_data.set_container_id('AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE')
             protocol.update_goal_state()
             contained_id = create_event_and_return_container_id()
-            self.assertEquals(contained_id, 'AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE', "Incorrect container ID") # pylint: disable=deprecated-method
+            self.assertEqual(contained_id, 'AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE', "Incorrect container ID")
 
             protocol.mock_wire_data.set_container_id('11111111-2222-3333-4444-555555555555')
             protocol.update_goal_state()
             contained_id = create_event_and_return_container_id()
-            self.assertEquals(contained_id, '11111111-2222-3333-4444-555555555555', "Incorrect container ID") # pylint: disable=deprecated-method
+            self.assertEqual(contained_id, '11111111-2222-3333-4444-555555555555', "Incorrect container ID")
 
 
     def test_add_event_should_handle_event_errors(self):
@@ -237,12 +237,12 @@ class TestEvent(HttpRequestPredicates, AgentTestCase): # pylint: disable=too-man
                   message="dummy event message",
                   reporter=mock_reporter)
 
-        self.assertEquals(1, mock_logger_error.call_count) # pylint: disable=deprecated-method
-        self.assertEquals(1, mock_logger_warn.call_count) # pylint: disable=deprecated-method
-        self.assertEquals(0, mock_logger_info.call_count) # pylint: disable=deprecated-method
+        self.assertEqual(1, mock_logger_error.call_count)
+        self.assertEqual(1, mock_logger_warn.call_count)
+        self.assertEqual(0, mock_logger_info.call_count)
 
         args = mock_logger_error.call_args[0]
-        self.assertEquals(('dummy name', 'Download', 'dummy event message', 0), args[1:]) # pylint: disable=deprecated-method
+        self.assertEqual(('dummy name', 'Download', 'dummy event message', 0), args[1:])
 
     @patch('azurelinuxagent.common.event.EventLogger')
     @patch('azurelinuxagent.common.logger.error')
@@ -264,13 +264,13 @@ class TestEvent(HttpRequestPredicates, AgentTestCase): # pylint: disable=too-man
                               is_success=False,
                               message="dummy event message")
 
-                    self.assertEquals(1, mock_should_emit_event.call_count) # pylint: disable=deprecated-method
-                    self.assertEquals(1, mock_logger_error.call_count) # pylint: disable=deprecated-method
-                    self.assertEquals(0, mock_logger_warn.call_count) # pylint: disable=deprecated-method
-                    self.assertEquals(0, mock_logger_info.call_count) # pylint: disable=deprecated-method
+                    self.assertEqual(1, mock_should_emit_event.call_count)
+                    self.assertEqual(1, mock_logger_error.call_count)
+                    self.assertEqual(0, mock_logger_warn.call_count)
+                    self.assertEqual(0, mock_logger_info.call_count)
 
                     args = mock_logger_error.call_args[0]
-                    self.assertEquals(('dummy name', 'Download', 'dummy event message', 0), args[1:]) # pylint: disable=deprecated-method
+                    self.assertEqual(('dummy name', 'Download', 'dummy event message', 0), args[1:])
 
     @patch('azurelinuxagent.common.event.EventLogger.add_event')
     def test_periodic_emits_if_not_previously_sent(self, mock_event):
@@ -344,13 +344,13 @@ class TestEvent(HttpRequestPredicates, AgentTestCase): # pylint: disable=too-man
         add_event(name='Event3')
 
         event_files = os.listdir(self.event_dir)
-        self.assertEquals(len(event_files), 3, "Did not find all the event files that were created") # pylint: disable=deprecated-method
+        self.assertEqual(len(event_files), 3, "Did not find all the event files that were created")
 
         event_list = event.collect_events()
         event_files = os.listdir(self.event_dir)
 
-        self.assertEquals(len(event_list.events), 3, "Did not collect all the events that were created") # pylint: disable=deprecated-method
-        self.assertEquals(len(event_files), 0, "The event files were not deleted") # pylint: disable=deprecated-method
+        self.assertEqual(len(event_list.events), 3, "Did not collect all the events that were created")
+        self.assertEqual(len(event_files), 0, "The event files were not deleted")
 
     def test_save_event(self):
         add_event('test', message='test event')
@@ -373,8 +373,8 @@ class TestEvent(HttpRequestPredicates, AgentTestCase): # pylint: disable=too-man
 
         event_list = event.collect_events()
 
-        self.assertEquals(len(event_list.events), 1) # pylint: disable=deprecated-method
-        self.assertEquals(TestEvent._get_event_message(event_list.events[0]), u'World\u05e2\u05d9\u05d5\u05ea \u05d0\u05d7\u05e8\u05d5\u05ea\u0906\u091c') # pylint: disable=deprecated-method
+        self.assertEqual(len(event_list.events), 1)
+        self.assertEqual(TestEvent._get_event_message(event_list.events[0]), u'World\u05e2\u05d9\u05d5\u05ea \u05d0\u05d7\u05e8\u05d5\u05ea\u0906\u091c')
 
     def test_collect_events_should_ignore_invalid_event_files(self):
         self._create_test_event_file("custom_script_1.tld")  # a valid event
@@ -386,7 +386,7 @@ class TestEvent(HttpRequestPredicates, AgentTestCase): # pylint: disable=too-man
         with patch("azurelinuxagent.common.event.add_event") as mock_add_event:
             event_list = event.collect_events()
 
-            self.assertEquals( # pylint: disable=deprecated-method
+            self.assertEqual(
                 len(event_list.events), 2)
             self.assertTrue(
                 all(TestEvent._get_event_message(evt) == "A test telemetry message." for evt in event_list.events),
@@ -400,7 +400,7 @@ class TestEvent(HttpRequestPredicates, AgentTestCase): # pylint: disable=too-man
                     invalid_events.append(kwargs['op'])
                     total_dropped_count += int(match.groups()[0])
 
-            self.assertEquals(3, total_dropped_count, "Total dropped events dont match") # pylint: disable=deprecated-method
+            self.assertEqual(3, total_dropped_count, "Total dropped events dont match")
             self.assertIn(WALAEventOperation.CollectEventErrors, invalid_events,
                           "{0} errors not reported".format(WALAEventOperation.CollectEventErrors))
             self.assertIn(WALAEventOperation.CollectEventUnicodeErrors, invalid_events,
@@ -516,7 +516,7 @@ class TestEvent(HttpRequestPredicates, AgentTestCase): # pylint: disable=too-man
         # retrieve the event that was created
         event_list = event.collect_events()
 
-        self.assertEquals(len(event_list.events), 1) # pylint: disable=deprecated-method
+        self.assertEqual(len(event_list.events), 1)
 
         # verify the event parameters
         self._assert_event_includes_all_parameters_in_the_telemetry_schema(
@@ -590,7 +590,7 @@ class TestEvent(HttpRequestPredicates, AgentTestCase): # pylint: disable=too-man
     def test_add_log_event_should_not_create_event_if_not_allowed_and_not_forced(self):
         add_log_event(logger.LogLevel.WARNING, 'A test WARNING log event')
         event_list = event.collect_events()
-        self.assertEquals(len(event_list.events), 0, "No events should be created if not forced and not allowed") # pylint: disable=deprecated-method
+        self.assertEqual(len(event_list.events), 0, "No events should be created if not forced and not allowed")
 
     def test_report_metric_should_create_events_that_have_all_the_parameters_in_the_telemetry_schema(self):
         self._test_create_event_function_should_create_events_that_have_all_the_parameters_in_the_telemetry_schema(
@@ -619,7 +619,7 @@ class TestEvent(HttpRequestPredicates, AgentTestCase): # pylint: disable=too-man
 
         event_list = event.collect_events()
 
-        self.assertEquals(len(event_list.events), 1) # pylint: disable=deprecated-method
+        self.assertEqual(len(event_list.events), 1)
 
         self._assert_event_includes_all_parameters_in_the_telemetry_schema(
             event_list.events[0],
@@ -639,7 +639,7 @@ class TestEvent(HttpRequestPredicates, AgentTestCase): # pylint: disable=too-man
                 CommonTelemetryEventSchema.TaskName: "ALegacyTask",
                 CommonTelemetryEventSchema.KeywordName: "ALegacyKeywordName"},
             assert_timestamp=lambda timestamp:
-                self.assertEquals(timestamp, '1970-01-01 12:00:00', "The event timestamp (opcode) is incorrect") # pylint: disable=deprecated-method
+                self.assertEqual(timestamp, '1970-01-01 12:00:00', "The event timestamp (opcode) is incorrect")
         )
 
     def test_collect_events_should_use_the_file_creation_time_for_legacy_agent_events_missing_a_timestamp(self):
@@ -649,7 +649,7 @@ class TestEvent(HttpRequestPredicates, AgentTestCase): # pylint: disable=too-man
 
         event_list = event.collect_events()
 
-        self.assertEquals(len(event_list.events), 1) # pylint: disable=deprecated-method
+        self.assertEqual(len(event_list.events), 1)
 
         self._assert_event_includes_all_parameters_in_the_telemetry_schema(
             event_list.events[0],
@@ -669,7 +669,7 @@ class TestEvent(HttpRequestPredicates, AgentTestCase): # pylint: disable=too-man
                 CommonTelemetryEventSchema.TaskName: "ALegacyTask",
                 CommonTelemetryEventSchema.KeywordName: "ALegacyKeywordName"},
             assert_timestamp=lambda timestamp:
-                self.assertEquals(timestamp, event_creation_time, "The event timestamp (opcode) is incorrect") # pylint: disable=deprecated-method
+                self.assertEqual(timestamp, event_creation_time, "The event timestamp (opcode) is incorrect")
         )
 
     def _assert_extension_event_includes_all_parameters_in_the_telemetry_schema(self, event_file):
@@ -681,7 +681,7 @@ class TestEvent(HttpRequestPredicates, AgentTestCase): # pylint: disable=too-man
 
         event_list = event.collect_events()
 
-        self.assertEquals(len(event_list.events), 1) # pylint: disable=deprecated-method
+        self.assertEqual(len(event_list.events), 1)
 
         self._assert_event_includes_all_parameters_in_the_telemetry_schema(
             event_list.events[0],
@@ -694,7 +694,7 @@ class TestEvent(HttpRequestPredicates, AgentTestCase): # pylint: disable=too-man
                 GuestAgentExtensionEventsSchema.Duration: 150000,
                 GuestAgentExtensionEventsSchema.ExtensionType: 'json'},
             assert_timestamp=lambda timestamp:
-                self.assertEquals(timestamp, event_creation_time, "The event timestamp (opcode) is incorrect") # pylint: disable=deprecated-method
+                self.assertEqual(timestamp, event_creation_time, "The event timestamp (opcode) is incorrect")
             )
 
     def test_collect_events_should_add_all_the_parameters_in_the_telemetry_schema_to_extension_events(self):
@@ -768,7 +768,7 @@ class TestEvent(HttpRequestPredicates, AgentTestCase): # pylint: disable=too-man
 
             event_message = get_event_message_from_http_request_body(http_post_handler.request_body)
 
-            self.assertEquals(event_message, expected_message, "The Message in the HTTP request does not match the Message in the event's *.tld file") # pylint: disable=deprecated-method
+            self.assertEqual(event_message, expected_message, "The Message in the HTTP request does not match the Message in the event's *.tld file")
 
     def test_report_event_should_encode_events_correctly(self):
 
@@ -866,11 +866,11 @@ class TestMetrics(AgentTestCase):
                          ev_logger._clean_up_message('[PERIODIC] Daemon Cgroup controller "memory" is not mounted. ' # pylint: disable=protected-access
                                                      'Failed to create a cgroup for the VM Agent; resource usage will '
                                                      'not be tracked'))
-        self.assertEquals('The time should be in UTC', ev_logger._clean_up_message( # pylint: disable=deprecated-method,protected-access
+        self.assertEqual('The time should be in UTC', ev_logger._clean_up_message( # pylint: disable=protected-access
             '2019-11-26T18:15:06.866746Z INFO The time should be in UTC'))
-        self.assertEquals('The time should be in UTC', ev_logger._clean_up_message( # pylint: disable=deprecated-method,protected-access
+        self.assertEqual('The time should be in UTC', ev_logger._clean_up_message( # pylint: disable=protected-access
             '2019-11-26T18:15:06.866746Z The time should be in UTC'))
-        self.assertEquals('[PERIODIC] The time should be in UTC', ev_logger._clean_up_message( # pylint: disable=deprecated-method,protected-access
+        self.assertEqual('[PERIODIC] The time should be in UTC', ev_logger._clean_up_message( # pylint: disable=protected-access
             '2019-11-26T18:15:06.866746Z INFO [PERIODIC] The time should be in UTC'))
-        self.assertEquals('[PERIODIC] The time should be in UTC', ev_logger._clean_up_message( # pylint: disable=deprecated-method,protected-access
+        self.assertEqual('[PERIODIC] The time should be in UTC', ev_logger._clean_up_message( # pylint: disable=protected-access
             '2019-11-26T18:15:06.866746Z [PERIODIC] The time should be in UTC'))

--- a/tests/common/test_logcollector.py
+++ b/tests/common/test_logcollector.py
@@ -210,7 +210,7 @@ diskinfo,""".format(folder_to_list, file_to_collect)
         self._assert_files_are_in_archive(expected_files=[file_to_collect])
 
         no_files = self._get_number_of_files_in_archive()
-        self.assertEquals(1, no_files, "Expected 1 file in archive, found {0}!".format(no_files)) # pylint: disable=deprecated-method
+        self.assertEqual(1, no_files, "Expected 1 file in archive, found {0}!".format(no_files))
 
     def test_log_collector_should_collect_all_files(self):
         # All files in the manifest should be collected, since none of them are over the individual file size limit,
@@ -231,7 +231,7 @@ diskinfo,""".format(folder_to_list, file_to_collect)
         self._assert_files_are_in_archive(expected_files)
 
         no_files = self._get_number_of_files_in_archive()
-        self.assertEquals(6, no_files, "Expected 6 files in archive, found {0}!".format(no_files)) # pylint: disable=deprecated-method
+        self.assertEqual(6, no_files, "Expected 6 files in archive, found {0}!".format(no_files))
 
     def test_log_collector_should_truncate_large_text_files_and_ignore_large_binary_files(self):
         # Set the size limit so that some files are too large to collect in full.
@@ -255,7 +255,7 @@ diskinfo,""".format(folder_to_list, file_to_collect)
         self._assert_files_are_not_in_archive(unexpected_files)
 
         no_files = self._get_number_of_files_in_archive()
-        self.assertEquals(5, no_files, "Expected 5 files in archive, found {0}!".format(no_files)) # pylint: disable=deprecated-method
+        self.assertEqual(5, no_files, "Expected 5 files in archive, found {0}!".format(no_files))
 
     def test_log_collector_should_prioritize_important_files_if_archive_too_big(self):
         # Set the archive size limit so that not all files can be collected. In that case, files will be added to the
@@ -288,7 +288,7 @@ diskinfo,""".format(folder_to_list, file_to_collect)
         self._assert_files_are_not_in_archive(unexpected_files)
 
         no_files = self._get_number_of_files_in_archive()
-        self.assertEquals(3, no_files, "Expected 3 files in archive, found {0}!".format(no_files)) # pylint: disable=deprecated-method
+        self.assertEqual(3, no_files, "Expected 3 files in archive, found {0}!".format(no_files))
 
         # Second collection, if a file got deleted, delete it from the archive and add next file on the priority list
         # if there is enough space.
@@ -314,7 +314,7 @@ diskinfo,""".format(folder_to_list, file_to_collect)
         self._assert_archive_created(second_archive)
 
         no_files = self._get_number_of_files_in_archive()
-        self.assertEquals(5, no_files, "Expected 5 files in archive, found {0}!".format(no_files)) # pylint: disable=deprecated-method
+        self.assertEqual(5, no_files, "Expected 5 files in archive, found {0}!".format(no_files))
 
     def test_log_collector_should_update_archive_when_files_are_new_or_modified_or_deleted(self):
         # Ensure the archive reflects the state of files on the disk at collection time. If a file was updated, it
@@ -335,7 +335,7 @@ diskinfo,""".format(folder_to_list, file_to_collect)
         self._assert_files_are_in_archive(expected_files)
 
         no_files = self._get_number_of_files_in_archive()
-        self.assertEquals(6, no_files, "Expected 6 files in archive, found {0}!".format(no_files)) # pylint: disable=deprecated-method
+        self.assertEqual(6, no_files, "Expected 6 files in archive, found {0}!".format(no_files))
 
         # Update a file and its last modified time to ensure the last modified time and last collection time are not
         # the same in this test
@@ -368,11 +368,11 @@ diskinfo,""".format(folder_to_list, file_to_collect)
 
         file = os.path.join(self.root_collect_dir, "waagent.log") # pylint: disable=redefined-builtin
         new_file_size = self._get_uncompressed_file_size(file)
-        self.assertEquals(LARGE_FILE_SIZE, new_file_size, "File {0} hasn't been updated! Size in archive is {1}, but " # pylint: disable=deprecated-method
+        self.assertEqual(LARGE_FILE_SIZE, new_file_size, "File {0} hasn't been updated! Size in archive is {1}, but "
                                                           "should be {2}.".format(file, new_file_size, LARGE_FILE_SIZE))
 
         no_files = self._get_number_of_files_in_archive()
-        self.assertEquals(6, no_files, "Expected 6 files in archive, found {0}!".format(no_files)) # pylint: disable=deprecated-method
+        self.assertEqual(6, no_files, "Expected 6 files in archive, found {0}!".format(no_files))
 
     def test_log_collector_should_clean_up_uncollected_truncated_files(self):
         # Make sure that truncated files that are no longer needed are cleaned up. If an existing truncated file
@@ -401,7 +401,7 @@ diskinfo,""".format(folder_to_list, file_to_collect)
         self._assert_files_are_in_archive(expected_files)
 
         no_files = self._get_number_of_files_in_archive()
-        self.assertEquals(2, no_files, "Expected 2 files in archive, found {0}!".format(no_files)) # pylint: disable=deprecated-method
+        self.assertEqual(2, no_files, "Expected 2 files in archive, found {0}!".format(no_files))
 
         # Remove the original file so it is not collected anymore. In the next collection, the truncated file should be
         # removed both from the archive and from the filesystem.
@@ -426,7 +426,7 @@ diskinfo,""".format(folder_to_list, file_to_collect)
         self._assert_archive_created(second_archive)
 
         no_files = self._get_number_of_files_in_archive()
-        self.assertEquals(2, no_files, "Expected 2 files in archive, found {0}!".format(no_files)) # pylint: disable=deprecated-method
+        self.assertEqual(2, no_files, "Expected 2 files in archive, found {0}!".format(no_files))
 
         truncated_files = os.listdir(self.truncated_files_dir)
-        self.assertEquals(0, len(truncated_files), "Uncollected truncated file waagent.log.1 should have been deleted!") # pylint: disable=deprecated-method
+        self.assertEqual(0, len(truncated_files), "Uncollected truncated file waagent.log.1 should have been deleted!")

--- a/tests/common/test_logger.py
+++ b/tests/common/test_logger.py
@@ -305,7 +305,7 @@ class TestLogger(AgentTestCase):
         prefix = "YoloLogger"
 
         lg.set_prefix(prefix)
-        self.assertEquals(lg.prefix, prefix) # pylint: disable=deprecated-method
+        self.assertEqual(lg.prefix, prefix)
 
         lg.add_appender(logger.AppenderType.FILE, logger.LogLevel.INFO, path=self.log_file)
         lg.add_appender(logger.AppenderType.TELEMETRY, logger.LogLevel.WARNING, path=add_log_event)

--- a/tests/daemon/test_daemon.py
+++ b/tests/daemon/test_daemon.py
@@ -52,7 +52,7 @@ class TestDaemon(AgentTestCase):
         daemon_handler.run()
 
         mock_sleep.assert_any_call(15)
-        self.assertEquals(2, daemon_handler.daemon.call_count) # pylint: disable=deprecated-method
+        self.assertEqual(2, daemon_handler.daemon.call_count)
 
     @patch("time.sleep")
     @patch("azurelinuxagent.daemon.main.conf")

--- a/tests/ga/test_env.py
+++ b/tests/ga/test_env.py
@@ -41,28 +41,28 @@ class TestEnvHandler(AgentTestCase):
     def test_get_dhcp_client_pid_should_return_a_sorted_list_of_pids(self):
         with patch("azurelinuxagent.common.utils.shellutil.run_command", return_value="11 9 5 22 4 6"):
             pids = EnvHandler().get_dhcp_client_pid()
-            self.assertEquals(pids, [4, 5, 6, 9, 11, 22]) # pylint: disable=deprecated-method
+            self.assertEqual(pids, [4, 5, 6, 9, 11, 22])
 
     def test_get_dhcp_client_pid_should_return_an_empty_list_and_log_a_warning_when_dhcp_client_is_not_running(self):
         with patch("azurelinuxagent.common.osutil.default.shellutil.run_command", side_effect=lambda _: self.shellutil_run_command(["pidof", "non-existing-process"])):
             with patch('azurelinuxagent.common.logger.Logger.warn') as mock_warn:
                 pids = EnvHandler().get_dhcp_client_pid()
 
-        self.assertEquals(pids, []) # pylint: disable=deprecated-method
+        self.assertEqual(pids, [])
 
-        self.assertEquals(mock_warn.call_count, 1) # pylint: disable=deprecated-method
+        self.assertEqual(mock_warn.call_count, 1)
         args, kwargs = mock_warn.call_args # pylint: disable=unused-variable
         message = args[0]
-        self.assertEquals("Dhcp client is not running.", message) # pylint: disable=deprecated-method
+        self.assertEqual("Dhcp client is not running.", message)
 
     def test_get_dhcp_client_pid_should_return_and_empty_list_and_log_an_error_when_an_invalid_command_is_used(self):
         with patch("azurelinuxagent.common.osutil.default.shellutil.run_command", side_effect=lambda _: self.shellutil_run_command(["non-existing-command"])):
             with patch('azurelinuxagent.common.logger.Logger.error') as mock_error:
                 pids = EnvHandler().get_dhcp_client_pid()
 
-        self.assertEquals(pids, []) # pylint: disable=deprecated-method
+        self.assertEqual(pids, [])
 
-        self.assertEquals(mock_error.call_count, 1) # pylint: disable=deprecated-method
+        self.assertEqual(mock_error.call_count, 1)
         args, kwargs = mock_error.call_args # pylint: disable=unused-variable
         self.assertIn("Failed to get the PID of the DHCP client", args[0])
         self.assertIn("No such file or directory", args[1])
@@ -72,41 +72,41 @@ class TestEnvHandler(AgentTestCase):
 
         with patch('azurelinuxagent.common.logger.Logger.warn') as mock_warn:
             def assert_warnings(count):
-                self.assertEquals(mock_warn.call_count, count) # pylint: disable=deprecated-method
+                self.assertEqual(mock_warn.call_count, count)
 
                 for call_args in mock_warn.call_args_list:
                     args, kwargs = call_args # pylint: disable=unused-variable
-                    self.assertEquals("Dhcp client is not running.", args[0]) # pylint: disable=deprecated-method
+                    self.assertEqual("Dhcp client is not running.", args[0])
 
             with patch("azurelinuxagent.common.osutil.default.shellutil.run_command", side_effect=lambda _: self.shellutil_run_command(["pidof", "non-existing-process"])):
                 # it should log the first error
                 pids = env_handler.get_dhcp_client_pid()
-                self.assertEquals(pids, []) # pylint: disable=deprecated-method
+                self.assertEqual(pids, [])
                 assert_warnings(1)
 
                 # it should not log subsequent errors
                 for i in range(0, 3): # pylint: disable=unused-variable
                     pids = env_handler.get_dhcp_client_pid()
-                    self.assertEquals(pids, []) # pylint: disable=deprecated-method
-                    self.assertEquals(mock_warn.call_count, 1) # pylint: disable=deprecated-method
+                    self.assertEqual(pids, [])
+                    self.assertEqual(mock_warn.call_count, 1)
 
             with patch("azurelinuxagent.common.osutil.default.shellutil.run_command", return_value="123"):
                 # now it should succeed
                 pids = env_handler.get_dhcp_client_pid()
-                self.assertEquals(pids, [123]) # pylint: disable=deprecated-method
+                self.assertEqual(pids, [123])
                 assert_warnings(1)
 
             with patch("azurelinuxagent.common.osutil.default.shellutil.run_command", side_effect=lambda _: self.shellutil_run_command(["pidof", "non-existing-process"])):
                 # it should log the new error
                 pids = env_handler.get_dhcp_client_pid()
-                self.assertEquals(pids, []) # pylint: disable=deprecated-method
+                self.assertEqual(pids, [])
                 assert_warnings(2)
 
                 # it should not log subsequent errors
                 for i in range(0, 3):
                     pids = env_handler.get_dhcp_client_pid()
-                    self.assertEquals(pids, []) # pylint: disable=deprecated-method
-                    self.assertEquals(mock_warn.call_count, 2) # pylint: disable=deprecated-method
+                    self.assertEqual(pids, [])
+                    self.assertEqual(mock_warn.call_count, 2)
 
     def test_handle_dhclient_restart_should_reconfigure_network_routes_when_dhcp_client_restarts(self):
         with patch("azurelinuxagent.common.dhcp.DhcpHandler.conf_routes") as mock_conf_routes:
@@ -118,7 +118,7 @@ class TestEnvHandler(AgentTestCase):
             with patch.object(env_handler, "get_dhcp_client_pid", return_value=[123]):
                 env_handler.dhcp_handler.conf_routes()
                 env_handler.dhcp_id_list = env_handler.get_dhcp_client_pid()
-                self.assertEquals(mock_conf_routes.call_count, 1) # pylint: disable=deprecated-method
+                self.assertEqual(mock_conf_routes.call_count, 1)
 
             #
             # if the dhcp client has not been restarted then it should not reconfigure the network routes
@@ -131,7 +131,7 @@ class TestEnvHandler(AgentTestCase):
             with patch("azurelinuxagent.common.osutil.default.DefaultOSUtil.check_pid_alive", side_effect=mock_check_pid_alive):
                 with patch.object(env_handler, "get_dhcp_client_pid", side_effect=Exception("get_dhcp_client_pid should not have been invoked")):
                     env_handler.handle_dhclient_restart()
-                    self.assertEquals(mock_conf_routes.call_count, 1)  # count did not change # pylint: disable=deprecated-method
+                    self.assertEqual(mock_conf_routes.call_count, 1)  # count did not change
 
             #
             # if the process was restarted then it should reconfigure the network routes
@@ -144,7 +144,7 @@ class TestEnvHandler(AgentTestCase):
             with patch("azurelinuxagent.common.osutil.default.DefaultOSUtil.check_pid_alive", side_effect=mock_check_pid_alive):
                 with patch.object(env_handler, "get_dhcp_client_pid", return_value=[456, 789]):
                     env_handler.handle_dhclient_restart()
-                    self.assertEquals(mock_conf_routes.call_count, 2)  # count increased # pylint: disable=deprecated-method
+                    self.assertEqual(mock_conf_routes.call_count, 2)  # count increased
 
             #
             # if the new dhcp client has not been restarted then it should not reconfigure the network routes
@@ -157,4 +157,4 @@ class TestEnvHandler(AgentTestCase):
             with patch("azurelinuxagent.common.osutil.default.DefaultOSUtil.check_pid_alive", side_effect=mock_check_pid_alive):
                 with patch.object(env_handler, "get_dhcp_client_pid", side_effect=Exception("get_dhcp_client_pid should not have been invoked")):
                     env_handler.handle_dhclient_restart()
-                    self.assertEquals(mock_conf_routes.call_count, 2)  # count did not change # pylint: disable=deprecated-method
+                    self.assertEqual(mock_conf_routes.call_count, 2)  # count did not change

--- a/tests/ga/test_extension.py
+++ b/tests/ga/test_extension.py
@@ -114,8 +114,8 @@ class TestExtensionCleanup(AgentTestCase):
                          "All ExtensionHandlers: {0}".format(handler_statuses))
         for ext_handler_status in handler_statuses:
             debug_info = "ExtensionHandler: {0}".format(ext_handler_status)
-            self.assertEquals(expected_status, ext_handler_status['status'], debug_info) # pylint: disable=deprecated-method
-            self.assertEquals(version, ext_handler_status['handlerVersion'], debug_info) # pylint: disable=deprecated-method
+            self.assertEqual(expected_status, ext_handler_status['status'], debug_info)
+            self.assertEqual(version, ext_handler_status['handlerVersion'], debug_info)
         return
 
     @contextlib.contextmanager
@@ -260,8 +260,8 @@ class TestHandlerStateMigration(AgentTestCase):
 
         migrate_handler_state()
 
-        self.assertEquals(self.ext_handler_i.get_handler_state(), self.handler_state) # pylint: disable=deprecated-method
-        self.assertEquals( # pylint: disable=deprecated-method
+        self.assertEqual(self.ext_handler_i.get_handler_state(), self.handler_state)
+        self.assertEqual(
             self.ext_handler_i.get_handler_status().status,
             self.handler_status.status)
         return
@@ -294,21 +294,21 @@ class TestHandlerStateMigration(AgentTestCase):
         status = "NotReady"
         code = 1
         message = "A message"
-        self.assertNotEquals(state, self.handler_state) # pylint: disable=deprecated-method
-        self.assertNotEquals(status, self.handler_status.status) # pylint: disable=deprecated-method
-        self.assertNotEquals(code, self.handler_status.code) # pylint: disable=deprecated-method
-        self.assertNotEquals(message, self.handler_status.message) # pylint: disable=deprecated-method
+        self.assertNotEqual(state, self.handler_state)
+        self.assertNotEqual(status, self.handler_status.status)
+        self.assertNotEqual(code, self.handler_status.code)
+        self.assertNotEqual(message, self.handler_status.message)
 
         self.ext_handler_i.set_handler_state(state)
         self.ext_handler_i.set_handler_status(status=status, code=code, message=message)
 
         migrate_handler_state()
 
-        self.assertEquals(self.ext_handler_i.get_handler_state(), state) # pylint: disable=deprecated-method
+        self.assertEqual(self.ext_handler_i.get_handler_state(), state)
         handler_status = self.ext_handler_i.get_handler_status()
-        self.assertEquals(handler_status.status, status) # pylint: disable=deprecated-method
-        self.assertEquals(handler_status.code, code) # pylint: disable=deprecated-method
-        self.assertEquals(handler_status.message, message) # pylint: disable=deprecated-method
+        self.assertEqual(handler_status.status, status)
+        self.assertEqual(handler_status.code, code)
+        self.assertEqual(handler_status.message, message)
         return
 
     def test_set_handler_status_ignores_none_content(self):
@@ -380,13 +380,13 @@ class TestExtension(ExtensionTestCase):
         self.assertTrue(report_vm_status.called)
         args, kw = report_vm_status.call_args # pylint: disable=unused-variable,invalid-name
         vm_status = args[0]
-        self.assertNotEquals(0, len(vm_status.vmAgent.extensionHandlers)) # pylint: disable=deprecated-method
+        self.assertNotEqual(0, len(vm_status.vmAgent.extensionHandlers))
         handler_status = vm_status.vmAgent.extensionHandlers[0]
-        self.assertEquals(expected_status, handler_status.status) # pylint: disable=deprecated-method
-        self.assertEquals(expected_handler_name, # pylint: disable=deprecated-method
+        self.assertEqual(expected_status, handler_status.status)
+        self.assertEqual(expected_handler_name,
                           handler_status.name)
-        self.assertEquals(version, handler_status.version) # pylint: disable=deprecated-method
-        self.assertEquals(expected_ext_count, len(handler_status.extensions)) # pylint: disable=deprecated-method
+        self.assertEqual(version, handler_status.version)
+        self.assertEqual(expected_ext_count, len(handler_status.extensions))
         return
 
     def _assert_ext_pkg_file_status(self, expected_to_be_present=True, extension_version="1.0.0",
@@ -401,7 +401,7 @@ class TestExtension(ExtensionTestCase):
         self.assertTrue(report_vm_status.called)
         args, kw = report_vm_status.call_args # pylint: disable=unused-variable,invalid-name
         vm_status = args[0]
-        self.assertEquals(0, len(vm_status.vmAgent.extensionHandlers)) # pylint: disable=deprecated-method
+        self.assertEqual(0, len(vm_status.vmAgent.extensionHandlers))
         return
 
     def _create_mock(self, test_data, mock_http_get, MockCryptUtil, *args): # pylint: disable=unused-argument,invalid-name
@@ -832,7 +832,7 @@ class TestExtension(ExtensionTestCase):
         status_path = os.path.join(conf.get_lib_dir(), AGENT_STATUS_FILE)
         actual_status_json = json.loads(fileutil.read_file(status_path))
 
-        self.assertEquals(expected_status_json, actual_status_json) # pylint: disable=deprecated-method
+        self.assertEqual(expected_status_json, actual_status_json)
 
     def test_ext_handler_rollingupgrade(self, *args):
         # Test enable scenario.
@@ -939,7 +939,7 @@ class TestExtension(ExtensionTestCase):
 
         exthandlers_handler.run()
 
-        self.assertEquals(0, mock_add_event.call_count) # pylint: disable=deprecated-method
+        self.assertEqual(0, mock_add_event.call_count)
 
     def test_it_should_create_extension_events_dir_and_set_handler_environment_only_if_extension_telemetry_enabled(self, *args):
 
@@ -1026,11 +1026,11 @@ class TestExtension(ExtensionTestCase):
 
         mock_error_state.return_value = True
         exthandlers_handler.run()
-        self.assertEquals(5, mock_add_event.call_count) # pylint: disable=deprecated-method
+        self.assertEqual(5, mock_add_event.call_count)
         args, kw = mock_add_event.call_args # pylint: disable=invalid-name
-        self.assertEquals(False, kw['is_success']) # pylint: disable=deprecated-method
+        self.assertEqual(False, kw['is_success'])
         self.assertTrue("Failed to report vm agent status" in kw['message'])
-        self.assertEquals("ReportStatusExtended", kw['op']) # pylint: disable=deprecated-method
+        self.assertEqual("ReportStatusExtended", kw['op'])
 
     @patch('azurelinuxagent.ga.exthandlers.add_event')
     def test_ext_handler_report_status_resource_gone(self, mock_add_event, *args):
@@ -1039,11 +1039,11 @@ class TestExtension(ExtensionTestCase):
         protocol.report_vm_status = Mock(side_effect=ResourceGoneError)
 
         exthandlers_handler.run()
-        self.assertEquals(4, mock_add_event.call_count) # pylint: disable=deprecated-method
+        self.assertEqual(4, mock_add_event.call_count)
         args, kw = mock_add_event.call_args # pylint: disable=invalid-name
-        self.assertEquals(False, kw['is_success']) # pylint: disable=deprecated-method
+        self.assertEqual(False, kw['is_success'])
         self.assertTrue("ResourceGoneError" in kw['message'])
-        self.assertEquals("ExtensionProcessing", kw['op']) # pylint: disable=deprecated-method
+        self.assertEqual("ExtensionProcessing", kw['op'])
 
     @patch('azurelinuxagent.common.errorstate.ErrorState.is_triggered')
     @patch('azurelinuxagent.ga.exthandlers.ExtHandlerInstance.report_event')
@@ -1056,9 +1056,9 @@ class TestExtension(ExtensionTestCase):
 
         exthandlers_handler.run()
 
-        self.assertEquals(1, mock_add_event.call_count) # pylint: disable=deprecated-method
+        self.assertEqual(1, mock_add_event.call_count)
         args, kw = mock_add_event.call_args_list[0] # pylint: disable=invalid-name
-        self.assertEquals(False, kw['is_success']) # pylint: disable=deprecated-method
+        self.assertEqual(False, kw['is_success'])
         self.assertTrue("Failed to get ext handler pkgs" in kw['message'])
         self.assertTrue("ProtocolError" in kw['message'])
 
@@ -1068,7 +1068,7 @@ class TestExtension(ExtensionTestCase):
         def _assert_mock_add_event_call(expected_download_failed_event_count, err_msg_guid):
             event_occurrences = [kw for _, kw in mock_add_event.call_args_list if
                           "Failed to download artifacts: [ExtensionDownloadError] {0}".format(err_msg_guid) in kw['message']]
-            self.assertEquals(expected_download_failed_event_count, len(event_occurrences), "Call count do not match") # pylint: disable=deprecated-method
+            self.assertEqual(expected_download_failed_event_count, len(event_occurrences), "Call count do not match")
             self.assertFalse(any([kw['is_success'] for kw in event_occurrences]), "The events should have failed")
             self.assertEqual(expected_download_failed_event_count, len([kw['op'] for kw in event_occurrences]),
                              "Incorrect Operation, all events should be a download errors")
@@ -1193,8 +1193,8 @@ class TestExtension(ExtensionTestCase):
         self.assertTrue(report_ext_status.called)
         args, kw = report_ext_status.call_args # pylint: disable=unused-variable,invalid-name
         ext_status = args[-1]
-        self.assertEquals(expected_status, ext_status.status) # pylint: disable=deprecated-method
-        self.assertEquals(expected_seq_no, ext_status.sequenceNumber) # pylint: disable=deprecated-method
+        self.assertEqual(expected_status, ext_status.status)
+        self.assertEqual(expected_seq_no, ext_status.sequenceNumber)
 
     def test_ext_handler_no_reporting_status(self, *args):
         test_data = mockwiredata.WireProtocolData(mockwiredata.DATA_FILE)
@@ -1649,7 +1649,7 @@ class TestExtension(ExtensionTestCase):
 
         self.assertEqual(1, patch_get_uninstall_command.call_count)
         self.assertEqual(2, protocol.report_vm_status.call_count)
-        self.assertEquals("Ready", protocol.report_vm_status.call_args[0][0].vmAgent.status) # pylint: disable=deprecated-method
+        self.assertEqual("Ready", protocol.report_vm_status.call_args[0][0].vmAgent.status)
         self._assert_no_handler_status(protocol.report_vm_status)
 
         # Ensure there are no further retries
@@ -1657,7 +1657,7 @@ class TestExtension(ExtensionTestCase):
 
         self.assertEqual(1, patch_get_uninstall_command.call_count)
         self.assertEqual(3, protocol.report_vm_status.call_count)
-        self.assertEquals("Ready", protocol.report_vm_status.call_args[0][0].vmAgent.status) # pylint: disable=deprecated-method
+        self.assertEqual("Ready", protocol.report_vm_status.call_args[0][0].vmAgent.status)
         self._assert_no_handler_status(protocol.report_vm_status)
 
     @patch('azurelinuxagent.ga.exthandlers.HandlerManifest.get_update_command')
@@ -1687,8 +1687,8 @@ class TestExtension(ExtensionTestCase):
             enable_command_count = len([extension_call for extension_call in extension_calls
                                         if "-enable" in extension_call])
 
-            self.assertEquals(1, update_command_count) # pylint: disable=deprecated-method
-            self.assertEquals(0, enable_command_count) # pylint: disable=deprecated-method
+            self.assertEqual(1, update_command_count)
+            self.assertEqual(0, enable_command_count)
 
             # We report the failure of the new extension version
             self._assert_handler_status(protocol.report_vm_status, "NotReady", expected_ext_count=1, version="1.0.1")
@@ -1702,8 +1702,8 @@ class TestExtension(ExtensionTestCase):
                                         if patch_get_update_command.return_value in extension_call])
             enable_command_count = len([extension_call for extension_call in extension_calls
                                         if "-enable" in extension_call])
-            self.assertEquals(1, update_command_count) # pylint: disable=deprecated-method
-            self.assertEquals(0, enable_command_count) # pylint: disable=deprecated-method
+            self.assertEqual(1, update_command_count)
+            self.assertEqual(0, enable_command_count)
 
             # If the incarnation number changes (there's a new goal state), ensure we go through the entire upgrade
             # process again.
@@ -1716,8 +1716,8 @@ class TestExtension(ExtensionTestCase):
                                         if patch_get_update_command.return_value in extension_call])
             enable_command_count = len([extension_call for extension_call in extension_calls
                                         if "-enable" in extension_call])
-            self.assertEquals(2, update_command_count) # pylint: disable=deprecated-method
-            self.assertEquals(0, enable_command_count) # pylint: disable=deprecated-method
+            self.assertEqual(2, update_command_count)
+            self.assertEqual(0, enable_command_count)
 
             # We report the failure of the new extension version
             self._assert_handler_status(protocol.report_vm_status, "NotReady", expected_ext_count=1, version="1.0.1")

--- a/tests/ga/test_exthandlers.py
+++ b/tests/ga/test_exthandlers.py
@@ -396,7 +396,7 @@ with open("{2}", "w") as file:
             self.assertRegex(message, r"Timeout\(\d+\):\s+{0}\s+{1}".format(command_full_path, LaunchCommandTestCase._output_regex(stdout, stderr)))
 
             # the exception code should be as specified in the call to launch_command
-            self.assertEquals(context_manager.exception.code, extension_error_code) # pylint: disable=deprecated-method
+            self.assertEqual(context_manager.exception.code, extension_error_code)
 
             # the timeout period should have elapsed
             self.assertGreaterEqual(mock_sleep.call_count, timeout)
@@ -440,7 +440,7 @@ exit({2})
         message = str(context_manager.exception)
         self.assertRegex(message, r"Non-zero exit code: {0}.+{1}\s+{2}".format(exit_code, command, LaunchCommandTestCase._output_regex(stdout, stderr)))
 
-        self.assertEquals(context_manager.exception.code, extension_error_code) # pylint: disable=deprecated-method
+        self.assertEqual(context_manager.exception.code, extension_error_code)
 
     def test_it_should_not_wait_for_child_process(self):
         stdout = "stdout"
@@ -581,7 +581,7 @@ echo {1}
 
         with open(command_output_file, "r") as command_output:
             output = command_output.read()
-            self.assertEquals(output, "{0}\n{1}\n".format(stdout, stderr)) # pylint: disable=deprecated-method
+            self.assertEqual(output, "{0}\n{1}\n".format(stdout, stderr))
 
     def test_it_should_truncate_the_command_output(self):
         stdout = "STDOUT"

--- a/tests/ga/test_exthandlers_download_extension.py
+++ b/tests/ga/test_exthandlers_download_extension.py
@@ -197,7 +197,7 @@ class DownloadExtensionTestCase(AgentTestCase): # pylint: disable=too-many-insta
         with patch("azurelinuxagent.common.protocol.wire.WireProtocol.download_ext_handler_pkg", side_effect=download_ext_handler_pkg) as mock_download_ext_handler_pkg:
             self.ext_handler_instance.download()
 
-        self.assertEquals(mock_download_ext_handler_pkg.call_count, self.download_failures + 1) # pylint: disable=deprecated-method
+        self.assertEqual(mock_download_ext_handler_pkg.call_count, self.download_failures + 1)
 
         self._assert_download_and_expand_succeeded()
 
@@ -215,7 +215,7 @@ class DownloadExtensionTestCase(AgentTestCase): # pylint: disable=too-many-insta
         with patch("azurelinuxagent.common.protocol.wire.WireProtocol.download_ext_handler_pkg", side_effect=download_ext_handler_pkg) as mock_download_ext_handler_pkg:
             self.ext_handler_instance.download()
 
-        self.assertEquals(mock_download_ext_handler_pkg.call_count, self.download_failures + 1) # pylint: disable=deprecated-method
+        self.assertEqual(mock_download_ext_handler_pkg.call_count, self.download_failures + 1)
 
         self._assert_download_and_expand_succeeded()
 
@@ -234,7 +234,7 @@ class DownloadExtensionTestCase(AgentTestCase): # pylint: disable=too-many-insta
         with patch("azurelinuxagent.common.protocol.wire.WireProtocol.download_ext_handler_pkg", side_effect=download_ext_handler_pkg) as mock_download_ext_handler_pkg:
             self.ext_handler_instance.download()
 
-        self.assertEquals(mock_download_ext_handler_pkg.call_count, self.download_failures + 1) # pylint: disable=deprecated-method
+        self.assertEqual(mock_download_ext_handler_pkg.call_count, self.download_failures + 1)
 
         self._assert_download_and_expand_succeeded()
 
@@ -248,10 +248,10 @@ class DownloadExtensionTestCase(AgentTestCase): # pylint: disable=too-many-insta
                 with self.assertRaises(ExtensionDownloadError) as context_manager:
                     self.ext_handler_instance.download()
 
-        self.assertEquals(mock_download_ext_handler_pkg.call_count, NUMBER_OF_DOWNLOAD_RETRIES * len(self.pkg.uris)) # pylint: disable=deprecated-method
+        self.assertEqual(mock_download_ext_handler_pkg.call_count, NUMBER_OF_DOWNLOAD_RETRIES * len(self.pkg.uris))
 
         self.assertRegex(str(context_manager.exception), "Failed to download extension")
-        self.assertEquals(context_manager.exception.code, ExtensionErrorCodes.PluginManifestDownloadError) # pylint: disable=deprecated-method
+        self.assertEqual(context_manager.exception.code, ExtensionErrorCodes.PluginManifestDownloadError)
 
         self.assertFalse(os.path.exists(self.extension_dir), "The extension directory was not removed")
         self.assertFalse(os.path.exists(self._get_extension_package_file()), "The extension package was not removed")

--- a/tests/ga/test_monitor.py
+++ b/tests/ga/test_monitor.py
@@ -576,7 +576,7 @@ Directory /sys/fs/cgroup/cpu/system.slice/walinuxagent.service:
                 search = re.search(r'\[(?P<processes>.+)\]', messages[0])
                 self.assertIsNotNone(search, "The event message is not in the expected format: {0}".format(messages[0]))
                 processes = search.group('processes')
-                self.assertEquals(5, len(processes.split(',')), 'Extra processes were reported as unexpected: {0}'.format(processes)) # pylint: disable=deprecated-method
+                self.assertEqual(5, len(processes.split(',')), 'Extra processes were reported as unexpected: {0}'.format(processes))
 
 
 @patch("azurelinuxagent.common.utils.restutil.http_post")

--- a/tests/ga/test_remoteaccess.py
+++ b/tests/ga/test_remoteaccess.py
@@ -26,12 +26,12 @@ class TestRemoteAccess(AgentTestCase):
     def test_parse_remote_access(self):
         data_str = load_data('wire/remote_access_single_account.xml')
         remote_access = RemoteAccess(data_str)
-        self.assertNotEquals(None, remote_access) # pylint: disable=deprecated-method
-        self.assertEquals("1", remote_access.incarnation) # pylint: disable=deprecated-method
-        self.assertEquals(1, len(remote_access.user_list.users), "User count does not match.") # pylint: disable=deprecated-method
-        self.assertEquals("testAccount", remote_access.user_list.users[0].name, "Account name does not match") # pylint: disable=deprecated-method
-        self.assertEquals("encryptedPasswordString", remote_access.user_list.users[0].encrypted_password, "Encrypted password does not match.") # pylint: disable=deprecated-method
-        self.assertEquals("2019-01-01", remote_access.user_list.users[0].expiration, "Expiration does not match.") # pylint: disable=deprecated-method
+        self.assertNotEqual(None, remote_access)
+        self.assertEqual("1", remote_access.incarnation)
+        self.assertEqual(1, len(remote_access.user_list.users), "User count does not match.")
+        self.assertEqual("testAccount", remote_access.user_list.users[0].name, "Account name does not match")
+        self.assertEqual("encryptedPasswordString", remote_access.user_list.users[0].encrypted_password, "Encrypted password does not match.")
+        self.assertEqual("2019-01-01", remote_access.user_list.users[0].expiration, "Expiration does not match.")
 
     def test_goal_state_with_no_remote_access(self):
         with mock_wire_protocol(mockwiredata.DATA_FILE) as protocol:
@@ -40,46 +40,46 @@ class TestRemoteAccess(AgentTestCase):
     def test_parse_two_remote_access_accounts(self):
         data_str = load_data('wire/remote_access_two_accounts.xml')
         remote_access = RemoteAccess(data_str)
-        self.assertNotEquals(None, remote_access) # pylint: disable=deprecated-method
-        self.assertEquals("1", remote_access.incarnation) # pylint: disable=deprecated-method
-        self.assertEquals(2, len(remote_access.user_list.users), "User count does not match.") # pylint: disable=deprecated-method
-        self.assertEquals("testAccount1", remote_access.user_list.users[0].name, "Account name does not match") # pylint: disable=deprecated-method
-        self.assertEquals("encryptedPasswordString", remote_access.user_list.users[0].encrypted_password, "Encrypted password does not match.") # pylint: disable=deprecated-method
-        self.assertEquals("2019-01-01", remote_access.user_list.users[0].expiration, "Expiration does not match.") # pylint: disable=deprecated-method
-        self.assertEquals("testAccount2", remote_access.user_list.users[1].name, "Account name does not match") # pylint: disable=deprecated-method
-        self.assertEquals("encryptedPasswordString", remote_access.user_list.users[1].encrypted_password, "Encrypted password does not match.") # pylint: disable=deprecated-method
-        self.assertEquals("2019-01-01", remote_access.user_list.users[1].expiration, "Expiration does not match.") # pylint: disable=deprecated-method
+        self.assertNotEqual(None, remote_access)
+        self.assertEqual("1", remote_access.incarnation)
+        self.assertEqual(2, len(remote_access.user_list.users), "User count does not match.")
+        self.assertEqual("testAccount1", remote_access.user_list.users[0].name, "Account name does not match")
+        self.assertEqual("encryptedPasswordString", remote_access.user_list.users[0].encrypted_password, "Encrypted password does not match.")
+        self.assertEqual("2019-01-01", remote_access.user_list.users[0].expiration, "Expiration does not match.")
+        self.assertEqual("testAccount2", remote_access.user_list.users[1].name, "Account name does not match")
+        self.assertEqual("encryptedPasswordString", remote_access.user_list.users[1].encrypted_password, "Encrypted password does not match.")
+        self.assertEqual("2019-01-01", remote_access.user_list.users[1].expiration, "Expiration does not match.")
 
     def test_parse_ten_remote_access_accounts(self):
         data_str = load_data('wire/remote_access_10_accounts.xml')
         remote_access = RemoteAccess(data_str)
-        self.assertNotEquals(None, remote_access) # pylint: disable=deprecated-method
-        self.assertEquals(10, len(remote_access.user_list.users), "User count does not match.") # pylint: disable=deprecated-method
+        self.assertNotEqual(None, remote_access)
+        self.assertEqual(10, len(remote_access.user_list.users), "User count does not match.")
 
     def test_parse_duplicate_remote_access_accounts(self):
         data_str = load_data('wire/remote_access_duplicate_accounts.xml')
         remote_access = RemoteAccess(data_str)
-        self.assertNotEquals(None, remote_access) # pylint: disable=deprecated-method
-        self.assertEquals(2, len(remote_access.user_list.users), "User count does not match.") # pylint: disable=deprecated-method
-        self.assertEquals("testAccount", remote_access.user_list.users[0].name, "Account name does not match") # pylint: disable=deprecated-method
-        self.assertEquals("encryptedPasswordString", remote_access.user_list.users[0].encrypted_password, "Encrypted password does not match.") # pylint: disable=deprecated-method
-        self.assertEquals("2019-01-01", remote_access.user_list.users[0].expiration, "Expiration does not match.") # pylint: disable=deprecated-method
-        self.assertEquals("testAccount", remote_access.user_list.users[1].name, "Account name does not match") # pylint: disable=deprecated-method
-        self.assertEquals("encryptedPasswordString", remote_access.user_list.users[1].encrypted_password, "Encrypted password does not match.") # pylint: disable=deprecated-method
-        self.assertEquals("2019-01-01", remote_access.user_list.users[1].expiration, "Expiration does not match.") # pylint: disable=deprecated-method
+        self.assertNotEqual(None, remote_access)
+        self.assertEqual(2, len(remote_access.user_list.users), "User count does not match.")
+        self.assertEqual("testAccount", remote_access.user_list.users[0].name, "Account name does not match")
+        self.assertEqual("encryptedPasswordString", remote_access.user_list.users[0].encrypted_password, "Encrypted password does not match.")
+        self.assertEqual("2019-01-01", remote_access.user_list.users[0].expiration, "Expiration does not match.")
+        self.assertEqual("testAccount", remote_access.user_list.users[1].name, "Account name does not match")
+        self.assertEqual("encryptedPasswordString", remote_access.user_list.users[1].encrypted_password, "Encrypted password does not match.")
+        self.assertEqual("2019-01-01", remote_access.user_list.users[1].expiration, "Expiration does not match.")
 
     def test_parse_zero_remote_access_accounts(self):
         data_str = load_data('wire/remote_access_no_accounts.xml')
         remote_access = RemoteAccess(data_str)
-        self.assertNotEquals(None, remote_access) # pylint: disable=deprecated-method
-        self.assertEquals(0, len(remote_access.user_list.users), "User count does not match.") # pylint: disable=deprecated-method
+        self.assertNotEqual(None, remote_access)
+        self.assertEqual(0, len(remote_access.user_list.users), "User count does not match.")
 
     def test_update_remote_access_conf_remote_access(self):
         with mock_wire_protocol(mockwiredata.DATA_FILE_REMOTE_ACCESS) as protocol:
             self.assertIsNotNone(protocol.client.get_remote_access())
-            self.assertEquals(1, len(protocol.client.get_remote_access().user_list.users)) # pylint: disable=deprecated-method
-            self.assertEquals('testAccount', protocol.client.get_remote_access().user_list.users[0].name) # pylint: disable=deprecated-method
-            self.assertEquals('encryptedPasswordString', protocol.client.get_remote_access().user_list.users[0].encrypted_password) # pylint: disable=deprecated-method
+            self.assertEqual(1, len(protocol.client.get_remote_access().user_list.users))
+            self.assertEqual('testAccount', protocol.client.get_remote_access().user_list.users[0].name)
+            self.assertEqual('encryptedPasswordString', protocol.client.get_remote_access().user_list.users[0].encrypted_password)
 
     def test_parse_bad_remote_access_data(self):
         data = "foobar"

--- a/tests/protocol/test_datacontract.py
+++ b/tests/protocol/test_datacontract.py
@@ -32,8 +32,8 @@ class TestDataContract(unittest.TestCase):
         obj.foo = "foo"
         obj.bar.append(1)
         data = get_properties(obj)
-        self.assertEquals("foo", data["foo"]) # pylint: disable=deprecated-method
-        self.assertEquals(list, type(data["bar"])) # pylint: disable=deprecated-method
+        self.assertEqual("foo", data["foo"])
+        self.assertEqual(list, type(data["bar"]))
 
     def test_set_properties(self):
         obj = SampleDataContract()

--- a/tests/protocol/test_protocol_util.py
+++ b/tests/protocol/test_protocol_util.py
@@ -99,7 +99,7 @@ class TestProtocolUtil(AgentTestCase):
 
         # Test wire protocol is available
         protocol = protocol_util.get_protocol()
-        self.assertEquals(WireProtocol.return_value, protocol) # pylint: disable=deprecated-method
+        self.assertEqual(WireProtocol.return_value, protocol)
 
         # Test wire protocol is not available
         protocol_util.clear_protocol()
@@ -145,7 +145,7 @@ class TestProtocolUtil(AgentTestCase):
 
         protocol = protocol_util.get_protocol()
 
-        self.assertEquals(WireProtocol.return_value, protocol) # pylint: disable=deprecated-method
+        self.assertEqual(WireProtocol.return_value, protocol)
         protocol_util.get_wireserver_endpoint.assert_any_call()
 
     @patch('azurelinuxagent.common.conf.get_lib_dir')
@@ -235,11 +235,11 @@ class TestProtocolUtil(AgentTestCase):
 
         # Check Protocol File is updated to WireProtocol
         with open(os.path.join(dir, PROTOCOL_FILE_NAME), "r") as f: # pylint: disable=invalid-name
-            self.assertEquals(f.read(), WIRE_PROTOCOL_NAME) # pylint: disable=deprecated-method
+            self.assertEqual(f.read(), WIRE_PROTOCOL_NAME)
         
         # Check Endpoint file is updated to WireServer IP
         with open(os.path.join(dir, ENDPOINT_FILE_NAME), 'r') as f: # pylint: disable=invalid-name
-            self.assertEquals(f.read(), KNOWN_WIRESERVER_IP) # pylint: disable=deprecated-method
+            self.assertEqual(f.read(), KNOWN_WIRESERVER_IP)
 
     @patch('azurelinuxagent.common.conf.get_lib_dir')
     @patch('azurelinuxagent.common.conf.enable_firewall')
@@ -273,11 +273,11 @@ class TestProtocolUtil(AgentTestCase):
 
         # Check Protocol File is updated to WireProtocol
         with open(os.path.join(dir, PROTOCOL_FILE_NAME), "r") as f: # pylint: disable=invalid-name
-            self.assertEquals(f.read(), WIRE_PROTOCOL_NAME) # pylint: disable=deprecated-method
+            self.assertEqual(f.read(), WIRE_PROTOCOL_NAME)
         
         # Check Endpoint file is updated to WireServer IP
         with open(os.path.join(dir, ENDPOINT_FILE_NAME), 'r') as f: # pylint: disable=invalid-name
-            self.assertEquals(f.read(), KNOWN_WIRESERVER_IP) # pylint: disable=deprecated-method
+            self.assertEqual(f.read(), KNOWN_WIRESERVER_IP)
 
     @patch("azurelinuxagent.common.protocol.util.fileutil")
     @patch("azurelinuxagent.common.conf.get_lib_dir")
@@ -291,19 +291,19 @@ class TestProtocolUtil(AgentTestCase):
         mock_fileutil.read_file.side_effect = IOError()
 
         ep = protocol_util.get_wireserver_endpoint() # pylint: disable=invalid-name
-        self.assertEquals(ep, KNOWN_WIRESERVER_IP) # pylint: disable=deprecated-method
+        self.assertEqual(ep, KNOWN_WIRESERVER_IP)
 
         # Test get endpoint when file not found
         mock_fileutil.read_file.side_effect = IOError(ENOENT, 'File not found')
 
         ep = protocol_util.get_wireserver_endpoint() # pylint: disable=invalid-name
-        self.assertEquals(ep, KNOWN_WIRESERVER_IP) # pylint: disable=deprecated-method
+        self.assertEqual(ep, KNOWN_WIRESERVER_IP)
 
         # Test get endpoint for empty file
         mock_fileutil.read_file.return_value = ""
 
         ep = protocol_util.get_wireserver_endpoint() # pylint: disable=invalid-name
-        self.assertEquals(ep, KNOWN_WIRESERVER_IP) # pylint: disable=deprecated-method
+        self.assertEqual(ep, KNOWN_WIRESERVER_IP)
 
         # Test set endpoint for io error
         mock_fileutil.write_file.side_effect = IOError()

--- a/tests/protocol/test_wire.py
+++ b/tests/protocol/test_wire.py
@@ -480,11 +480,11 @@ class TestWireClient(HttpRequestPredicates, AgentTestCase):
             success = protocol.download_ext_handler_pkg(extension_url, target_file)
 
             urls = protocol.get_tracked_urls()
-            self.assertEquals(success, True, 'The download should have succeeded') # pylint: disable=deprecated-method
-            self.assertEquals(len(urls), 1, "Unexpected number of HTTP requests: [{0}]".format(urls)) # pylint: disable=deprecated-method
-            self.assertEquals(urls[0], extension_url, "The extension should have been downloaded over the direct channel") # pylint: disable=deprecated-method
+            self.assertEqual(success, True, 'The download should have succeeded')
+            self.assertEqual(len(urls), 1, "Unexpected number of HTTP requests: [{0}]".format(urls))
+            self.assertEqual(urls[0], extension_url, "The extension should have been downloaded over the direct channel")
             self.assertTrue(os.path.exists(target_file), 'The extension package was not downloaded')
-            self.assertEquals(HostPluginProtocol.is_default_channel(), False, "The host channel should not have been set as the default") # pylint: disable=deprecated-method
+            self.assertEqual(HostPluginProtocol.is_default_channel(), False, "The host channel should not have been set as the default")
 
     def test_download_ext_handler_pkg_should_use_host_channel_when_direct_channel_fails_and_set_host_as_default(self):
         extension_url = 'https://fake_host/fake_extension.zip'
@@ -503,12 +503,12 @@ class TestWireClient(HttpRequestPredicates, AgentTestCase):
             success = protocol.download_ext_handler_pkg(extension_url, target_file)
 
             urls = protocol.get_tracked_urls()
-            self.assertEquals(success, True, 'The download should have succeeded') # pylint: disable=deprecated-method
-            self.assertEquals(len(urls), 2, "Unexpected number of HTTP requests: [{0}]".format(urls)) # pylint: disable=deprecated-method
-            self.assertEquals(urls[0], extension_url, "The first attempt should have been over the direct channel") # pylint: disable=deprecated-method
+            self.assertEqual(success, True, 'The download should have succeeded')
+            self.assertEqual(len(urls), 2, "Unexpected number of HTTP requests: [{0}]".format(urls))
+            self.assertEqual(urls[0], extension_url, "The first attempt should have been over the direct channel")
             self.assertTrue(self.is_host_plugin_extension_artifact_request(urls[1]), "The retry attempt should have been over the host channel")
             self.assertTrue(os.path.exists(target_file), 'The extension package was not downloaded')
-            self.assertEquals(HostPluginProtocol.is_default_channel(), True, "The host channel should have been set as the default") # pylint: disable=deprecated-method
+            self.assertEqual(HostPluginProtocol.is_default_channel(), True, "The host channel should have been set as the default")
 
     def test_download_ext_handler_pkg_should_retry_the_host_channel_after_refreshing_host_plugin(self):
         extension_url = 'https://fake_host/fake_extension.zip'
@@ -540,14 +540,14 @@ class TestWireClient(HttpRequestPredicates, AgentTestCase):
                 success = protocol.download_ext_handler_pkg(extension_url, target_file)
 
                 urls = protocol.get_tracked_urls()
-                self.assertEquals(success, True, 'The download should have succeeded') # pylint: disable=deprecated-method
-                self.assertEquals(len(urls), 4, "Unexpected number of HTTP requests: [{0}]".format(urls)) # pylint: disable=deprecated-method
-                self.assertEquals(urls[0], extension_url, "The first attempt should have been over the direct channel") # pylint: disable=deprecated-method
+                self.assertEqual(success, True, 'The download should have succeeded')
+                self.assertEqual(len(urls), 4, "Unexpected number of HTTP requests: [{0}]".format(urls))
+                self.assertEqual(urls[0], extension_url, "The first attempt should have been over the direct channel")
                 self.assertTrue(self.is_host_plugin_extension_artifact_request(urls[1]), "The second attempt should have been over the host channel")
                 self.assertTrue(self.is_goal_state_request(urls[2]), "The host channel should have been refreshed the goal state")
                 self.assertTrue(self.is_host_plugin_extension_artifact_request(urls[3]), "The third attempt should have been over the host channel")
                 self.assertTrue(os.path.exists(target_file), 'The extension package was not downloaded')
-                self.assertEquals(HostPluginProtocol.is_default_channel(), True, "The host channel should have been set as the default") # pylint: disable=deprecated-method
+                self.assertEqual(HostPluginProtocol.is_default_channel(), True, "The host channel should have been set as the default")
             finally:
                 HostPluginProtocol.set_default_channel(False)
 
@@ -574,13 +574,13 @@ class TestWireClient(HttpRequestPredicates, AgentTestCase):
             success = protocol.download_ext_handler_pkg(extension_url, "/an-invalid-directory/an-invalid-file.zip")
 
             urls = protocol.get_tracked_urls()
-            self.assertEquals(success, False, "The download should have failed") # pylint: disable=deprecated-method
-            self.assertEquals(len(urls), 4, "Unexpected number of HTTP requests: [{0}]".format(urls)) # pylint: disable=deprecated-method
-            self.assertEquals(urls[0], extension_url, "The first attempt should have been over the direct channel") # pylint: disable=deprecated-method
+            self.assertEqual(success, False, "The download should have failed")
+            self.assertEqual(len(urls), 4, "Unexpected number of HTTP requests: [{0}]".format(urls))
+            self.assertEqual(urls[0], extension_url, "The first attempt should have been over the direct channel")
             self.assertTrue(self.is_host_plugin_extension_artifact_request(urls[1]), "The second attempt should have been over the host channel")
             self.assertTrue(self.is_goal_state_request(urls[2]), "The host channel should have been refreshed the goal state")
             self.assertTrue(self.is_host_plugin_extension_artifact_request(urls[3]), "The third attempt should have been over the host channel")
-            self.assertEquals(HostPluginProtocol.is_default_channel(), False, "The host channel should not have been set as the default") # pylint: disable=deprecated-method
+            self.assertEqual(HostPluginProtocol.is_default_channel(), False, "The host channel should not have been set as the default")
 
     def test_fetch_manifest_should_not_invoke_host_channel_when_direct_channel_succeeds(self):
         manifest_url = 'https://fake_host/fake_manifest.xml'
@@ -599,10 +599,10 @@ class TestWireClient(HttpRequestPredicates, AgentTestCase):
             manifest = protocol.client.fetch_manifest([VMAgentManifestUri(uri=manifest_url)])
 
             urls = protocol.get_tracked_urls()
-            self.assertEquals(manifest, manifest_xml, 'The expected manifest was not downloaded') # pylint: disable=deprecated-method
-            self.assertEquals(len(urls), 1, "Unexpected number of HTTP requests: [{0}]".format(urls)) # pylint: disable=deprecated-method
-            self.assertEquals(urls[0], manifest_url, "The manifest should have been downloaded over the direct channel") # pylint: disable=deprecated-method
-            self.assertEquals(HostPluginProtocol.is_default_channel(), False, "The default channel should not have changed") # pylint: disable=deprecated-method
+            self.assertEqual(manifest, manifest_xml, 'The expected manifest was not downloaded')
+            self.assertEqual(len(urls), 1, "Unexpected number of HTTP requests: [{0}]".format(urls))
+            self.assertEqual(urls[0], manifest_url, "The manifest should have been downloaded over the direct channel")
+            self.assertEqual(HostPluginProtocol.is_default_channel(), False, "The default channel should not have changed")
 
     def test_fetch_manifest_should_use_host_channel_when_direct_channel_fails_and_set_it_to_default(self):
         manifest_url = 'https://fake_host/fake_manifest.xml'
@@ -622,11 +622,11 @@ class TestWireClient(HttpRequestPredicates, AgentTestCase):
                 manifest = protocol.client.fetch_manifest([VMAgentManifestUri(uri=manifest_url)])
 
                 urls = protocol.get_tracked_urls()
-                self.assertEquals(manifest, manifest_xml, 'The expected manifest was not downloaded') # pylint: disable=deprecated-method
-                self.assertEquals(len(urls), 2, "Unexpected number of HTTP requests: [{0}]".format(urls)) # pylint: disable=deprecated-method
-                self.assertEquals(urls[0], manifest_url, "The first attempt should have been over the direct channel") # pylint: disable=deprecated-method
+                self.assertEqual(manifest, manifest_xml, 'The expected manifest was not downloaded')
+                self.assertEqual(len(urls), 2, "Unexpected number of HTTP requests: [{0}]".format(urls))
+                self.assertEqual(urls[0], manifest_url, "The first attempt should have been over the direct channel")
                 self.assertTrue(self.is_host_plugin_extension_artifact_request(urls[1]), "The retry should have been over the host channel")
-                self.assertEquals(HostPluginProtocol.is_default_channel(), True, "The host should have been set as the default channel") # pylint: disable=deprecated-method
+                self.assertEqual(HostPluginProtocol.is_default_channel(), True, "The host should have been set as the default channel")
             finally:
                 HostPluginProtocol.set_default_channel(False)  # Reset default channel
 
@@ -659,13 +659,13 @@ class TestWireClient(HttpRequestPredicates, AgentTestCase):
                 manifest = protocol.client.fetch_manifest([VMAgentManifestUri(uri=manifest_url)])
 
                 urls = protocol.get_tracked_urls()
-                self.assertEquals(manifest, manifest_xml) # pylint: disable=deprecated-method
-                self.assertEquals(len(urls), 4, "Unexpected number of HTTP requests: [{0}]".format(urls)) # pylint: disable=deprecated-method
-                self.assertEquals(urls[0], manifest_url, "The first attempt should have been over the direct channel") # pylint: disable=deprecated-method
+                self.assertEqual(manifest, manifest_xml)
+                self.assertEqual(len(urls), 4, "Unexpected number of HTTP requests: [{0}]".format(urls))
+                self.assertEqual(urls[0], manifest_url, "The first attempt should have been over the direct channel")
                 self.assertTrue(self.is_host_plugin_extension_artifact_request(urls[1]), "The second attempt should have been over the host channel")
                 self.assertTrue(self.is_goal_state_request(urls[2]), "The host channel should have been refreshed the goal state")
                 self.assertTrue(self.is_host_plugin_extension_artifact_request(urls[3]), "The third attempt should have been over the host channel")
-                self.assertEquals(HostPluginProtocol.is_default_channel(), True, "The host should have been set as the default channel") # pylint: disable=deprecated-method
+                self.assertEqual(HostPluginProtocol.is_default_channel(), True, "The host should have been set as the default channel")
             finally:
                 HostPluginProtocol.set_default_channel(False)  # Reset default channel
 
@@ -693,18 +693,18 @@ class TestWireClient(HttpRequestPredicates, AgentTestCase):
                 protocol.client.fetch_manifest([VMAgentManifestUri(uri=manifest_url)])
 
             urls = protocol.get_tracked_urls()
-            self.assertEquals(len(urls), 4, "Unexpected number of HTTP requests: [{0}]".format(urls)) # pylint: disable=deprecated-method
-            self.assertEquals(urls[0], manifest_url, "The first attempt should have been over the direct channel") # pylint: disable=deprecated-method
+            self.assertEqual(len(urls), 4, "Unexpected number of HTTP requests: [{0}]".format(urls))
+            self.assertEqual(urls[0], manifest_url, "The first attempt should have been over the direct channel")
             self.assertTrue(self.is_host_plugin_extension_artifact_request(urls[1]),
                             "The second attempt should have been over the host channel")
             self.assertTrue(self.is_goal_state_request(urls[2]),
                             "The host channel should have been refreshed the goal state")
             self.assertTrue(self.is_host_plugin_extension_artifact_request(urls[3]),
                             "The third attempt should have been over the host channel")
-            self.assertEquals(HostPluginProtocol.is_default_channel(), False, # pylint: disable=deprecated-method
+            self.assertEqual(HostPluginProtocol.is_default_channel(), False,
                               "The host should not have been set as the default channel")
 
-            self.assertEquals(HostPluginProtocol.is_default_channel(), False) # pylint: disable=deprecated-method
+            self.assertEqual(HostPluginProtocol.is_default_channel(), False)
 
     def test_get_artifacts_profile_should_not_invoke_host_channel_when_direct_channel_succeeds(self):
         def http_get_handler(url, *_, **__): # pylint: disable=useless-return
@@ -719,8 +719,8 @@ class TestWireClient(HttpRequestPredicates, AgentTestCase):
 
             self.assertIsInstance(return_value, InVMArtifactsProfile, 'The request did not return a valid artifacts profile: {0}'.format(return_value))
             urls = protocol.get_tracked_urls()
-            self.assertEquals(len(urls), 1, "Unexpected HTTP requests: [{0}]".format(urls)) # pylint: disable=deprecated-method
-            self.assertEquals(HostPluginProtocol.is_default_channel(), False) # pylint: disable=deprecated-method
+            self.assertEqual(len(urls), 1, "Unexpected HTTP requests: [{0}]".format(urls))
+            self.assertEqual(HostPluginProtocol.is_default_channel(), False)
 
     def test_get_artifacts_profile_should_use_host_channel_when_direct_channel_fails(self):
         def http_get_handler(url, *_, **kwargs):
@@ -742,10 +742,10 @@ class TestWireClient(HttpRequestPredicates, AgentTestCase):
                 self.assertIsInstance(return_value, InVMArtifactsProfile, 'The request did not return a valid artifacts profile: {0}'.format(return_value))
                 self.assertTrue(return_value.onHold, 'The OnHold property should be True') # pylint: disable=no-member
                 urls = protocol.get_tracked_urls()
-                self.assertEquals(len(urls), 2, "Invalid number of requests: [{0}]".format(urls)) # pylint: disable=deprecated-method
+                self.assertEqual(len(urls), 2, "Invalid number of requests: [{0}]".format(urls))
                 self.assertTrue(self.is_in_vm_artifacts_profile_request(urls[0]), "The first request should have been over the direct channel")
                 self.assertTrue(self.is_host_plugin_extension_artifact_request(urls[1]), "The second request should have been over the host channel")
-                self.assertEquals(HostPluginProtocol.is_default_channel(), True, "The default channel should have changed to the host") # pylint: disable=deprecated-method
+                self.assertEqual(HostPluginProtocol.is_default_channel(), True, "The default channel should have changed to the host")
             finally:
                 HostPluginProtocol.set_default_channel(False)
 
@@ -778,12 +778,12 @@ class TestWireClient(HttpRequestPredicates, AgentTestCase):
                 self.assertIsInstance(return_value, InVMArtifactsProfile, 'The request did not return a valid artifacts profile: {0}'.format(return_value))
                 self.assertTrue(return_value.onHold, 'The OnHold property should be True') # pylint: disable=no-member
                 urls = protocol.get_tracked_urls()
-                self.assertEquals(len(urls), 4, "Invalid number of requests: [{0}]".format(urls)) # pylint: disable=deprecated-method
+                self.assertEqual(len(urls), 4, "Invalid number of requests: [{0}]".format(urls))
                 self.assertTrue(self.is_in_vm_artifacts_profile_request(urls[0]), "The first request should have been over the direct channel")
                 self.assertTrue(self.is_host_plugin_extension_artifact_request(urls[1]), "The second request should have been over the host channel")
                 self.assertTrue(self.is_goal_state_request(urls[2]), "The goal state should have been refreshed before retrying the host channel")
                 self.assertTrue(self.is_host_plugin_extension_artifact_request(urls[3]), "The retry request should have been over the host channel")
-                self.assertEquals(HostPluginProtocol.is_default_channel(), True, "The default channel should have changed to the host") # pylint: disable=deprecated-method
+                self.assertEqual(HostPluginProtocol.is_default_channel(), True, "The default channel should have changed to the host")
             finally:
                 HostPluginProtocol.set_default_channel(False)
 
@@ -809,12 +809,12 @@ class TestWireClient(HttpRequestPredicates, AgentTestCase):
 
             self.assertIsNone(return_value, "The artifacts profile request should have failed")
             urls = protocol.get_tracked_urls()
-            self.assertEquals(len(urls), 4, "Invalid number of requests: [{0}]".format(urls)) # pylint: disable=deprecated-method
+            self.assertEqual(len(urls), 4, "Invalid number of requests: [{0}]".format(urls))
             self.assertTrue(self.is_in_vm_artifacts_profile_request(urls[0]), "The first request should have been over the direct channel")
             self.assertTrue(self.is_host_plugin_extension_artifact_request(urls[1]), "The second request should have been over the host channel")
             self.assertTrue(self.is_goal_state_request(urls[2]), "The goal state should have been refreshed before retrying the host channel")
             self.assertTrue(self.is_host_plugin_extension_artifact_request(urls[3]), "The retry request should have been over the host channel")
-            self.assertEquals(HostPluginProtocol.is_default_channel(), False, "The default channel should not have changed") # pylint: disable=deprecated-method
+            self.assertEqual(HostPluginProtocol.is_default_channel(), False, "The default channel should not have changed")
 
     def test_upload_logs_should_not_refresh_plugin_when_first_attempt_succeeds(self):
         def http_put_handler(url, *_, **__): # pylint: disable=inconsistent-return-statements
@@ -844,7 +844,7 @@ class TestWireClient(HttpRequestPredicates, AgentTestCase):
             protocol.client.upload_logs(content)
 
             urls = protocol.get_tracked_urls()
-            self.assertEquals(len(urls), 2, "Invalid number of requests: [{0}]".format(urls)) # pylint: disable=deprecated-method
+            self.assertEqual(len(urls), 2, "Invalid number of requests: [{0}]".format(urls))
             self.assertTrue(self.is_host_plugin_put_logs_request(urls[0]),
                             "The first request should have been over the host channel")
             self.assertTrue(self.is_host_plugin_put_logs_request(urls[1]),
@@ -867,9 +867,9 @@ class TestWireClient(HttpRequestPredicates, AgentTestCase):
 
             # Assert we've only called the direct channel functions and that it succeeded.
             ret = protocol.client.send_request_using_appropriate_channel(direct_func, host_func)
-            self.assertEquals(42, ret) # pylint: disable=deprecated-method
-            self.assertEquals(1, direct_func.counter) # pylint: disable=deprecated-method
-            self.assertEquals(0, host_func.counter) # pylint: disable=deprecated-method
+            self.assertEqual(42, ret)
+            self.assertEqual(1, direct_func.counter)
+            self.assertEqual(0, host_func.counter)
 
     def test_send_request_using_appropriate_channel_should_not_use_direct_channel_when_host_channel_is_default(self):
         with mock_wire_protocol(mockwiredata.DATA_FILE) as protocol:
@@ -888,9 +888,9 @@ class TestWireClient(HttpRequestPredicates, AgentTestCase):
 
             # Assert we've only called the host channel function since it's the default channel
             ret = protocol.client.send_request_using_appropriate_channel(direct_func, host_func)
-            self.assertEquals(43, ret) # pylint: disable=deprecated-method
-            self.assertEquals(0, direct_func.counter) # pylint: disable=deprecated-method
-            self.assertEquals(1, host_func.counter) # pylint: disable=deprecated-method
+            self.assertEqual(43, ret)
+            self.assertEqual(0, direct_func.counter)
+            self.assertEqual(1, host_func.counter)
 
     def test_send_request_using_appropriate_channel_should_use_host_channel_when_direct_channel_fails(self):
         with mock_wire_protocol(mockwiredata.DATA_FILE) as protocol:
@@ -911,10 +911,10 @@ class TestWireClient(HttpRequestPredicates, AgentTestCase):
             # Assert we've called both the direct channel function and the host channel function, which succeeded.
             # After the host channel succeeds, the host plugin should have been set as the default channel.
             ret = protocol.client.send_request_using_appropriate_channel(direct_func, host_func)
-            self.assertEquals(42, ret) # pylint: disable=deprecated-method
-            self.assertEquals(1, direct_func.counter) # pylint: disable=deprecated-method
-            self.assertEquals(1, host_func.counter) # pylint: disable=deprecated-method
-            self.assertEquals(True, host.is_default_channel()) # pylint: disable=deprecated-method
+            self.assertEqual(42, ret)
+            self.assertEqual(1, direct_func.counter)
+            self.assertEqual(1, host_func.counter)
+            self.assertEqual(True, host.is_default_channel())
 
     def test_send_request_using_appropriate_channel_should_retry_the_host_channel_after_reloading_goal_state(self):
         with mock_wire_protocol(mockwiredata.DATA_FILE) as protocol:
@@ -938,11 +938,11 @@ class TestWireClient(HttpRequestPredicates, AgentTestCase):
             with patch(
                     'azurelinuxagent.common.protocol.wire.WireClient.update_host_plugin_from_goal_state') as mock_update_host_plugin_from_goal_state:
                 ret = protocol.client.send_request_using_appropriate_channel(direct_func, host_func)
-                self.assertEquals(42, ret) # pylint: disable=deprecated-method
-                self.assertEquals(1, direct_func.counter) # pylint: disable=deprecated-method
-                self.assertEquals(2, host_func.counter) # pylint: disable=deprecated-method
-                self.assertEquals(1, mock_update_host_plugin_from_goal_state.call_count) # pylint: disable=deprecated-method
-                self.assertEquals(True, protocol.client.get_host_plugin().is_default_channel()) # pylint: disable=deprecated-method
+                self.assertEqual(42, ret)
+                self.assertEqual(1, direct_func.counter)
+                self.assertEqual(2, host_func.counter)
+                self.assertEqual(1, mock_update_host_plugin_from_goal_state.call_count)
+                self.assertEqual(True, protocol.client.get_host_plugin().is_default_channel())
 
 
 class UpdateGoalStateTestCase(AgentTestCase):
@@ -1121,8 +1121,8 @@ class TryUpdateGoalStateTestCase(HttpRequestPredicates, AgentTestCase):
 
                 w = warnings() # pylint: disable=invalid-name
                 pw = periodic_warnings() # pylint: disable=invalid-name
-                self.assertEquals(len(w), 1, "A failure should have produced a warning: [{0}]".format(w)) # pylint: disable=deprecated-method
-                self.assertEquals(len(pw), 1, "A failure should have produced a periodic warning: [{0}]".format(pw)) # pylint: disable=deprecated-method
+                self.assertEqual(len(w), 1, "A failure should have produced a warning: [{0}]".format(w))
+                self.assertEqual(len(pw), 1, "A failure should have produced a periodic warning: [{0}]".format(pw))
 
                 gs = goal_state_events() # pylint: disable=invalid-name
                 self.assertTrue(len(gs) == 1 and 'is_success=False' in gs[0], "A failure should produce a telemetry event (success=false): [{0}]".format(gs))
@@ -1138,7 +1138,7 @@ class TryUpdateGoalStateTestCase(HttpRequestPredicates, AgentTestCase):
                 w = warnings() # pylint: disable=invalid-name
                 pw = periodic_warnings() # pylint: disable=invalid-name
                 self.assertTrue(len(w) == 0, "Subsequent failures should not produce warnings: [{0}]".format(w))
-                self.assertEquals(len(pw), 3, "Subsequent failures should produce periodic warnings: [{0}]".format(pw)) # pylint: disable=deprecated-method
+                self.assertEqual(len(pw), 3, "Subsequent failures should produce periodic warnings: [{0}]".format(pw))
 
                 tc = telemetry_calls() # pylint: disable=invalid-name
                 self.assertTrue(len(tc) == 0, "Subsequent failures should not produce any telemetry events: [{0}]".format(tc))
@@ -1153,7 +1153,7 @@ class TryUpdateGoalStateTestCase(HttpRequestPredicates, AgentTestCase):
                 s = success_messages() # pylint: disable=invalid-name
                 w = warnings() # pylint: disable=invalid-name
                 pw = periodic_warnings() # pylint: disable=invalid-name
-                self.assertEquals(len(s), 1, "Recovering after failures should have produced an info message: [{0}]".format(s)) # pylint: disable=deprecated-method
+                self.assertEqual(len(s), 1, "Recovering after failures should have produced an info message: [{0}]".format(s))
                 self.assertTrue(len(w) == 0 and len(pw) == 0, "Recovering after failures should have not produced any warnings: [{0}] [{1}]".format(w, pw))
 
                 gs = goal_state_events() # pylint: disable=invalid-name

--- a/tests/utils/test_crypt_util.py
+++ b/tests/utils/test_crypt_util.py
@@ -34,7 +34,7 @@ class TestCryptoUtilOperations(AgentTestCase):
         secret = ']aPPEv}uNg1FPnl?'
         crypto = CryptUtil(conf.get_openssl_cmd())
         decrypted_string = crypto.decrypt_secret(encrypted_string, prv_key)
-        self.assertEquals(secret, decrypted_string, "decrypted string does not match expected") # pylint: disable=deprecated-method
+        self.assertEqual(secret, decrypted_string, "decrypted string does not match expected")
 
     def test_decrypt_encrypted_text_missing_private_key(self):
         encrypted_string = load_data("wire/encrypted.enc")

--- a/tests/utils/test_extension_process_util.py
+++ b/tests/utils/test_extension_process_util.py
@@ -49,8 +49,8 @@ class TestProcessUtils(AgentTestCase):
             stderr=subprocess.PIPE)
 
         timed_out, ret = wait_for_process_completion_or_timeout(process=process, timeout=5)
-        self.assertEquals(timed_out, False) # pylint: disable=deprecated-method
-        self.assertEquals(ret, 0) # pylint: disable=deprecated-method
+        self.assertEqual(timed_out, False) 
+        self.assertEqual(ret, 0) 
 
     def test_wait_for_process_completion_or_timeout_should_kill_process_on_timeout(self):
         timeout = 5
@@ -70,11 +70,11 @@ class TestProcessUtils(AgentTestCase):
 
                 # We're mocking sleep to avoid prolonging the test execution time, but we still want to make sure
                 # we're "waiting" the correct amount of time before killing the process
-                self.assertEquals(mock_sleep.call_count, timeout) # pylint: disable=deprecated-method
+                self.assertEqual(mock_sleep.call_count, timeout) 
 
-                self.assertEquals(patch_kill.call_count, 1) # pylint: disable=deprecated-method
-                self.assertEquals(timed_out, True) # pylint: disable=deprecated-method
-                self.assertEquals(ret, None) # pylint: disable=deprecated-method
+                self.assertEqual(patch_kill.call_count, 1) 
+                self.assertEqual(timed_out, True) 
+                self.assertEqual(ret, None) 
 
     def test_handle_process_completion_should_return_nonzero_when_process_fails(self):
         process = subprocess.Popen(
@@ -86,8 +86,8 @@ class TestProcessUtils(AgentTestCase):
             stderr=subprocess.PIPE)
 
         timed_out, ret = wait_for_process_completion_or_timeout(process=process, timeout=5)
-        self.assertEquals(timed_out, False) # pylint: disable=deprecated-method
-        self.assertEquals(ret, 2) # pylint: disable=deprecated-method
+        self.assertEqual(timed_out, False) 
+        self.assertEqual(ret, 2) 
 
     def test_handle_process_completion_should_return_process_output(self):
         command = "echo 'dummy stdout' && 1>&2 echo 'dummy stderr'"
@@ -109,7 +109,7 @@ class TestProcessUtils(AgentTestCase):
                                                            error_code=42)
 
         expected_output = "[stdout]\ndummy stdout\n\n\n[stderr]\ndummy stderr\n"
-        self.assertEquals(process_output, expected_output) # pylint: disable=deprecated-method
+        self.assertEqual(process_output, expected_output) 
 
     def test_handle_process_completion_should_raise_on_timeout(self):
         command = "sleep 1m"
@@ -161,7 +161,7 @@ class TestProcessUtils(AgentTestCase):
                                               stderr=stderr,
                                               error_code=error_code)
 
-                self.assertEquals(context_manager.exception.code, error_code) # pylint: disable=deprecated-method
+                self.assertEqual(context_manager.exception.code, error_code) 
                 self.assertIn("Non-zero exit code:", ustr(context_manager.exception))
 
     def test_read_output_should_return_no_content(self):

--- a/tests/utils/test_file_util.py
+++ b/tests/utils/test_file_util.py
@@ -39,7 +39,7 @@ class TestFileOperations(AgentTestCase):
         fileutil.write_file(test_file, content)
 
         content_read = fileutil.read_file(test_file)
-        self.assertEquals(content, content_read) # pylint: disable=deprecated-method
+        self.assertEqual(content, content_read)
         os.remove(test_file)
 
     def test_write_file_content_is_None(self): # pylint: disable=invalid-name
@@ -52,7 +52,7 @@ class TestFileOperations(AgentTestCase):
 
             self.fail("expected write_file to throw an exception")
         except: # pylint: disable=bare-except
-            self.assertEquals(False, os.path.exists(test_file)) # pylint: disable=deprecated-method
+            self.assertEqual(False, os.path.exists(test_file))
 
     def test_rw_utf8_file(self):
         test_file=os.path.join(self.tmp_dir, self.test_file)
@@ -60,7 +60,7 @@ class TestFileOperations(AgentTestCase):
         fileutil.write_file(test_file, content, encoding="utf-8")
 
         content_read = fileutil.read_file(test_file)
-        self.assertEquals(content, content_read) # pylint: disable=deprecated-method
+        self.assertEqual(content, content_read)
         os.remove(test_file)
 
     def test_remove_bom(self):
@@ -68,7 +68,7 @@ class TestFileOperations(AgentTestCase):
         data = b'\xef\xbb\xbfhehe'
         fileutil.write_file(test_file, data, asbin=True)
         data = fileutil.read_file(test_file, remove_bom=True)
-        self.assertNotEquals(0xbb, ord(data[0])) # pylint: disable=deprecated-method
+        self.assertNotEqual(0xbb, ord(data[0]))
    
     def test_append_file(self):
         test_file=os.path.join(self.tmp_dir, self.test_file)
@@ -76,7 +76,7 @@ class TestFileOperations(AgentTestCase):
         fileutil.append_file(test_file, content)
 
         content_read = fileutil.read_file(test_file)
-        self.assertEquals(content, content_read) # pylint: disable=deprecated-method
+        self.assertEqual(content, content_read)
 
         os.remove(test_file)
 
@@ -91,19 +91,19 @@ Third line with more words
 '''
             )
 
-        self.assertNotEquals( # pylint: disable=deprecated-method
+        self.assertNotEqual(
             None,
             fileutil.findre_in_file(fp, ".*rst line$"))
-        self.assertNotEquals( # pylint: disable=deprecated-method
+        self.assertNotEqual(
             None,
             fileutil.findre_in_file(fp, ".*ond line$"))
-        self.assertNotEquals( # pylint: disable=deprecated-method
+        self.assertNotEqual(
             None,
             fileutil.findre_in_file(fp, ".*with more.*"))
-        self.assertNotEquals( # pylint: disable=deprecated-method
+        self.assertNotEqual(
             None,
             fileutil.findre_in_file(fp, "^Third.*"))
-        self.assertEquals( # pylint: disable=deprecated-method
+        self.assertEqual(
             None,
             fileutil.findre_in_file(fp, "^Do not match.*"))
 
@@ -127,11 +127,11 @@ Third line with more words
     def test_get_last_path_element(self):
         filepath = '/tmp/abc.def'
         filename = fileutil.base_name(filepath)
-        self.assertEquals('abc.def', filename) # pylint: disable=deprecated-method
+        self.assertEqual('abc.def', filename)
 
         filepath = '/tmp/abc'
         filename = fileutil.base_name(filepath)
-        self.assertEquals('abc', filename) # pylint: disable=deprecated-method
+        self.assertEqual('abc', filename)
 
     def test_remove_files(self):
         random_word = lambda : ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(5))

--- a/tests/utils/test_rest_util.py
+++ b/tests/utils/test_rest_util.py
@@ -93,47 +93,47 @@ class TestHttpOperations(AgentTestCase): # pylint: disable=too-many-public-metho
     def test_parse_url(self):
         test_uri = "http://abc.def/ghi#hash?jkl=mn"
         host, port, secure, rel_uri = restutil._parse_url(test_uri) # pylint: disable=unused-variable,protected-access
-        self.assertEquals("abc.def", host) # pylint: disable=deprecated-method
-        self.assertEquals("/ghi#hash?jkl=mn", rel_uri) # pylint: disable=deprecated-method
+        self.assertEqual("abc.def", host) 
+        self.assertEqual("/ghi#hash?jkl=mn", rel_uri) 
 
         test_uri = "http://abc.def/"
         host, port, secure, rel_uri = restutil._parse_url(test_uri) # pylint: disable=protected-access
-        self.assertEquals("abc.def", host) # pylint: disable=deprecated-method
-        self.assertEquals("/", rel_uri) # pylint: disable=deprecated-method
-        self.assertEquals(False, secure) # pylint: disable=deprecated-method
+        self.assertEqual("abc.def", host) 
+        self.assertEqual("/", rel_uri) 
+        self.assertEqual(False, secure) 
 
         test_uri = "https://abc.def/ghi?jkl=mn"
         host, port, secure, rel_uri = restutil._parse_url(test_uri) # pylint: disable=protected-access
-        self.assertEquals(True, secure) # pylint: disable=deprecated-method
+        self.assertEqual(True, secure) 
 
         test_uri = "http://abc.def:80/"
         host, port, secure, rel_uri = restutil._parse_url(test_uri) # pylint: disable=protected-access
-        self.assertEquals("abc.def", host) # pylint: disable=deprecated-method
+        self.assertEqual("abc.def", host) 
 
         host, port, secure, rel_uri = restutil._parse_url("") # pylint: disable=protected-access
-        self.assertEquals(None, host) # pylint: disable=deprecated-method
-        self.assertEquals(rel_uri, "") # pylint: disable=deprecated-method
+        self.assertEqual(None, host) 
+        self.assertEqual(rel_uri, "") 
 
         host, port, secure, rel_uri = restutil._parse_url("None") # pylint: disable=protected-access
-        self.assertEquals(None, host) # pylint: disable=deprecated-method
-        self.assertEquals(rel_uri, "None") # pylint: disable=deprecated-method
+        self.assertEqual(None, host) 
+        self.assertEqual(rel_uri, "None") 
 
     def test_cleanup_sas_tokens_from_urls_for_normal_cases(self):
         test_url = "http://abc.def/ghi#hash?jkl=mn"
         filtered_url = restutil.redact_sas_tokens_in_urls(test_url)
-        self.assertEquals(test_url, filtered_url) # pylint: disable=deprecated-method
+        self.assertEqual(test_url, filtered_url) 
 
         test_url = "http://abc.def:80/"
         filtered_url = restutil.redact_sas_tokens_in_urls(test_url)
-        self.assertEquals(test_url, filtered_url) # pylint: disable=deprecated-method
+        self.assertEqual(test_url, filtered_url) 
 
         test_url = "http://abc.def/"
         filtered_url = restutil.redact_sas_tokens_in_urls(test_url)
-        self.assertEquals(test_url, filtered_url) # pylint: disable=deprecated-method
+        self.assertEqual(test_url, filtered_url) 
 
         test_url = "https://abc.def/ghi?jkl=mn"
         filtered_url = restutil.redact_sas_tokens_in_urls(test_url)
-        self.assertEquals(test_url, filtered_url) # pylint: disable=deprecated-method
+        self.assertEqual(test_url, filtered_url) 
 
     def test_cleanup_sas_tokens_from_urls_containing_sas_tokens(self):
         # Contains pair of URLs (RawURL, RedactedURL)
@@ -178,7 +178,7 @@ class TestHttpOperations(AgentTestCase): # pylint: disable=too-many-public-metho
                        ]
 
         for x in urls_tuples: # pylint: disable=invalid-name
-            self.assertEquals(restutil.redact_sas_tokens_in_urls(x[0]), x[1]) # pylint: disable=deprecated-method
+            self.assertEqual(restutil.redact_sas_tokens_in_urls(x[0]), x[1]) 
 
     @patch('azurelinuxagent.common.conf.get_httpproxy_port')
     @patch('azurelinuxagent.common.conf.get_httpproxy_host')
@@ -250,7 +250,7 @@ class TestHttpOperations(AgentTestCase): # pylint: disable=too-many-public-metho
         }):
             no_proxy_from_environment = restutil.get_no_proxy()
 
-            self.assertEquals(len(no_proxy_list), len(no_proxy_from_environment)) # pylint: disable=deprecated-method
+            self.assertEqual(len(no_proxy_list), len(no_proxy_from_environment)) 
 
             for i, j in zip(no_proxy_from_environment, no_proxy_list):
                 self.assertEqual(i, j)
@@ -264,7 +264,7 @@ class TestHttpOperations(AgentTestCase): # pylint: disable=too-many-public-metho
         }):
             no_proxy_from_environment = restutil.get_no_proxy()
 
-            self.assertEquals(len(no_proxy_list_cleaned), len(no_proxy_from_environment)) # pylint: disable=deprecated-method
+            self.assertEqual(len(no_proxy_list_cleaned), len(no_proxy_from_environment)) 
 
             for i, j in zip(no_proxy_from_environment, no_proxy_list_cleaned):
                 print(i, j)
@@ -280,7 +280,7 @@ class TestHttpOperations(AgentTestCase): # pylint: disable=too-many-public-metho
         }):
             no_proxy_from_environment = restutil.get_no_proxy()
 
-            self.assertEquals(len(no_proxy_list), len(no_proxy_from_environment)) # pylint: disable=deprecated-method
+            self.assertEqual(len(no_proxy_list), len(no_proxy_from_environment)) 
 
             for i, j in zip(no_proxy_from_environment, no_proxy_list):
                 self.assertEqual(i, j)
@@ -307,11 +307,11 @@ class TestHttpOperations(AgentTestCase): # pylint: disable=too-many-public-metho
         self.assertFalse(restutil.address_in_network('172.16.0.1', '192.168.1.0/24'))
 
     def test_dotted_netmask(self):
-        self.assertEquals(restutil.dotted_netmask(0), '0.0.0.0') # pylint: disable=deprecated-method
-        self.assertEquals(restutil.dotted_netmask(8), '255.0.0.0') # pylint: disable=deprecated-method
-        self.assertEquals(restutil.dotted_netmask(16), '255.255.0.0') # pylint: disable=deprecated-method
-        self.assertEquals(restutil.dotted_netmask(24), '255.255.255.0') # pylint: disable=deprecated-method
-        self.assertEquals(restutil.dotted_netmask(32), '255.255.255.255') # pylint: disable=deprecated-method
+        self.assertEqual(restutil.dotted_netmask(0), '0.0.0.0') 
+        self.assertEqual(restutil.dotted_netmask(8), '255.0.0.0') 
+        self.assertEqual(restutil.dotted_netmask(16), '255.255.0.0') 
+        self.assertEqual(restutil.dotted_netmask(24), '255.255.255.0') 
+        self.assertEqual(restutil.dotted_netmask(32), '255.255.255.255') 
         self.assertRaises(ValueError, restutil.dotted_netmask, 33)
 
     def test_bypass_proxy(self):
@@ -346,8 +346,8 @@ class TestHttpOperations(AgentTestCase): # pylint: disable=too-many-public-metho
             call(method="GET", url="/bar", body=None, headers={'User-Agent': HTTP_USER_AGENT, 'Connection': 'close'})
         ])
         self.assertEqual(1, mock_conn.getresponse.call_count)
-        self.assertNotEquals(None, resp) # pylint: disable=deprecated-method
-        self.assertEquals("TheResults", resp.read()) # pylint: disable=deprecated-method
+        self.assertNotEqual(None, resp) 
+        self.assertEqual("TheResults", resp.read()) 
 
     @patch("azurelinuxagent.common.future.httpclient.HTTPSConnection")
     @patch("azurelinuxagent.common.future.httpclient.HTTPConnection")
@@ -369,8 +369,8 @@ class TestHttpOperations(AgentTestCase): # pylint: disable=too-many-public-metho
             call(method="GET", url="/bar", body=None, headers={'User-Agent': HTTP_USER_AGENT, 'Connection': 'close'})
         ])
         self.assertEqual(1, mock_conn.getresponse.call_count)
-        self.assertNotEquals(None, resp) # pylint: disable=deprecated-method
-        self.assertEquals("TheResults", resp.read()) # pylint: disable=deprecated-method
+        self.assertNotEqual(None, resp) 
+        self.assertEqual("TheResults", resp.read()) 
 
     @patch("azurelinuxagent.common.future.httpclient.HTTPSConnection")
     @patch("azurelinuxagent.common.future.httpclient.HTTPConnection")
@@ -393,8 +393,8 @@ class TestHttpOperations(AgentTestCase): # pylint: disable=too-many-public-metho
             call(method="GET", url="http://foo:80/bar", body=None, headers={'User-Agent': HTTP_USER_AGENT, 'Connection': 'close'})
         ])
         self.assertEqual(1, mock_conn.getresponse.call_count)
-        self.assertNotEquals(None, resp) # pylint: disable=deprecated-method
-        self.assertEquals("TheResults", resp.read()) # pylint: disable=deprecated-method
+        self.assertNotEqual(None, resp) 
+        self.assertEqual("TheResults", resp.read()) 
 
     @patch("azurelinuxagent.common.utils.restutil._get_http_proxy")
     @patch("time.sleep")
@@ -411,13 +411,13 @@ class TestHttpOperations(AgentTestCase): # pylint: disable=too-many-public-metho
         }):
             # Test http get
             resp = restutil.http_get("http://foo.com", use_proxy=True)
-            self.assertEquals("hehe", resp.read()) # pylint: disable=deprecated-method
-            self.assertEquals(0, mock_get_http_proxy.call_count) # pylint: disable=deprecated-method
+            self.assertEqual("hehe", resp.read()) 
+            self.assertEqual(0, mock_get_http_proxy.call_count) 
 
             # Test http get
             resp = restutil.http_get("http://bar.com", use_proxy=True)
-            self.assertEquals("hehe", resp.read()) # pylint: disable=deprecated-method
-            self.assertEquals(1, mock_get_http_proxy.call_count) # pylint: disable=deprecated-method
+            self.assertEqual("hehe", resp.read()) 
+            self.assertEqual(1, mock_get_http_proxy.call_count) 
 
     def test_proxy_conditions_with_no_proxy(self):
         should_use_proxy = True
@@ -429,32 +429,32 @@ class TestHttpOperations(AgentTestCase): # pylint: disable=too-many-public-metho
             'no_proxy': ",".join(no_proxy_list)
         }):
             host = "10.0.0.1"
-            self.assertEquals(should_use_proxy, use_proxy and not restutil.bypass_proxy(host)) # pylint: disable=deprecated-method
+            self.assertEqual(should_use_proxy, use_proxy and not restutil.bypass_proxy(host)) 
 
             host = "foo.com"
-            self.assertEquals(should_not_use_proxy, use_proxy and not restutil.bypass_proxy(host)) # pylint: disable=deprecated-method
+            self.assertEqual(should_not_use_proxy, use_proxy and not restutil.bypass_proxy(host)) 
 
             host = "www.google.com"
-            self.assertEquals(should_not_use_proxy, use_proxy and not restutil.bypass_proxy(host)) # pylint: disable=deprecated-method
+            self.assertEqual(should_not_use_proxy, use_proxy and not restutil.bypass_proxy(host)) 
 
             host = "168.63.129.16"
-            self.assertEquals(should_not_use_proxy, use_proxy and not restutil.bypass_proxy(host)) # pylint: disable=deprecated-method
+            self.assertEqual(should_not_use_proxy, use_proxy and not restutil.bypass_proxy(host)) 
 
             host = "www.bar.com"
-            self.assertEquals(should_use_proxy, use_proxy and not restutil.bypass_proxy(host)) # pylint: disable=deprecated-method
+            self.assertEqual(should_use_proxy, use_proxy and not restutil.bypass_proxy(host)) 
 
         no_proxy_list = ["10.0.0.1/24"]
         with patch.dict(os.environ, {
             'no_proxy': ",".join(no_proxy_list)
         }):
             host = "www.bar.com"
-            self.assertEquals(should_use_proxy, use_proxy and not restutil.bypass_proxy(host)) # pylint: disable=deprecated-method
+            self.assertEqual(should_use_proxy, use_proxy and not restutil.bypass_proxy(host)) 
 
             host = "10.0.0.1"
-            self.assertEquals(should_not_use_proxy, use_proxy and not restutil.bypass_proxy(host)) # pylint: disable=deprecated-method
+            self.assertEqual(should_not_use_proxy, use_proxy and not restutil.bypass_proxy(host)) 
 
             host = "10.0.1.1"
-            self.assertEquals(should_use_proxy, use_proxy and not restutil.bypass_proxy(host)) # pylint: disable=deprecated-method
+            self.assertEqual(should_use_proxy, use_proxy and not restutil.bypass_proxy(host)) 
 
         # When No_proxy is empty
         with patch.dict(os.environ, {
@@ -526,8 +526,8 @@ class TestHttpOperations(AgentTestCase): # pylint: disable=too-many-public-metho
             call(method="GET", url="https://foo:443/bar", body=None, headers={'User-Agent': HTTP_USER_AGENT, 'Connection': 'close'})
         ])
         self.assertEqual(1, mock_conn.getresponse.call_count)
-        self.assertNotEquals(None, resp) # pylint: disable=deprecated-method
-        self.assertEquals("TheResults", resp.read()) # pylint: disable=deprecated-method
+        self.assertNotEqual(None, resp) 
+        self.assertEqual("TheResults", resp.read()) 
 
     @patch("time.sleep")
     @patch("azurelinuxagent.common.utils.restutil._http_request")
@@ -538,11 +538,11 @@ class TestHttpOperations(AgentTestCase): # pylint: disable=too-many-public-metho
 
         # Test http get
         resp = restutil.http_get("http://foo.bar")
-        self.assertEquals("hehe", resp.read()) # pylint: disable=deprecated-method
+        self.assertEqual("hehe", resp.read()) 
 
         # Test https get
         resp = restutil.http_get("https://foo.bar")
-        self.assertEquals("hehe", resp.read()) # pylint: disable=deprecated-method
+        self.assertEqual("hehe", resp.read()) 
 
         # Test http failure
         _http_request.side_effect = httpclient.HTTPException("Http failure")

--- a/tests/utils/test_shell_util.py
+++ b/tests/utils/test_shell_util.py
@@ -30,31 +30,31 @@ class ShellQuoteTestCase(AgentTestCase):
 class RunTestCase(AgentTestCase):
     def test_it_should_return_the_exit_code_of_the_command(self):
         exit_code = shellutil.run("exit 123")
-        self.assertEquals(123, exit_code) # pylint: disable=deprecated-method
+        self.assertEqual(123, exit_code)
 
     def test_it_should_be_a_pass_thru_to_run_get_output(self):
         with patch.object(shellutil, "run_get_output", return_value=(0, "")) as mock_run_get_output:
             shellutil.run("echo hello word!", chk_err=False, expected_errors=[1, 2, 3])
 
-        self.assertEquals(mock_run_get_output.call_count, 1) # pylint: disable=deprecated-method
+        self.assertEqual(mock_run_get_output.call_count, 1)
 
         args, kwargs = mock_run_get_output.call_args
-        self.assertEquals(args[0], "echo hello word!") # pylint: disable=deprecated-method
-        self.assertEquals(kwargs["chk_err"], False) # pylint: disable=deprecated-method
-        self.assertEquals(kwargs["expected_errors"], [1, 2, 3]) # pylint: disable=deprecated-method
+        self.assertEqual(args[0], "echo hello word!")
+        self.assertEqual(kwargs["chk_err"], False)
+        self.assertEqual(kwargs["expected_errors"], [1, 2, 3])
 
 
 class RunGetOutputTestCase(AgentTestCase):
     def test_run_get_output(self):
         output = shellutil.run_get_output(u"ls /")
-        self.assertNotEquals(None, output) # pylint: disable=deprecated-method
-        self.assertEquals(0, output[0]) # pylint: disable=deprecated-method
+        self.assertNotEqual(None, output)
+        self.assertEqual(0, output[0])
 
         err = shellutil.run_get_output(u"ls /not-exists")
-        self.assertNotEquals(0, err[0]) # pylint: disable=deprecated-method
+        self.assertNotEqual(0, err[0])
             
         err = shellutil.run_get_output(u"ls 我")
-        self.assertNotEquals(0, err[0]) # pylint: disable=deprecated-method
+        self.assertNotEqual(0, err[0])
 
     def test_it_should_log_the_command(self):
         command = "echo hello world!"
@@ -62,7 +62,7 @@ class RunGetOutputTestCase(AgentTestCase):
         with patch("azurelinuxagent.common.utils.shellutil.logger", autospec=True) as mock_logger:
             shellutil.run_get_output(command)
 
-        self.assertEquals(mock_logger.verbose.call_count, 1) # pylint: disable=deprecated-method
+        self.assertEqual(mock_logger.verbose.call_count, 1)
 
         args, kwargs = mock_logger.verbose.call_args # pylint: disable=unused-variable
         command_in_message = args[1]
@@ -75,7 +75,7 @@ class RunGetOutputTestCase(AgentTestCase):
         with patch("azurelinuxagent.common.utils.shellutil.logger", autospec=True) as mock_logger:
             shellutil.run_get_output(command, log_cmd=False)
 
-        self.assertEquals(mock_logger.error.call_count, 1) # pylint: disable=deprecated-method
+        self.assertEqual(mock_logger.error.call_count, 1)
 
         args, kwargs = mock_logger.error.call_args # pylint: disable=unused-variable
 
@@ -83,9 +83,9 @@ class RunGetOutputTestCase(AgentTestCase):
         self.assertIn("[{0}]".format(command), message)
         self.assertIn("[{0}]".format(return_code), message)
 
-        self.assertEquals(mock_logger.verbose.call_count, 0) # pylint: disable=deprecated-method
-        self.assertEquals(mock_logger.info.call_count, 0) # pylint: disable=deprecated-method
-        self.assertEquals(mock_logger.warn.call_count, 0) # pylint: disable=deprecated-method
+        self.assertEqual(mock_logger.verbose.call_count, 0)
+        self.assertEqual(mock_logger.info.call_count, 0)
+        self.assertEqual(mock_logger.warn.call_count, 0)
 
     def test_it_should_log_expected_errors_as_info(self):
         return_code = 99
@@ -94,7 +94,7 @@ class RunGetOutputTestCase(AgentTestCase):
         with patch("azurelinuxagent.common.utils.shellutil.logger", autospec=True) as mock_logger:
             shellutil.run_get_output(command, log_cmd=False, expected_errors=[return_code])
 
-        self.assertEquals(mock_logger.info.call_count, 1) # pylint: disable=deprecated-method
+        self.assertEqual(mock_logger.info.call_count, 1)
 
         args, kwargs = mock_logger.info.call_args # pylint: disable=unused-variable
 
@@ -102,9 +102,9 @@ class RunGetOutputTestCase(AgentTestCase):
         self.assertIn("[{0}]".format(command), message)
         self.assertIn("[{0}]".format(return_code), message)
 
-        self.assertEquals(mock_logger.verbose.call_count, 0) # pylint: disable=deprecated-method
-        self.assertEquals(mock_logger.warn.call_count, 0) # pylint: disable=deprecated-method
-        self.assertEquals(mock_logger.error.call_count, 0) # pylint: disable=deprecated-method
+        self.assertEqual(mock_logger.verbose.call_count, 0)
+        self.assertEqual(mock_logger.warn.call_count, 0)
+        self.assertEqual(mock_logger.error.call_count, 0)
 
     def test_it_should_log_unexpected_errors_as_errors(self):
         return_code = 99
@@ -113,7 +113,7 @@ class RunGetOutputTestCase(AgentTestCase):
         with patch("azurelinuxagent.common.utils.shellutil.logger", autospec=True) as mock_logger:
             shellutil.run_get_output(command, log_cmd=False, expected_errors=[return_code + 1])
 
-        self.assertEquals(mock_logger.error.call_count, 1) # pylint: disable=deprecated-method
+        self.assertEqual(mock_logger.error.call_count, 1)
 
         args, kwargs = mock_logger.error.call_args # pylint: disable=unused-variable
 
@@ -121,16 +121,16 @@ class RunGetOutputTestCase(AgentTestCase):
         self.assertIn("[{0}]".format(command), message)
         self.assertIn("[{0}]".format(return_code), message)
 
-        self.assertEquals(mock_logger.info.call_count, 0) # pylint: disable=deprecated-method
-        self.assertEquals(mock_logger.verbose.call_count, 0) # pylint: disable=deprecated-method
-        self.assertEquals(mock_logger.warn.call_count, 0) # pylint: disable=deprecated-method
+        self.assertEqual(mock_logger.info.call_count, 0)
+        self.assertEqual(mock_logger.verbose.call_count, 0)
+        self.assertEqual(mock_logger.warn.call_count, 0)
 
 
 class RunCommandTestCase(AgentTestCase):
     def test_run_command_should_execute_the_command(self):
         command = ["echo", "-n", "A TEST STRING"]
         ret = shellutil.run_command(command)
-        self.assertEquals(ret, "A TEST STRING") # pylint: disable=deprecated-method
+        self.assertEqual(ret, "A TEST STRING")
 
     def test_run_command_should_raise_an_exception_when_the_command_fails(self):
         command = ["ls", "-d", "/etc", "nonexistent_file"]
@@ -141,9 +141,9 @@ class RunCommandTestCase(AgentTestCase):
         exception = context_manager.exception
         self.assertIn("'ls' failed: 2", str(exception))
         self.assertIn("No such file or directory", str(exception))
-        self.assertEquals(exception.stdout, "/etc\n") # pylint: disable=deprecated-method
+        self.assertEqual(exception.stdout, "/etc\n")
         self.assertIn("No such file or directory", exception.stderr)
-        self.assertEquals(exception.returncode, 2) # pylint: disable=deprecated-method
+        self.assertEqual(exception.returncode, 2)
 
     def test_run_command_should_raise_an_exception_when_it_cannot_execute_the_command(self):
         command = "nonexistent_command"
@@ -163,10 +163,10 @@ class RunCommandTestCase(AgentTestCase):
             except: # pylint: disable=bare-except
                 pass
 
-            self.assertEquals(mock_logger.info.call_count, 0) # pylint: disable=deprecated-method
-            self.assertEquals(mock_logger.verbose.call_count, 0) # pylint: disable=deprecated-method
-            self.assertEquals(mock_logger.warn.call_count, 0) # pylint: disable=deprecated-method
-            self.assertEquals(mock_logger.error.call_count, 0) # pylint: disable=deprecated-method
+            self.assertEqual(mock_logger.info.call_count, 0)
+            self.assertEqual(mock_logger.verbose.call_count, 0)
+            self.assertEqual(mock_logger.warn.call_count, 0)
+            self.assertEqual(mock_logger.error.call_count, 0)
 
             assert_no_message_logged(["ls", "nonexistent_file"])
             assert_no_message_logged("nonexistent_command")
@@ -180,7 +180,7 @@ class RunCommandTestCase(AgentTestCase):
             except: # pylint: disable=bare-except
                 pass
 
-            self.assertEquals(mock_log_error.call_count, 1) # pylint: disable=deprecated-method
+            self.assertEqual(mock_log_error.call_count, 1)
 
             args, kwargs = mock_log_error.call_args # pylint: disable=unused-variable
             self.assertIn("ls -d /etc nonexistent_file", args, msg="The command was not logged")
@@ -196,7 +196,7 @@ class RunCommandTestCase(AgentTestCase):
             except: # pylint: disable=bare-except
                 pass
 
-            self.assertEquals(mock_log_error.call_count, 1) # pylint: disable=deprecated-method
+            self.assertEqual(mock_log_error.call_count, 1)
 
             args, kwargs = mock_log_error.call_args
             self.assertIn(command, args, msg="The command was not logged")

--- a/tests/utils/test_text_util.py
+++ b/tests/utils/test_text_util.py
@@ -35,7 +35,7 @@ class TestTextUtil(AgentTestCase):
                 data = textutil.remove_bom(data)
                 data = ustr(data, encoding='utf-8')
                 password_hash = textutil.gen_password_hash(data, 6, 10)
-                self.assertNotEquals(None, password_hash) # pylint: disable=deprecated-method
+                self.assertNotEqual(None, password_hash)
 
     def test_replace_non_ascii(self):
         data = ustr(b'\xef\xbb\xbfhehe', encoding='utf-8')
@@ -54,31 +54,31 @@ class TestTextUtil(AgentTestCase):
         #Test bom could be removed
         data = ustr(b'\xef\xbb\xbfhehe', encoding='utf-8')
         data = textutil.remove_bom(data)
-        self.assertNotEquals(0xbb, data[0]) # pylint: disable=deprecated-method
+        self.assertNotEqual(0xbb, data[0])
 
         #bom is comprised of a sequence of three bytes and ff length of the input is shorter
         # than three bytes, remove_bom should not do anything
         data = u"\xa7"
         data = textutil.remove_bom(data)
-        self.assertEquals(data, data[0]) # pylint: disable=deprecated-method
+        self.assertEqual(data, data[0])
 
         data = u"\xa7\xef"
         data = textutil.remove_bom(data)
-        self.assertEquals(u"\xa7", data[0]) # pylint: disable=deprecated-method
-        self.assertEquals(u"\xef", data[1]) # pylint: disable=deprecated-method
+        self.assertEqual(u"\xa7", data[0])
+        self.assertEqual(u"\xef", data[1])
 
         #Test string without BOM is not affected
         data = u"hehe"
         data = textutil.remove_bom(data)
-        self.assertEquals(u"h", data[0]) # pylint: disable=deprecated-method
+        self.assertEqual(u"h", data[0])
 
         data = u""
         data = textutil.remove_bom(data)
-        self.assertEquals(u"", data) # pylint: disable=deprecated-method
+        self.assertEqual(u"", data)
 
         data = u"  "
         data = textutil.remove_bom(data)
-        self.assertEquals(u"  ", data) # pylint: disable=deprecated-method
+        self.assertEqual(u"  ", data)
 
     def test_version_compare(self):
         self.assertTrue(Version("1.0") < Version("1.1"))
@@ -102,14 +102,14 @@ class TestTextUtil(AgentTestCase):
                    "certificate\n"
                    "-----END CERTIFICATE----\n")
         base64_bytes = textutil.get_bytes_from_pem(content)
-        self.assertEquals("certificate", base64_bytes) # pylint: disable=deprecated-method
+        self.assertEqual("certificate", base64_bytes)
 
 
         content = ("-----BEGIN PRIVATE KEY-----\n"
                    "private key\n"
                    "-----END PRIVATE Key-----\n")
         base64_bytes = textutil.get_bytes_from_pem(content)
-        self.assertEquals("private key", base64_bytes) # pylint: disable=deprecated-method
+        self.assertEqual("private key", base64_bytes)
 
     def test_swap_hexstring(self):
         data = [


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Replace `assertEquals` with `assertEqual` since the former is deprecated according to pylint.

<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).