### PR TITLE
Fix timestamp for goal state archive

### DIFF
--- a/azurelinuxagent/common/protocol/goal_state.py
+++ b/azurelinuxagent/common/protocol/goal_state.py
@@ -20,6 +20,7 @@ import json
 import os
 import re
 import time
+from datetime import datetime
 
 import azurelinuxagent.common.conf as conf
 import azurelinuxagent.common.logger as logger
@@ -141,6 +142,7 @@ class GoalState(object):  # pylint: disable=R0902
             raise ProtocolError(msg="Error fetching goal state", inner=exception)
         finally:
             logger.info('Fetch goal state completed')
+            self.fetch_timestamp = datetime.utcnow()
 
     @staticmethod
     def fetch_goal_state(wire_client):

--- a/azurelinuxagent/common/protocol/goal_state.py
+++ b/azurelinuxagent/common/protocol/goal_state.py
@@ -20,19 +20,18 @@ import json
 import os
 import re
 import time
-from datetime import datetime
 
 import azurelinuxagent.common.conf as conf
 import azurelinuxagent.common.logger as logger
 from azurelinuxagent.common.AgentGlobals import AgentGlobals
 from azurelinuxagent.common.datacontract import set_properties
 from azurelinuxagent.common.event import add_event, WALAEventOperation
+from azurelinuxagent.common.exception import IncompleteGoalStateError
 from azurelinuxagent.common.exception import ProtocolError
 from azurelinuxagent.common.future import ustr
 from azurelinuxagent.common.protocol.restapi import Cert, CertList, Extension, ExtHandler, ExtHandlerList, \
     ExtHandlerVersionUri, RemoteAccessUser, RemoteAccessUsersList, \
     VMAgentManifest, VMAgentManifestList, VMAgentManifestUri
-from azurelinuxagent.common.exception import IncompleteGoalStateError
 from azurelinuxagent.common.utils import fileutil
 from azurelinuxagent.common.utils.cryptutil import CryptUtil
 from azurelinuxagent.common.utils.textutil import parse_doc, findall, find, findtext, getattrib, gettext
@@ -142,7 +141,6 @@ class GoalState(object):  # pylint: disable=R0902
             raise ProtocolError(msg="Error fetching goal state", inner=exception)
         finally:
             logger.info('Fetch goal state completed')
-            self.fetch_timestamp = datetime.utcnow()
 
     @staticmethod
     def fetch_goal_state(wire_client):

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -22,7 +22,6 @@ import random
 import time
 import traceback
 import xml.sax.saxutils as saxutils
-from datetime import datetime  # pylint: disable=ungrouped-imports
 
 import azurelinuxagent.common.conf as conf
 import azurelinuxagent.common.logger as logger
@@ -720,9 +719,8 @@ class WireClient(object): # pylint: disable=R0904
                 new_goal_state = GoalState.fetch_full_goal_state_if_incarnation_different_than(self, self._goal_state.incarnation)
 
             if new_goal_state is not None:
-                previous_goal_state_fetch_timestamp = self._goal_state.fetch_timestamp if self._goal_state else datetime.utcnow()
                 self._goal_state = new_goal_state
-                self._save_goal_state(previous_goal_state_fetch_timestamp)
+                self._save_goal_state()
                 self._update_host_plugin(new_goal_state.container_id, new_goal_state.role_config_name)
 
         except Exception as exception:
@@ -757,9 +755,9 @@ class WireClient(object): # pylint: disable=R0904
             self._host_plugin.update_container_id(container_id)
             self._host_plugin.update_role_config_name(role_config_name)
 
-    def _save_goal_state(self, previous_goal_state_fetch_timestamp):
+    def _save_goal_state(self):
         try:
-            self.goal_state_flusher.flush(previous_goal_state_fetch_timestamp)
+            self.goal_state_flusher.flush()
         except Exception as e: # pylint: disable=C0103
             logger.warn("Failed to save the previous goal state to the history folder: {0}", ustr(e))
 

--- a/azurelinuxagent/common/utils/archive.py
+++ b/azurelinuxagent/common/utils/archive.py
@@ -73,7 +73,10 @@ class StateFlusher(object):
             return
 
         archive_name = self._get_archive_name(files)
-        if archive_name and self._mkdir(archive_name):
+        if archive_name is None:
+            return
+
+        if self._mkdir(archive_name):
             self._archive(files, archive_name)
         else:
             self._purge(files)

--- a/azurelinuxagent/common/utils/archive.py
+++ b/azurelinuxagent/common/utils/archive.py
@@ -10,7 +10,6 @@ from azurelinuxagent.common.utils import fileutil
 
 import azurelinuxagent.common.logger as logger
 
-
 # pylint: disable=W0105
 """
 archive.py
@@ -41,32 +40,32 @@ ARCHIVE_DIRECTORY_NAME = 'history'
 MAX_ARCHIVED_STATES = 50
 
 CACHE_PATTERNS = [
-    re.compile("^(.*)\.(\d+)\.(agentsManifest)$", re.IGNORECASE), # pylint: disable=W1401
-    re.compile("^(.*)\.(\d+)\.(manifest\.xml)$", re.IGNORECASE), # pylint: disable=W1401
-    re.compile("^(.*)\.(\d+)\.(xml)$", re.IGNORECASE) # pylint: disable=W1401
+    re.compile("^(.*)\.(\d+)\.(agentsManifest)$", re.IGNORECASE),  # pylint: disable=W1401
+    re.compile("^(.*)\.(\d+)\.(manifest\.xml)$", re.IGNORECASE),  # pylint: disable=W1401
+    re.compile("^(.*)\.(\d+)\.(xml)$", re.IGNORECASE)  # pylint: disable=W1401
 ]
 
 # 2018-04-06T08:21:37.142697
 # 2018-04-06T08:21:37.142697.zip
-ARCHIVE_PATTERNS_DIRECTORY = re.compile('^\d{4}\-\d{2}\-\d{2}T\d{2}:\d{2}:\d{2}\.\d+$') # pylint: disable=W1401
-ARCHIVE_PATTERNS_ZIP       = re.compile('^\d{4}\-\d{2}\-\d{2}T\d{2}:\d{2}:\d{2}\.\d+\.zip$') # pylint: disable=W1401
+ARCHIVE_PATTERNS_DIRECTORY = re.compile('^\d{4}\-\d{2}\-\d{2}T\d{2}:\d{2}:\d{2}\.\d+$')  # pylint: disable=W1401
+ARCHIVE_PATTERNS_ZIP = re.compile('^\d{4}\-\d{2}\-\d{2}T\d{2}:\d{2}:\d{2}\.\d+\.zip$')  # pylint: disable=W1401
 
 
 class StateFlusher(object):
     def __init__(self, lib_dir):
         self._source = lib_dir
 
-        d = os.path.join(self._source, ARCHIVE_DIRECTORY_NAME) # pylint: disable=C0103
+        d = os.path.join(self._source, ARCHIVE_DIRECTORY_NAME)  # pylint: disable=C0103
         if not os.path.exists(d):
             try:
                 fileutil.mkdir(d)
-            except OSError as e: # pylint: disable=C0103
+            except OSError as e:  # pylint: disable=C0103
                 if e.errno != errno.EEXIST:
                     logger.error("{0} : {1}", self._source, e.strerror)
 
     def flush(self, timestamp):
         files = self._get_files_to_archive()
-        if len(files) == 0: # pylint: disable=len-as-condition
+        if len(files) == 0:  # pylint: disable=len-as-condition
             return
 
         if self._mkdir(timestamp):
@@ -79,10 +78,10 @@ class StateFlusher(object):
 
     def _get_files_to_archive(self):
         files = []
-        for f in os.listdir(self._source): # pylint: disable=C0103
+        for f in os.listdir(self._source):  # pylint: disable=C0103
             full_path = os.path.join(self._source, f)
             for pattern in CACHE_PATTERNS:
-                m = pattern.match(f) # pylint: disable=C0103
+                m = pattern.match(f)  # pylint: disable=C0103
                 if m is not None:
                     files.append(full_path)
                     break
@@ -90,21 +89,21 @@ class StateFlusher(object):
         return files
 
     def _archive(self, files, timestamp):
-        for f in files: # pylint: disable=C0103
+        for f in files:  # pylint: disable=C0103
             dst = os.path.join(self.history_dir(timestamp), os.path.basename(f))
             shutil.move(f, dst)
 
     def _purge(self, files):
-        for f in files: # pylint: disable=C0103
+        for f in files:  # pylint: disable=C0103
             os.remove(f)
 
     def _mkdir(self, timestamp):
-        d = self.history_dir(timestamp) # pylint: disable=C0103
+        d = self.history_dir(timestamp)  # pylint: disable=C0103
 
         try:
             fileutil.mkdir(d, mode=0o700)
             return True
-        except IOError as e: # pylint: disable=C0103
+        except IOError as e:  # pylint: disable=C0103
             logger.error("{0} : {1}".format(d, e.strerror))
             return False
 
@@ -148,15 +147,15 @@ class State(object):
 
 
 class StateZip(State):
-    def __init__(self, path, timestamp): # pylint: disable=W0235
-        super(StateZip,self).__init__(path, timestamp)
+    def __init__(self, path, timestamp):  # pylint: disable=W0235
+        super(StateZip, self).__init__(path, timestamp)
 
     def delete(self):
         os.remove(self._path)
 
 
 class StateDirectory(State):
-    def __init__(self, path, timestamp): # pylint: disable=W0235
+    def __init__(self, path, timestamp):  # pylint: disable=W0235
         super(StateDirectory, self).__init__(path, timestamp)
 
     def delete(self):
@@ -164,10 +163,10 @@ class StateDirectory(State):
 
     def archive(self):
         fn_tmp = "{0}.zip.tmp".format(self._path)
-        fn = "{0}.zip".format(self._path) # pylint: disable=C0103
+        fn = "{0}.zip".format(self._path)  # pylint: disable=C0103
 
         ziph = zipfile.ZipFile(fn_tmp, 'w')
-        for f in os.listdir(self._path): # pylint: disable=C0103
+        for f in os.listdir(self._path):  # pylint: disable=C0103
             full_path = os.path.join(self._path, f)
             ziph.write(full_path, f, zipfile.ZIP_DEFLATED)
 
@@ -184,7 +183,7 @@ class StateArchiver(object):
         if not os.path.isdir(self._source):
             try:
                 fileutil.mkdir(self._source, mode=0o700)
-            except IOError as e: # pylint: disable=C0103
+            except IOError as e:  # pylint: disable=C0103
                 if e.errno != errno.EEXIST:
                     logger.error("{0} : {1}", self._source, e.strerror)
 
@@ -207,13 +206,13 @@ class StateArchiver(object):
 
     def _get_archive_states(self):
         states = []
-        for f in os.listdir(self._source): # pylint: disable=C0103
+        for f in os.listdir(self._source):  # pylint: disable=C0103
             full_path = os.path.join(self._source, f)
-            m = ARCHIVE_PATTERNS_DIRECTORY.match(f) # pylint: disable=C0103
+            m = ARCHIVE_PATTERNS_DIRECTORY.match(f)  # pylint: disable=C0103
             if m is not None:
                 states.append(StateDirectory(full_path, m.group(0)))
 
-            m = ARCHIVE_PATTERNS_ZIP.match(f) # pylint: disable=C0103
+            m = ARCHIVE_PATTERNS_ZIP.match(f)  # pylint: disable=C0103
             if m is not None:
                 states.append(StateZip(full_path, m.group(0)))
 

--- a/azurelinuxagent/common/utils/archive.py
+++ b/azurelinuxagent/common/utils/archive.py
@@ -48,10 +48,11 @@ _CACHE_PATTERNS = [
 
 _GOAL_STATE_PATTERN = re.compile(r"^(.*)/GoalState\.(\d+)\.xml$", re.IGNORECASE)
 
+# Old names didn't have incarnation, new ones do. Ensure the regex captures both cases.
 # 2018-04-06T08:21:37.142697_incarnation_N
 # 2018-04-06T08:21:37.142697_incarnation_N.zip
-_ARCHIVE_PATTERNS_DIRECTORY = re.compile(r"^\d{4}\-\d{2}\-\d{2}T\d{2}:\d{2}:\d{2}\.\d+_incarnation_(\d+)$")
-_ARCHIVE_PATTERNS_ZIP = re.compile(r"^\d{4}\-\d{2}\-\d{2}T\d{2}:\d{2}:\d{2}\.\d+_incarnation_(\d+)\.zip$")
+_ARCHIVE_PATTERNS_DIRECTORY = re.compile(r"^\d{4}\-\d{2}\-\d{2}T\d{2}:\d{2}:\d{2}\.\d+(_incarnation_(\d+))?$$")
+_ARCHIVE_PATTERNS_ZIP = re.compile(r"^\d{4}\-\d{2}\-\d{2}T\d{2}:\d{2}:\d{2}\.\d+(_incarnation_(\d+))?\.zip$")
 
 
 class StateFlusher(object):

--- a/tests/protocol/test_wire.py
+++ b/tests/protocol/test_wire.py
@@ -1077,21 +1077,21 @@ class UpdateGoalStateTestCase(AgentTestCase):
                 protocol.client.update_goal_state()
 
                 # The initial goal state should be in the archive
-                first_archive_name = datetime.utcfromtimestamp(first_gs_ms).isoformat()
+                first_archive_name = datetime.utcfromtimestamp(first_gs_ms).isoformat() + "_incarnation_1"
                 archives = os.listdir(history_dir)
                 self.assertEqual(len(archives), 1, "Only one goal state should have been archived")
-                self.assertEqual(archives[0], first_archive_name, "The name of goal state archive should match the first goal state timestamp")
+                self.assertEqual(archives[0], first_archive_name, "The name of goal state archive should match the first goal state timestamp and incarnation")
 
                 # Create the third goal state, so the second one should be archived too
                 protocol.mock_wire_data.set_incarnation("3")
                 protocol.client.update_goal_state()
 
                 # The second goal state should be in the archive
-                second_archive_name = datetime.utcfromtimestamp(second_gs_ms).isoformat()
+                second_archive_name = datetime.utcfromtimestamp(second_gs_ms).isoformat() + "_incarnation_2"
                 archives = os.listdir(history_dir)
                 archives.sort()
                 self.assertEqual(len(archives), 2, "Two goal states should have been archived")
-                self.assertEqual(archives[1], second_archive_name, "The name of goal state archive should match the second goal state timestamp")
+                self.assertEqual(archives[1], second_archive_name, "The name of goal state archive should match the second goal state timestamp and incarnation")
 
 # pylint: enable=too-many-public-methods
 

--- a/tests/protocol/test_wire.py
+++ b/tests/protocol/test_wire.py
@@ -1058,7 +1058,7 @@ class UpdateGoalStateTestCase(AgentTestCase):
             self.assertEqual(protocol.client.get_host_plugin().role_config_name, new_role_config_name)
 
     def test_update_goal_state_should_archive_last_goal_state(self):
-        with patch("azurelinuxagent.common.protocol.wire.datetime") as patch_datetime:
+        with patch("azurelinuxagent.common.protocol.goal_state.datetime") as patch_datetime:
             first_gs_timestamp = datetime.utcnow() + timedelta(minutes=5)
             second_gs_timestamp = datetime.utcnow() + timedelta(minutes=10)
             third_gs_timestamp = datetime.utcnow() + timedelta(minutes=15)

--- a/tests/utils/test_archive.py
+++ b/tests/utils/test_archive.py
@@ -9,7 +9,7 @@ import tempfile
 
 import azurelinuxagent.common.logger as logger
 from azurelinuxagent.common.utils import fileutil
-from azurelinuxagent.common.utils.archive import StateFlusher, StateArchiver, MAX_ARCHIVED_STATES
+from azurelinuxagent.common.utils.archive import StateFlusher, StateArchiver, _MAX_ARCHIVED_STATES
 from tests.tools import AgentTestCase
 
 debug = False # pylint: disable=invalid-name
@@ -126,7 +126,7 @@ class TestArchive(AgentTestCase):
         directories are properly deleted from the disk.
         """
         count = 6
-        total = MAX_ARCHIVED_STATES + count
+        total = _MAX_ARCHIVED_STATES + count
 
         start = datetime.now()
         timestamps = []
@@ -148,11 +148,11 @@ class TestArchive(AgentTestCase):
         test_subject.purge()
 
         archived_entries = os.listdir(self.history_dir)
-        self.assertEqual(MAX_ARCHIVED_STATES, len(archived_entries))
+        self.assertEqual(_MAX_ARCHIVED_STATES, len(archived_entries))
 
         archived_entries.sort()
 
-        for i in range(0, MAX_ARCHIVED_STATES):
+        for i in range(0, _MAX_ARCHIVED_STATES):
             ts = timestamps[i + count].isoformat() # pylint: disable=invalid-name
             if i % 2 == 0:
                 fn = ts # pylint: disable=invalid-name

--- a/tests/utils/test_archive.py
+++ b/tests/utils/test_archive.py
@@ -160,7 +160,7 @@ class TestArchive(AgentTestCase):
                 fn = "{0}.zip".format(ts) # pylint: disable=invalid-name
             self.assertTrue(fn in archived_entries, "'{0}' is not in the list of unpurged entires".format(fn))
 
-    def test_archive04(self):
+    def test_archive03(self):
         """
         The archive directory is created if it does not exist.
 


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Today, we archive the last processed goal state when a new goal state comes in. However, we erroneously use the *new* goal state timestamp for that archive instead of when we received the *last* processed goal state. This PR fixed the archive timestamp.

<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).