### PR TITLE
Start exthandler with the same python interpreter

### DIFF
--- a/azurelinuxagent/common/utils/shellutil.py
+++ b/azurelinuxagent/common/utils/shellutil.py
@@ -24,10 +24,9 @@ import azurelinuxagent.common.logger as logger
 from azurelinuxagent.common.future import ustr
 
 
-def get_current_python_cmd():
+def get_complete_python_cmd():
+    # Returns the complete python command (with path) for the current python interpreter
     return sys.executable
-    # major_version = platform.python_version_tuple()[0]
-    # return "python" if int(major_version) <= 2 else "python{0}".format(major_version)
 
 
 if not hasattr(subprocess, 'check_output'):

--- a/azurelinuxagent/common/utils/shellutil.py
+++ b/azurelinuxagent/common/utils/shellutil.py
@@ -17,16 +17,17 @@
 # Requires Python 2.6+ and Openssl 1.0+
 #
 
-import platform
 import subprocess
+import sys
 
 import azurelinuxagent.common.logger as logger
 from azurelinuxagent.common.future import ustr
 
 
-def get_python_cmd():
-    major_version = platform.python_version_tuple()[0]
-    return "python" if int(major_version) <= 2 else "python{0}".format(major_version)
+def get_current_python_cmd():
+    return sys.executable
+    # major_version = platform.python_version_tuple()[0]
+    # return "python" if int(major_version) <= 2 else "python{0}".format(major_version)
 
 
 if not hasattr(subprocess, 'check_output'):

--- a/azurelinuxagent/common/utils/shellutil.py
+++ b/azurelinuxagent/common/utils/shellutil.py
@@ -18,15 +18,9 @@
 #
 
 import subprocess
-import sys
 
 import azurelinuxagent.common.logger as logger
 from azurelinuxagent.common.future import ustr
-
-
-def get_complete_python_cmd():
-    # Returns the complete python command (with path) for the current python interpreter
-    return sys.executable
 
 
 if not hasattr(subprocess, 'check_output'):

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -48,7 +48,7 @@ from azurelinuxagent.common.osutil import get_osutil
 from azurelinuxagent.common.protocol.util import get_protocol_util
 from azurelinuxagent.common.protocol.hostplugin import HostPluginProtocol
 from azurelinuxagent.common.utils.flexible_version import FlexibleVersion
-from azurelinuxagent.common.utils.shellutil import get_python_cmd
+from azurelinuxagent.common.utils.shellutil import get_current_python_cmd
 from azurelinuxagent.common.version import AGENT_NAME, AGENT_VERSION, AGENT_DIR_PATTERN, CURRENT_AGENT,\
     CURRENT_VERSION, DISTRO_NAME, DISTRO_VERSION, is_current_agent_installed, PY_VERSION_MAJOR, PY_VERSION_MINOR, \
     PY_VERSION_MICRO
@@ -154,7 +154,7 @@ class UpdateHandler(object): # pylint: disable=R0902
             # Launch the correct Python version for python-based agents
             cmds = textutil.safe_shlex_split(agent_cmd)
             if cmds[0].lower() == "python":
-                cmds[0] = get_python_cmd()
+                cmds[0] = get_current_python_cmd()
                 agent_cmd = " ".join(cmds)
 
             self._evaluate_agent_health(latest_agent)

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -48,7 +48,7 @@ from azurelinuxagent.common.osutil import get_osutil
 from azurelinuxagent.common.protocol.util import get_protocol_util
 from azurelinuxagent.common.protocol.hostplugin import HostPluginProtocol
 from azurelinuxagent.common.utils.flexible_version import FlexibleVersion
-from azurelinuxagent.common.utils.shellutil import get_current_python_cmd
+from azurelinuxagent.common.utils.shellutil import get_complete_python_cmd
 from azurelinuxagent.common.version import AGENT_NAME, AGENT_VERSION, AGENT_DIR_PATTERN, CURRENT_AGENT,\
     CURRENT_VERSION, DISTRO_NAME, DISTRO_VERSION, is_current_agent_installed, PY_VERSION_MAJOR, PY_VERSION_MINOR, \
     PY_VERSION_MICRO
@@ -154,7 +154,7 @@ class UpdateHandler(object): # pylint: disable=R0902
             # Launch the correct Python version for python-based agents
             cmds = textutil.safe_shlex_split(agent_cmd)
             if cmds[0].lower() == "python":
-                cmds[0] = get_current_python_cmd()
+                cmds[0] = get_complete_python_cmd()
                 agent_cmd = " ".join(cmds)
 
             self._evaluate_agent_health(latest_agent)

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -48,7 +48,6 @@ from azurelinuxagent.common.osutil import get_osutil
 from azurelinuxagent.common.protocol.util import get_protocol_util
 from azurelinuxagent.common.protocol.hostplugin import HostPluginProtocol
 from azurelinuxagent.common.utils.flexible_version import FlexibleVersion
-from azurelinuxagent.common.utils.shellutil import get_complete_python_cmd
 from azurelinuxagent.common.version import AGENT_NAME, AGENT_VERSION, AGENT_DIR_PATTERN, CURRENT_AGENT,\
     CURRENT_VERSION, DISTRO_NAME, DISTRO_VERSION, is_current_agent_installed, PY_VERSION_MAJOR, PY_VERSION_MINOR, \
     PY_VERSION_MICRO
@@ -154,7 +153,7 @@ class UpdateHandler(object): # pylint: disable=R0902
             # Launch the correct Python version for python-based agents
             cmds = textutil.safe_shlex_split(agent_cmd)
             if cmds[0].lower() == "python":
-                cmds[0] = get_complete_python_cmd()
+                cmds[0] = sys.executable
                 agent_cmd = " ".join(cmds)
 
             self._evaluate_agent_health(latest_agent)

--- a/tests/ga/test_update.py
+++ b/tests/ga/test_update.py
@@ -1090,7 +1090,7 @@ class TestUpdate(UpdateTestCase): # pylint: disable=too-many-public-methods
 
         self.assertEqual(args, cmds)
         self.assertTrue(len(args) > 1)
-        self.assertRegex(args[0], r"(/*/python\d*)$", "The command doesn't contain full python path")
+        self.assertRegex(args[0], r"(/.*/python[\d.]*)$", "The command doesn't contain full python path")
         self.assertEqual("-run-exthandlers", args[len(args) - 1])
         self.assertEqual(True, 'cwd' in kwargs)
         self.assertEqual(agent.get_agent_dir(), kwargs['cwd'])
@@ -1104,7 +1104,7 @@ class TestUpdate(UpdateTestCase): # pylint: disable=too-many-public-methods
         args = args[0]
 
         self.assertTrue(len(args) > 1)
-        self.assertRegex(args[0], r"(/*/python\d*)$", "The command doesn't contain full python path")
+        self.assertRegex(args[0], r"(/.*/python[\d.]*)$", "The command doesn't contain full python path")
         self.assertEqual("AnArgument", args[len(args) - 1])
 
     def test_run_latest_polls_and_waits_for_success(self):

--- a/tests/ga/test_update.py
+++ b/tests/ga/test_update.py
@@ -32,7 +32,7 @@ from azurelinuxagent.common.protocol.util import ProtocolUtil
 from azurelinuxagent.common.protocol.wire import WireProtocol
 from azurelinuxagent.common.utils import fileutil, restutil, textutil
 from azurelinuxagent.common.utils.flexible_version import FlexibleVersion
-from azurelinuxagent.common.utils.shellutil import get_current_python_cmd
+from azurelinuxagent.common.utils.shellutil import get_complete_python_cmd
 from azurelinuxagent.common.version import AGENT_PKG_GLOB, AGENT_DIR_GLOB, AGENT_NAME, AGENT_DIR_PATTERN, \
     AGENT_VERSION, CURRENT_AGENT, CURRENT_VERSION
 from azurelinuxagent.ga.exthandlers import ExtHandlerInstance, HandlerEnvironment
@@ -1086,11 +1086,11 @@ class TestUpdate(UpdateTestCase): # pylint: disable=too-many-public-methods
         args = args[0]
         cmds = textutil.safe_shlex_split(agent.get_agent_cmd())
         if cmds[0].lower() == "python":
-            cmds[0] = get_current_python_cmd()
+            cmds[0] = get_complete_python_cmd()
 
         self.assertEqual(args, cmds)
         self.assertTrue(len(args) > 1)
-        self.assertTrue(args[0].startswith("python"))
+        self.assertRegex(args[0], r"(/*/python\d*)$", "The command doesn't contain full python path")
         self.assertEqual("-run-exthandlers", args[len(args) - 1])
         self.assertEqual(True, 'cwd' in kwargs)
         self.assertEqual(agent.get_agent_dir(), kwargs['cwd'])
@@ -1104,7 +1104,7 @@ class TestUpdate(UpdateTestCase): # pylint: disable=too-many-public-methods
         args = args[0]
 
         self.assertTrue(len(args) > 1)
-        self.assertTrue(args[0].startswith("python"))
+        self.assertRegex(args[0], r"(/*/python\d*)$", "The command doesn't contain full python path")
         self.assertEqual("AnArgument", args[len(args) - 1])
 
     def test_run_latest_polls_and_waits_for_success(self):
@@ -1146,7 +1146,7 @@ class TestUpdate(UpdateTestCase): # pylint: disable=too-many-public-methods
 
         args, kwargs = self._test_run_latest()
 
-        self.assertEqual(args[0], [get_current_python_cmd(), "-u", sys.argv[0], "-run-exthandlers"])
+        self.assertEqual(args[0], [get_complete_python_cmd(), "-u", sys.argv[0], "-run-exthandlers"])
         self.assertEqual(True, 'cwd' in kwargs)
         self.assertEqual(os.getcwd(), kwargs['cwd'])
 

--- a/tests/ga/test_update.py
+++ b/tests/ga/test_update.py
@@ -32,7 +32,7 @@ from azurelinuxagent.common.protocol.util import ProtocolUtil
 from azurelinuxagent.common.protocol.wire import WireProtocol
 from azurelinuxagent.common.utils import fileutil, restutil, textutil
 from azurelinuxagent.common.utils.flexible_version import FlexibleVersion
-from azurelinuxagent.common.utils.shellutil import get_python_cmd
+from azurelinuxagent.common.utils.shellutil import get_current_python_cmd
 from azurelinuxagent.common.version import AGENT_PKG_GLOB, AGENT_DIR_GLOB, AGENT_NAME, AGENT_DIR_PATTERN, \
     AGENT_VERSION, CURRENT_AGENT, CURRENT_VERSION
 from azurelinuxagent.ga.exthandlers import ExtHandlerInstance, HandlerEnvironment
@@ -1086,7 +1086,7 @@ class TestUpdate(UpdateTestCase): # pylint: disable=too-many-public-methods
         args = args[0]
         cmds = textutil.safe_shlex_split(agent.get_agent_cmd())
         if cmds[0].lower() == "python":
-            cmds[0] = get_python_cmd()
+            cmds[0] = get_current_python_cmd()
 
         self.assertEqual(args, cmds)
         self.assertTrue(len(args) > 1)
@@ -1146,7 +1146,7 @@ class TestUpdate(UpdateTestCase): # pylint: disable=too-many-public-methods
 
         args, kwargs = self._test_run_latest()
 
-        self.assertEqual(args[0], [get_python_cmd(), "-u", sys.argv[0], "-run-exthandlers"])
+        self.assertEqual(args[0], [get_current_python_cmd(), "-u", sys.argv[0], "-run-exthandlers"])
         self.assertEqual(True, 'cwd' in kwargs)
         self.assertEqual(os.getcwd(), kwargs['cwd'])
 

--- a/tests/ga/test_update.py
+++ b/tests/ga/test_update.py
@@ -32,7 +32,6 @@ from azurelinuxagent.common.protocol.util import ProtocolUtil
 from azurelinuxagent.common.protocol.wire import WireProtocol
 from azurelinuxagent.common.utils import fileutil, restutil, textutil
 from azurelinuxagent.common.utils.flexible_version import FlexibleVersion
-from azurelinuxagent.common.utils.shellutil import get_complete_python_cmd
 from azurelinuxagent.common.version import AGENT_PKG_GLOB, AGENT_DIR_GLOB, AGENT_NAME, AGENT_DIR_PATTERN, \
     AGENT_VERSION, CURRENT_AGENT, CURRENT_VERSION
 from azurelinuxagent.ga.exthandlers import ExtHandlerInstance, HandlerEnvironment
@@ -1086,7 +1085,7 @@ class TestUpdate(UpdateTestCase): # pylint: disable=too-many-public-methods
         args = args[0]
         cmds = textutil.safe_shlex_split(agent.get_agent_cmd())
         if cmds[0].lower() == "python":
-            cmds[0] = get_complete_python_cmd()
+            cmds[0] = sys.executable
 
         self.assertEqual(args, cmds)
         self.assertTrue(len(args) > 1)
@@ -1146,7 +1145,7 @@ class TestUpdate(UpdateTestCase): # pylint: disable=too-many-public-methods
 
         args, kwargs = self._test_run_latest()
 
-        self.assertEqual(args[0], [get_complete_python_cmd(), "-u", sys.argv[0], "-run-exthandlers"])
+        self.assertEqual(args[0], [sys.executable, "-u", sys.argv[0], "-run-exthandlers"])
         self.assertEqual(True, 'cwd' in kwargs)
         self.assertEqual(os.getcwd(), kwargs['cwd'])
 

--- a/tests/ga/test_update.py
+++ b/tests/ga/test_update.py
@@ -1090,7 +1090,7 @@ class TestUpdate(UpdateTestCase): # pylint: disable=too-many-public-methods
 
         self.assertEqual(args, cmds)
         self.assertTrue(len(args) > 1)
-        self.assertRegex(args[0], r"(/.*/python[\d.]*)$", "The command doesn't contain full python path")
+        self.assertRegex(args[0], r"^(/.*/python[\d.]*)$", "The command doesn't contain full python path")
         self.assertEqual("-run-exthandlers", args[len(args) - 1])
         self.assertEqual(True, 'cwd' in kwargs)
         self.assertEqual(agent.get_agent_dir(), kwargs['cwd'])
@@ -1104,7 +1104,7 @@ class TestUpdate(UpdateTestCase): # pylint: disable=too-many-public-methods
         args = args[0]
 
         self.assertTrue(len(args) > 1)
-        self.assertRegex(args[0], r"(/.*/python[\d.]*)$", "The command doesn't contain full python path")
+        self.assertRegex(args[0], r"^(/.*/python[\d.]*)$", "The command doesn't contain full python path")
         self.assertEqual("AnArgument", args[len(args) - 1])
 
     def test_run_latest_polls_and_waits_for_success(self):


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Currently we do this to start the exthandler service –
`python3 -u /usr/sbin/waagent -run-exthandlers`

 instead of doing this –
`/usr/bin/python3 -u /usr/sbin/waagent -run-exthandlers`

This was causing issues in VMs where python3 and /usr/bin/python3 were different interpreters (multiple ICMs reported)

This PR basically starts the exthandler process using the same python interpreter as the daemon process to ensure that there can be no discrepency there.

Here's the link to the TFS bug - https://msazure.visualstudio.com/One/_workitems/edit/8240001

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).