### PR TITLE
Limit description character length sent for health report

### DIFF
--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -220,8 +220,12 @@ def _build_health_report(incarnation, container_id, role_instance_id, # pylint: 
                          status, substatus, description):
     # Escape '&', '<' and '>'
     description = saxutils.escape(ustr(description))
+
+    # The max description that can be sent to WireServer is 4096 bytes.
+    # Exceeding this max can result in a failure to report health.
     max_description_length = 4096
     description = description[-max_description_length:]
+
     detail = u''
     if substatus is not None:
         substatus = saxutils.escape(ustr(substatus))

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -220,6 +220,8 @@ def _build_health_report(incarnation, container_id, role_instance_id, # pylint: 
                          status, substatus, description):
     # Escape '&', '<' and '>'
     description = saxutils.escape(ustr(description))
+    max_description_length = 4096
+    description = description[-max_description_length:]
     detail = u''
     if substatus is not None:
         substatus = saxutils.escape(ustr(substatus))

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -223,8 +223,18 @@ def _build_health_report(incarnation, container_id, role_instance_id, # pylint: 
 
     # The max description that can be sent to WireServer is 4096 bytes.
     # Exceeding this max can result in a failure to report health.
-    max_description_length = 4096
-    description = description[-max_description_length:]
+    # This max leaves about a 7% buffer in case the platform does any
+    # formatting on this description string prior to being received
+    # by WireServer.
+    max_description_length = 3840
+    current_description_length = len(description)
+    if current_description_length > max_description_length:
+        logger.info(
+            'Trimmed health report description by {0} characters'.format(
+                current_description_length - max_description_length
+            )
+        )
+        description = description[-max_description_length:]
 
     detail = u''
     if substatus is not None:


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

This PR limits the description length that can be sent for a health report. The platform supports a maximum of 4096 characters for the description text.

E.g. `<Description>this text can only be a max of 4096 characters</Description>`

Issue #2017 
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).