### PR TITLE
Multiply CPU percentage by number of processors

### DIFF
--- a/azurelinuxagent/common/cgroupstelemetry.py
+++ b/azurelinuxagent/common/cgroupstelemetry.py
@@ -111,13 +111,6 @@ class CGroupsTelemetry(object):
         return metrics
 
     @staticmethod
-    def prune_all_tracked():
-        with CGroupsTelemetry._rlock:
-            for cgroup in CGroupsTelemetry._tracked[:]:
-                if not cgroup.is_active():
-                    CGroupsTelemetry.stop_tracking(cgroup)
-
-    @staticmethod
     def reset():
         with CGroupsTelemetry._rlock:
             CGroupsTelemetry._tracked *= 0  # emptying the list

--- a/tests/common/test_cgroups.py
+++ b/tests/common/test_cgroups.py
@@ -25,7 +25,7 @@ from azurelinuxagent.common.cgroup import CpuCgroup, MemoryCgroup, CGroup
 from azurelinuxagent.common.exception import CGroupsException
 from azurelinuxagent.common.osutil import get_osutil
 from azurelinuxagent.common.utils import fileutil
-from tests.tools import AgentTestCase, patch, data_dir, Mock
+from tests.tools import AgentTestCase, patch, data_dir
 
 
 def consume_cpu_time():

--- a/tests/common/test_cgroupstelemetry.py
+++ b/tests/common/test_cgroupstelemetry.py
@@ -317,20 +317,6 @@ class TestCGroupsTelemetry(AgentTestCase):
         self._assert_cgroups_are_tracked(num_extensions)
         self.assertEqual(num_extensions * num_controllers, len(CGroupsTelemetry._tracked)) # pylint: disable=protected-access
 
-    def test_cgroup_pruning(self, *args): # pylint: disable=unused-argument
-        num_extensions = 5
-        num_controllers = 2
-        self._track_new_extension_cgroups(num_extensions)
-        self._assert_cgroups_are_tracked(num_extensions)
-        self.assertEqual(num_extensions * num_controllers, len(CGroupsTelemetry._tracked)) # pylint: disable=protected-access
-
-        CGroupsTelemetry.prune_all_tracked()
-        for i in range(num_extensions):
-            self.assertFalse(CGroupsTelemetry.is_tracked("dummy_cpu_path_{0}".format(i)))
-            self.assertFalse(CGroupsTelemetry.is_tracked("dummy_memory_path_{0}".format(i)))
-
-        self.assertEqual(0, len(CGroupsTelemetry._tracked)) # pylint: disable=protected-access
-
     def test_cgroup_is_tracked(self, *args): # pylint: disable=unused-argument
         num_extensions = 5
         self._track_new_extension_cgroups(num_extensions)


### PR DESCRIPTION
Changed the CPU usage to multiply by the number of CPUs. This matches the input that systemd takes when setting the CPU quota.

Also, removed some dead code.