### PR TITLE
Add LIS version to OSInfo.message

### DIFF
--- a/azurelinuxagent/common/version.py
+++ b/azurelinuxagent/common/version.py
@@ -21,6 +21,7 @@ import platform
 import sys
 
 import azurelinuxagent.common.conf as conf
+import azurelinuxagent.common.utils.shellutil as shellutil
 from azurelinuxagent.common.utils.flexible_version import FlexibleVersion
 from azurelinuxagent.common.future import ustr, get_linux_distribution
 
@@ -88,7 +89,7 @@ def get_distro():
         try:
             # dist() removed in Python 3.8
             osinfo = list(platform.dist()) + [''] # pylint: disable=W1505,E1101
-        except: # pylint: disable=W0702
+        except Exception:
             osinfo = ['UNKNOWN', 'FFFF', '', '']
 
     # The platform.py lib has issue with detecting oracle linux distribution.
@@ -114,6 +115,37 @@ def get_distro():
     # Remove trailing whitespace and quote in distro name
     osinfo[0] = osinfo[0].strip('"').strip(' ').lower()
     return osinfo
+
+
+def get_lis_version():
+    """
+    This uses the Linux kernel's 'modinfo' command to retrieve the
+    "version" field for the "hv_vmbus" kernel module (the LIS
+    drivers). This is the documented method to retrieve the LIS module
+    version. Every Linux guest on Hyper-V will have this driver, but
+    it may not be installed as a module (it could instead be built
+    into the kernel). In that case, this will return "Absent" instead
+    of the version, indicating the driver version can be deduced from
+    the kernel version. It will only return "Failed" in the presence
+    of an exception.
+
+    This function is used to generate telemetry for the version of the
+    LIS drivers installed on the VM. The function and associated
+    telemetry can be removed after a few releases.
+    """
+    try:
+        modinfo_output = shellutil.run_command(["modinfo", "-F", "version", "hv_vmbus"])
+        if modinfo_output:
+            return modinfo_output
+        # If the system doesn't have LIS drivers, 'modinfo' will
+        # return nothing on stdout, which will cause 'run_command'
+        # to return an empty string.
+        return "Absent"
+    except Exception:
+        # Ignore almost every possible exception because this is in a
+        # critical code path. Unfortunately the logger isn't already
+        # imported in this module or we'd log this too.
+        return "Failed"
 
 
 AGENT_NAME = "WALinuxAgent"

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -49,8 +49,8 @@ from azurelinuxagent.common.protocol.util import get_protocol_util
 from azurelinuxagent.common.protocol.hostplugin import HostPluginProtocol
 from azurelinuxagent.common.utils.flexible_version import FlexibleVersion
 from azurelinuxagent.common.version import AGENT_NAME, AGENT_VERSION, AGENT_DIR_PATTERN, CURRENT_AGENT,\
-    CURRENT_VERSION, DISTRO_NAME, DISTRO_VERSION, is_current_agent_installed, PY_VERSION_MAJOR, PY_VERSION_MINOR, \
-    PY_VERSION_MICRO
+    CURRENT_VERSION, DISTRO_NAME, DISTRO_VERSION, is_current_agent_installed, get_lis_version, PY_VERSION_MAJOR, \
+    PY_VERSION_MINOR, PY_VERSION_MICRO
 from azurelinuxagent.ga.collect_logs import get_collect_logs_handler, is_log_collection_allowed
 from azurelinuxagent.ga.env import get_env_handler
 from azurelinuxagent.ga.extension_telemetry import get_extension_telemetry_handler
@@ -262,9 +262,9 @@ class UpdateHandler(object): # pylint: disable=R0902
             initialize_event_logger_vminfo_common_parameters(protocol)
 
             # Log OS-specific info.
-            os_info_msg = u"Distro: {0}-{1}; OSUtil: {2}; AgentService: {3}; Python: {4}.{5}.{6}".format(
+            os_info_msg = u"Distro: {0}-{1}; OSUtil: {2}; AgentService: {3}; Python: {4}.{5}.{6}; LISDrivers: {7}".format(
                 DISTRO_NAME, DISTRO_VERSION, type(self.osutil).__name__, self.osutil.service_name, PY_VERSION_MAJOR,
-                PY_VERSION_MINOR, PY_VERSION_MICRO)
+                PY_VERSION_MINOR, PY_VERSION_MICRO, get_lis_version())
             logger.info(os_info_msg)
             add_event(AGENT_NAME, op=WALAEventOperation.OSInfo, message=os_info_msg)
 

--- a/tests/common/test_version.py
+++ b/tests/common/test_version.py
@@ -17,9 +17,10 @@
 
 from __future__ import print_function
 
+import os
+import textwrap
+
 import mock
-import os # pylint: disable=wrong-import-order
-import textwrap # pylint: disable=wrong-import-order
 
 import azurelinuxagent.common.conf as conf
 from azurelinuxagent.common.event import EVENTS_DIRECTORY
@@ -60,34 +61,31 @@ def default_system_exception():
 
 def is_platform_dist_supported():
     # platform.dist() and platform.linux_distribution() is deprecated from Python 3.8+
-    if PY_VERSION_MAJOR == 3 and PY_VERSION_MINOR >= 8: # pylint: disable=no-else-return
+    if PY_VERSION_MAJOR == 3 and PY_VERSION_MINOR >= 8:
         return False
-    else:
-        return True
+    return True
+
 
 class TestAgentVersion(AgentTestCase):
-    def setUp(self): # pylint: disable=useless-return
+    def setUp(self):
         AgentTestCase.setUp(self)
-        return
 
     @mock.patch('platform.system', side_effect=freebsd_system)
     @mock.patch('re.sub', side_effect=freebsd_system_release)
-    def test_distro_is_correct_format_when_freebsd(self, platform_system_name, mock_variable): # pylint: disable=useless-return,unused-argument
+    def test_distro_is_correct_format_when_freebsd(self, platform_system_name, mock_variable): # pylint: disable=unused-argument
         osinfo = get_distro()
         freebsd_list = ['freebsd', "10.0", '', 'freebsd']
         self.assertListEqual(freebsd_list, osinfo)
-        return
 
     @mock.patch('platform.system', side_effect=openbsd_system)
     @mock.patch('re.sub', side_effect=openbsd_system_release)
-    def test_distro_is_correct_format_when_openbsd(self, platform_system_name, mock_variable): # pylint: disable=useless-return,unused-argument
+    def test_distro_is_correct_format_when_openbsd(self, platform_system_name, mock_variable): # pylint: disable=unused-argument
         osinfo = get_distro()
         openbsd_list = ['openbsd', "20.0", '', 'openbsd']
         self.assertListEqual(openbsd_list, osinfo)
-        return
 
     @mock.patch('platform.system', side_effect=default_system)
-    def test_distro_is_correct_format_when_default_case(self, *args): # pylint: disable=useless-return,unused-argument
+    def test_distro_is_correct_format_when_default_case(self, *args): # pylint: disable=unused-argument
         default_list = ['', '', '', '']
         unknown_list = ['unknown', 'FFFF', '', '']
 
@@ -99,10 +97,9 @@ class TestAgentVersion(AgentTestCase):
             # platform.dist() is deprecated in Python 3.7+ and would throw, resulting in unknown distro
             osinfo = get_distro()
             self.assertListEqual(unknown_list, osinfo)
-        return
 
     @mock.patch('platform.system', side_effect=default_system)
-    def test_distro_is_correct_for_exception_case(self, *args): # pylint: disable=useless-return,unused-argument
+    def test_distro_is_correct_for_exception_case(self, *args): # pylint: disable=unused-argument
         default_list = ['unknown', 'FFFF', '', '']
 
         if is_platform_dist_supported():
@@ -114,9 +111,8 @@ class TestAgentVersion(AgentTestCase):
             osinfo = get_distro()
 
         self.assertListEqual(default_list, osinfo)
-        return
 
-    def test_get_lis_version_should_return_a_string(self, *args): # pylint: disable=useless-return,unused-argument
+    def test_get_lis_version_should_return_a_string(self):
         """
         On a Hyper-V guest with the LIS drivers installed as a module,
         this function should return a string of the version, like
@@ -126,39 +122,34 @@ class TestAgentVersion(AgentTestCase):
         """
         lis_version = get_lis_version()
         self.assertIsInstance(lis_version, str)
-        return
 
 
 class TestCurrentAgentName(AgentTestCase):
-    def setUp(self): # pylint: disable=useless-return
+    def setUp(self):
         AgentTestCase.setUp(self)
-        return
 
     @patch("os.getcwd", return_value="/default/install/directory")
-    def test_extract_name_finds_installed(self, mock_cwd): # pylint: disable=useless-return,unused-argument
+    def test_extract_name_finds_installed(self, mock_cwd): # pylint: disable=unused-argument
         current_agent, current_version = set_current_agent()
         self.assertEqual(AGENT_LONG_VERSION, current_agent)
         self.assertEqual(AGENT_VERSION, str(current_version))
-        return
 
     @patch("os.getcwd", return_value="/")
-    def test_extract_name_root_finds_installed(self, mock_cwd): # pylint: disable=useless-return,unused-argument
+    def test_extract_name_root_finds_installed(self, mock_cwd): # pylint: disable=unused-argument
         current_agent, current_version = set_current_agent()
         self.assertEqual(AGENT_LONG_VERSION, current_agent)
         self.assertEqual(AGENT_VERSION, str(current_version))
-        return
 
     @patch("os.getcwd")
-    def test_extract_name_in_path_finds_installed(self, mock_cwd): # pylint: disable=useless-return
+    def test_extract_name_in_path_finds_installed(self, mock_cwd):
         path = os.path.join(conf.get_lib_dir(), EVENTS_DIRECTORY)
         mock_cwd.return_value = path
         current_agent, current_version = set_current_agent()
         self.assertEqual(AGENT_LONG_VERSION, current_agent)
         self.assertEqual(AGENT_VERSION, str(current_version))
-        return
 
     @patch("os.getcwd")
-    def test_extract_name_finds_latest_agent(self, mock_cwd): # pylint: disable=useless-return
+    def test_extract_name_finds_latest_agent(self, mock_cwd):
         path = os.path.join(conf.get_lib_dir(), "{0}-{1}".format(
             AGENT_NAME,
             "1.2.3"))
@@ -168,7 +159,6 @@ class TestCurrentAgentName(AgentTestCase):
         current_agent, current_version = set_current_agent()
         self.assertEqual(agent, current_agent)
         self.assertEqual(version, str(current_version))
-        return
 
 
 class TestGetF5Platforms(AgentTestCase):
@@ -185,8 +175,8 @@ class TestGetF5Platforms(AgentTestCase):
         Changelist: 1874858
         JobID: 705993""")
 
-        mo = mock.mock_open(read_data=version_file) # pylint: disable=invalid-name
-        with patch(open_patch(), mo):
+        mocked_open = mock.mock_open(read_data=version_file)
+        with patch(open_patch(), mocked_open):
             platform = get_f5_platform()
             self.assertTrue(platform[0] == 'bigip')
             self.assertTrue(platform[1] == '12.1.1')
@@ -206,8 +196,8 @@ class TestGetF5Platforms(AgentTestCase):
         Changelist: 1773831
         JobID: 673467""")
 
-        mo = mock.mock_open(read_data=version_file) # pylint: disable=invalid-name
-        with patch(open_patch(), mo):
+        mocked_open = mock.mock_open(read_data=version_file)
+        with patch(open_patch(), mocked_open):
             platform = get_f5_platform()
             self.assertTrue(platform[0] == 'bigip')
             self.assertTrue(platform[1] == '12.1.0')
@@ -227,8 +217,8 @@ class TestGetF5Platforms(AgentTestCase):
         Changelist: 1486072
         JobID: 536212""")
 
-        mo = mock.mock_open(read_data=version_file) # pylint: disable=invalid-name
-        with patch(open_patch(), mo):
+        mocked_open = mock.mock_open(read_data=version_file)
+        with patch(open_patch(), mocked_open):
             platform = get_f5_platform()
             self.assertTrue(platform[0] == 'bigip')
             self.assertTrue(platform[1] == '12.0.0')
@@ -248,8 +238,8 @@ class TestGetF5Platforms(AgentTestCase):
         Changelist: 1924048
         JobID: 734712""")
 
-        mo = mock.mock_open(read_data=version_file) # pylint: disable=invalid-name
-        with patch(open_patch(), mo):
+        mocked_open = mock.mock_open(read_data=version_file)
+        with patch(open_patch(), mocked_open):
             platform = get_f5_platform()
             self.assertTrue(platform[0] == 'iworkflow')
             self.assertTrue(platform[1] == '2.0.1')
@@ -269,8 +259,8 @@ class TestGetF5Platforms(AgentTestCase):
         Changelist: 1907534
         JobID: 726344""")
 
-        mo = mock.mock_open(read_data=version_file) # pylint: disable=invalid-name
-        with patch(open_patch(), mo):
+        mocked_open = mock.mock_open(read_data=version_file)
+        with patch(open_patch(), mocked_open):
             platform = get_f5_platform()
             self.assertTrue(platform[0] == 'bigiq')
             self.assertTrue(platform[1] == '5.1.0')

--- a/tests/common/test_version.py
+++ b/tests/common/test_version.py
@@ -25,7 +25,8 @@ import azurelinuxagent.common.conf as conf
 from azurelinuxagent.common.event import EVENTS_DIRECTORY
 from azurelinuxagent.common.version import set_current_agent, \
     AGENT_LONG_VERSION, AGENT_VERSION, AGENT_NAME, AGENT_NAME_PATTERN, \
-    get_f5_platform, get_distro, PY_VERSION_MAJOR, PY_VERSION_MINOR
+    get_f5_platform, get_distro, get_lis_version, PY_VERSION_MAJOR, \
+    PY_VERSION_MINOR
 from tests.tools import AgentTestCase, open_patch, patch
 
 
@@ -113,6 +114,18 @@ class TestAgentVersion(AgentTestCase):
             osinfo = get_distro()
 
         self.assertListEqual(default_list, osinfo)
+        return
+
+    def test_get_lis_version_should_return_a_string(self, *args): # pylint: disable=useless-return,unused-argument
+        """
+        On a Hyper-V guest with the LIS drivers installed as a module,
+        this function should return a string of the version, like
+        '4.3.5'. Anywhere else it should return 'Absent' and possibly
+        return 'Failed' if an exception was raised, so we check that
+        it returns a string'.
+        """
+        lis_version = get_lis_version()
+        self.assertIsInstance(lis_version, str)
         return
 
 


### PR DESCRIPTION
## Description
This uses the Linux kernel’s `modinfo` command to retrieve the “version”
field for the “hv_vmbus” kernel module (the LIS drivers). This is the
documented method to retrieve the LIS version.

This command should not fail, given that it’s part of the Linux kernel.
Moreover, the existing RDMA code already relies on `modinfo` without a
timeout etc. It is also distribution-agnostic.

If for some reason the module’s version is unavailable, or `modinfo`
somehow doesn’t exist, we catch the exception and return “Unknown”
instead.

While a timeout would be nice, the existing `run_command` doesn’t
currently support it (and adding it will require some work because we
can’t use Python 3.3’s `timeout` due to Python 2.6 being our minimum
version). Again, there is already existing code which calls `modinfo`
without a timeout, so if this were to fail, it seems it would fail
regardless of this patch.

---

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes in the description.
- [x] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [x] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).