### PR TITLE
Use dd instead of fallocate for ext4

### DIFF
--- a/azurelinuxagent/daemon/resourcedisk/default.py
+++ b/azurelinuxagent/daemon/resourcedisk/default.py
@@ -333,7 +333,7 @@ class ResourceDiskHandler(object):
         # fallocate
         ret = 0
         fn_sh = shellutil.quote((filename,))
-        if self.fs != 'xfs':
+        if self.fs not in ['xfs', 'ext4']:
             # os.posix_fallocate
             if sys.version_info >= (3, 3):
                 # Probable errors:


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Issue #2036 

`swapon` will fail if there are holes in the swap file. Directly from the swapon man pages:

```
NOTES
       You should not use swapon on a file with holes.  This can be seen in the system log as

              swapon: swapfile has holes.

       The  swap  file  implementation  in the kernel expects to be able to write to the file directly, without the assistance of the filesystem.  This is a problem on preallocated files
       (e.g.  fallocate(1)) on filesystems like XFS or ext4, and on copy-on-write filesystems like btrfs.

       It is recommended to use dd(1) and /dev/zero to avoid holes on XFS and ext4.
```

This PR modifies the logic so that a resource disk filesystem of ext4 will use `dd` to create the swap file instead of `fallocate`.

---

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [x] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).