### PR TITLE
Verify that the extension status is an array

### DIFF
--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -153,7 +153,8 @@ def parse_ext_status(ext_status, data):
     if data is None:
         return
     if not isinstance(data, list):
-        raise ExtensionStatusError(msg="The extension status must be an array: {0}".format(data), code=ExtensionStatusError.StatusFileMalformed)
+        data_string = ustr(data)[:4096]
+        raise ExtensionStatusError(msg="The extension status must be an array: {0}".format(data_string), code=ExtensionStatusError.StatusFileMalformed)
     if not data:
         return
 

--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -150,8 +150,13 @@ def parse_ext_substatus(substatus):
 
 
 def parse_ext_status(ext_status, data):
-    if data is None or len(data) == 0: # pylint: disable=len-as-condition
+    if data is None:
         return
+    if not isinstance(data, list):
+        raise ExtensionStatusError(msg="The extension status must be an array: {0}".format(data), code=ExtensionStatusError.StatusFileMalformed)
+    if not data:
+        return
+
     # Currently, only the first status will be reported
     data = data[0]
     # Check extension status format

--- a/tests/ga/test_exthandlers.py
+++ b/tests/ga/test_exthandlers.py
@@ -43,20 +43,23 @@ class TestExtHandlers(AgentTestCase):
 
     def test_parse_ext_status_should_raise_on_non_array(self):
         status = json.loads('''
-            {
-                "status": {
+            {{
+                "status": {{
                     "status": "transitioning",
                     "operation": "Enabling Handler",
                     "code": 0,
                     "name": "Microsoft.Azure.RecoveryServices.SiteRecovery.Linux"
-                },
+                }},
                 "version": 1.0,
-                "timestampUTC": "2020-01-14T15:04:43Z"
-            }''')
+                "timestampUTC": "2020-01-14T15:04:43Z",
+                "longText": "{0}"
+            }}'''.format("*" * 5 * 1024))
 
         with self.assertRaises(ExtensionStatusError) as context_manager:
             parse_ext_status(ExtensionStatus(seq_no=0), status)
-        self.assertIn("The extension status must be an array", str(context_manager.exception))
+        error_message = str(context_manager.exception)
+        self.assertIn("The extension status must be an array", error_message)
+        self.assertTrue(0 < len(error_message) - 64 < 4096, "The error message should not be much longer than 4K characters: [{0}]".format(error_message))
 
     def test_parse_extension_status00(self):
         """


### PR DESCRIPTION
If the status for one extension is not an array, the agent fails to report status for all extensions