### PR TITLE
Add space to inline pylint suppression

### DIFF
--- a/azurelinuxagent/agent.py
+++ b/azurelinuxagent/agent.py
@@ -84,7 +84,7 @@ class Agent(object):
                 raise Exception("{0} is a file".format(ext_log_dir))
             if not os.path.isdir(ext_log_dir):
                 fileutil.mkdir(ext_log_dir, mode=0o755, owner="root")
-        except Exception as e: # pylint: disable=C0103
+        except Exception as e:  # pylint: disable=C0103
             logger.error(
                 "Exception occurred while creating extension "
                 "log directory {0}: {1}".format(ext_log_dir, e))
@@ -185,20 +185,20 @@ class Agent(object):
             archive = log_collector.collect_logs_and_get_archive()
             print("Log collection successfully completed. Archive can be found at {0} "
                   "and detailed log output can be found at {1}".format(archive, OUTPUT_RESULTS_FILE_PATH))
-        except Exception as e: # pylint: disable=C0103
+        except Exception as e:  # pylint: disable=C0103
             print("Log collection completed unsuccessfully. Error: {0}".format(ustr(e)))
             print("Detailed log output can be found at {0}".format(OUTPUT_RESULTS_FILE_PATH))
             sys.exit(1)
 
 
-def main(args=None): # pylint: disable=R0912
+def main(args=None):  # pylint: disable=R0912
     """
     Parse command line arguments, exit with usage() on error.
     Invoke different methods according to different command
     """
     if args is None:
         args = []
-    if len(args) <= 0: # pylint: disable=len-as-condition
+    if len(args) <= 0:  # pylint: disable=len-as-condition
         args = sys.argv[1:]
     command, force, verbose, debug, conf_file_path, log_collector_full_mode = parse_args(args)
     if command == "version":
@@ -232,7 +232,7 @@ def main(args=None): # pylint: disable=R0912
                          traceback.format_exc())
 
 
-def parse_args(sys_args): # pylint: disable=R0912
+def parse_args(sys_args):  # pylint: disable=R0912
     """
     Parse command line arguments
     """
@@ -244,7 +244,7 @@ def parse_args(sys_args): # pylint: disable=R0912
     log_collector_full_mode = False
 
     for arg in sys_args:
-        m = re.match("^(?:[-/]*)configuration-path:([\w/\.\-_]+)", arg) # pylint: disable=W1401,C0103
+        m = re.match("^(?:[-/]*)configuration-path:([\w/\.\-_]+)", arg)  # pylint: disable=W1401,C0103
         if not m is None:
             conf_file_path = m.group(1)
             if not os.path.exists(conf_file_path):
@@ -304,13 +304,13 @@ def usage():
     """
     Return agent usage message
     """
-    s  = "\n" # pylint: disable=C0103
-    s += ("usage: {0} [-verbose] [-force] [-help] " # pylint: disable=C0103
+    s  = "\n"  # pylint: disable=C0103
+    s += ("usage: {0} [-verbose] [-force] [-help] "  # pylint: disable=C0103
            "-configuration-path:<path to configuration file>" 
            "-deprovision[+user]|-register-service|-version|-daemon|-start|"
            "-run-exthandlers|-show-configuration|-collect-logs [-full]"
            "").format(sys.argv[0])
-    s += "\n" # pylint: disable=C0103
+    s += "\n"  # pylint: disable=C0103
     return s
 
 

--- a/azurelinuxagent/common/AgentGlobals.py
+++ b/azurelinuxagent/common/AgentGlobals.py
@@ -1,4 +1,4 @@
-# Microsoft Azure Linux Agent # pylint: disable=C0103
+# Microsoft Azure Linux Agent  # pylint: disable=C0103
 #
 # Copyright 2020 Microsoft Corporation
 #

--- a/azurelinuxagent/common/cgroup.py
+++ b/azurelinuxagent/common/cgroup.py
@@ -29,21 +29,21 @@ from azurelinuxagent.common.utils import fileutil
 MetricValue = namedtuple('Metric', ['category', 'counter', 'instance', 'value'])
 
 
-class MetricsCategory(object): # pylint: disable=R0903
+class MetricsCategory(object):  # pylint: disable=R0903
     MEMORY_CATEGORY = "Memory"
     CPU_CATEGORY = "CPU"
 
 
-class MetricsCounter(object): # pylint: disable=R0903
+class MetricsCounter(object):  # pylint: disable=R0903
     PROCESSOR_PERCENT_TIME = "% Processor Time"
     TOTAL_MEM_USAGE = "Total Memory Usage"
     MAX_MEM_USAGE = "Max Memory Usage"
 
 
-re_user_system_times = re.compile(r'user (\d+)\nsystem (\d+)\n') # pylint: disable=invalid-name
+re_user_system_times = re.compile(r'user (\d+)\nsystem (\d+)\n')  # pylint: disable=invalid-name
 
 
-class CGroupContollers(object): # pylint: disable=R0903
+class CGroupContollers(object):  # pylint: disable=R0903
     CPU = "cpu"
     MEMORY = "memory"
 
@@ -105,8 +105,8 @@ class CGroup(object):
             parameter_filename = self._get_cgroup_file(parameter_name)
             logger.error("File {0} is empty but should not be".format(parameter_filename))
             raise CGroupsException("File {0} is empty but should not be".format(parameter_filename))
-        except Exception as e: # pylint: disable=C0103
-            if isinstance(e, (IOError, OSError)) and e.errno == errno.ENOENT: # pylint: disable=E1101
+        except Exception as e:  # pylint: disable=C0103
+            if isinstance(e, (IOError, OSError)) and e.errno == errno.ENOENT:  # pylint: disable=E1101
                 raise e
             parameter_filename = self._get_cgroup_file(parameter_name)
             raise CGroupsException("Exception while attempting to read {0}".format(parameter_filename), e)
@@ -116,8 +116,8 @@ class CGroup(object):
         try:
             tasks = self._get_parameters("tasks")
             if tasks:
-                return len(tasks) != 0 # pylint: disable=len-as-condition
-        except (IOError, OSError) as e: # pylint: disable=C0103
+                return len(tasks) != 0  # pylint: disable=len-as-condition
+        except (IOError, OSError) as e:  # pylint: disable=C0103
             if e.errno == errno.ENOENT:
                 # only suppressing file not found exceptions.
                 pass
@@ -125,7 +125,7 @@ class CGroup(object):
                 logger.periodic_warn(logger.EVERY_HALF_HOUR,
                                      'Could not get list of tasks from "tasks" file in the cgroup: {0}.'
                                      ' Internal error: {1}'.format(self.path, ustr(e)))
-        except CGroupsException as e: # pylint: disable=C0103
+        except CGroupsException as e:  # pylint: disable=C0103
             logger.periodic_warn(logger.EVERY_HALF_HOUR,
                                  'Could not get list of tasks from "tasks" file in the cgroup: {0}.'
                                  ' Internal error: {1}'.format(self.path, ustr(e)))
@@ -162,8 +162,8 @@ class CpuCgroup(CGroup):
         """
         try:
             cpu_stat = self._get_file_contents('cpuacct.stat')
-        except Exception as e: # pylint: disable=C0103
-            if not isinstance(e, (IOError, OSError)) or e.errno != errno.ENOENT: # pylint: disable=E1101
+        except Exception as e:  # pylint: disable=C0103
+            if not isinstance(e, (IOError, OSError)) or e.errno != errno.ENOENT:  # pylint: disable=E1101
                 raise CGroupsException("Failed to read cpuacct.stat: {0}".format(ustr(e)))
             if not allow_no_such_file_or_directory_error:
                 raise e
@@ -243,8 +243,8 @@ class MemoryCgroup(CGroup):
         usage = None
         try:
             usage = self._get_parameters('memory.usage_in_bytes', first_line_only=True)
-        except Exception as e: # pylint: disable=C0103
-            if isinstance(e, (IOError, OSError)) and e.errno == errno.ENOENT: # pylint: disable=E1101
+        except Exception as e:  # pylint: disable=C0103
+            if isinstance(e, (IOError, OSError)) and e.errno == errno.ENOENT:  # pylint: disable=E1101
                 raise
             raise CGroupsException("Exception while attempting to read {0}".format("memory.usage_in_bytes"), e)
 
@@ -260,8 +260,8 @@ class MemoryCgroup(CGroup):
         usage = None
         try:
             usage = self._get_parameters('memory.max_usage_in_bytes', first_line_only=True)
-        except Exception as e: # pylint: disable=C0103
-            if isinstance(e, (IOError, OSError)) and e.errno == errno.ENOENT: # pylint: disable=E1101
+        except Exception as e:  # pylint: disable=C0103
+            if isinstance(e, (IOError, OSError)) and e.errno == errno.ENOENT:  # pylint: disable=E1101
                 raise
             raise CGroupsException("Exception while attempting to read {0}".format("memory.usage_in_bytes"), e)
 

--- a/azurelinuxagent/common/cgroupapi.py
+++ b/azurelinuxagent/common/cgroupapi.py
@@ -60,7 +60,7 @@ class CGroupsApi(object):
     def get_extension_cgroups(self, extension_name):
         raise NotImplementedError()
 
-    def start_extension_command(self, extension_name, command, timeout, shell, cwd, env, stdout, stderr, error_code): # pylint: disable=R0913
+    def start_extension_command(self, extension_name, command, timeout, shell, cwd, env, stdout, stderr, error_code):  # pylint: disable=R0913
         raise NotImplementedError()
 
     def cleanup_legacy_cgroups(self):
@@ -81,7 +81,7 @@ class CGroupsApi(object):
         try:
             for cgroup in extension_cgroups:
                 CGroupsTelemetry.track_cgroup(cgroup)
-        except Exception as e: # pylint: disable=C0103
+        except Exception as e:  # pylint: disable=C0103
             logger.warn("Cannot add cgroup '{0}' to tracking list; resource usage will not be tracked. "
                         "Error: {1}".format(cgroup.path, ustr(e)))
 
@@ -120,7 +120,7 @@ class CGroupsApi(object):
                     logger.warn('Cgroup controller "{0}" is not mounted. {1}', controller, message)
                 else:
                     operation(controller)
-            except Exception as e: # pylint: disable=C0103
+            except Exception as e:  # pylint: disable=C0103
                 logger.warn('Error in cgroup controller "{0}": {1}. {2}', controller, ustr(e), message)
 
     @staticmethod
@@ -176,9 +176,9 @@ class FileSystemCgroupsApi(CGroupsApi):
         if not os.path.isdir(path):
             try:
                 os.makedirs(path, 0o755)
-            except OSError as e: # pylint: disable=C0103
+            except OSError as e:  # pylint: disable=C0103
                 if e.errno == errno.EEXIST:
-                    if not os.path.isdir(path): # pylint: disable=R1720
+                    if not os.path.isdir(path):  # pylint: disable=R1720
                         raise CGroupsException("Create directory for cgroup {0}: normal file already exists with that name".format(path))
                     else:
                         pass  # There was a race to create the directory, but it's there now, and that's fine
@@ -259,11 +259,11 @@ class FileSystemCgroupsApi(CGroupsApi):
                     if not os.path.exists(target_path):
                         os.symlink(cgroup_path('cpu,cpuacct'), target_path)
 
-        except OSError as oe: # pylint: disable=C0103
+        except OSError as oe:  # pylint: disable=C0103
             # log a warning for read-only file systems
             logger.warn("Could not mount cgroups: {0}", ustr(oe))
             raise
-        except Exception as e: # pylint: disable=C0103
+        except Exception as e:  # pylint: disable=C0103
             logger.error("Could not mount cgroups: {0}", ustr(e))
             raise
 
@@ -303,7 +303,7 @@ class FileSystemCgroupsApi(CGroupsApi):
 
         self._foreach_controller(create_cgroup, 'Failed to create a cgroup for the VM Agent; resource usage will not be tracked')
 
-        if len(cgroups) == 0: # pylint: disable=len-as-condition
+        if len(cgroups) == 0:  # pylint: disable=len-as-condition
             raise CGroupsException("Failed to create any cgroup for the VM Agent")
 
         return cgroups
@@ -372,7 +372,7 @@ class FileSystemCgroupsApi(CGroupsApi):
 
         return cgroups
 
-    def start_extension_command(self, extension_name, command, timeout, shell, cwd, env, stdout, stderr, # pylint: disable=R0913
+    def start_extension_command(self, extension_name, command, timeout, shell, cwd, env, stdout, stderr,  # pylint: disable=R0913
                                 error_code=ExtensionErrorCodes.PluginUnknownFailure):
         """
         Starts a command (install/enable/etc) for an extension and adds the command's PID to the extension's cgroup
@@ -406,11 +406,11 @@ class FileSystemCgroupsApi(CGroupsApi):
                                     "Resource usage will not be tracked. Error: {2}".format(pid,
                                                                                             extension_name,
                                                                                             ustr(exception)))
-            except Exception as e: # pylint: disable=C0103
+            except Exception as e:  # pylint: disable=C0103
                 logger.warn("Failed to add extension {0} to its cgroup. Resource usage will not be tracked. "
                             "Error: {1}".format(extension_name, ustr(e)))
 
-        process = subprocess.Popen(command, # pylint: disable=W1509
+        process = subprocess.Popen(command,  # pylint: disable=W1509
                                    shell=shell,
                                    cwd=cwd,
                                    env=env,
@@ -543,7 +543,7 @@ class SystemdCgroupsApi(CGroupsApi):
         output = shellutil.run_command(["systemctl", "show", unit_name, "--property", property_name])
         match = re.match("[^=]+=(?P<value>.+)", output)
         if match is None:
-            raise ValueError("Can't find property {0} of {1}", property_name, unit_name) # pylint: disable=W0715
+            raise ValueError("Can't find property {0} of {1}", property_name, unit_name)  # pylint: disable=W0715
         return match.group('value')
 
     @staticmethod
@@ -553,7 +553,7 @@ class SystemdCgroupsApi(CGroupsApi):
             fileutil.write_file(unit_path, unit_contents)
             shellutil.run_command(["systemctl", "daemon-reload"])
             shellutil.run_command(["systemctl", "start", unit_filename])
-        except Exception as e: # pylint: disable=C0103
+        except Exception as e:  # pylint: disable=C0103
             raise CGroupsException("Failed to create and start {0}. Error: {1}".format(unit_filename, ustr(e)))
 
     @staticmethod
@@ -606,7 +606,7 @@ After=system-{1}.slice""".format(extension_name, EXTENSIONS_ROOT_CGROUP_NAME)
             shellutil.run_command(["systemctl", "stop", unit_filename])
             fileutil.rm_files(unit_path)
             shellutil.run_command(["systemctl", "daemon-reload"])
-        except Exception as e: # pylint: disable=C0103
+        except Exception as e:  # pylint: disable=C0103
             raise CGroupsException("Failed to remove {0}. Error: {1}".format(unit_filename, ustr(e)))
 
     def get_extension_cgroups(self, extension_name):
@@ -647,7 +647,7 @@ After=system-{1}.slice""".format(extension_name, EXTENSIONS_ROOT_CGROUP_NAME)
         processes = []
 
         for line in output.splitlines():
-            match = re.match('[^\d]*(?P<pid>\d+)\s+(?P<command>.+)', line) # pylint: disable=W1401
+            match = re.match('[^\d]*(?P<pid>\d+)\s+(?P<command>.+)', line)  # pylint: disable=W1401
             if match is not None:
                 processes.append((match.group('pid'), match.group('command')))
 
@@ -660,11 +660,11 @@ After=system-{1}.slice""".format(extension_name, EXTENSIONS_ROOT_CGROUP_NAME)
         unit_not_found = "Unit {0} not found.".format(scope_name)
         return unit_not_found in stderr or scope_name not in stderr
 
-    def start_extension_command(self, extension_name, command, timeout, shell, cwd, env, stdout, stderr, # pylint: disable=R0913
+    def start_extension_command(self, extension_name, command, timeout, shell, cwd, env, stdout, stderr,  # pylint: disable=R0913
                                 error_code=ExtensionErrorCodes.PluginUnknownFailure):
         scope = "{0}_{1}".format(self._get_extension_cgroup_name(extension_name), uuid.uuid4())
 
-        process = subprocess.Popen( # pylint: disable=W1509
+        process = subprocess.Popen(  # pylint: disable=W1509
             "systemd-run --unit={0} --scope {1}".format(scope, command),
             shell=shell,
             cwd=cwd,
@@ -695,11 +695,11 @@ After=system-{1}.slice""".format(extension_name, EXTENSIONS_ROOT_CGROUP_NAME)
                 memory_cgroup_path = os.path.join(memory_cgroup_mountpoint, cgroup_relative_path)
                 CGroupsTelemetry.track_cgroup(MemoryCgroup(extension_name, memory_cgroup_path))
 
-        except IOError as e: # pylint: disable=C0103
+        except IOError as e:  # pylint: disable=C0103
             if e.errno == 2:  # 'No such file or directory'
                 logger.info("The extension command already completed; will not track resource usage")
             logger.info("Failed to start tracking resource usage for the extension: {0}", ustr(e))
-        except Exception as e: # pylint: disable=C0103
+        except Exception as e:  # pylint: disable=C0103
             logger.info("Failed to start tracking resource usage for the extension: {0}", ustr(e))
 
         # Wait for process completion or timeout
@@ -710,19 +710,19 @@ After=system-{1}.slice""".format(extension_name, EXTENSIONS_ROOT_CGROUP_NAME)
                                                        stdout=stdout,
                                                        stderr=stderr,
                                                        error_code=error_code)
-        except ExtensionError as e: # pylint: disable=C0103
+        except ExtensionError as e:  # pylint: disable=C0103
             # The extension didn't terminate successfully. Determine whether it was due to systemd errors or
             # extension errors.
             systemd_failure = self._is_systemd_failure(scope, stderr)
             process_output = read_output(stdout, stderr)
 
-            if not systemd_failure: # pylint: disable=R1720
+            if not systemd_failure:  # pylint: disable=R1720
                 # There was an extension error; it either timed out or returned a non-zero exit code. Re-raise the error
                 raise
             else:
                 # There was an issue with systemd-run. We need to log it and retry the extension without systemd.
                 if isinstance(e, ExtensionOperationError):
-                    err_msg = 'Systemd process exited with code %s and output %s' % (e.exit_code, process_output) # pylint: disable=no-member
+                    err_msg = 'Systemd process exited with code %s and output %s' % (e.exit_code, process_output)  # pylint: disable=no-member
                 else:
                     err_msg = "Systemd timed-out, output: %s" % process_output
                     
@@ -739,7 +739,7 @@ After=system-{1}.slice""".format(extension_name, EXTENSIONS_ROOT_CGROUP_NAME)
                 # Try invoking the process again, this time without systemd-run
                 logger.info('Extension invocation using systemd failed, falling back to regular invocation '
                             'without cgroups tracking.')
-                process = subprocess.Popen(command, # pylint: disable=W1509
+                process = subprocess.Popen(command,  # pylint: disable=W1509
                                            shell=shell,
                                            cwd=cwd,
                                            env=env,

--- a/azurelinuxagent/common/cgroupconfigurator.py
+++ b/azurelinuxagent/common/cgroupconfigurator.py
@@ -334,7 +334,7 @@ class CGroupConfigurator(object):
             #
             r"^ifdown .+ && ifup .+",
         ]
-        for p in patterns: # pylint: disable=C0103
+        for p in patterns:  # pylint: disable=C0103
             if re.match(p, command_line) is not None:
                 return True
         return False

--- a/azurelinuxagent/common/cgroupstelemetry.py
+++ b/azurelinuxagent/common/cgroupstelemetry.py
@@ -43,12 +43,12 @@ class CGroupsTelemetry(object):
         # details from those files.
         try:
             process_cmdline = ProcessInfo.get_proc_cmdline(process_id) if not None else DEFAULT_PROCESS_COMMANDLINE
-        except Exception as e: # pylint: disable=C0103
+        except Exception as e:  # pylint: disable=C0103
             logger.periodic_info(EVERY_SIX_HOURS, "[PERIODIC] {0}", ustr(e))
 
         try:
             process_name = ProcessInfo.get_proc_name(process_id) if not None else DEFAULT_PROCESS_NAME
-        except Exception as e: # pylint: disable=C0103
+        except Exception as e:  # pylint: disable=C0103
             logger.periodic_info(EVERY_SIX_HOURS, "[PERIODIC] {0}", ustr(e))
 
         return process_id + DELIM + process_name + DELIM + process_cmdline
@@ -97,12 +97,12 @@ class CGroupsTelemetry(object):
             for cgroup in CGroupsTelemetry._tracked[:]:
                 try:
                     metrics.extend(cgroup.get_tracked_metrics())
-                except Exception as e: # pylint: disable=C0103
+                except Exception as e:  # pylint: disable=C0103
                     # There can be scenarios when the CGroup has been deleted by the time we are fetching the values
                     # from it. This would raise IOError with file entry not found (ERRNO: 2). We do not want to log
                     # every occurrences of such case as it would be very verbose. We do want to log all the other
                     # exceptions which could occur, which is why we do a periodic log for all the other errors.
-                    if not isinstance(e, (IOError, OSError)) or e.errno != errno.ENOENT: # pylint: disable=E1101
+                    if not isinstance(e, (IOError, OSError)) or e.errno != errno.ENOENT:  # pylint: disable=E1101
                         logger.periodic_warn(logger.EVERY_HOUR, '[PERIODIC] Could not collect metrics for cgroup '
                                                                 '{0}. Error : {1}'.format(cgroup.name, ustr(e)))
                 if not cgroup.is_active():

--- a/azurelinuxagent/common/conf.py
+++ b/azurelinuxagent/common/conf.py
@@ -19,7 +19,7 @@
 
 """
 Module conf loads and parses configuration file
-""" # pylint: disable=W0105
+"""  # pylint: disable=W0105
 import os
 import os.path
 
@@ -55,7 +55,7 @@ class ConfigurationProvider(object):
 
     def get_switch(self, key, default_val):
         val = self.values.get(key)
-        if val is not None and val.lower() == 'y': # pylint: disable=R1705
+        if val is not None and val.lower() == 'y':  # pylint: disable=R1705
             return True
         elif val is not None and val.lower() == 'n':
             return False
@@ -77,7 +77,7 @@ def load_conf_from_file(conf_file_path, conf=__conf__):
     """
     Load conf file from: conf_file_path
     """
-    if os.path.isfile(conf_file_path) == False: # pylint: disable=C0121
+    if os.path.isfile(conf_file_path) == False:  # pylint: disable=C0121
         raise AgentConfigError(("Missing configuration in {0}"
                                 "").format(conf_file_path))
     try:
@@ -459,4 +459,4 @@ def get_cgroups_enforce_limits(conf=__conf__):
 
 def get_cgroups_excluded(conf=__conf__):
     excluded_value = conf.get("CGroups.Excluded", "customscript, runcommand")
-    return [s for s in [i.strip().lower() for i in excluded_value.split(',')] if len(s) > 0] if excluded_value else [] # pylint: disable=len-as-condition
+    return [s for s in [i.strip().lower() for i in excluded_value.split(',')] if len(s) > 0] if excluded_value else []  # pylint: disable=len-as-condition

--- a/azurelinuxagent/common/datacontract.py
+++ b/azurelinuxagent/common/datacontract.py
@@ -27,12 +27,12 @@ Base class for data contracts between guest and host and utilities to manipulate
 # pylint: enable=W0105
 
 
-class DataContract(object): # pylint: disable=R0903
+class DataContract(object):  # pylint: disable=R0903
     pass
 
 
 class DataContractList(list):
-    def __init__(self, item_cls): # pylint: disable=W0231
+    def __init__(self, item_cls):  # pylint: disable=W0231
         self.item_cls = item_cls
 
 
@@ -45,7 +45,7 @@ def validate_param(name, val, expected_type):
 
 
 def set_properties(name, obj, data):
-    if isinstance(obj, DataContract): # pylint: disable=R1705
+    if isinstance(obj, DataContract):  # pylint: disable=R1705
         validate_param("Property '{0}'".format(name), data, dict)
         for prob_name, prob_val in data.items():
             prob_full_name = "{0}.{1}".format(name, prob_name)
@@ -69,7 +69,7 @@ def set_properties(name, obj, data):
 
 
 def get_properties(obj):
-    if isinstance(obj, DataContract): # pylint: disable=R1705
+    if isinstance(obj, DataContract):  # pylint: disable=R1705
         data = {}
         props = vars(obj)
         for prob_name, prob in list(props.items()):

--- a/azurelinuxagent/common/dhcp.py
+++ b/azurelinuxagent/common/dhcp.py
@@ -67,7 +67,7 @@ class DhcpHandler(object):
         Wait for network stack to be initialized.
         """
         ipv4 = self.osutil.get_ip4_addr()
-        while ipv4 == '' or ipv4 == '0.0.0.0': # pylint: disable=R1714
+        while ipv4 == '' or ipv4 == '0.0.0.0':  # pylint: disable=R1714
             logger.info("Waiting for network.")
             time.sleep(10)
             logger.info("Try to start network interface.")
@@ -96,7 +96,7 @@ class DhcpHandler(object):
                 logger.info("Route to {0} exists".format(KNOWN_WIRESERVER_IP))
             else:
                 logger.warn("No route exists to {0}".format(KNOWN_WIRESERVER_IP))
-        except Exception as e: # pylint: disable=C0103
+        except Exception as e:  # pylint: disable=C0103
             logger.error(
                 "Could not determine whether route exists to {0}: {1}".format(
                     KNOWN_WIRESERVER_IP, e))
@@ -116,7 +116,7 @@ class DhcpHandler(object):
         exists = False
 
         logger.info("Checking for dhcp lease cache")
-        cached_endpoint = self.osutil.get_dhcp_lease_endpoint() # pylint: disable=E1128
+        cached_endpoint = self.osutil.get_dhcp_lease_endpoint()  # pylint: disable=E1128
         if cached_endpoint is not None:
             self.endpoint = cached_endpoint
             exists = True
@@ -142,7 +142,7 @@ class DhcpHandler(object):
                 response = socket_send(request)
                 validate_dhcp_resp(request, response)
                 return response
-            except DhcpError as e: # pylint: disable=C0103
+            except DhcpError as e:  # pylint: disable=C0103
                 logger.warn("Failed to send DHCP request: {0}", e)
             time.sleep(duration)
         return None
@@ -197,7 +197,7 @@ class DhcpHandler(object):
         self.endpoint, self.gateway, self.routes = parse_dhcp_resp(resp)
 
 
-def validate_dhcp_resp(request, response): # pylint: disable=R1710
+def validate_dhcp_resp(request, response):  # pylint: disable=R1710
     bytes_recv = len(response)
     if bytes_recv < 0xF6:
         logger.error("HandleDhcpResponse: Too few bytes received:{0}",
@@ -231,7 +231,7 @@ def validate_dhcp_resp(request, response): # pylint: disable=R1710
                         "doesn't match the request")
 
 
-def parse_route(response, option, i, length, bytes_recv): # pylint: disable=W0613
+def parse_route(response, option, i, length, bytes_recv):  # pylint: disable=W0613
     # http://msdn.microsoft.com/en-us/library/cc227282%28PROT.10%29.aspx
     logger.verbose("Routes at offset: {0} with length:{1}", hex(i),
                    hex(length))
@@ -257,7 +257,7 @@ def parse_route(response, option, i, length, bytes_recv): # pylint: disable=W061
 
 
 def parse_ip_addr(response, option, i, length, bytes_recv):
-    if i + 5 < bytes_recv: # pylint: disable=R1705
+    if i + 5 < bytes_recv:  # pylint: disable=R1705
         if length != 4:
             logger.error("Endpoint or Default Gateway not 4 bytes")
             return None
@@ -293,7 +293,7 @@ def parse_dhcp_resp(response):
             length = str_to_ord(response[i + 1])
         logger.verbose("DHCP option {0} at offset:{1} with length:{2}",
                        hex(option), hex(i), hex(length))
-        if option == 255: # pylint: disable=R1723
+        if option == 255:  # pylint: disable=R1723
             logger.verbose("DHCP packet ended at offset:{0}", hex(i))
             break
         elif option == 249:
@@ -327,7 +327,7 @@ def socket_send(request):
                        "entering recv")
         response = sock.recv(1024)
         return response
-    except IOError as e: # pylint: disable=C0103
+    except IOError as e:  # pylint: disable=C0103
         raise DhcpError("{0}".format(e))
     finally:
         if sock is not None:
@@ -374,11 +374,11 @@ def build_dhcp_request(mac_addr, request_broadcast):
     # Opcode = 1
     # HardwareAddressType = 1 (ethernet/MAC)
     # HardwareAddressLength = 6 (ethernet/MAC/48 bits)
-    for a in range(0, 3): # pylint: disable=C0103
+    for a in range(0, 3):  # pylint: disable=C0103
         request[a] = [1, 1, 6][a]
 
     # fill in transaction id (random number to ensure response matches request)
-    for a in range(0, 4): # pylint: disable=C0103
+    for a in range(0, 4):  # pylint: disable=C0103
         request[4 + a] = str_to_ord(trans_id[a])
 
     logger.verbose("BuildDhcpRequest: transactionId:%s,%04X" % (
@@ -392,7 +392,7 @@ def build_dhcp_request(mac_addr, request_broadcast):
         request[0x0A] = 0x80
 
     # fill in ClientHardwareAddress
-    for a in range(0, 6): # pylint: disable=C0103
+    for a in range(0, 6):  # pylint: disable=C0103
         request[0x1C + a] = str_to_ord(mac_addr[a])
 
     # DHCP Magic Cookie: 99, 130, 83, 99
@@ -400,7 +400,7 @@ def build_dhcp_request(mac_addr, request_broadcast):
     # MessageTypeLength = 1
     # MessageType = DHCPDISCOVER
     # End = 255 DHCP_END
-    for a in range(0, 8): # pylint: disable=C0103
+    for a in range(0, 8):  # pylint: disable=C0103
         request[0xEC + a] = [99, 130, 83, 99, 53, 1, 1, 255][a]
     return array.array("B", request)
 

--- a/azurelinuxagent/common/event.py
+++ b/azurelinuxagent/common/event.py
@@ -65,7 +65,7 @@ def send_logs_to_telemetry():
     return SEND_LOGS_TO_TELEMETRY
 
 
-class WALAEventOperation: # pylint: disable=R0903,no-init
+class WALAEventOperation:  # pylint: disable=R0903,no-init
     ActivateResourceDisk = "ActivateResourceDisk"
     AgentBlacklisted = "AgentBlacklisted"
     AgentEnabled = "AgentEnabled"
@@ -144,10 +144,10 @@ class EventStatus(object):
         self._status = {}
         self._save()
 
-    def event_marked(self, name, version, op): # pylint: disable=C0103
+    def event_marked(self, name, version, op):  # pylint: disable=C0103
         return self._event_name(name, version, op) in self._status
 
-    def event_succeeded(self, name, version, op): # pylint: disable=C0103
+    def event_succeeded(self, name, version, op):  # pylint: disable=C0103
         event = self._event_name(name, version, op)
         if event not in self._status:
             return True
@@ -157,29 +157,29 @@ class EventStatus(object):
         self._path = os.path.join(status_dir, EventStatus.EVENT_STATUS_FILE)
         self._load()
 
-    def mark_event_status(self, name, version, op, status): # pylint: disable=C0103
+    def mark_event_status(self, name, version, op, status):  # pylint: disable=C0103
         event = self._event_name(name, version, op)
         self._status[event] = (status is True)
         self._save()
 
-    def _event_name(self, name, version, op): # pylint: disable=C0103
+    def _event_name(self, name, version, op):  # pylint: disable=C0103
         return "{0}-{1}-{2}".format(name, version, op)
 
     def _load(self):
         try:
             self._status = {}
             if os.path.isfile(self._path):
-                with open(self._path, 'r') as f: # pylint: disable=C0103
+                with open(self._path, 'r') as f:  # pylint: disable=C0103
                     self._status = json.load(f)
-        except Exception as e: # pylint: disable=C0103
+        except Exception as e:  # pylint: disable=C0103
             logger.warn("Exception occurred loading event status: {0}".format(e))
             self._status = {}
 
     def _save(self):
         try:
-            with open(self._path, 'w') as f: # pylint: disable=C0103
+            with open(self._path, 'w') as f:  # pylint: disable=C0103
                 json.dump(self._status, f)
-        except Exception as e: # pylint: disable=C0103
+        except Exception as e:  # pylint: disable=C0103
             logger.warn("Exception occurred saving event status: {0}".format(e))
 
 
@@ -203,7 +203,7 @@ def parse_event(data_str):
             return parse_json_event(data_str)
         except ValueError:
             return parse_xml_event(data_str)
-    except Exception as e: # pylint: disable=C0103
+    except Exception as e:  # pylint: disable=C0103
         raise EventError("Error parsing event: {0}".format(ustr(e)))
 
 
@@ -232,11 +232,11 @@ def parse_xml_event(data_str):
             event.parameters.append(parse_xml_param(param_node))
         event.file_type = "xml"
         return event
-    except Exception as e: # pylint: disable=C0103
+    except Exception as e:  # pylint: disable=C0103
         raise ValueError(ustr(e))
 
 
-def _encode_message(op, message): # pylint: disable=C0103
+def _encode_message(op, message):  # pylint: disable=C0103
     """
     Gzip and base64 encode a message based on the operation.
 
@@ -257,7 +257,7 @@ def _encode_message(op, message): # pylint: disable=C0103
     :return: gzip'ed and base64 encoded message, or the original message
     """
 
-    if len(message) == 0: # pylint: disable=len-as-condition
+    if len(message) == 0:  # pylint: disable=len-as-condition
         return message
 
     if op not in SHOULD_ENCODE_MESSAGE_OP:
@@ -271,8 +271,8 @@ def _encode_message(op, message): # pylint: disable=C0103
         return "<>"
 
 
-def _log_event(name, op, message, duration, is_success=True): # pylint: disable=C0103
-    global _EVENT_MSG # pylint: disable=W0603
+def _log_event(name, op, message, duration, is_success=True):  # pylint: disable=C0103
+    global _EVENT_MSG  # pylint: disable=W0603
 
     message = _encode_message(op, message)
     if not is_success:
@@ -385,7 +385,7 @@ class EventLogger(object):
     def _get_ram(osutil):
         try:
             return osutil.get_total_mem()
-        except OSUtilError as e: # pylint: disable=C0103
+        except OSUtilError as e:  # pylint: disable=C0103
             logger.warn("Failed to get RAM info; will be missing from telemetry: {0}", ustr(e))
         return 0
 
@@ -393,7 +393,7 @@ class EventLogger(object):
     def _get_processors(osutil):
         try:
             return osutil.get_processor_cores()
-        except OSUtilError as e: # pylint: disable=C0103
+        except OSUtilError as e:  # pylint: disable=C0103
             logger.warn("Failed to get Processors info; will be missing from telemetry: {0}", ustr(e))
         return 0
 
@@ -403,7 +403,7 @@ class EventLogger(object):
         """
         # create an index of the event parameters for faster updates
         parameters = {}
-        for p in self._common_parameters: # pylint: disable=C0103
+        for p in self._common_parameters:  # pylint: disable=C0103
             parameters[p.name] = p
 
         try:
@@ -411,7 +411,7 @@ class EventLogger(object):
             parameters[CommonTelemetryEventSchema.TenantName].value = vminfo.tenantName
             parameters[CommonTelemetryEventSchema.RoleName].value = vminfo.roleName
             parameters[CommonTelemetryEventSchema.RoleInstanceName].value = vminfo.roleInstanceName
-        except Exception as e: # pylint: disable=C0103
+        except Exception as e:  # pylint: disable=C0103
             logger.warn("Failed to get VM info from goal state; will be missing from telemetry: {0}", ustr(e))
 
         try:
@@ -422,7 +422,7 @@ class EventLogger(object):
             parameters[CommonTelemetryEventSchema.ResourceGroupName].value = imds_info.resourceGroupName
             parameters[CommonTelemetryEventSchema.VMId].value = imds_info.vmId
             parameters[CommonTelemetryEventSchema.ImageOrigin].value = int(imds_info.image_origin)
-        except Exception as e: # pylint: disable=C0103
+        except Exception as e:  # pylint: disable=C0103
             logger.warn("Failed to get IMDS info; will be missing from telemetry: {0}", ustr(e))
 
     def save_event(self, data):
@@ -432,7 +432,7 @@ class EventLogger(object):
 
         try:
             fileutil.mkdir(self.event_dir, mode=0o700)
-        except (IOError, OSError) as e: # pylint: disable=C0103
+        except (IOError, OSError) as e:  # pylint: disable=C0103
             msg = "Failed to create events folder {0}. Error: {1}".format(self.event_dir, ustr(e))
             raise EventError(msg)
 
@@ -446,7 +446,7 @@ class EventLogger(object):
                 oldest_files = existing_events[:-999]
                 for event_file in oldest_files:
                     os.remove(os.path.join(self.event_dir, event_file))
-        except (IOError, OSError) as e: # pylint: disable=C0103
+        except (IOError, OSError) as e:  # pylint: disable=C0103
             msg = "Failed to remove old events from events folder {0}. Error: {1}".format(self.event_dir, ustr(e))
             raise EventError(msg)
 
@@ -456,27 +456,27 @@ class EventLogger(object):
             with open(filename + ".tmp", 'wb+') as hfile:
                 hfile.write(data.encode("utf-8"))
             os.rename(filename + ".tmp", filename + AGENT_EVENT_FILE_EXTENSION)
-        except (IOError, OSError) as e: # pylint: disable=C0103
+        except (IOError, OSError) as e:  # pylint: disable=C0103
             msg = "Failed to write events to file: {0}".format(e)
             raise EventError(msg)
 
     def reset_periodic(self):
         self.periodic_events = {}
 
-    def is_period_elapsed(self, delta, h): # pylint: disable=C0103
+    def is_period_elapsed(self, delta, h):  # pylint: disable=C0103
         return h not in self.periodic_events or \
             (self.periodic_events[h] + delta) <= datetime.now()
 
-    def add_periodic(self, delta, name, op=WALAEventOperation.Unknown, is_success=True, duration=0, # pylint: disable=R0913,C0103
+    def add_periodic(self, delta, name, op=WALAEventOperation.Unknown, is_success=True, duration=0,  # pylint: disable=R0913,C0103
                      version=str(CURRENT_VERSION), message="", log_event=True, force=False):
-        h = hash(name + op + ustr(is_success) + message) # pylint: disable=C0103
+        h = hash(name + op + ustr(is_success) + message)  # pylint: disable=C0103
 
         if force or self.is_period_elapsed(delta, h):
             self.add_event(name, op=op, is_success=is_success, duration=duration,
                            version=version, message=message, log_event=log_event)
             self.periodic_events[h] = datetime.now()
 
-    def add_event(self, name, op=WALAEventOperation.Unknown, is_success=True, duration=0, version=str(CURRENT_VERSION), # pylint: disable=R0913,C0103
+    def add_event(self, name, op=WALAEventOperation.Unknown, is_success=True, duration=0, version=str(CURRENT_VERSION),  # pylint: disable=R0913,C0103
                   message="", log_event=True):
 
         if (not is_success) and log_event:
@@ -494,7 +494,7 @@ class EventLogger(object):
         data = get_properties(event)
         try:
             self.save_event(json.dumps(data))
-        except EventError as e: # pylint: disable=C0103
+        except EventError as e:  # pylint: disable=C0103
             logger.periodic_error(logger.EVERY_FIFTEEN_MINUTES, "[PERIODIC] {0}".format(ustr(e)))
 
     def add_log_event(self, level, message):
@@ -512,7 +512,7 @@ class EventLogger(object):
         except EventError:
             pass
 
-    def add_metric(self, category, counter, instance, value, log_event=False): # pylint: disable=R0913
+    def add_metric(self, category, counter, instance, value, log_event=False):  # pylint: disable=R0913
         """
         Create and save an event which contains a telemetry event.
 
@@ -536,7 +536,7 @@ class EventLogger(object):
         data = get_properties(event)
         try:
             self.save_event(json.dumps(data))
-        except EventError as e: # pylint: disable=C0103
+        except EventError as e:  # pylint: disable=C0103
             logger.periodic_error(logger.EVERY_FIFTEEN_MINUTES, "[PERIODIC] {0}".format(ustr(e)))
 
     @staticmethod
@@ -570,12 +570,12 @@ class EventLogger(object):
 
         # Parsing the log messages containing levels in it
         extract_level_message = log_level_format_parser.search(message)
-        if extract_level_message: # pylint: disable=R1705
+        if extract_level_message:  # pylint: disable=R1705
             return extract_level_message.group(2)  # The message bit
         else:
             # Parsing the log messages without levels in it.
             extract_message = log_format_parser.search(message)
-            if extract_message: # pylint: disable=R1705
+            if extract_message:  # pylint: disable=R1705
                 return extract_message.group(1)  # The message bit
             else:
                 return message
@@ -614,12 +614,12 @@ def elapsed_milliseconds(utc_start):
     if now < utc_start:
         return 0
 
-    d = now - utc_start # pylint: disable=C0103
+    d = now - utc_start  # pylint: disable=C0103
     return int(((d.days * 24 * 60 * 60 + d.seconds) * 1000) + \
                     (d.microseconds / 1000.0))
 
 
-def report_event(op, is_success=True, message='', log_event=True): # pylint: disable=C0103
+def report_event(op, is_success=True, message='', log_event=True):  # pylint: disable=C0103
     add_event(AGENT_NAME,
               version=str(CURRENT_VERSION),
               is_success=is_success,
@@ -628,7 +628,7 @@ def report_event(op, is_success=True, message='', log_event=True): # pylint: dis
               log_event=log_event)
 
 
-def report_periodic(delta, op, is_success=True, message=''): # pylint: disable=C0103
+def report_periodic(delta, op, is_success=True, message=''):  # pylint: disable=C0103
     add_periodic(delta, AGENT_NAME,
                  version=str(CURRENT_VERSION),
                  is_success=is_success,
@@ -636,7 +636,7 @@ def report_periodic(delta, op, is_success=True, message=''): # pylint: disable=C
                  op=op)
 
 
-def report_metric(category, counter, instance, value, log_event=False, reporter=__event_logger__): # pylint: disable=R0913
+def report_metric(category, counter, instance, value, log_event=False, reporter=__event_logger__):  # pylint: disable=R0913
     """
     Send a telemetry event reporting a single instance of a performance counter.
     :param str category: The category of the metric (cpu, memory, etc)
@@ -662,7 +662,7 @@ def initialize_event_logger_vminfo_common_parameters(protocol, reporter=__event_
     reporter.initialize_vminfo_common_parameters(protocol)
 
 
-def add_event(name=AGENT_NAME, op=WALAEventOperation.Unknown, is_success=True, duration=0, version=str(CURRENT_VERSION), # pylint: disable=R0913,C0103
+def add_event(name=AGENT_NAME, op=WALAEventOperation.Unknown, is_success=True, duration=0, version=str(CURRENT_VERSION),  # pylint: disable=R0913,C0103
               message="", log_event=True, reporter=__event_logger__):
     if reporter.event_dir is None:
         logger.warn("Cannot add event -- Event reporter is not initialized.")
@@ -695,7 +695,7 @@ def add_log_event(level, message, forced=False, reporter=__event_logger__):
         reporter.add_log_event(level, message)
 
 
-def add_periodic(delta, name, op=WALAEventOperation.Unknown, is_success=True, duration=0, version=str(CURRENT_VERSION), # pylint: disable=R0913,C0103
+def add_periodic(delta, name, op=WALAEventOperation.Unknown, is_success=True, duration=0, version=str(CURRENT_VERSION),  # pylint: disable=R0913,C0103
                  message="", log_event=True, force=False, reporter=__event_logger__):
     if reporter.event_dir is None:
         logger.warn("Cannot add periodic event -- Event reporter is not initialized.")
@@ -706,12 +706,12 @@ def add_periodic(delta, name, op=WALAEventOperation.Unknown, is_success=True, du
                           message=message, log_event=log_event, force=force)
 
 
-def mark_event_status(name, version, op, status): # pylint: disable=C0103
+def mark_event_status(name, version, op, status):  # pylint: disable=C0103
     if op in __event_status_operations__:
         __event_status__.mark_event_status(name, version, op, status)
 
 
-def should_emit_event(name, version, op, status): # pylint: disable=C0103
+def should_emit_event(name, version, op, status):  # pylint: disable=C0103
     return \
         op not in __event_status_operations__ or \
         __event_status__ is None or \

--- a/azurelinuxagent/common/exception.py
+++ b/azurelinuxagent/common/exception.py
@@ -87,7 +87,7 @@ class ExtensionUpdateError(ExtensionError):
     When failed to update an extension
     """
 
-    def __init__(self, msg=None, inner=None, code=-1): # pylint: disable=W0235
+    def __init__(self, msg=None, inner=None, code=-1):  # pylint: disable=W0235
         super(ExtensionUpdateError, self).__init__(msg, inner, code)
 
 
@@ -96,7 +96,7 @@ class ExtensionDownloadError(ExtensionError):
     When failed to download and setup an extension
     """
 
-    def __init__(self, msg=None, inner=None, code=-1): # pylint: disable=W0235
+    def __init__(self, msg=None, inner=None, code=-1):  # pylint: disable=W0235
         super(ExtensionDownloadError, self).__init__(msg, inner, code)
 
 
@@ -150,7 +150,7 @@ class ProtocolNotFoundError(ProtocolError):
     Azure protocol endpoint not found
     """
 
-    def __init__(self, msg=None, inner=None): # pylint: disable=W0235
+    def __init__(self, msg=None, inner=None):  # pylint: disable=W0235
         super(ProtocolNotFoundError, self).__init__(msg, inner)
 
 
@@ -168,7 +168,7 @@ class InvalidContainerError(HttpError):
     Container id sent in the header is invalid
     """
 
-    def __init__(self, msg=None, inner=None): # pylint: disable=W0235
+    def __init__(self, msg=None, inner=None):  # pylint: disable=W0235
         super(InvalidContainerError, self).__init__(msg, inner)
 
 
@@ -231,7 +231,7 @@ class ServiceStoppedError(AgentError):
         super(ServiceStoppedError, self).__init__(msg, inner)
 
 
-class ExtensionErrorCodes(object): # pylint: disable=R0903
+class ExtensionErrorCodes(object):  # pylint: disable=R0903
     """
     Common Error codes used across by Compute RP for better understanding
     the cause and clarify common occurring errors

--- a/azurelinuxagent/common/future.py
+++ b/azurelinuxagent/common/future.py
@@ -6,7 +6,7 @@ import re
 # Note broken dependency handling to avoid potential backward
 # compatibility issues on different distributions
 try:
-    import distro # pylint: disable=E0401
+    import distro  # pylint: disable=E0401
 except Exception:
     pass
 
@@ -17,13 +17,13 @@ Add alias for python2 and python3 libs and functions.
 # pylint: enable=W0105
 
 if sys.version_info[0] == 3:
-    import http.client as httpclient # pylint: disable=W0611,import-error
-    from urllib.parse import urlparse # pylint: disable=W0611,import-error,no-name-in-module
+    import http.client as httpclient  # pylint: disable=W0611,import-error
+    from urllib.parse import urlparse  # pylint: disable=W0611,import-error,no-name-in-module
 
-    """Rename Python3 str to ustr""" # pylint: disable=W0105
-    ustr = str # pylint: disable=C0103
+    """Rename Python3 str to ustr"""  # pylint: disable=W0105
+    ustr = str  # pylint: disable=C0103
 
-    bytebuffer = memoryview # pylint: disable=C0103
+    bytebuffer = memoryview  # pylint: disable=C0103
 
     # We aren't using these imports in this file, but we want them to be available
     # to import from this module in others.
@@ -31,14 +31,14 @@ if sys.version_info[0] == 3:
     # as well.
 
     # unused-import<W0611>, import-error<E0401> Disabled: Due to backward compatibility between py2 and py3
-    from builtins import int, range # pylint: disable=unused-import,import-error
-    from collections import OrderedDict # pylint: disable=W0611
-    from queue import Queue, Empty # pylint: disable=W0611,import-error
+    from builtins import int, range  # pylint: disable=unused-import,import-error
+    from collections import OrderedDict  # pylint: disable=W0611
+    from queue import Queue, Empty  # pylint: disable=W0611,import-error
 
 elif sys.version_info[0] == 2:
-    import httplib as httpclient # pylint: disable=E0401,W0611
-    from urlparse import urlparse # pylint: disable=E0401
-    from Queue import Queue, Empty # pylint: disable=W0611,import-error
+    import httplib as httpclient  # pylint: disable=E0401,W0611
+    from urlparse import urlparse  # pylint: disable=E0401
+    from Queue import Queue, Empty  # pylint: disable=W0611,import-error
 
     
     # We want to suppress the following:
@@ -62,9 +62,9 @@ elif sys.version_info[0] == 2:
     # pylint: enable=undefined-variable,invalid-name,redefined-builtin
 
     if sys.version_info[1] >= 7:
-        from collections import OrderedDict  # For Py 2.7+ # pylint: disable=C0412
+        from collections import OrderedDict  # For Py 2.7+  # pylint: disable=C0412
     else:
-        from ordereddict import OrderedDict  # Works only on 2.6 # pylint: disable=E0401
+        from ordereddict import OrderedDict  # Works only on 2.6  # pylint: disable=E0401
 else:
     raise ImportError("Unknown python version: {0}".format(sys.version_info))
 
@@ -73,9 +73,9 @@ def get_linux_distribution(get_full_name, supported_dists):
     """Abstract platform.linux_distribution() call which is deprecated as of
        Python 3.5 and removed in Python 3.7"""
     try:
-        supported = platform._supported_dists + (supported_dists,) # pylint: disable=W0212
+        supported = platform._supported_dists + (supported_dists,)  # pylint: disable=W0212
         osinfo = list(
-            platform.linux_distribution( # pylint: disable=W1505
+            platform.linux_distribution(  # pylint: disable=W1505
                 full_distribution_name=get_full_name,
                 supported_dists=supported
             )
@@ -88,7 +88,7 @@ def get_linux_distribution(get_full_name, supported_dists):
 
         if not osinfo or osinfo == ['', '', '']:
             return get_linux_distribution_from_distro(get_full_name)
-        full_name = platform.linux_distribution()[0].strip() # pylint: disable=W1505
+        full_name = platform.linux_distribution()[0].strip()  # pylint: disable=W1505
         osinfo.append(full_name)
     except AttributeError:
         return get_linux_distribution_from_distro(get_full_name)
@@ -120,7 +120,7 @@ def get_openwrt_platform():
     openwrt_version = re.compile(r"^DISTRIB_RELEASE=['\"](\d+\.\d+.\d+)['\"]")
     openwrt_product = re.compile(r"^DISTRIB_ID=['\"]([\w-]+)['\"]")
 
-    with open('/etc/openwrt_release', 'r') as fh: # pylint: disable=C0103
+    with open('/etc/openwrt_release', 'r') as fh:  # pylint: disable=C0103
         content = fh.readlines()
         for line in content:
             version_matches = openwrt_version.match(line)

--- a/azurelinuxagent/common/logcollector.py
+++ b/azurelinuxagent/common/logcollector.py
@@ -63,7 +63,7 @@ _UNCOMPRESSED_ARCHIVE_SIZE_LIMIT = 150 * 1024 * 1024  # 150 MB
 _LOGGER = logging.getLogger(__name__)
 
 
-class LogCollector(object): # pylint: disable=R0903
+class LogCollector(object):  # pylint: disable=R0903
 
     _TRUNCATED_FILE_PREFIX = "truncated_"
 
@@ -118,7 +118,7 @@ class LogCollector(object): # pylint: disable=R0903
             process = subprocess.Popen(command, stdin=subprocess.PIPE, stdout=stdout, stderr=subprocess.PIPE, shell=False)
             stdout, stderr = process.communicate()
             return_code = process.returncode
-        except Exception as e: # pylint: disable=C0103
+        except Exception as e:  # pylint: disable=C0103
             error_msg = u"Command [{0}] raised unexpected exception: [{1}]".format(format_command(command), ustr(e))
             _LOGGER.error(error_msg)
             return
@@ -171,7 +171,7 @@ class LogCollector(object): # pylint: disable=R0903
         # (leading separator is removed by the archive).
         # For truncated files: /var/lib/waagent/logcollector/truncated/var/log/syslog.1 on disk becomes
         # truncated_var_log_syslog.1 in the archive.
-        if file_name.startswith(_TRUNCATED_FILES_DIR): # pylint: disable=R1705
+        if file_name.startswith(_TRUNCATED_FILES_DIR):  # pylint: disable=R1705
             original_file_path = file_name[len(_TRUNCATED_FILES_DIR):].lstrip(os.path.sep)
             archive_file_name = LogCollector._TRUNCATED_FILE_PREFIX + original_file_path.replace(os.path.sep, "_")
             return archive_file_name
@@ -221,7 +221,7 @@ class LogCollector(object): # pylint: disable=R0903
             contents = entry.split(",")
             if len(contents) != 2:
                 # If it's not a comment or an empty line, it's a malformed entry
-                if not entry.startswith("#") and len(entry.strip()) > 0: # pylint: disable=len-as-condition
+                if not entry.startswith("#") and len(entry.strip()) > 0:  # pylint: disable=len-as-condition
                     _LOGGER.error("Couldn't parse \"%s\"", entry)
                 continue
 
@@ -258,11 +258,11 @@ class LogCollector(object): # pylint: disable=R0903
                     return truncated_file_path
 
             # Get the last N bytes of the file
-            with open(truncated_file_path, "w+") as fh: # pylint: disable=C0103
+            with open(truncated_file_path, "w+") as fh:  # pylint: disable=C0103
                 LogCollector._run_shell_command(["tail", "-c", str(_FILE_SIZE_LIMIT), file_path], stdout=fh)
 
             return truncated_file_path
-        except OSError as e: # pylint: disable=C0103
+        except OSError as e:  # pylint: disable=C0103
             _LOGGER.error("Failed to truncate large file: %s", ustr(e))
             return None
 
@@ -361,7 +361,7 @@ class LogCollector(object): # pylint: disable=R0903
                 compressed_archive.write(OUTPUT_RESULTS_FILE_PATH.encode("utf-8"), arcname="results.txt")
 
             return COMPRESSED_ARCHIVE_PATH
-        except Exception as e: # pylint: disable=C0103
+        except Exception as e:  # pylint: disable=C0103
             msg = "Failed to collect logs: {0}".format(ustr(e))
             _LOGGER.error(msg)
 

--- a/azurelinuxagent/common/logger.py
+++ b/azurelinuxagent/common/logger.py
@@ -52,12 +52,12 @@ class Logger(object):
     def set_prefix(self, prefix):
         self.prefix = prefix
 
-    def _is_period_elapsed(self, delta, h): # pylint: disable=C0103
+    def _is_period_elapsed(self, delta, h):  # pylint: disable=C0103
         return h not in self.logger.periodic_messages or \
             (self.logger.periodic_messages[h] + delta) <= datetime.now()
 
     def _periodic(self, delta, log_level_op, msg_format, *args):
-        h = hash(msg_format) # pylint: disable=C0103
+        h = hash(msg_format)  # pylint: disable=C0103
         if self._is_period_elapsed(delta, h):
             log_level_op(msg_format, *args)
             self.logger.periodic_messages[h] = datetime.now()
@@ -87,7 +87,7 @@ class Logger(object):
         self.log(LogLevel.ERROR, msg_format, *args)
 
     def log(self, level, msg_format, *args):
-        def write_log(log_appender): # pylint: disable=W0612
+        def write_log(log_appender):  # pylint: disable=W0612
             """
             The appender_lock flag is used to signal if the logger is currently in use. This prevents a subsequent log
             coming in due to writing of a log statement to be not written.
@@ -125,9 +125,9 @@ class Logger(object):
                     log_appender.appender_lock = False
 
         # if msg_format is not unicode convert it to unicode
-        if type(msg_format) is not ustr: # pylint: disable=C0123
+        if type(msg_format) is not ustr:  # pylint: disable=C0123
             msg_format = ustr(msg_format, errors="backslashreplace")
-        if len(args) > 0: # pylint: disable=len-as-condition
+        if len(args) > 0:  # pylint: disable=len-as-condition
             msg = msg_format.format(*args)
         else:
             msg = msg_format
@@ -178,7 +178,7 @@ class Logger(object):
         self.appenders = [appender for appender in self.appenders if not isinstance(appender, ConsoleAppender)]
 
 
-class Appender(object): # pylint: disable=R0903
+class Appender(object):  # pylint: disable=R0903
     def __init__(self, level):
         self.appender_lock = False
         self.level = level
@@ -187,7 +187,7 @@ class Appender(object): # pylint: disable=R0903
         pass
 
 
-class ConsoleAppender(Appender): # pylint: disable=R0903
+class ConsoleAppender(Appender):  # pylint: disable=R0903
     def __init__(self, level, path):
         super(ConsoleAppender, self).__init__(level)
         self.path = path
@@ -201,7 +201,7 @@ class ConsoleAppender(Appender): # pylint: disable=R0903
                 pass
 
 
-class FileAppender(Appender): # pylint: disable=R0903
+class FileAppender(Appender):  # pylint: disable=R0903
     def __init__(self, level, path):
         super(FileAppender, self).__init__(level)
         self.path = path
@@ -215,8 +215,8 @@ class FileAppender(Appender): # pylint: disable=R0903
                 pass
 
 
-class StdoutAppender(Appender): # pylint: disable=R0903
-    def __init__(self, level): # pylint: disable=W0235
+class StdoutAppender(Appender):  # pylint: disable=R0903
+    def __init__(self, level):  # pylint: disable=W0235
         super(StdoutAppender, self).__init__(level)
 
     def write(self, level, msg):
@@ -227,7 +227,7 @@ class StdoutAppender(Appender): # pylint: disable=R0903
                 pass
 
 
-class TelemetryAppender(Appender): # pylint: disable=R0903
+class TelemetryAppender(Appender):  # pylint: disable=R0903
     def __init__(self, level, event_func):
         super(TelemetryAppender, self).__init__(level)
         self.event_func = event_func
@@ -244,7 +244,7 @@ class TelemetryAppender(Appender): # pylint: disable=R0903
 DEFAULT_LOGGER = Logger()
 
 
-class LogLevel(object): # pylint: disable=R0903
+class LogLevel(object):  # pylint: disable=R0903
     VERBOSE = 0
     INFO = 1
     WARNING = 2
@@ -257,7 +257,7 @@ class LogLevel(object): # pylint: disable=R0903
     ]
 
 
-class AppenderType(object): # pylint: disable=R0903
+class AppenderType(object):  # pylint: disable=R0903
     FILE = 0
     CONSOLE = 1
     STDOUT = 2
@@ -337,7 +337,7 @@ def log(level, msg_format, *args):
 
 
 def _create_logger_appender(appender_type, level=LogLevel.INFO, path=None):
-    if appender_type == AppenderType.CONSOLE: # pylint: disable=R1705
+    if appender_type == AppenderType.CONSOLE:  # pylint: disable=R1705
         return ConsoleAppender(level, path)
     elif appender_type == AppenderType.FILE:
         return FileAppender(level, path)

--- a/azurelinuxagent/common/osutil/alpine.py
+++ b/azurelinuxagent/common/osutil/alpine.py
@@ -37,8 +37,8 @@ class AlpineOSUtil(DefaultOSUtil):
     def restart_if(self, ifname, retries=None, wait=None):
         logger.info('restarting {} (sort of, actually SIGHUPing dhcpcd)'.format(ifname))
         pid = self.get_dhcp_pid()
-        if pid != None: # pylint: disable=C0121
-            ret = shellutil.run_get_output('kill -HUP {}'.format(pid)) # pylint: disable=W0612
+        if pid != None:  # pylint: disable=C0121
+            ret = shellutil.run_get_output('kill -HUP {}'.format(pid))  # pylint: disable=W0612
 
     def set_ssh_client_alive_interval(self):
         # Alpine will handle this.

--- a/azurelinuxagent/common/osutil/arch.py
+++ b/azurelinuxagent/common/osutil/arch.py
@@ -16,7 +16,7 @@
 # Requires Python 2.6+ and Openssl 1.0+
 #
 
-import os # pylint: disable=W0611
+import os  # pylint: disable=W0611
 import azurelinuxagent.common.utils.shellutil as shellutil
 from azurelinuxagent.common.osutil.default import DefaultOSUtil
 

--- a/azurelinuxagent/common/osutil/bigip.py
+++ b/azurelinuxagent/common/osutil/bigip.py
@@ -42,7 +42,7 @@ except ImportError:
 
 class BigIpOSUtil(DefaultOSUtil):
 
-    def __init__(self): # pylint: disable=W0235
+    def __init__(self):  # pylint: disable=W0235
         super(BigIpOSUtil, self).__init__()
 
     def _wait_until_mcpd_is_initialized(self):
@@ -58,10 +58,10 @@ class BigIpOSUtil(DefaultOSUtil):
         :raises OSUtilError: Raises exception if mcpd does not come up within
                              roughly 50 minutes (100 * 30 seconds)
         """
-        for retries in range(1, 100): # pylint: disable=W0612
+        for retries in range(1, 100):  # pylint: disable=W0612
             # Retry until mcpd completes startup:
             logger.info("Checking to see if mcpd is up")
-            rc = shellutil.run("/usr/bin/tmsh -a show sys mcp-state field-fmt 2>/dev/null | grep phase | grep running", chk_err=False) # pylint: disable=C0103
+            rc = shellutil.run("/usr/bin/tmsh -a show sys mcp-state field-fmt 2>/dev/null | grep phase | grep running", chk_err=False)  # pylint: disable=C0103
             if rc == 0:
                 logger.info("mcpd is up!")
                 break
@@ -76,7 +76,7 @@ class BigIpOSUtil(DefaultOSUtil):
 
     def _save_sys_config(self):
         cmd = "/usr/bin/tmsh save sys config"
-        rc = shellutil.run(cmd) # pylint: disable=C0103
+        rc = shellutil.run(cmd)  # pylint: disable=C0103
         if rc != 0:
             logger.error("WARNING: Cannot save sys config on 1st boot.")
         return rc
@@ -230,7 +230,7 @@ class BigIpOSUtil(DefaultOSUtil):
     # option _not_ accepted by the original). Additionally, this method allows us
     # to keep the defaults for mount_dvd in one place (the original function) instead
     # of having to duplicate it here as well. 
-    def mount_dvd(self, **kwargs): # pylint: disable=W0221
+    def mount_dvd(self, **kwargs):  # pylint: disable=W0221
         """Mount the DVD containing the provisioningiso.iso file
 
         This is the _first_ hook that WAAgent provides for us, so this is the
@@ -292,11 +292,11 @@ class BigIpOSUtil(DefaultOSUtil):
             iface = self._format_single_interface_name(sock, i)
 
             # Azure public was returning "lo:1" when deploying WAF
-            if b'lo' in iface: # pylint: disable=R1724
+            if b'lo' in iface:  # pylint: disable=R1724
                 continue
             else:
                 break
-        return iface.decode('latin-1'), socket.inet_ntoa(sock[i+20:i+24]) # pylint: disable=undefined-loop-variable
+        return iface.decode('latin-1'), socket.inet_ntoa(sock[i+20:i+24])  # pylint: disable=undefined-loop-variable
 
     def _format_single_interface_name(self, sock, offset):
         return sock[offset:offset+16].split(b'\0', 1)[0]
@@ -322,9 +322,9 @@ class BigIpOSUtil(DefaultOSUtil):
         :param port_id:
         :return:
         """
-        for retries in range(1, 100): # pylint: disable=W0612
+        for retries in range(1, 100):  # pylint: disable=W0612
             # Retry until devices are ready
-            if os.path.exists("/sys/bus/vmbus/devices/"): # pylint: disable=R1723
+            if os.path.exists("/sys/bus/vmbus/devices/"):  # pylint: disable=R1723
                 break
             else:
                 time.sleep(10)

--- a/azurelinuxagent/common/osutil/clearlinux.py
+++ b/azurelinuxagent/common/osutil/clearlinux.py
@@ -16,22 +16,22 @@
 # Requires Python 2.6+ and Openssl 1.0+
 #
 
-import os # pylint: disable=W0611
-import re # pylint: disable=W0611
-import pwd # pylint: disable=W0611
-import shutil # pylint: disable=W0611
-import socket # pylint: disable=W0611
-import array # pylint: disable=W0611
-import struct # pylint: disable=W0611
-import fcntl # pylint: disable=W0611
-import time # pylint: disable=W0611
-import base64 # pylint: disable=W0611
+import os  # pylint: disable=W0611
+import re  # pylint: disable=W0611
+import pwd  # pylint: disable=W0611
+import shutil  # pylint: disable=W0611
+import socket  # pylint: disable=W0611
+import array  # pylint: disable=W0611
+import struct  # pylint: disable=W0611
+import fcntl  # pylint: disable=W0611
+import time  # pylint: disable=W0611
+import base64  # pylint: disable=W0611
 import errno
 import azurelinuxagent.common.conf as conf
-import azurelinuxagent.common.logger as logger # pylint: disable=W0611
+import azurelinuxagent.common.logger as logger  # pylint: disable=W0611
 import azurelinuxagent.common.utils.fileutil as fileutil
 import azurelinuxagent.common.utils.shellutil as shellutil
-import azurelinuxagent.common.utils.textutil as textutil # pylint: disable=W0611
+import azurelinuxagent.common.utils.textutil as textutil  # pylint: disable=W0611
 from azurelinuxagent.common.osutil.default import DefaultOSUtil
 from azurelinuxagent.common.exception import OSUtilError
 
@@ -91,6 +91,6 @@ class ClearLinuxUtil(DefaultOSUtil):
                 new_passwd = [x for x in passwd if not x.startswith("root:")]
                 new_passwd.insert(0, "root:*LOCK*:14600::::::")
             fileutil.write_file(passwd_file_path, "\n".join(new_passwd))
-        except IOError as e: # pylint: disable=C0103
+        except IOError as e:  # pylint: disable=C0103
             raise OSUtilError("Failed to delete root password:{0}".format(e))
-        pass # pylint: disable=W0107
+        pass  # pylint: disable=W0107

--- a/azurelinuxagent/common/osutil/debian.py
+++ b/azurelinuxagent/common/osutil/debian.py
@@ -16,20 +16,20 @@
 # Requires Python 2.6+ and Openssl 1.0+
 #
 
-import os # pylint: disable=W0611
-import re # pylint: disable=W0611
-import pwd # pylint: disable=W0611
-import shutil # pylint: disable=W0611
-import socket # pylint: disable=W0611
-import array # pylint: disable=W0611
-import struct # pylint: disable=W0611
-import fcntl # pylint: disable=W0611
-import time # pylint: disable=W0611
-import base64 # pylint: disable=W0611
-import azurelinuxagent.common.logger as logger # pylint: disable=W0611
-import azurelinuxagent.common.utils.fileutil as fileutil # pylint: disable=W0611
+import os  # pylint: disable=W0611
+import re  # pylint: disable=W0611
+import pwd  # pylint: disable=W0611
+import shutil  # pylint: disable=W0611
+import socket  # pylint: disable=W0611
+import array  # pylint: disable=W0611
+import struct  # pylint: disable=W0611
+import fcntl  # pylint: disable=W0611
+import time  # pylint: disable=W0611
+import base64  # pylint: disable=W0611
+import azurelinuxagent.common.logger as logger  # pylint: disable=W0611
+import azurelinuxagent.common.utils.fileutil as fileutil  # pylint: disable=W0611
 import azurelinuxagent.common.utils.shellutil as shellutil
-import azurelinuxagent.common.utils.textutil as textutil # pylint: disable=W0611
+import azurelinuxagent.common.utils.textutil as textutil  # pylint: disable=W0611
 from azurelinuxagent.common.osutil.default import DefaultOSUtil
 
 

--- a/azurelinuxagent/common/osutil/default.py
+++ b/azurelinuxagent/common/osutil/default.py
@@ -1,4 +1,4 @@
-# # pylint: disable=C0302
+#  # pylint: disable=C0302
 # Copyright 2018 Microsoft Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -977,7 +977,7 @@ class DefaultOSUtil(object):  # pylint: disable=R0904
         return None
 
     @staticmethod
-    def get_endpoint_from_leases_path(pathglob): # pylint: disable=R0912
+    def get_endpoint_from_leases_path(pathglob):  # pylint: disable=R0912
         """
         Try to discover and decode the wireserver endpoint in the
         specified dhcp leases path.
@@ -1410,7 +1410,7 @@ class DefaultOSUtil(object):  # pylint: disable=R0904
 
         self._update_nic_state(state, "ip -4 -a -o address", NetworkInterfaceCard.add_ipv4, "an IPv4 address")
         # pylint: disable=W0105
-        """ # pylint: disable=W1401
+        """  # pylint: disable=W1401
         1: lo    inet 127.0.0.1/8 scope host lo\       valid_lft forever preferred_lft forever
         2: eth0    inet 10.145.187.220/26 brd 10.145.187.255 scope global eth0\       valid_lft forever preferred_lft forever
         3: docker0    inet 192.168.43.1/24 brd 192.168.43.255 scope global docker0\       valid_lft forever preferred_lft forever
@@ -1419,7 +1419,7 @@ class DefaultOSUtil(object):  # pylint: disable=R0904
 
         self._update_nic_state(state, "ip -6 -a -o address", NetworkInterfaceCard.add_ipv6, "an IPv6 address")
         # pylint: disable=W0105
-        """ # pylint: disable=W1401
+        """  # pylint: disable=W1401
         1: lo    inet6 ::1/128 scope host \       valid_lft forever preferred_lft forever
         2: eth0    inet6 fe80::20d:3aff:fe30:c35a/64 scope link \       valid_lft forever preferred_lft forever
         """

--- a/azurelinuxagent/common/osutil/factory.py
+++ b/azurelinuxagent/common/osutil/factory.py
@@ -16,7 +16,7 @@
 #
 
 
-from distutils.version import LooseVersion as Version # pylint: disable=no-name-in-module, import-error
+from distutils.version import LooseVersion as Version  # pylint: disable=no-name-in-module, import-error
 
 import azurelinuxagent.common.logger as logger
 from azurelinuxagent.common.version import DISTRO_NAME, DISTRO_CODE_NAME, DISTRO_VERSION, DISTRO_FULL_NAME
@@ -50,7 +50,7 @@ def get_osutil(distro_name=DISTRO_NAME,
     return _get_osutil(distro_name, distro_code_name, distro_version, distro_full_name)
 
 
-def _get_osutil(distro_name, distro_code_name, distro_version, distro_full_name): # pylint: disable=R0912,R0911
+def _get_osutil(distro_name, distro_code_name, distro_version, distro_full_name):  # pylint: disable=R0912,R0911
 
     if distro_name == "arch":
         return ArchUtil()
@@ -59,7 +59,7 @@ def _get_osutil(distro_name, distro_code_name, distro_version, distro_full_name)
         return ClearLinuxUtil()
 
     if distro_name == "ubuntu":
-        if Version(distro_version) in [Version("12.04"), Version("12.10")]: # pylint: disable=R1705
+        if Version(distro_version) in [Version("12.04"), Version("12.10")]:  # pylint: disable=R1705
             return Ubuntu12OSUtil()
         elif Version(distro_version) in [Version("14.04"), Version("14.10")]:
             return Ubuntu14OSUtil()
@@ -93,7 +93,7 @@ def _get_osutil(distro_name, distro_code_name, distro_version, distro_full_name)
             return SUSEOSUtil()
 
     if distro_name == "debian":
-        if "sid" in distro_version or Version(distro_version) > Version("7"): # pylint: disable=R1705
+        if "sid" in distro_version or Version(distro_version) > Version("7"):  # pylint: disable=R1705
             return DebianOSModernUtil()
         else:
             return DebianOSBaseUtil()
@@ -102,7 +102,7 @@ def _get_osutil(distro_name, distro_code_name, distro_version, distro_full_name)
     if distro_name == "redhat" \
             or distro_name == "centos" \
             or distro_name == "oracle":
-        if Version(distro_version) < Version("7"): # pylint: disable=R1705
+        if Version(distro_version) < Version("7"):  # pylint: disable=R1705
             return Redhat6xOSUtil()
         else:
             return RedhatOSUtil()
@@ -128,7 +128,7 @@ def _get_osutil(distro_name, distro_code_name, distro_version, distro_full_name)
     if distro_name == "nsbsd":
         return NSBSDOSUtil()
 
-    if distro_name == "openwrt": # pylint: disable=R1705
+    if distro_name == "openwrt":  # pylint: disable=R1705
         return OpenWRTOSUtil()
 
     else:

--- a/azurelinuxagent/common/osutil/gaia.py
+++ b/azurelinuxagent/common/osutil/gaia.py
@@ -23,7 +23,7 @@ import time
 
 import azurelinuxagent.common.conf as conf
 from azurelinuxagent.common.exception import OSUtilError
-from azurelinuxagent.common.future import ustr, bytebuffer, range, int # pylint: disable=redefined-builtin
+from azurelinuxagent.common.future import ustr, bytebuffer, range, int  # pylint: disable=redefined-builtin
 import azurelinuxagent.common.logger as logger
 from azurelinuxagent.common.osutil.default import DefaultOSUtil
 from azurelinuxagent.common.utils.cryptutil import CryptUtil
@@ -34,22 +34,22 @@ import azurelinuxagent.common.utils.textutil as textutil
 
 class GaiaOSUtil(DefaultOSUtil):
 
-    def __init__(self): # pylint: disable=W0235
+    def __init__(self):  # pylint: disable=W0235
         super(GaiaOSUtil, self).__init__()
 
     def _run_clish(self, cmd):
         ret = 0
         out = ""
-        for i in range(10): # pylint: disable=W0612
+        for i in range(10):  # pylint: disable=W0612
             try:
                 final_command = ["/bin/clish", "-s", "-c", "'{0}'".format(cmd)]
                 out = shellutil.run_command(final_command, log_error=True)
                 ret = 0
                 break
-            except shellutil.CommandError as e: # pylint: disable=C0103
+            except shellutil.CommandError as e:  # pylint: disable=C0103
                 ret = e.returncode
                 out = e.stdout
-            except Exception as e: # pylint: disable=C0103
+            except Exception as e:  # pylint: disable=C0103
                 ret = -1
                 out = ustr(e)
 
@@ -76,7 +76,7 @@ class GaiaOSUtil(DefaultOSUtil):
 
     def del_root_password(self):
         logger.info('del_root_password')
-        ret, out = self._run_clish('set user admin password-hash *LOCK*') # pylint: disable=W0612
+        ret, out = self._run_clish('set user admin password-hash *LOCK*')  # pylint: disable=W0612
         if ret != 0:
             raise OSUtilError("Failed to delete root password")
 
@@ -123,8 +123,8 @@ class GaiaOSUtil(DefaultOSUtil):
                 return int(buf[0].split()[1])
             return int(''.join(buf[1:]), 16)
 
-        n = text_to_num(modulus) # pylint: disable=C0103
-        e = text_to_num(exponent) # pylint: disable=C0103
+        n = text_to_num(modulus)  # pylint: disable=C0103
+        e = text_to_num(exponent)  # pylint: disable=C0103
 
         keydata = bytearray()
         keydata.extend(struct.pack('>I', len('ssh-rsa')))
@@ -190,7 +190,7 @@ class GaiaOSUtil(DefaultOSUtil):
             cidr = self._address_to_string(net) + '/' + self._get_prefix(
                 self._address_to_string(mask))
 
-        ret, out = self._run_clish( # pylint: disable=W0612
+        ret, out = self._run_clish(  # pylint: disable=W0612
             'set static-route ' + cidr +
             ' nexthop gateway address ' +
             self._address_to_string(gateway) + ' on')

--- a/azurelinuxagent/common/osutil/iosxe.py
+++ b/azurelinuxagent/common/osutil/iosxe.py
@@ -23,7 +23,7 @@ import azurelinuxagent.common.logger as logger
 import azurelinuxagent.common.utils.shellutil as shellutil
 from azurelinuxagent.common.future import ustr
 from azurelinuxagent.common.osutil.default import DefaultOSUtil, PRODUCT_ID_FILE, DMIDECODE_CMD, UUID_PATTERN
-from azurelinuxagent.common.utils import textutil, fileutil # pylint: disable=W0611
+from azurelinuxagent.common.utils import textutil, fileutil  # pylint: disable=W0611
 
 # pylint: disable=W0105
 '''
@@ -38,7 +38,7 @@ the waagent environment:
 # pylint: enable=W0105
 
 class IosxeOSUtil(DefaultOSUtil):
-    def __init__(self): # pylint: disable=W0235
+    def __init__(self):  # pylint: disable=W0235
         super(IosxeOSUtil, self).__init__()
 
     def set_hostname(self, hostname):
@@ -50,7 +50,7 @@ class IosxeOSUtil(DefaultOSUtil):
         hostnamectl_cmd = ["hostnamectl", "set-hostname", hostname, "--static"]
         try:
             shellutil.run_command(hostnamectl_cmd)
-        except Exception as e: # pylint: disable=C0103
+        except Exception as e:  # pylint: disable=C0103
             logger.warn("[{0}] failed with error: {1}, attempting fallback".format(' '.join(hostnamectl_cmd), ustr(e)))
             DefaultOSUtil.set_hostname(self, hostname)
 
@@ -82,11 +82,11 @@ class IosxeOSUtil(DefaultOSUtil):
         '''
         if os.path.isfile(PRODUCT_ID_FILE):
             try:
-                s = fileutil.read_file(PRODUCT_ID_FILE).strip() # pylint: disable=C0103
+                s = fileutil.read_file(PRODUCT_ID_FILE).strip()  # pylint: disable=C0103
                 return self._correct_instance_id(s.strip())
             except IOError:
                 pass
-        rc, s = shellutil.run_get_output(DMIDECODE_CMD) # pylint: disable=C0103
+        rc, s = shellutil.run_get_output(DMIDECODE_CMD)  # pylint: disable=C0103
         if rc != 0 or UUID_PATTERN.match(s) is None:
             return ""
         return self._correct_instance_id(s.strip())

--- a/azurelinuxagent/common/osutil/nsbsd.py
+++ b/azurelinuxagent/common/osutil/nsbsd.py
@@ -41,13 +41,13 @@ class NSBSDOSUtil(FreeBSDOSUtil):
             self.resolver = dns.resolver.Resolver()
             servers = []
             cmd = "getconf /usr/Firewall/ConfigFiles/dns Servers | tail -n +2"
-            ret, output = shellutil.run_get_output(cmd) # pylint: disable=W0612
+            ret, output = shellutil.run_get_output(cmd)  # pylint: disable=W0612
             for server in output.split("\n"):
                 if server == '':
                     break
                 server = server[:-1] # remove last '='
                 cmd = "grep '{}' /etc/hosts".format(server) + " | awk '{print $1}'"
-                ret, ip = shellutil.run_get_output(cmd) # pylint: disable=C0103
+                ret, ip = shellutil.run_get_output(cmd)  # pylint: disable=C0103
                 servers.append(ip)
             self.resolver.nameservers = servers
             dns.resolver.override_system_resolver(self.resolver)
@@ -99,7 +99,7 @@ class NSBSDOSUtil(FreeBSDOSUtil):
         """
         Deploy authorized_key
         """
-        path, thumbprint, value = pubkey # pylint: disable=W0612
+        path, thumbprint, value = pubkey  # pylint: disable=W0612
 
         #overide parameters
         super(NSBSDOSUtil, self).deploy_ssh_pubkey('admin',

--- a/azurelinuxagent/common/osutil/openbsd.py
+++ b/azurelinuxagent/common/osutil/openbsd.py
@@ -36,7 +36,7 @@ UUID_PATTERN = re.compile(
     re.IGNORECASE)
 
 
-class OpenBSDOSUtil(DefaultOSUtil): # pylint: disable=R0904
+class OpenBSDOSUtil(DefaultOSUtil):  # pylint: disable=R0904
 
     def __init__(self):
         super(OpenBSDOSUtil, self).__init__()
@@ -146,21 +146,21 @@ class OpenBSDOSUtil(DefaultOSUtil): # pylint: disable=R0904
     def stop_dhcp_service(self):
         pass
 
-    def get_dhcp_lease_endpoint(self): # pylint: disable=R0912
+    def get_dhcp_lease_endpoint(self):  # pylint: disable=R0912
         """
         OpenBSD has a sligthly different lease file format.
         """
         endpoint = None
         pathglob = '/var/db/dhclient.leases.{}'.format(self.get_first_if()[0])
 
-        HEADER_LEASE = "lease" # pylint: disable=C0103
-        HEADER_OPTION = "option option-245" # pylint: disable=C0103
-        HEADER_EXPIRE = "expire" # pylint: disable=C0103
-        FOOTER_LEASE = "}" # pylint: disable=C0103
-        FORMAT_DATETIME = "%Y/%m/%d %H:%M:%S %Z" # pylint: disable=C0103
+        HEADER_LEASE = "lease"  # pylint: disable=C0103
+        HEADER_OPTION = "option option-245"  # pylint: disable=C0103
+        HEADER_EXPIRE = "expire"  # pylint: disable=C0103
+        FOOTER_LEASE = "}"  # pylint: disable=C0103
+        FORMAT_DATETIME = "%Y/%m/%d %H:%M:%S %Z"  # pylint: disable=C0103
 
         logger.info("looking for leases in path [{0}]".format(pathglob))
-        for lease_file in glob.glob(pathglob): # pylint: disable=R1702
+        for lease_file in glob.glob(pathglob):  # pylint: disable=R1702
             leases = open(lease_file).read()
             if HEADER_OPTION in leases:
                 cached_endpoint = None
@@ -228,7 +228,7 @@ class OpenBSDOSUtil(DefaultOSUtil): # pylint: disable=R0904
                 return "/dev/{0}".format(dvd.group(0))
         raise OSUtilError("Failed to get DVD device")
 
-    def mount_dvd(self, # pylint: disable=R0913
+    def mount_dvd(self,  # pylint: disable=R0913
                   max_retry=6,
                   chk_err=True,
                   dvd_device=None,
@@ -293,7 +293,7 @@ class OpenBSDOSUtil(DefaultOSUtil): # pylint: disable=R0904
     def set_scsi_disks_timeout(self, timeout):
         pass
 
-    def check_pid_alive(self, pid): # pylint: disable=R1710
+    def check_pid_alive(self, pid):  # pylint: disable=R1710
         if not pid:
             return
         return shellutil.run('ps -p {0}'.format(pid), chk_err=False) == 0

--- a/azurelinuxagent/common/osutil/openwrt.py
+++ b/azurelinuxagent/common/osutil/openwrt.py
@@ -31,7 +31,7 @@ class OpenWRTOSUtil(DefaultOSUtil):
         super(OpenWRTOSUtil, self).__init__()
         self.agent_conf_file_path = '/etc/waagent.conf'
         self.dhclient_name = 'udhcpc'
-        self.ip_command_output = re.compile('^\d+:\s+(\w+):\s+(.*)$') # pylint: disable=W1401
+        self.ip_command_output = re.compile('^\d+:\s+(\w+):\s+(.*)$')  # pylint: disable=W1401
         self.jit_enabled = True
         
     def eject_dvd(self, chk_err=True):
@@ -121,9 +121,9 @@ class OpenWRTOSUtil(DefaultOSUtil):
     def start_network(self) :
         return shellutil.run("/etc/init.d/network start", chk_err=True)
 
-    def restart_ssh_service(self): # pylint: disable=R1710
+    def restart_ssh_service(self):  # pylint: disable=R1710
         # Since Dropbear is the default ssh server on OpenWRt, lets do a sanity check
-        if os.path.exists("/etc/init.d/sshd"): # pylint: disable=R1705
+        if os.path.exists("/etc/init.d/sshd"):  # pylint: disable=R1705
             return shellutil.run("/etc/init.d/sshd restart", chk_err=True)
         else:
             logger.warn("sshd service does not exists")

--- a/azurelinuxagent/common/osutil/redhat.py
+++ b/azurelinuxagent/common/osutil/redhat.py
@@ -16,23 +16,23 @@
 # Requires Python 2.6+ and Openssl 1.0+
 #
 
-import os # pylint: disable=W0611
-import re # pylint: disable=W0611
-import pwd # pylint: disable=W0611
-import shutil # pylint: disable=W0611
-import socket # pylint: disable=W0611
-import array # pylint: disable=W0611
-import struct # pylint: disable=W0611
-import fcntl # pylint: disable=W0611
-import time # pylint: disable=W0611
-import base64 # pylint: disable=W0611
+import os  # pylint: disable=W0611
+import re  # pylint: disable=W0611
+import pwd  # pylint: disable=W0611
+import shutil  # pylint: disable=W0611
+import socket  # pylint: disable=W0611
+import array  # pylint: disable=W0611
+import struct  # pylint: disable=W0611
+import fcntl  # pylint: disable=W0611
+import time  # pylint: disable=W0611
+import base64  # pylint: disable=W0611
 import azurelinuxagent.common.conf as conf
 import azurelinuxagent.common.logger as logger
-from azurelinuxagent.common.future import ustr, bytebuffer # pylint: disable=W0611
+from azurelinuxagent.common.future import ustr, bytebuffer  # pylint: disable=W0611
 from azurelinuxagent.common.exception import OSUtilError, CryptError
 import azurelinuxagent.common.utils.fileutil as fileutil
 import azurelinuxagent.common.utils.shellutil as shellutil
-import azurelinuxagent.common.utils.textutil as textutil # pylint: disable=W0611
+import azurelinuxagent.common.utils.textutil as textutil  # pylint: disable=W0611
 from azurelinuxagent.common.utils.cryptutil import CryptUtil
 from azurelinuxagent.common.osutil.default import DefaultOSUtil
 
@@ -66,7 +66,7 @@ class Redhat6xOSUtil(DefaultOSUtil):
         try:
             cryptutil = CryptUtil(conf.get_openssl_cmd())
             ssh_rsa_pubkey = cryptutil.asn1_to_ssh(pubkey)
-        except CryptError as e: # pylint: disable=C0103
+        except CryptError as e:  # pylint: disable=C0103
             raise OSUtilError(ustr(e))
         fileutil.append_file(output_file, ssh_rsa_pubkey)
 

--- a/azurelinuxagent/common/osutil/suse.py
+++ b/azurelinuxagent/common/osutil/suse.py
@@ -17,9 +17,9 @@
 #
 
 import azurelinuxagent.common.utils.fileutil as fileutil
-import azurelinuxagent.common.utils.shellutil as shellutil # pylint: disable=W0611
-from azurelinuxagent.common.exception import OSUtilError # pylint: disable=W0611
-from azurelinuxagent.common.future import ustr # pylint: disable=W0611
+import azurelinuxagent.common.utils.shellutil as shellutil  # pylint: disable=W0611
+from azurelinuxagent.common.exception import OSUtilError  # pylint: disable=W0611
+from azurelinuxagent.common.future import ustr  # pylint: disable=W0611
 from azurelinuxagent.common.osutil.default import DefaultOSUtil
 
 

--- a/azurelinuxagent/common/osutil/ubuntu.py
+++ b/azurelinuxagent/common/osutil/ubuntu.py
@@ -63,7 +63,7 @@ class Ubuntu14OSUtil(DefaultOSUtil):
 
 
 class Ubuntu12OSUtil(Ubuntu14OSUtil):
-    def __init__(self): # pylint: disable=W0235
+    def __init__(self):  # pylint: disable=W0235
         super(Ubuntu12OSUtil, self).__init__()
 
     # Override
@@ -117,7 +117,7 @@ class Ubuntu18OSUtil(Ubuntu16OSUtil):
 
 
 class UbuntuOSUtil(Ubuntu16OSUtil):
-    def __init__(self): # pylint: disable=W0235
+    def __init__(self):  # pylint: disable=W0235
         super(UbuntuOSUtil, self).__init__()
 
     def restart_if(self, ifname, retries=3, wait=5):

--- a/azurelinuxagent/common/protocol/goal_state.py
+++ b/azurelinuxagent/common/protocol/goal_state.py
@@ -178,7 +178,7 @@ class SharedConfig(object):  # pylint: disable=R0903
 
 # too-few-public-methods<R0903> Disabled: This is just a data object that does not need any public methods
 class Certificates(object):  # pylint: disable=R0903
-    def __init__(self, xml_text): # pylint: disable=R0912
+    def __init__(self, xml_text):  # pylint: disable=R0912
         self.cert_list = CertList()
 
         # Save the certificates
@@ -192,14 +192,14 @@ class Certificates(object):  # pylint: disable=R0903
             return
 
         # if the certificates format is not Pkcs7BlobWithPfxContents do not parse it
-        certificateFormat = findtext(xml_doc, "Format") # pylint: disable=C0103
+        certificateFormat = findtext(xml_doc, "Format")  # pylint: disable=C0103
         if certificateFormat and certificateFormat != "Pkcs7BlobWithPfxContents":
             logger.warn("The Format is not Pkcs7BlobWithPfxContents. Format is " + certificateFormat)
             return
 
         cryptutil = CryptUtil(conf.get_openssl_cmd())
         p7m_file = os.path.join(conf.get_lib_dir(), P7M_FILE_NAME)
-        p7m = ("MIME-Version:1.0\n" # pylint: disable=W1308
+        p7m = ("MIME-Version:1.0\n"  # pylint: disable=W1308
                "Content-Disposition: attachment; filename=\"{0}\"\n"
                "Content-Type: application/x-pkcs7-mime; name=\"{1}\"\n"
                "Content-Transfer-Encoding: base64\n"
@@ -216,8 +216,8 @@ class Certificates(object):  # pylint: disable=R0903
 
         # The parsing process use public key to match prv and crt.
         buf = []
-        begin_crt = False # pylint: disable=W0612
-        begin_prv = False # pylint: disable=W0612
+        begin_crt = False  # pylint: disable=W0612
+        begin_prv = False  # pylint: disable=W0612
         prvs = {}
         thumbprints = {}
         index = 0
@@ -309,7 +309,7 @@ class ExtensionsConfig(object):  # pylint: disable=R0903
             manifest = VMAgentManifest()
             manifest.family = family
             for uri in uris:
-                manifestUri = VMAgentManifestUri(uri=gettext(uri)) # pylint: disable=C0103
+                manifestUri = VMAgentManifestUri(uri=gettext(uri))  # pylint: disable=C0103
                 manifest.versionsManifestUris.append(manifestUri)
             self.vmagent_manifests.vmAgentManifests.append(manifest)
 
@@ -374,17 +374,17 @@ class ExtensionsConfig(object):  # pylint: disable=R0903
 
         runtime_settings = None
         runtime_settings_node = find(settings[0], "RuntimeSettings")
-        seqNo = getattrib(runtime_settings_node, "seqNo") # pylint: disable=C0103
+        seqNo = getattrib(runtime_settings_node, "seqNo")  # pylint: disable=C0103
         runtime_settings_str = gettext(runtime_settings_node)
         try:
             runtime_settings = json.loads(runtime_settings_str)
-        except ValueError as e: # pylint: disable=W0612,C0103
+        except ValueError as e:  # pylint: disable=W0612,C0103
             logger.error("Invalid extension settings")
             return
 
         depends_on_level = 0
         depends_on_node = find(settings[0], "DependsOn")
-        if depends_on_node != None: # pylint: disable=C0121
+        if depends_on_node != None:  # pylint: disable=C0121
             try:
                 depends_on_level = int(getattrib(depends_on_node, "dependencyLevel"))
             except (ValueError, TypeError):
@@ -431,7 +431,7 @@ class RemoteAccess(object):  # pylint: disable=R0903
         self.incarnation = None
         self.user_list = RemoteAccessUsersList()
 
-        if self.xml_text is None or len(self.xml_text) == 0: # pylint: disable=len-as-condition
+        if self.xml_text is None or len(self.xml_text) == 0:  # pylint: disable=len-as-condition
             return
 
         xml_doc = parse_doc(self.xml_text)

--- a/azurelinuxagent/common/protocol/healthservice.py
+++ b/azurelinuxagent/common/protocol/healthservice.py
@@ -26,7 +26,7 @@ from azurelinuxagent.common.utils import restutil
 from azurelinuxagent.common.version import AGENT_NAME, CURRENT_VERSION
 
 
-class Observation(object): # pylint: disable=R0903
+class Observation(object):  # pylint: disable=R0903
     def __init__(self, name, is_healthy, description='', value=''):
         if name is None:
             raise ValueError("Observation name must be provided")
@@ -154,7 +154,7 @@ class HealthService(object):
         try:
             restutil.http_post(self.endpoint, self.as_json, headers={'Content-Type': 'application/json'})
             logger.verbose('HealthService: Reported observations to {0}: {1}', self.endpoint, self.as_json)
-        except HttpError as e: # pylint: disable=C0103
+        except HttpError as e:  # pylint: disable=C0103
             logger.warn("HealthService: could not report observations: {0}", ustr(e))
         finally:
             # report any failures via telemetry
@@ -166,12 +166,12 @@ class HealthService(object):
         try:
             logger.verbose("HealthService: report failures as telemetry")
             from azurelinuxagent.common.event import add_event, WALAEventOperation
-            for o in self.observations: # pylint: disable=C0103
+            for o in self.observations:  # pylint: disable=C0103
                 if not o.is_healthy:
                     add_event(AGENT_NAME,
                               version=CURRENT_VERSION,
                               op=WALAEventOperation.HealthObservation,
                               is_success=False,
                               message=json.dumps(o.as_obj))
-        except Exception as e: # pylint: disable=C0103
+        except Exception as e:  # pylint: disable=C0103
             logger.verbose("HealthService: could not report failures: {0}".format(ustr(e)))

--- a/azurelinuxagent/common/protocol/hostplugin.py
+++ b/azurelinuxagent/common/protocol/hostplugin.py
@@ -56,7 +56,7 @@ _HEADER_ARTIFACT_MANIFEST_LOCATION = "x-ms-artifact-manifest-location"
 MAXIMUM_PAGEBLOB_PAGE_SIZE = 4 * 1024 * 1024  # Max page size: 4MB
 
 
-class HostPluginProtocol(object): # pylint: disable=R0902
+class HostPluginProtocol(object):  # pylint: disable=R0902
     _is_default_channel = False
 
     FETCH_REPORTING_PERIOD = datetime.timedelta(minutes=1)
@@ -141,7 +141,7 @@ class HostPluginProtocol(object): # pylint: disable=R0902
             else:
                 return_val = ustr(remove_bom(response.read()), encoding='utf-8')
                 is_healthy = True
-        except HttpError as e: # pylint: disable=C0103
+        except HttpError as e:  # pylint: disable=C0103
             logger.error("HostGAPlugin: Exception Get API versions: {0}".format(e))
 
         self.health_service.report_host_plugin_versions(is_healthy=is_healthy, response=error_response)
@@ -233,7 +233,7 @@ class HostPluginProtocol(object): # pylint: disable=R0902
                                      headers=self._build_log_headers(),
                                      redact_data=True)
 
-        if restutil.request_failed(response): # pylint: disable=R1720
+        if restutil.request_failed(response):  # pylint: disable=R1720
             error_response = restutil.read_response_error(response)
             raise HttpError("HostGAPlugin: Upload VM logs failed: {0}".format(error_response))
 
@@ -270,7 +270,7 @@ class HostPluginProtocol(object): # pylint: disable=R0902
                                          bytearray(status_blob.data, encoding='utf-8')),
                                      headers=self._build_status_headers())
 
-        if restutil.request_failed(response): # pylint: disable=R1720
+        if restutil.request_failed(response):  # pylint: disable=R1720
             error_response = restutil.read_response_error(response)
             is_healthy = not restutil.request_failed_at_hostplugin(response)
             self.report_status_health(is_healthy=is_healthy, response=error_response)
@@ -295,7 +295,7 @@ class HostPluginProtocol(object): # pylint: disable=R0902
                                          status_blob.get_page_blob_create_headers(status_size)),
                                      headers=self._build_status_headers())
 
-        if restutil.request_failed(response): # pylint: disable=R1720
+        if restutil.request_failed(response):  # pylint: disable=R1720
             error_response = restutil.read_response_error(response)
             is_healthy = not restutil.request_failed_at_hostplugin(response)
             self.report_status_health(is_healthy=is_healthy, response=error_response)
@@ -374,7 +374,7 @@ class HostPluginProtocol(object): # pylint: disable=R0902
         }
 
     def _base64_encode(self, data):
-        s = base64.b64encode(bytes(data)) # pylint: disable=C0103
+        s = base64.b64encode(bytes(data))  # pylint: disable=C0103
         if PY_VERSION_MAJOR > 2:
             return s.decode('utf-8')
         return s

--- a/azurelinuxagent/common/protocol/imds.py
+++ b/azurelinuxagent/common/protocol/imds.py
@@ -139,7 +139,7 @@ ENDORSED_IMAGE_INFO_MATCHER_JSON = """{
 }"""
 
 
-class ImageInfoMatcher(object): # pylint: disable=R0903
+class ImageInfoMatcher(object):  # pylint: disable=R0903
     def __init__(self, doc):
         self.doc = json.loads(doc)
 
@@ -169,10 +169,10 @@ class ImageInfoMatcher(object): # pylint: disable=R0903
         return _is_match_walk(self.doc, [ publisher, offer, sku, version ])
 
 
-class ComputeInfo(DataContract): # pylint: disable=R0902
+class ComputeInfo(DataContract):  # pylint: disable=R0902
     __matcher = ImageInfoMatcher(ENDORSED_IMAGE_INFO_MATCHER_JSON)
 
-    def __init__(self, # pylint: disable=R0913
+    def __init__(self,  # pylint: disable=R0913
                  location=None,
                  name=None,
                  offer=None,
@@ -193,19 +193,19 @@ class ComputeInfo(DataContract): # pylint: disable=R0902
         self.location = location
         self.name = name
         self.offer = offer
-        self.osType = osType # pylint: disable=C0103
-        self.placementGroupId = placementGroupId # pylint: disable=C0103
-        self.platformFaultDomain = platformFaultDomain # pylint: disable=C0103
-        self.platformUpdateDomain = placementUpdateDomain # pylint: disable=C0103
+        self.osType = osType  # pylint: disable=C0103
+        self.placementGroupId = placementGroupId  # pylint: disable=C0103
+        self.platformFaultDomain = platformFaultDomain  # pylint: disable=C0103
+        self.platformUpdateDomain = placementUpdateDomain  # pylint: disable=C0103
         self.publisher = publisher
-        self.resourceGroupName = resourceGroupName # pylint: disable=C0103
+        self.resourceGroupName = resourceGroupName  # pylint: disable=C0103
         self.sku = sku
-        self.subscriptionId = subscriptionId # pylint: disable=C0103
+        self.subscriptionId = subscriptionId  # pylint: disable=C0103
         self.tags = tags
         self.version = version
-        self.vmId = vmId # pylint: disable=C0103
-        self.vmSize = vmSize # pylint: disable=C0103
-        self.vmScaleSetName = vmScaleSetName # pylint: disable=C0103
+        self.vmId = vmId  # pylint: disable=C0103
+        self.vmSize = vmSize  # pylint: disable=C0103
+        self.vmScaleSetName = vmScaleSetName  # pylint: disable=C0103
         self.zone = zone
 
     @property
@@ -227,12 +227,12 @@ class ComputeInfo(DataContract): # pylint: disable=R0902
             if self.publisher == "":
                 return IMDS_IMAGE_ORIGIN_CUSTOM
 
-            if ComputeInfo.__matcher.is_match(self.publisher, self.offer, self.sku, self.version): # pylint: disable=R1705
+            if ComputeInfo.__matcher.is_match(self.publisher, self.offer, self.sku, self.version):  # pylint: disable=R1705
                 return IMDS_IMAGE_ORIGIN_ENDORSED
             else:
                 return IMDS_IMAGE_ORIGIN_PLATFORM
 
-        except Exception as e: # pylint: disable=C0103
+        except Exception as e:  # pylint: disable=C0103
             logger.periodic_warn(logger.EVERY_FIFTEEN_MINUTES,
                                  "[PERIODIC] Could not determine the image origin from IMDS: {0}".format(ustr(e)))
             return IMDS_IMAGE_ORIGIN_UNKNOWN
@@ -260,7 +260,7 @@ class ImdsClient(object):
         url = self._get_metadata_url(endpoint, resource_path)
         return restutil.http_get(url, headers=headers, use_proxy=False)
 
-    def _get_metadata_from_endpoint(self, endpoint, resource_path, headers): # pylint: disable=R0911
+    def _get_metadata_from_endpoint(self, endpoint, resource_path, headers):  # pylint: disable=R0911
         """
         Get metadata from one of the IMDS endpoints.
 
@@ -276,7 +276,7 @@ class ImdsClient(object):
             resp = self._http_get(endpoint=endpoint, resource_path=resource_path, headers=headers)
         except ResourceGoneError:
             return IMDS_INTERNAL_SERVER_ERROR, "IMDS error in /metadata/{0}: HTTP Failed with Status Code 410: Gone".format(resource_path)
-        except HttpError as e: # pylint: disable=C0103
+        except HttpError as e:  # pylint: disable=C0103
             msg = str(e)
             if self._regex_throttled.match(msg):
                 return IMDS_RESPONSE_ERROR, "IMDS error in /metadata/{0}: Throttled".format(resource_path)
@@ -313,7 +313,7 @@ class ImdsClient(object):
             endpoint = self._wireserver_endpoint
             status, resp = self._get_metadata_from_endpoint(endpoint, resource_path, headers)
 
-        if status == IMDS_RESPONSE_SUCCESS: # pylint: disable=R1705
+        if status == IMDS_RESPONSE_SUCCESS:  # pylint: disable=R1705
             return MetadataResult(True, False, resp)
         elif status == IMDS_INTERNAL_SERVER_ERROR:
             return MetadataResult(False, True, resp)
@@ -359,7 +359,7 @@ class ImdsClient(object):
         # ensure the response is valid json
         try:
             json_data = json.loads(ustr(result.response, encoding="utf-8"))
-        except Exception as e: # pylint: disable=C0103
+        except Exception as e:  # pylint: disable=C0103
             return False, "JSON parsing failed: {0}".format(ustr(e))
 
         # ensure all expected fields are present and have a value
@@ -372,7 +372,7 @@ class ImdsClient(object):
             self.check_field(json_data['network']['interface'][0], 'ipv4')
             self.check_field(json_data['network']['interface'][0]['ipv4'], 'ipAddress')
             self.check_field(json_data['network']['interface'][0]['ipv4']['ipAddress'][0], 'privateIpAddress')
-        except ValueError as v: # pylint: disable=C0103
+        except ValueError as v:  # pylint: disable=C0103
             return False, ustr(v)
 
         return True, ''
@@ -382,5 +382,5 @@ class ImdsClient(object):
         if field not in dict_obj or dict_obj[field] is None:
             raise ValueError('Missing field: [{0}]'.format(field))
 
-        if len(dict_obj[field]) == 0: # pylint: disable=len-as-condition
+        if len(dict_obj[field]) == 0:  # pylint: disable=len-as-condition
             raise ValueError('Empty field: [{0}]'.format(field))

--- a/azurelinuxagent/common/protocol/ovfenv.py
+++ b/azurelinuxagent/common/protocol/ovfenv.py
@@ -19,14 +19,14 @@
 """
 Copy and parse ovf-env.xml from provisioning ISO and local cache
 """
-import os # pylint: disable=W0611
-import re # pylint: disable=W0611
-import shutil # pylint: disable=W0611
-import xml.dom.minidom as minidom # pylint: disable=W0611
+import os  # pylint: disable=W0611
+import re  # pylint: disable=W0611
+import shutil  # pylint: disable=W0611
+import xml.dom.minidom as minidom  # pylint: disable=W0611
 import azurelinuxagent.common.logger as logger
 from azurelinuxagent.common.exception import ProtocolError
-from azurelinuxagent.common.future import ustr # pylint: disable=W0611
-import azurelinuxagent.common.utils.fileutil as fileutil # pylint: disable=W0611
+from azurelinuxagent.common.future import ustr  # pylint: disable=W0611
+import azurelinuxagent.common.utils.fileutil as fileutil  # pylint: disable=W0611
 from azurelinuxagent.common.utils.textutil import parse_doc, findall, find, findtext
 
 OVF_VERSION = "1.0"
@@ -37,7 +37,7 @@ def _validate_ovf(val, msg):
     if val is None:
         raise ProtocolError("Failed to validate OVF: {0}".format(msg))
 
-class OvfEnv(object): # pylint: disable=R0903,R0902
+class OvfEnv(object):  # pylint: disable=R0903,R0902
     """
     Read, and process provisioning info from provisioning file OvfEnv.xml
     """
@@ -94,7 +94,7 @@ class OvfEnv(object): # pylint: disable=R0903,R0902
         
         auth_option = findtext(conf_set, "DisableSshPasswordAuthentication", 
                                namespace=wans)
-        if auth_option is not None and auth_option.lower() == "true": # pylint: disable=simplifiable-if-statement
+        if auth_option is not None and auth_option.lower() == "true":  # pylint: disable=simplifiable-if-statement
             self.disable_ssh_password_auth = True
         else:
             self.disable_ssh_password_auth = False

--- a/azurelinuxagent/common/protocol/restapi.py
+++ b/azurelinuxagent/common/protocol/restapi.py
@@ -23,27 +23,27 @@ from azurelinuxagent.common.version import DISTRO_VERSION, DISTRO_NAME, CURRENT_
 from azurelinuxagent.common.datacontract import DataContract, DataContractList
 
 
-class VMInfo(DataContract): # pylint: disable=R0903
-    def __init__(self, # pylint: disable=R0913
+class VMInfo(DataContract):  # pylint: disable=R0903
+    def __init__(self,  # pylint: disable=R0913
                  subscriptionId=None,
                  vmName=None,
                  roleName=None,
                  roleInstanceName=None,
                  tenantName=None):
-        self.subscriptionId = subscriptionId # pylint: disable=C0103
-        self.vmName = vmName # pylint: disable=C0103
-        self.roleName = roleName # pylint: disable=C0103
-        self.roleInstanceName = roleInstanceName # pylint: disable=C0103
-        self.tenantName = tenantName # pylint: disable=C0103
+        self.subscriptionId = subscriptionId  # pylint: disable=C0103
+        self.vmName = vmName  # pylint: disable=C0103
+        self.roleName = roleName  # pylint: disable=C0103
+        self.roleInstanceName = roleInstanceName  # pylint: disable=C0103
+        self.tenantName = tenantName  # pylint: disable=C0103
 
 
-class CertificateData(DataContract): # pylint: disable=R0903
+class CertificateData(DataContract):  # pylint: disable=R0903
     def __init__(self, certificateData=None):
-        self.certificateData = certificateData # pylint: disable=C0103
+        self.certificateData = certificateData  # pylint: disable=C0103
 
 
-class Cert(DataContract): # pylint: disable=R0903
-    def __init__(self, # pylint: disable=R0913
+class Cert(DataContract):  # pylint: disable=R0903
+    def __init__(self,  # pylint: disable=R0913
                  name=None,
                  thumbprint=None,
                  certificateDataUri=None,
@@ -51,35 +51,35 @@ class Cert(DataContract): # pylint: disable=R0903
                  storeLocation=None):
         self.name = name
         self.thumbprint = thumbprint
-        self.certificateDataUri = certificateDataUri # pylint: disable=C0103
-        self.storeLocation = storeLocation # pylint: disable=C0103
-        self.storeName = storeName # pylint: disable=C0103
+        self.certificateDataUri = certificateDataUri  # pylint: disable=C0103
+        self.storeLocation = storeLocation  # pylint: disable=C0103
+        self.storeName = storeName  # pylint: disable=C0103
 
 
-class CertList(DataContract): # pylint: disable=R0903
+class CertList(DataContract):  # pylint: disable=R0903
     def __init__(self):
         self.certificates = DataContractList(Cert)
 
 
 # TODO: confirm vmagent manifest schema
-class VMAgentManifestUri(DataContract): # pylint: disable=R0903
+class VMAgentManifestUri(DataContract):  # pylint: disable=R0903
     def __init__(self, uri=None):
         self.uri = uri
 
 
-class VMAgentManifest(DataContract): # pylint: disable=R0903
+class VMAgentManifest(DataContract):  # pylint: disable=R0903
     def __init__(self, family=None):
         self.family = family
-        self.versionsManifestUris = DataContractList(VMAgentManifestUri) # pylint: disable=C0103
+        self.versionsManifestUris = DataContractList(VMAgentManifestUri)  # pylint: disable=C0103
 
 
-class VMAgentManifestList(DataContract): # pylint: disable=R0903
+class VMAgentManifestList(DataContract):  # pylint: disable=R0903
     def __init__(self):
-        self.vmAgentManifests = DataContractList(VMAgentManifest) # pylint: disable=C0103
+        self.vmAgentManifests = DataContractList(VMAgentManifest)  # pylint: disable=C0103
 
 
-class Extension(DataContract): # pylint: disable=R0903
-    def __init__(self, # pylint: disable=R0913
+class Extension(DataContract):  # pylint: disable=R0903
+    def __init__(self,  # pylint: disable=R0913
                  name=None,
                  sequenceNumber=None,
                  publicSettings=None,
@@ -87,34 +87,34 @@ class Extension(DataContract): # pylint: disable=R0903
                  certificateThumbprint=None,
                  dependencyLevel=0):
         self.name = name
-        self.sequenceNumber = sequenceNumber # pylint: disable=C0103
-        self.publicSettings = publicSettings # pylint: disable=C0103
-        self.protectedSettings = protectedSettings # pylint: disable=C0103
-        self.certificateThumbprint = certificateThumbprint # pylint: disable=C0103
-        self.dependencyLevel = dependencyLevel # pylint: disable=C0103
+        self.sequenceNumber = sequenceNumber  # pylint: disable=C0103
+        self.publicSettings = publicSettings  # pylint: disable=C0103
+        self.protectedSettings = protectedSettings  # pylint: disable=C0103
+        self.certificateThumbprint = certificateThumbprint  # pylint: disable=C0103
+        self.dependencyLevel = dependencyLevel  # pylint: disable=C0103
 
 
-class ExtHandlerProperties(DataContract): # pylint: disable=R0903
+class ExtHandlerProperties(DataContract):  # pylint: disable=R0903
     def __init__(self):
         self.version = None
         self.state = None
         self.extensions = DataContractList(Extension)
 
 
-class ExtHandlerVersionUri(DataContract): # pylint: disable=R0903
+class ExtHandlerVersionUri(DataContract):  # pylint: disable=R0903
     def __init__(self):
         self.uri = None
 
 
-class ExtHandler(DataContract): # pylint: disable=R0903
+class ExtHandler(DataContract):  # pylint: disable=R0903
     def __init__(self, name=None):
         self.name = name
         self.properties = ExtHandlerProperties()
-        self.versionUris = DataContractList(ExtHandlerVersionUri) # pylint: disable=C0103
+        self.versionUris = DataContractList(ExtHandlerVersionUri)  # pylint: disable=C0103
 
     def sort_key(self):
         levels = [e.dependencyLevel for e in self.properties.extensions]
-        if len(levels) == 0: # pylint: disable=len-as-condition
+        if len(levels) == 0:  # pylint: disable=len-as-condition
             level = 0
         else:
             level = min(levels)
@@ -125,17 +125,17 @@ class ExtHandler(DataContract): # pylint: disable=R0903
         return level
 
 
-class ExtHandlerList(DataContract): # pylint: disable=R0903
+class ExtHandlerList(DataContract):  # pylint: disable=R0903
     def __init__(self):
-        self.extHandlers = DataContractList(ExtHandler) # pylint: disable=C0103
+        self.extHandlers = DataContractList(ExtHandler)  # pylint: disable=C0103
 
 
-class ExtHandlerPackageUri(DataContract): # pylint: disable=R0903
+class ExtHandlerPackageUri(DataContract):  # pylint: disable=R0903
     def __init__(self, uri=None):
         self.uri = uri
 
 
-class ExtHandlerPackage(DataContract): # pylint: disable=R0903
+class ExtHandlerPackage(DataContract):  # pylint: disable=R0903
     def __init__(self, version=None):
         self.version = version
         self.uris = DataContractList(ExtHandlerPackageUri)
@@ -144,26 +144,26 @@ class ExtHandlerPackage(DataContract): # pylint: disable=R0903
         self.disallow_major_upgrade = False
 
 
-class ExtHandlerPackageList(DataContract): # pylint: disable=R0903
+class ExtHandlerPackageList(DataContract):  # pylint: disable=R0903
     def __init__(self):
         self.versions = DataContractList(ExtHandlerPackage)
 
 
-class VMProperties(DataContract): # pylint: disable=R0903
+class VMProperties(DataContract):  # pylint: disable=R0903
     def __init__(self, certificateThumbprint=None):
         # TODO need to confirm the property name
-        self.certificateThumbprint = certificateThumbprint # pylint: disable=C0103
+        self.certificateThumbprint = certificateThumbprint  # pylint: disable=C0103
 
 
-class ProvisionStatus(DataContract): # pylint: disable=R0903
+class ProvisionStatus(DataContract):  # pylint: disable=R0903
     def __init__(self, status=None, subStatus=None, description=None):
         self.status = status
-        self.subStatus = subStatus # pylint: disable=C0103
+        self.subStatus = subStatus  # pylint: disable=C0103
         self.description = description
         self.properties = VMProperties()
 
 
-class ExtensionSubStatus(DataContract): # pylint: disable=R0903
+class ExtensionSubStatus(DataContract):  # pylint: disable=R0903
     def __init__(self, name=None, status=None, code=None, message=None):
         self.name = name
         self.status = status
@@ -171,25 +171,25 @@ class ExtensionSubStatus(DataContract): # pylint: disable=R0903
         self.message = message
 
 
-class ExtensionStatus(DataContract): # pylint: disable=R0903
-    def __init__(self, # pylint: disable=R0913
+class ExtensionStatus(DataContract):  # pylint: disable=R0903
+    def __init__(self,  # pylint: disable=R0913
                  configurationAppliedTime=None,
                  operation=None,
                  status=None,
                  seq_no=None,
                  code=None,
                  message=None):
-        self.configurationAppliedTime = configurationAppliedTime # pylint: disable=C0103
+        self.configurationAppliedTime = configurationAppliedTime  # pylint: disable=C0103
         self.operation = operation
         self.status = status
-        self.sequenceNumber = seq_no # pylint: disable=C0103
+        self.sequenceNumber = seq_no  # pylint: disable=C0103
         self.code = code
         self.message = message
-        self.substatusList = DataContractList(ExtensionSubStatus) # pylint: disable=C0103
+        self.substatusList = DataContractList(ExtensionSubStatus)  # pylint: disable=C0103
 
 
-class ExtHandlerStatus(DataContract): # pylint: disable=R0903
-    def __init__(self, # pylint: disable=R0913
+class ExtHandlerStatus(DataContract):  # pylint: disable=R0903
+    def __init__(self,  # pylint: disable=R0913
                  name=None,
                  version=None,
                  status=None,
@@ -203,7 +203,7 @@ class ExtHandlerStatus(DataContract): # pylint: disable=R0903
         self.extensions = DataContractList(ustr)
 
 
-class VMAgentStatus(DataContract): # pylint: disable=R0903
+class VMAgentStatus(DataContract):  # pylint: disable=R0903
     def __init__(self, status=None, message=None):
         self.status = status
         self.message = message
@@ -211,22 +211,22 @@ class VMAgentStatus(DataContract): # pylint: disable=R0903
         self.version = str(CURRENT_VERSION)
         self.osname = DISTRO_NAME
         self.osversion = DISTRO_VERSION
-        self.extensionHandlers = DataContractList(ExtHandlerStatus) # pylint: disable=C0103
+        self.extensionHandlers = DataContractList(ExtHandlerStatus)  # pylint: disable=C0103
 
 
-class VMStatus(DataContract): # pylint: disable=R0903
+class VMStatus(DataContract):  # pylint: disable=R0903
     def __init__(self, status, message):
-        self.vmAgent = VMAgentStatus(status=status, message=message) # pylint: disable=C0103
+        self.vmAgent = VMAgentStatus(status=status, message=message)  # pylint: disable=C0103
 
 
-class RemoteAccessUser(DataContract): # pylint: disable=R0903
+class RemoteAccessUser(DataContract):  # pylint: disable=R0903
     def __init__(self, name, encrypted_password, expiration):
         self.name = name
         self.encrypted_password = encrypted_password
         self.expiration = expiration
 
 
-class RemoteAccessUsersList(DataContract): # pylint: disable=R0903
+class RemoteAccessUsersList(DataContract):  # pylint: disable=R0903
     def __init__(self):
         self.users = DataContractList(RemoteAccessUser)
 

--- a/azurelinuxagent/common/protocol/util.py
+++ b/azurelinuxagent/common/protocol/util.py
@@ -79,14 +79,14 @@ class ProtocolUtil(SingletonPerThread):
 
         try:
             self.osutil.mount_dvd()
-        except OSUtilError as e: # pylint: disable=C0103
+        except OSUtilError as e:  # pylint: disable=C0103
             raise ProtocolError("[CopyOvfEnv] Error mounting dvd: "
                                 "{0}".format(ustr(e)))
 
         try:
             ovfxml = fileutil.read_file(ovf_file_path_on_dvd, remove_bom=True)
             ovfenv = OvfEnv(ovfxml)
-        except (IOError, OSError) as e: # pylint: disable=C0103
+        except (IOError, OSError) as e:  # pylint: disable=C0103
             raise ProtocolError("[CopyOvfEnv] Error reading file "
                                 "{0}: {1}".format(ovf_file_path_on_dvd,
                                                   ustr(e)))
@@ -96,7 +96,7 @@ class ProtocolUtil(SingletonPerThread):
                             PASSWORD_REPLACEMENT,
                             ovfxml)
             fileutil.write_file(ovf_file_path, ovfxml)
-        except (IOError, OSError) as e: # pylint: disable=C0103
+        except (IOError, OSError) as e:  # pylint: disable=C0103
             raise ProtocolError("[CopyOvfEnv] Error writing file "
                                 "{0}: {1}".format(ovf_file_path,
                                                   ustr(e)))
@@ -109,7 +109,7 @@ class ProtocolUtil(SingletonPerThread):
         try:
             self.osutil.umount_dvd()
             self.osutil.eject_dvd()
-        except OSUtilError as e: # pylint: disable=C0103
+        except OSUtilError as e:  # pylint: disable=C0103
             logger.warn(ustr(e))
 
     def get_ovf_env(self):
@@ -117,7 +117,7 @@ class ProtocolUtil(SingletonPerThread):
         Load saved ovf-env.xml
         """
         ovf_file_path = os.path.join(conf.get_lib_dir(), OVF_FILE_NAME)
-        if os.path.isfile(ovf_file_path): # pylint: disable=R1705
+        if os.path.isfile(ovf_file_path):  # pylint: disable=R1705
             xml_text = fileutil.read_file(ovf_file_path)
             return OvfEnv(xml_text)
         else:
@@ -150,7 +150,7 @@ class ProtocolUtil(SingletonPerThread):
                         return self.endpoint
 
                     logger.error("[GetWireserverEndpoint] Unexpected empty file {0}", file_path)
-                except (IOError, OSError) as e: # pylint: disable=C0103
+                except (IOError, OSError) as e:  # pylint: disable=C0103
                     logger.error("[GetWireserverEndpoint] Error reading file {0}: {1}", file_path, str(e))
             else:
                 logger.error("[GetWireserverEndpoint] Missing file {0}", file_path)
@@ -167,7 +167,7 @@ class ProtocolUtil(SingletonPerThread):
             self.endpoint = endpoint
             file_path = self._get_wireserver_endpoint_file_path()
             fileutil.write_file(file_path, endpoint)
-        except (IOError, OSError) as e: # pylint: disable=C0103
+        except (IOError, OSError) as e:  # pylint: disable=C0103
             raise OSUtilError(ustr(e))
 
     def _clear_wireserver_endpoint(self):
@@ -182,7 +182,7 @@ class ProtocolUtil(SingletonPerThread):
 
         try:
             os.remove(endpoint_file_path)
-        except (IOError, OSError) as e: # pylint: disable=C0103
+        except (IOError, OSError) as e:  # pylint: disable=C0103
             # Ignore file-not-found errors (since the file is being removed)
             if e.errno == errno.ENOENT:
                 return
@@ -208,7 +208,7 @@ class ProtocolUtil(SingletonPerThread):
                         logger.info("WireServer endpoint is not found. Rerun dhcp handler")
                         try:
                             self.dhcp_handler.run()
-                        except DhcpError as e: # pylint: disable=C0103
+                        except DhcpError as e:  # pylint: disable=C0103
                             raise ProtocolError(ustr(e))
                         endpoint = self.dhcp_handler.endpoint
                     else:
@@ -221,13 +221,13 @@ class ProtocolUtil(SingletonPerThread):
                     self._set_wireserver_endpoint(endpoint)
                     return protocol
 
-                except ProtocolError as e: # pylint: disable=C0103
+                except ProtocolError as e:  # pylint: disable=C0103
                     logger.info("WireServer is not responding. Reset dhcp endpoint")
                     self.dhcp_handler.endpoint = None
                     self.dhcp_handler.skip_cache = True
                     raise e
     
-            except ProtocolError as e: # pylint: disable=C0103
+            except ProtocolError as e:  # pylint: disable=C0103
                 logger.info("Protocol endpoint not found: {0}", e)
 
             if retry < MAX_RETRY - 1:
@@ -242,7 +242,7 @@ class ProtocolUtil(SingletonPerThread):
         protocol_file_path = self._get_protocol_file_path()
         try:
             fileutil.write_file(protocol_file_path, protocol_name)
-        except (IOError, OSError) as e: # pylint: disable=C0103
+        except (IOError, OSError) as e:  # pylint: disable=C0103
             logger.error("Failed to save protocol endpoint: {0}", e)
 
     def clear_protocol(self):
@@ -260,7 +260,7 @@ class ProtocolUtil(SingletonPerThread):
 
             try:
                 os.remove(protocol_file_path)
-            except (IOError, OSError) as e: # pylint: disable=C0103
+            except (IOError, OSError) as e:  # pylint: disable=C0103
                 # Ignore file-not-found errors (since the file is being removed)
                 if e.errno == errno.ENOENT:
                     return

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -1,4 +1,4 @@
-# Microsoft Azure Linux Agent # pylint: disable=C0302
+# Microsoft Azure Linux Agent  # pylint: disable=C0302
 #
 # Copyright 2018 Microsoft Corporation
 #
@@ -155,7 +155,7 @@ class WireProtocol(DataContract):
         success = self.client.stream(uri, destination, headers=headers, use_proxy=False)
         return success
 
-    def download_ext_handler_pkg(self, uri, destination, headers=None, use_proxy=True): # pylint: disable=W0613
+    def download_ext_handler_pkg(self, uri, destination, headers=None, use_proxy=True):  # pylint: disable=W0613
         direct_func = lambda: self.client.stream(uri, destination, headers=None, use_proxy=True)
         # NOTE: the host_func may be called after refreshing the goal state, be careful about any goal state data
         # in the lambda.
@@ -184,7 +184,7 @@ class WireProtocol(DataContract):
         self.client.status_blob.set_vm_status(vm_status)
         self.client.upload_status_blob()
 
-    def report_ext_status(self, ext_handler_name, ext_name, ext_status): # pylint: disable=W0613
+    def report_ext_status(self, ext_handler_name, ext_name, ext_status):  # pylint: disable=W0613
         validate_param("ext_status", ext_status, ExtensionStatus)
         self.client.status_blob.set_ext_status(ext_handler_name, ext_status)
 
@@ -214,7 +214,7 @@ def _build_role_properties(container_id, role_instance_id, thumbprint):
     return xml
 
 
-def _build_health_report(incarnation, container_id, role_instance_id, # pylint: disable=R0913
+def _build_health_report(incarnation, container_id, role_instance_id,  # pylint: disable=R0913
                          status, substatus, description):
     # The max description that can be sent to WireServer is 4096 bytes.
     # Exceeding this max can result in a failure to report health.
@@ -330,12 +330,12 @@ def ext_status_to_v1(ext_name, ext_status):
         "version": 1.0,
         "timestampUTC": timestamp
     }
-    if len(v1_sub_status) != 0: # pylint: disable=len-as-condition
+    if len(v1_sub_status) != 0:  # pylint: disable=len-as-condition
         v1_ext_status['status']['substatus'] = v1_sub_status
     return v1_ext_status
 
 
-def ext_handler_status_to_v1(handler_status, ext_statuses, timestamp): # pylint: disable=W0613
+def ext_handler_status_to_v1(handler_status, ext_statuses, timestamp):  # pylint: disable=W0613
     v1_handler_status = {
         'handlerVersion': handler_status.version,
         'handlerName': handler_status.name,
@@ -349,7 +349,7 @@ def ext_handler_status_to_v1(handler_status, ext_statuses, timestamp): # pylint:
             "message": handler_status.message
         }
 
-    if len(handler_status.extensions) > 0: # pylint: disable=len-as-condition
+    if len(handler_status.extensions) > 0:  # pylint: disable=len-as-condition
         # Currently, no more than one extension per handler
         ext_name = handler_status.extensions[0]
         ext_status = ext_statuses.get(ext_name)
@@ -425,7 +425,7 @@ class StatusBlob(object):
                 self.put_page_blob(url, self.data)
             return True
 
-        except Exception as e: # pylint: disable=C0103
+        except Exception as e:  # pylint: disable=C0103
             logger.verbose("Initial status upload failed: {0}", e)
 
         return False
@@ -533,7 +533,7 @@ def event_to_v1(event):
     return event_str
 
 
-class WireClient(object): # pylint: disable=R0904
+class WireClient(object):  # pylint: disable=R0904
 
     def __init__(self, endpoint):
         logger.info("Wire server endpoint:{0}", endpoint)
@@ -563,7 +563,7 @@ class WireClient(object): # pylint: disable=R0904
         except ResourceGoneError:
             raise
 
-        except Exception as e: # pylint: disable=C0103
+        except Exception as e:  # pylint: disable=C0103
             raise ProtocolError("[Wireserver Exception] {0}".format(
                 ustr(e)))
 
@@ -587,20 +587,20 @@ class WireClient(object): # pylint: disable=R0904
             raise ProtocolError("{0} is missing.".format(local_file))
         try:
             return fileutil.read_file(local_file)
-        except IOError as e: # pylint: disable=C0103
+        except IOError as e:  # pylint: disable=C0103
             raise ProtocolError("Failed to read cache: {0}".format(e))
 
     def save_cache(self, local_file, data):
         try:
             fileutil.write_file(local_file, data)
-        except IOError as e: # pylint: disable=C0103
+        except IOError as e:  # pylint: disable=C0103
             fileutil.clean_ioerror(e, paths=[local_file])
             raise ProtocolError("Failed to write cache: {0}".format(e))
 
     @staticmethod
     def call_storage_service(http_req, *args, **kwargs):
         # Default to use the configured HTTP proxy
-        if not 'use_proxy' in kwargs or kwargs['use_proxy'] is None: # pylint: disable=C0113
+        if not 'use_proxy' in kwargs or kwargs['use_proxy'] is None:  # pylint: disable=C0113
             kwargs['use_proxy'] = True
 
         return http_req(*args, **kwargs)
@@ -623,10 +623,10 @@ class WireClient(object): # pylint: disable=R0904
                 logger.verbose('The specified manifest URL is empty, ignored.')
                 continue
 
-            direct_func = lambda: self.fetch(version.uri) # pylint: disable=W0640
+            direct_func = lambda: self.fetch(version.uri)  # pylint: disable=W0640
             # NOTE: the host_func may be called after refreshing the goal state, be careful about any goal state data
             # in the lambda.
-            host_func = lambda: self.fetch_manifest_through_host(version.uri) # pylint: disable=W0640
+            host_func = lambda: self.fetch_manifest_through_host(version.uri)  # pylint: disable=W0640
 
             try:
                 response = self.send_request_using_appropriate_channel(direct_func, host_func)
@@ -635,7 +635,7 @@ class WireClient(object): # pylint: disable=R0904
                     host = self.get_host_plugin()
                     host.update_manifest_uri(version.uri)
                     return response
-            except Exception as e: # pylint: disable=C0103
+            except Exception as e:  # pylint: disable=C0103
                 logger.warn("Exception when fetching manifest. Error: {0}".format(ustr(e)))
 
         raise ExtensionDownloadError("Failed to fetch manifest from all sources")
@@ -655,7 +655,7 @@ class WireClient(object): # pylint: disable=R0904
                         destination_fh.write(chunk)
                         complete = len(chunk) < chunk_size
                 success = True
-            except Exception as e: # pylint: disable=C0103
+            except Exception as e:  # pylint: disable=C0103
                 logger.error('Error streaming {0} to {1}: {2}'.format(uri, destination, ustr(e)))
 
         return success
@@ -680,7 +680,7 @@ class WireClient(object): # pylint: disable=R0904
 
             host_plugin = self.get_host_plugin()
 
-            if restutil.request_failed(resp): # pylint: disable=R1720
+            if restutil.request_failed(resp):  # pylint: disable=R1720
                 error_response = restutil.read_response_error(resp)
                 msg = "Fetch failed from [{0}]: {1}".format(uri, error_response)
                 logger.warn(msg)
@@ -695,9 +695,9 @@ class WireClient(object): # pylint: disable=R0904
                 if host_plugin is not None:
                     host_plugin.report_fetch_health(uri, source='WireClient')
 
-        except (HttpError, ProtocolError, IOError) as e: # pylint: disable=C0103
+        except (HttpError, ProtocolError, IOError) as e:  # pylint: disable=C0103
             logger.verbose("Fetch failed from [{0}]: {1}", uri, e)
-            if isinstance(e, ResourceGoneError) or isinstance(e, InvalidContainerError): # pylint: disable=R1701
+            if isinstance(e, ResourceGoneError) or isinstance(e, InvalidContainerError):  # pylint: disable=R1701
                 raise
         return resp
 
@@ -738,7 +738,7 @@ class WireClient(object): # pylint: disable=R0904
                 message = u"Retrieving the goal state recovered from previous errors"
                 add_event(AGENT_NAME, op=WALAEventOperation.FetchGoalState, version=CURRENT_VERSION, is_success=True, message=message, log_event=False)
                 logger.info(message)
-        except Exception as e: # pylint: disable=C0103
+        except Exception as e:  # pylint: disable=C0103
             if not self._last_try_update_goal_state_failed:
                 self._last_try_update_goal_state_failed = True
                 message = u"An error occurred while retrieving the goal state: {0}".format(ustr(e))
@@ -758,7 +758,7 @@ class WireClient(object): # pylint: disable=R0904
     def _save_goal_state(self):
         try:
             self.goal_state_flusher.flush()
-        except Exception as e: # pylint: disable=C0103
+        except Exception as e:  # pylint: disable=C0103
             logger.warn("Failed to save the previous goal state to the history folder: {0}", ustr(e))
 
         try:
@@ -778,7 +778,7 @@ class WireClient(object): # pylint: disable=R0904
             save_if_not_none(self._goal_state.ext_conf, EXT_CONF_FILE_NAME.format(self._goal_state.incarnation))
             save_if_not_none(self._goal_state.remote_access, REMOTE_ACCESS_FILE_NAME.format(self._goal_state.incarnation))
 
-        except Exception as e: # pylint: disable=C0103
+        except Exception as e:  # pylint: disable=C0103
             logger.warn("Failed to save the goal state to disk: {0}", ustr(e))
 
     def _set_host_plugin(self, new_host_plugin):
@@ -822,7 +822,7 @@ class WireClient(object): # pylint: disable=R0904
             xml_text = self.fetch_manifest(ext_handler.versionUris)
             self.save_cache(local_file, xml_text)
             return ExtensionManifest(xml_text)
-        except Exception as e: # pylint: disable=C0103
+        except Exception as e:  # pylint: disable=C0103
             raise ExtensionDownloadError("Failed to retrieve extension manifest. Error: {0}".format(ustr(e)))
 
     def get_remote_access(self):
@@ -838,7 +838,7 @@ class WireClient(object): # pylint: disable=R0904
             xml_text = self.fetch_manifest(vmagent_manifest.versionsManifestUris)
             fileutil.write_file(local_file, xml_text)
             return ExtensionManifest(xml_text)
-        except Exception as e: # pylint: disable=C0103
+        except Exception as e:  # pylint: disable=C0103
             raise ProtocolError("Failed to retrieve GAFamily manifest. Error: {0}".format(ustr(e)))
 
     def check_wire_protocol_version(self):
@@ -861,7 +861,7 @@ class WireClient(object): # pylint: disable=R0904
         ret = None
         try:
             ret = host_func()
-        except (ResourceGoneError, InvalidContainerError) as e: # pylint: disable=C0103
+        except (ResourceGoneError, InvalidContainerError) as e:  # pylint: disable=C0103
             host_plugin = self.get_host_plugin()
             old_container_id = host_plugin.container_id
             old_role_config_name = host_plugin.role_config_name
@@ -894,7 +894,7 @@ class WireClient(object): # pylint: disable=R0904
                                  message=msg,
                                  log_event=True)
 
-            except (ResourceGoneError, InvalidContainerError) as e: # pylint: disable=C0103
+            except (ResourceGoneError, InvalidContainerError) as e:  # pylint: disable=C0103
                 msg = "[PERIODIC] Request failed using the host plugin channel after goal state refresh. " \
                       "ContainerId changed from {0} to {1}, role config file changed from {2} to {3}. " \
                       "Exception type: {4}.".format(old_container_id, new_container_id, old_role_config_name,
@@ -936,7 +936,7 @@ class WireClient(object): # pylint: disable=R0904
                 if not ret:
                     logger.periodic_info(logger.EVERY_HOUR, "[PERIODIC] Request failed using the direct channel, "
                                                             "switching to host plugin.")
-            except (ResourceGoneError, InvalidContainerError) as e: # pylint: disable=C0103
+            except (ResourceGoneError, InvalidContainerError) as e:  # pylint: disable=C0103
                 logger.periodic_info(logger.EVERY_HOUR, "[PERIODIC] Request failed using the direct channel, "
                                                         "switching to host plugin. Error: {0}".format(ustr(e)))
 
@@ -972,8 +972,8 @@ class WireClient(object): # pylint: disable=R0904
 
         try:
             self.status_blob.prepare(blob_type)
-        except Exception as e: # pylint: disable=C0103
-            raise ProtocolError("Exception creating status blob: {0}", ustr(e)) # pylint: disable=W0715
+        except Exception as e:  # pylint: disable=C0103
+            raise ProtocolError("Exception creating status blob: {0}", ustr(e))  # pylint: disable=W0715
 
         # Swap the order of use for the HostPlugin vs. the "direct" route.
         # Prefer the use of HostPlugin. If HostPlugin fails fall back to the
@@ -992,7 +992,7 @@ class WireClient(object): # pylint: disable=R0904
             # refresh the host plugin client and try again on the next iteration of the main loop
             self.update_host_plugin_from_goal_state()
             return
-        except Exception as e: # pylint: disable=C0103
+        except Exception as e:  # pylint: disable=C0103
             # for all other errors, fall back to direct
             msg = "Falling back to direct upload: {0}".format(ustr(e))
             self.report_status_event(msg, is_success=True)
@@ -1000,7 +1000,7 @@ class WireClient(object): # pylint: disable=R0904
         try:
             if self.status_blob.upload(ext_conf.status_upload_blob):
                 return
-        except Exception as e: # pylint: disable=C0103
+        except Exception as e:  # pylint: disable=C0103
             msg = "Exception uploading status blob: {0}".format(ustr(e))
             self.report_status_event(msg, is_success=False)
 
@@ -1019,7 +1019,7 @@ class WireClient(object): # pylint: disable=R0904
                                         role_prop_uri,
                                         role_prop,
                                         headers=headers)
-        except HttpError as e: # pylint: disable=C0103
+        except HttpError as e:  # pylint: disable=C0103
             raise ProtocolError((u"Failed to send role properties: "
                                  u"{0}").format(e))
         if resp.status != httpclient.ACCEPTED:
@@ -1048,7 +1048,7 @@ class WireClient(object): # pylint: disable=R0904
                                         headers=headers,
                                         max_retry=30,
                                         retry_delay=15)
-        except HttpError as e: # pylint: disable=C0103
+        except HttpError as e:  # pylint: disable=C0103
             raise ProtocolError((u"Failed to send provision status: "
                                  u"{0}").format(e))
         if restutil.request_failed(resp):
@@ -1069,7 +1069,7 @@ class WireClient(object): # pylint: disable=R0904
             # NOTE: The call to wireserver requests utf-8 encoding in the headers, but the body should not
             #       be encoded: some nodes in the telemetry pipeline do not support utf-8 encoding.
             resp = self.call_wireserver(restutil.http_post, uri, data, header)
-        except HttpError as e: # pylint: disable=C0103
+        except HttpError as e:  # pylint: disable=C0103
             raise ProtocolError("Failed to send events:{0}".format(e))
 
         if restutil.request_failed(resp):
@@ -1194,7 +1194,7 @@ class WireClient(object): # pylint: disable=R0904
 
             try:
                 profile = self.send_request_using_appropriate_channel(direct_func, host_func)
-            except Exception as e: # pylint: disable=C0103
+            except Exception as e:  # pylint: disable=C0103
                 logger.warn("Exception retrieving artifacts profile: {0}".format(ustr(e)))
                 return None
 
@@ -1255,7 +1255,7 @@ class VersionInfo(object):
         return self.supported
 
 
-class ExtensionManifest(object): # pylint: disable=R0903
+class ExtensionManifest(object):  # pylint: disable=R0903
     def __init__(self, xml_text):
         if xml_text is None:
             raise ValueError("ExtensionManifest is None")
@@ -1300,7 +1300,7 @@ class ExtensionManifest(object): # pylint: disable=R0903
 
 
 # Do not extend this class
-class InVMArtifactsProfile(object): # pylint: disable=R0903
+class InVMArtifactsProfile(object):  # pylint: disable=R0903
     """
     deserialized json string of InVMArtifactsProfile.
     It is expected to contain the following fields:
@@ -1319,5 +1319,5 @@ class InVMArtifactsProfile(object): # pylint: disable=R0903
     def is_on_hold(self):
         # hasattr() is not available in Python 2.6
         if 'onHold' in self.__dict__:
-            return str(self.onHold).lower() == 'true' # pylint: disable=E1101
+            return str(self.onHold).lower() == 'true'  # pylint: disable=E1101
         return False

--- a/azurelinuxagent/common/resourceusage.py
+++ b/azurelinuxagent/common/resourceusage.py
@@ -30,17 +30,17 @@ PROC_COMM_FILENAME_FORMAT = "/proc/{0}/comm"
 PROC_STATUS_FILENAME_FORMAT = "/proc/{0}/status"
 
 
-class ResourceUsage(object): # pylint: disable=R0903
+class ResourceUsage(object):  # pylint: disable=R0903
     pass
 
 
-class MemoryResourceUsage(ResourceUsage): # pylint: disable=R0903
+class MemoryResourceUsage(ResourceUsage):  # pylint: disable=R0903
     @staticmethod
     def get_memory_usage_from_proc_statm(process_id):
         proc_pid_rss = 0
         try:
             proc_pid_rss = MemoryResourceUsage._get_proc_rss(process_id)
-        except Exception as e: # pylint: disable=C0103
+        except Exception as e:  # pylint: disable=C0103
             if isinstance(e, (IOError, OSError)):
                 raise
             logger.periodic_info(EVERY_SIX_HOURS, "[PERIODIC] Could not get the /prod/{0}/statm data due to {1}", process_id, ustr(e))
@@ -100,7 +100,7 @@ class ProcessInfo(object):
         cmdline_file_name = PROC_CMDLINE_FILENAME_FORMAT.format(process_id)
         try:
             pid_cmdline = fileutil.read_file(cmdline_file_name).replace("\0", " ").strip()
-        except Exception as e: # pylint: disable=C0103
+        except Exception as e:  # pylint: disable=C0103
             if isinstance(e, (IOError, OSError)):
                 raise
             raise ProcessInfoException("Could not get contents from {0}".format(cmdline_file_name), e)
@@ -123,7 +123,7 @@ class ProcessInfo(object):
         try:
             pid_comm = fileutil.read_file(comm_file_name).strip()
             pid_comm_str = str(pid_comm)
-        except Exception as e: # pylint: disable=C0103
+        except Exception as e:  # pylint: disable=C0103
             if isinstance(e, (IOError, OSError)):
                 raise
             raise ProcessInfoException("Could not get contents from {0}".format(comm_file_name), e)

--- a/azurelinuxagent/common/singletonperthread.py
+++ b/azurelinuxagent/common/singletonperthread.py
@@ -14,7 +14,7 @@ class _SingletonPerThreadMetaClass(type):
             return cls._instances[obj_name]
 
 
-class SingletonPerThread(_SingletonPerThreadMetaClass('SingleObjectPerThreadMetaClass', (object,), {})): # pylint: disable=R0903
+class SingletonPerThread(_SingletonPerThreadMetaClass('SingleObjectPerThreadMetaClass', (object,), {})):  # pylint: disable=R0903
     # This base class calls the metaclass above to create the singleton per thread object. This class provides an
     # abstraction over how to invoke the Metaclass so just inheriting this class makes the
     # child class a singleton per thread (As opposed to invoking the Metaclass separately for each derived classes)

--- a/azurelinuxagent/common/telemetryevent.py
+++ b/azurelinuxagent/common/telemetryevent.py
@@ -20,7 +20,7 @@
 from azurelinuxagent.common.datacontract import DataContract, DataContractList
 from azurelinuxagent.common.version import AGENT_NAME
 
-class CommonTelemetryEventSchema(object): # pylint: disable=R0903
+class CommonTelemetryEventSchema(object):  # pylint: disable=R0903
 
     # Common schema keys for GuestAgentExtensionEvents, GuestAgentGenericLogs
     # and GuestAgentPerformanceCounterEvents tables in Kusto.
@@ -44,7 +44,7 @@ class CommonTelemetryEventSchema(object): # pylint: disable=R0903
     VMId = "VMId"
     ImageOrigin = "ImageOrigin"
 
-class GuestAgentGenericLogsSchema(CommonTelemetryEventSchema): # pylint: disable=R0903
+class GuestAgentGenericLogsSchema(CommonTelemetryEventSchema):  # pylint: disable=R0903
 
     # GuestAgentGenericLogs table specific schema keys
     EventName = "EventName"
@@ -53,7 +53,7 @@ class GuestAgentGenericLogsSchema(CommonTelemetryEventSchema): # pylint: disable
     Context2 = "Context2"
     Context3 = "Context3"
 
-class GuestAgentExtensionEventsSchema(CommonTelemetryEventSchema): # pylint: disable=R0903
+class GuestAgentExtensionEventsSchema(CommonTelemetryEventSchema):  # pylint: disable=R0903
 
     # GuestAgentExtensionEvents table specific schema keys
     ExtensionType = "ExtensionType"
@@ -65,7 +65,7 @@ class GuestAgentExtensionEventsSchema(CommonTelemetryEventSchema): # pylint: dis
     Message = "Message"
     Duration = "Duration"
 
-class GuestAgentPerfCounterEventsSchema(CommonTelemetryEventSchema): # pylint: disable=R0903
+class GuestAgentPerfCounterEventsSchema(CommonTelemetryEventSchema):  # pylint: disable=R0903
 
     # GuestAgentPerformanceCounterEvents table specific schema keys
     Category = "Category"
@@ -73,7 +73,7 @@ class GuestAgentPerfCounterEventsSchema(CommonTelemetryEventSchema): # pylint: d
     Instance = "Instance"
     Value = "Value"
 
-class TelemetryEventParam(DataContract): # pylint: disable=R0903
+class TelemetryEventParam(DataContract):  # pylint: disable=R0903
     def __init__(self, name=None, value=None):
         self.name = name
         self.value = value
@@ -84,8 +84,8 @@ class TelemetryEventParam(DataContract): # pylint: disable=R0903
 
 class TelemetryEvent(DataContract):
     def __init__(self, eventId=None, providerId=None):
-        self.eventId = eventId # pylint: disable=C0103
-        self.providerId = providerId # pylint: disable=C0103
+        self.eventId = eventId  # pylint: disable=C0103
+        self.providerId = providerId  # pylint: disable=C0103
         self.parameters = DataContractList(TelemetryEventParam)
         self.file_type = ""
 

--- a/azurelinuxagent/common/utils/cryptutil.py
+++ b/azurelinuxagent/common/utils/cryptutil.py
@@ -51,7 +51,7 @@ class CryptUtil(object):
             logger.error(msg)
 
     def get_pubkey_from_prv(self, file_name):
-        if not os.path.exists(file_name): # pylint: disable=R1720
+        if not os.path.exists(file_name):  # pylint: disable=R1720
             raise IOError(errno.ENOENT, "File not found", file_name)
         else:
             cmd = [self.openssl_cmd, "rsa", "-in", file_name, "-pubout"]
@@ -59,7 +59,7 @@ class CryptUtil(object):
             return pub
 
     def get_pubkey_from_crt(self, file_name):
-        if not os.path.exists(file_name): # pylint: disable=R1720
+        if not os.path.exists(file_name):  # pylint: disable=R1720
             raise IOError(errno.ENOENT, "File not found", file_name)
         else:
             cmd = [self.openssl_cmd, "x509", "-in", file_name, "-pubkey", "-noout"]
@@ -67,7 +67,7 @@ class CryptUtil(object):
             return pub
 
     def get_thumbprint_from_crt(self, file_name):
-        if not os.path.exists(file_name): # pylint: disable=R1720
+        if not os.path.exists(file_name):  # pylint: disable=R1720
             raise IOError(errno.ENOENT, "File not found", file_name)
         else:
             cmd = [self.openssl_cmd, "x509", "-in", file_name, "-fingerprint", "-noout"]
@@ -76,7 +76,7 @@ class CryptUtil(object):
             return thumbprint
 
     def decrypt_p7m(self, p7m_file, trans_prv_file, trans_cert_file, pem_file):
-        if not os.path.exists(p7m_file): # pylint: disable=R1720
+        if not os.path.exists(p7m_file):  # pylint: disable=R1720
             raise IOError(errno.ENOENT, "File not found", p7m_file)
         elif not os.path.exists(trans_prv_file):
             raise IOError(errno.ENOENT, "File not found", trans_prv_file)
@@ -130,10 +130,10 @@ class CryptUtil(object):
             #TODO remove pyasn1 dependency
             from pyasn1.codec.der import decoder as der_decoder
             der_encoded = base64.b64decode(base64_encoded)
-            der_encoded = der_decoder.decode(der_encoded)[0][1] # pylint: disable=unsubscriptable-object
+            der_encoded = der_decoder.decode(der_encoded)[0][1]  # pylint: disable=unsubscriptable-object
             key = der_decoder.decode(self.bits_to_bytes(der_encoded))[0]
-            n=key[0] # pylint: disable=C0103,unsubscriptable-object
-            e=key[1] # pylint: disable=C0103,unsubscriptable-object
+            n=key[0]  # pylint: disable=C0103,unsubscriptable-object
+            e=key[1]  # pylint: disable=C0103,unsubscriptable-object
             keydata = bytearray()
             keydata.extend(struct.pack('>I', len("ssh-rsa")))
             keydata.extend(b"ssh-rsa")
@@ -145,7 +145,7 @@ class CryptUtil(object):
             keydata_base64 = base64.b64encode(bytebuffer(keydata))
             return ustr(b"ssh-rsa " +  keydata_base64 + b"\n",
                         encoding='utf-8')
-        except ImportError as e: # pylint: disable=C0103
+        except ImportError as e:  # pylint: disable=C0103
             raise CryptError("Failed to load pyasn1.codec.der")
 
     def num_to_bytes(self, num):
@@ -179,12 +179,12 @@ class CryptUtil(object):
         try:
             decoded = base64.b64decode(encrypted_password)
             args = DECRYPT_SECRET_CMD.format(self.openssl_cmd, private_key).split(' ')
-            p = subprocess.Popen(args, stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.STDOUT) # pylint: disable=C0103
+            p = subprocess.Popen(args, stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.STDOUT)  # pylint: disable=C0103
             p.stdin.write(decoded)
             output = p.communicate()[0]
             retcode = p.poll()
             if retcode:
                 raise subprocess.CalledProcessError(retcode, "openssl cms -decrypt", output=output)
             return output.decode('utf-16')
-        except Exception as e: # pylint: disable=C0103
+        except Exception as e:  # pylint: disable=C0103
             raise CryptError("Error decoding secret", e)

--- a/azurelinuxagent/common/utils/extensionprocessutil.py
+++ b/azurelinuxagent/common/utils/extensionprocessutil.py
@@ -51,7 +51,7 @@ def wait_for_process_completion_or_timeout(process, timeout):
     return timeout == 0, return_code
 
 
-def handle_process_completion(process, command, timeout, stdout, stderr, error_code): # pylint: disable=R0913
+def handle_process_completion(process, command, timeout, stdout, stderr, error_code):  # pylint: disable=R0913
     """
     Utility function that waits for process completion and retrieves its output (stdout and stderr) if it completed
     before the timeout period. Otherwise, the process will get killed and an ExtensionError will be raised.
@@ -96,7 +96,7 @@ def read_output(stdout, stderr):
                       errors='backslashreplace')
 
         return format_stdout_stderr(stdout, stderr)
-    except Exception as e: # pylint: disable=C0103
+    except Exception as e:  # pylint: disable=C0103
         return format_stdout_stderr("", "Cannot read stdout/stderr: {0}".format(ustr(e)))
 
 
@@ -126,10 +126,10 @@ def format_stdout_stderr(stdout, stderr):
         return ''
 
     def to_s(captured_stdout, stdout_offset, captured_stderr, stderr_offset):
-        s = template.format(captured_stdout[stdout_offset:], captured_stderr[stderr_offset:]) # pylint: disable=C0103
+        s = template.format(captured_stdout[stdout_offset:], captured_stderr[stderr_offset:])  # pylint: disable=C0103
         return s
 
-    if len(stdout) + len(stderr) < max_len: # pylint: disable=R1705
+    if len(stdout) + len(stderr) < max_len:  # pylint: disable=R1705
         return to_s(stdout, 0, stderr, 0)
     elif len(stdout) < max_len_each:
         bonus = max_len_each - len(stdout)

--- a/azurelinuxagent/common/utils/fileutil.py
+++ b/azurelinuxagent/common/utils/fileutil.py
@@ -21,7 +21,7 @@
 File operation util functions
 """
 
-import errno as errno # pylint: disable=C0414
+import errno as errno  # pylint: disable=C0414
 import glob
 import os
 import pwd
@@ -85,7 +85,7 @@ def append_file(filepath, contents, asbin=False, encoding='utf-8'):
 
 
 def base_name(path):
-    head, tail = os.path.split(path) # pylint: disable=W0612
+    head, tail = os.path.split(path)  # pylint: disable=W0612
     return tail
 
 
@@ -135,11 +135,11 @@ def rm_dirs(*args):
     """
     Remove the contents of each directory
     """
-    for p in args: # pylint: disable=C0103
+    for p in args:  # pylint: disable=C0103
         if not os.path.isdir(p):
             continue
 
-        for pp in os.listdir(p): # pylint: disable=C0103
+        for pp in os.listdir(p):  # pylint: disable=C0103
             path = os.path.join(p, pp)
             if os.path.isfile(path):
                 os.remove(path)
@@ -167,7 +167,7 @@ def update_conf_file(path, line_start, val, chk_err=False):
 
 
 def search_file(target_dir_name, target_file_name):
-    for root, dirs, files in os.walk(target_dir_name): # pylint: disable=W0612
+    for root, dirs, files in os.walk(target_dir_name):  # pylint: disable=W0612
         for file_name in files:
             if file_name == target_file_name:
                 return os.path.join(root, file_name)
@@ -175,7 +175,7 @@ def search_file(target_dir_name, target_file_name):
 
 
 def chmod_tree(path, mode):
-    for root, dirs, files in os.walk(path): # pylint: disable=W0612
+    for root, dirs, files in os.walk(path):  # pylint: disable=W0612
         for file_name in files:
             os.chmod(os.path.join(root, file_name), mode)
 
@@ -186,7 +186,7 @@ def findstr_in_file(file_path, line_str):
     (Trailing whitespace is ignored.)
     """
     try:
-        with open(file_path, 'r') as fh: # pylint: disable=C0103
+        with open(file_path, 'r') as fh:  # pylint: disable=C0103
             for line in fh.readlines():
                 if line_str == line.rstrip():
                     return True
@@ -201,13 +201,13 @@ def findre_in_file(file_path, line_re):
     Return match object if found in file.
     """
     try:
-        with open(file_path, 'r') as fh: # pylint: disable=C0103
+        with open(file_path, 'r') as fh:  # pylint: disable=C0103
             pattern = re.compile(line_re)
             for line in fh.readlines():
                 match = re.search(pattern, line)
                 if match:
                     return match
-    except: # pylint: disable=W0702
+    except:  # pylint: disable=W0702
         pass
 
     return None
@@ -218,13 +218,13 @@ def get_all_files(root_path):
     Find all files under the given root path
     """
     result = []
-    for root, dirs, files in os.walk(root_path): # pylint: disable=W0612
-        result.extend([os.path.join(root, file) for file in files]) # pylint: disable=redefined-builtin
+    for root, dirs, files in os.walk(root_path):  # pylint: disable=W0612
+        result.extend([os.path.join(root, file) for file in files])  # pylint: disable=redefined-builtin
 
     return result
 
 
-def clean_ioerror(e, paths=None): # pylint: disable=C0103
+def clean_ioerror(e, paths=None):  # pylint: disable=C0103
     """
     Clean-up possibly bad files and directories after an IO error.
     The code ignores *all* errors since disk state may be unhealthy.

--- a/azurelinuxagent/common/utils/flexible_version.py
+++ b/azurelinuxagent/common/utils/flexible_version.py
@@ -17,11 +17,11 @@
 # Requires Python 2.6+ and Openssl 1.0+
 #
 
-from distutils import version # pylint: disable=no-name-in-module
+from distutils import version  # pylint: disable=no-name-in-module
 import re
 
 
-class FlexibleVersion(version.Version): # pylint: disable=R0902
+class FlexibleVersion(version.Version):  # pylint: disable=R0902
     """
     A more flexible implementation of distutils.version.StrictVersion
 
@@ -40,7 +40,7 @@ class FlexibleVersion(version.Version): # pylint: disable=R0902
         http://stackoverflow.com/questions/12255554/sort-versions-in-python
     """
 
-    def __init__(self, vstring=None, sep='.', prerel_tags=('alpha', 'beta', 'rc')): # pylint: disable=R1711
+    def __init__(self, vstring=None, sep='.', prerel_tags=('alpha', 'beta', 'rc')):  # pylint: disable=R1711
         version.Version.__init__(self) 
 
         if sep is None:
@@ -71,7 +71,7 @@ class FlexibleVersion(version.Version): # pylint: disable=R0902
 
     @property
     def major(self):
-        return self.version[0] if len(self.version) > 0 else 0 # pylint: disable=len-as-condition
+        return self.version[0] if len(self.version) > 0 else 0  # pylint: disable=len-as-condition
 
     @property
     def minor(self):
@@ -81,8 +81,8 @@ class FlexibleVersion(version.Version): # pylint: disable=R0902
     def patch(self):
         return self.version[2] if len(self.version) > 2 else 0
 
-    def _parse(self, vstring): # pylint: disable=R1711
-        m = self.version_re.match(vstring) # pylint: disable=C0103
+    def _parse(self, vstring):  # pylint: disable=R1711
+        m = self.version_re.match(vstring)  # pylint: disable=C0103
         if not m:
             raise ValueError("Invalid version number '{0}'".format(vstring))
 
@@ -94,19 +94,19 @@ class FlexibleVersion(version.Version): # pylint: disable=R0902
         tag_num = m.group(self._nn_prerel_num)
 
         if tag is not None and tag_num is not None:
-            self.prerelease = (tag, int(tag_num) if len(tag_num) else None) # pylint: disable=C1801
+            self.prerelease = (tag, int(tag_num) if len(tag_num) else None)  # pylint: disable=C1801
 
         self.version = tuple(map(int, self.sep_re.split(m.group(self._nn_version))))
         return
 
     def __add__(self, increment):
-        version = list(self.version) # pylint: disable=W0621
+        version = list(self.version)  # pylint: disable=W0621
         version[-1] += increment
         vstring = self._assemble(version, self.sep, self.prerel_sep, self.prerelease)
         return FlexibleVersion(vstring=vstring, sep=self.sep, prerel_tags=self.prerel_tags)
 
     def __sub__(self, decrement):
-        version = list(self.version) # pylint: disable=W0621
+        version = list(self.version)  # pylint: disable=W0621
         if version[-1] <= 0:
             raise ArithmeticError("Cannot decrement final numeric component of {0} below zero" \
                 .format(self))
@@ -179,23 +179,23 @@ class FlexibleVersion(version.Version): # pylint: disable=R0902
 
         return True
 
-    def _assemble(self, version, sep, prerel_sep, prerelease): # pylint: disable=W0621
-        s = sep.join(map(str, version)) # pylint: disable=C0103
+    def _assemble(self, version, sep, prerel_sep, prerelease):  # pylint: disable=W0621
+        s = sep.join(map(str, version))  # pylint: disable=C0103
         if prerelease is not None:
             if prerel_sep is not None:
-                s += prerel_sep # pylint: disable=C0103
-            s += prerelease[0] # pylint: disable=C0103
+                s += prerel_sep  # pylint: disable=C0103
+            s += prerelease[0]  # pylint: disable=C0103
             if prerelease[1] is not None:
-                s += str(prerelease[1]) # pylint: disable=C0103
+                s += str(prerelease[1])  # pylint: disable=C0103
         return s
 
-    def _compile_pattern(self): # pylint: disable=R1711
+    def _compile_pattern(self):  # pylint: disable=R1711
         sep, self.sep_re = self._compile_separator(self.sep)
 
         if self.prerel_tags:
             tags = '|'.join(re.escape(tag) for tag in self.prerel_tags)
             self.prerel_tags_set = dict(zip(self.prerel_tags, range(len(self.prerel_tags))))
-            release_re = '(?:{prerel_sep}(?P<{tn}>{tags})(?P<{nn}>\d*))?'.format( # pylint: disable=W1401
+            release_re = '(?:{prerel_sep}(?P<{tn}>{tags})(?P<{nn}>\d*))?'.format(  # pylint: disable=W1401
                         prerel_sep=self._re_prerel_sep, 
                         tags=tags, 
                         tn=self._nn_prerel_tag, 

--- a/azurelinuxagent/common/utils/networkutil.py
+++ b/azurelinuxagent/common/utils/networkutil.py
@@ -22,7 +22,7 @@ class RouteEntry(object):
     Represents a single route. The destination, gateway, and mask members are hex representations of the IPv4 address in
     network byte order.
     """
-    def __init__(self, interface, destination, gateway, mask, flags, metric): # pylint: disable=R0913
+    def __init__(self, interface, destination, gateway, mask, flags, metric):  # pylint: disable=R0913
         self.interface = interface
         self.destination = destination
         self.gateway = gateway
@@ -49,12 +49,12 @@ class RouteEntry(object):
         return self._net_hex_to_dotted_quad(self.mask)
 
     def to_json(self):
-        f = '{{"Iface": "{0}", "Destination": "{1}", "Gateway": "{2}", "Mask": "{3}", "Flags": "{4:#06x}", "Metric": "{5}"}}' # pylint: disable=C0103
+        f = '{{"Iface": "{0}", "Destination": "{1}", "Gateway": "{2}", "Mask": "{3}", "Flags": "{4:#06x}", "Metric": "{5}"}}'  # pylint: disable=C0103
         return f.format(self.interface, self.destination_quad(), self.gateway_quad(), self.mask_quad(),
                        self.flags, self.metric) 
 
     def __str__(self):
-        f = "Iface: {0}\tDestination: {1}\tGateway: {2}\tMask: {3}\tFlags: {4:#06x}\tMetric: {5}" # pylint: disable=C0103
+        f = "Iface: {0}\tDestination: {1}\tGateway: {2}\tMask: {3}\tFlags: {4:#06x}\tMetric: {5}"  # pylint: disable=C0103
         return f.format(self.interface, self.destination_quad(), self.gateway_quad(), self.mask_quad(),
                         self.flags, self.metric)
 
@@ -88,8 +88,8 @@ class NetworkInterfaceCard:
     def __str__(self):
         entries = ['"name": "{0}"'.format(self.name),
                    '"link": "{0}"'.format(self.link)]
-        if len(self.ipv4) > 0: # pylint: disable=len-as-condition
+        if len(self.ipv4) > 0:  # pylint: disable=len-as-condition
             entries.append('"ipv4": {0}'.format(self._json_array(self.ipv4)))
-        if len(self.ipv6) > 0: # pylint: disable=len-as-condition
+        if len(self.ipv6) > 0:  # pylint: disable=len-as-condition
             entries.append('"ipv6": {0}'.format(self._json_array(self.ipv6)))
         return "{{ {0} }}".format(", ".join(entries))

--- a/azurelinuxagent/common/utils/restutil.py
+++ b/azurelinuxagent/common/utils/restutil.py
@@ -148,7 +148,7 @@ def _is_retry_status(status, retry_codes=None):
     return status in retry_codes
 
 
-def _is_retry_exception(e): # pylint: disable=C0103
+def _is_retry_exception(e):  # pylint: disable=C0103
     return len([x for x in RETRY_EXCEPTIONS if isinstance(e, x)]) > 0
 
 
@@ -161,7 +161,7 @@ def _parse_url(url):
     Parse URL to get the components of the URL broken down to host, port
     :rtype: string, int, bool, string
     """
-    o = urlparse(url) # pylint: disable=C0103
+    o = urlparse(url)  # pylint: disable=C0103
     rel_uri = o.path
     if o.fragment:
         rel_uri = "{0}#{1}".format(rel_uri, o.fragment)
@@ -205,7 +205,7 @@ def dotted_netmask(mask):
     return socket.inet_ntoa(struct.pack('>I', bits))
 
 
-def address_in_network(ip, net): # pylint: disable=C0103
+def address_in_network(ip, net):  # pylint: disable=C0103
     """This function allows you to check if an IP belongs to a network subnet
     Example: returns True if ip = 192.168.1.1 and net = 192.168.1.0/24
              returns False if ip = 192.168.1.1 and net = 192.168.100.0/24
@@ -273,7 +273,7 @@ def _get_http_proxy(secure=False):
     else:
         http_proxy_env = HTTPS_PROXY_ENV if secure else HTTP_PROXY_ENV
         http_proxy_url = None
-        for v in [http_proxy_env, http_proxy_env.upper()]: # pylint: disable=C0103
+        for v in [http_proxy_env, http_proxy_env.upper()]:  # pylint: disable=C0103
             if v in os.environ:
                 http_proxy_url = os.environ[v]
                 break
@@ -288,7 +288,7 @@ def redact_sas_tokens_in_urls(url):
     return SAS_TOKEN_RETRIEVAL_REGEX.sub(r"\1" + REDACTED_TEXT + r"\3", url)
 
 
-def _http_request(method, host, rel_uri, port=None, data=None, secure=False, # pylint: disable=R0913
+def _http_request(method, host, rel_uri, port=None, data=None, secure=False,  # pylint: disable=R0913
                   headers=None, proxy_host=None, proxy_port=None, redact_data=False):
 
     headers = {} if headers is None else headers
@@ -335,7 +335,7 @@ def _http_request(method, host, rel_uri, port=None, data=None, secure=False, # p
     return conn.getresponse()
 
 
-def http_request(method, # pylint: disable=R0913,R0912
+def http_request(method,  # pylint: disable=R0913,R0912
                  url, data, headers=None,
                  use_proxy=False,
                  max_retry=DEFAULT_RETRIES,
@@ -345,7 +345,7 @@ def http_request(method, # pylint: disable=R0913,R0912
 
     if retry_codes is None:
         retry_codes = RETRY_CODES
-    global SECURE_WARNING_EMITTED # pylint: disable=W0603
+    global SECURE_WARNING_EMITTED  # pylint: disable=W0603
 
     host, port, secure, rel_uri = _parse_url(url)
 
@@ -449,14 +449,14 @@ def http_request(method, # pylint: disable=R0913,R0912
 
             return resp
 
-        except httpclient.HTTPException as e: # pylint: disable=C0103
+        except httpclient.HTTPException as e:  # pylint: disable=C0103
             clean_url = redact_sas_tokens_in_urls(url)
             msg = '[HTTP Failed] {0} {1} -- HttpException {2}'.format(method, clean_url, e)
             if _is_retry_exception(e):
                 continue
             break
 
-        except IOError as e: # pylint: disable=C0103
+        except IOError as e:  # pylint: disable=C0103
             IOErrorCounter.increment(host=host, port=port)
             clean_url = redact_sas_tokens_in_urls(url)
             msg = '[HTTP Failed] {0} {1} -- IOError {2}'.format(method, clean_url, e)
@@ -465,7 +465,7 @@ def http_request(method, # pylint: disable=R0913,R0912
     raise HttpError("{0} -- {1} attempts made".format(msg, attempt))
 
 
-def http_get(url, # pylint: disable=R0913
+def http_get(url,  # pylint: disable=R0913
              headers=None,
              use_proxy=False,
              max_retry=DEFAULT_RETRIES,
@@ -482,7 +482,7 @@ def http_get(url, # pylint: disable=R0913
                         retry_delay=retry_delay)
 
 
-def http_head(url, # pylint: disable=R0913
+def http_head(url,  # pylint: disable=R0913
               headers=None,
               use_proxy=False,
               max_retry=DEFAULT_RETRIES,
@@ -499,7 +499,7 @@ def http_head(url, # pylint: disable=R0913
                         retry_delay=retry_delay)
 
 
-def http_post(url, # pylint: disable=R0913
+def http_post(url,  # pylint: disable=R0913
               data,
               headers=None,
               use_proxy=False,
@@ -517,7 +517,7 @@ def http_post(url, # pylint: disable=R0913
                         retry_delay=retry_delay)
 
 
-def http_put(url, # pylint: disable=R0913
+def http_put(url,  # pylint: disable=R0913
              data,
              headers=None,
              use_proxy=False,
@@ -537,7 +537,7 @@ def http_put(url, # pylint: disable=R0913
                         redact_data=redact_data)
 
 
-def http_delete(url, # pylint: disable=R0913
+def http_delete(url,  # pylint: disable=R0913
                 headers=None,
                 use_proxy=False,
                 max_retry=DEFAULT_RETRIES,

--- a/azurelinuxagent/common/utils/shellutil.py
+++ b/azurelinuxagent/common/utils/shellutil.py
@@ -42,7 +42,7 @@ if not hasattr(subprocess, 'check_output'):
 
     # Exception classes used by this module.
     class CalledProcessError(Exception):
-        def __init__(self, returncode, cmd, output=None): # pylint: disable=W0231
+        def __init__(self, returncode, cmd, output=None):  # pylint: disable=W0231
             self.returncode = returncode
             self.cmd = cmd
             self.output = output
@@ -78,7 +78,7 @@ def run(cmd, chk_err=True, expected_errors=None):
     """
     if expected_errors is None:
         expected_errors = []
-    retcode, out = run_get_output(cmd, chk_err=chk_err, expected_errors=expected_errors) # pylint: disable=W0612
+    retcode, out = run_get_output(cmd, chk_err=chk_err, expected_errors=expected_errors)  # pylint: disable=W0612
     return retcode
 
 
@@ -101,7 +101,7 @@ def run_get_output(cmd, chk_err=True, log_cmd=True, expected_errors=None):
                                          stderr=subprocess.STDOUT,
                                          shell=True)
         output = _encode_command_output(output)
-    except subprocess.CalledProcessError as e: # pylint: disable=C0103
+    except subprocess.CalledProcessError as e:  # pylint: disable=C0103
         output = _encode_command_output(e.output)
 
         if chk_err:
@@ -113,7 +113,7 @@ def run_get_output(cmd, chk_err=True, log_cmd=True, expected_errors=None):
             else:
                 logger.error(msg)
         return e.returncode, output
-    except Exception as e: # pylint: disable=C0103
+    except Exception as e:  # pylint: disable=C0103
         if chk_err:
             logger.error(u"Command [{0}] raised unexpected exception: [{1}]"
                          .format(cmd, ustr(e)))
@@ -131,11 +131,11 @@ class CommandError(Exception):
     """
     @staticmethod
     def _get_message(command, return_code, stderr):
-        command_name = command[0] if isinstance(command, list) and len(command) > 0 else command # pylint: disable=len-as-condition
+        command_name = command[0] if isinstance(command, list) and len(command) > 0 else command  # pylint: disable=len-as-condition
         return "'{0}' failed: {1} ({2})".format(command_name, return_code, stderr.rstrip())
 
     def __init__(self, command, return_code, stdout, stderr):
-        super(Exception, self).__init__(CommandError._get_message(command, return_code, stderr)) # pylint: disable=E1003
+        super(Exception, self).__init__(CommandError._get_message(command, return_code, stderr))  # pylint: disable=E1003
         self.command = command
         self.returncode = return_code
         self.stdout = stdout
@@ -165,7 +165,7 @@ def run_command(command, log_error=False, cmd_input=None):
         process = subprocess.Popen(command, stdin=stdin, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=False)
         stdout, stderr = process.communicate(input=process_input)
         returncode = process.returncode
-    except Exception as e: # pylint: disable=C0103
+    except Exception as e:  # pylint: disable=C0103
         if log_error:
             logger.error(u"Command [{0}] raised unexpected exception: [{1}]", format_command(command), ustr(e))
         raise

--- a/azurelinuxagent/common/utils/textutil.py
+++ b/azurelinuxagent/common/utils/textutil.py
@@ -45,7 +45,7 @@ def findall(root, tag, namespace=None):
     if root is None:
         return []
 
-    if namespace is None: # pylint: disable=R1705
+    if namespace is None:  # pylint: disable=R1705
         return root.getElementsByTagName(tag)
     else:
         return root.getElementsByTagNameNS(namespace, tag)
@@ -56,7 +56,7 @@ def find(root, tag, namespace=None):
     Get first node by tag and namespace under Node root.
     """
     nodes = findall(root, tag, namespace=namespace)
-    if nodes is not None and len(nodes) >= 1: # pylint: disable=R1705
+    if nodes is not None and len(nodes) >= 1:  # pylint: disable=R1705
         return nodes[0]
     else:
         return None
@@ -87,7 +87,7 @@ def getattrib(node, attr_name):
     """
     Get attribute of xml node
     """
-    if node is not None: # pylint: disable=R1705
+    if node is not None:  # pylint: disable=R1705
         return node.getAttribute(attr_name)
     else:
         return None
@@ -131,14 +131,14 @@ def hex_dump2(buf):
     return hex_dump3(buf, 0, len(buf))
 
 
-def is_in_range(a, low, high): # pylint: disable=C0103
+def is_in_range(a, low, high):  # pylint: disable=C0103
     """
     Return True if 'a' in 'low' <= a <= 'high'
     """
     return low <= a <= high
 
 
-def is_printable(ch): # pylint: disable=C0103
+def is_printable(ch):  # pylint: disable=C0103
     """
     Return True if character is displayable.
     """
@@ -147,7 +147,7 @@ def is_printable(ch): # pylint: disable=C0103
             or is_in_range(ch, str_to_ord('0'), str_to_ord('9')))
 
 
-def hex_dump(buffer, size): # pylint: disable=redefined-builtin
+def hex_dump(buffer, size):  # pylint: disable=redefined-builtin
     """
     Return Hex formated dump of a 'buffer' of 'size'.
     """
@@ -158,7 +158,7 @@ def hex_dump(buffer, size): # pylint: disable=redefined-builtin
         if (i % 16) == 0:
             result += "%06X: " % i
         byte = buffer[i]
-        if type(byte) == str: # pylint: disable=C0123
+        if type(byte) == str:  # pylint: disable=C0123
             byte = ord(byte.decode('latin1'))
         result += "%02X " % byte
         if (i & 15) == 7:
@@ -173,7 +173,7 @@ def hex_dump(buffer, size): # pylint: disable=redefined-builtin
             result += " "
             for j in range(i - (i % 16), i + 1):
                 byte = buffer[j]
-                if type(byte) == str: # pylint: disable=C0123
+                if type(byte) == str:  # pylint: disable=C0123
                     byte = str_to_ord(byte.decode('latin1'))
                 k = '.'
                 if is_printable(byte):
@@ -184,24 +184,24 @@ def hex_dump(buffer, size): # pylint: disable=redefined-builtin
     return result
 
 
-def str_to_ord(a): # pylint: disable=C0103
+def str_to_ord(a):  # pylint: disable=C0103
     """
     Allows indexing into a string or an array of integers transparently.
     Generic utility function.
     """
-    if type(a) == type(b'') or type(a) == type(u''): # pylint: disable=C0123
+    if type(a) == type(b'') or type(a) == type(u''):  # pylint: disable=C0123
         a = ord(a)
     return a
 
 
-def compare_bytes(a, b, start, length): # pylint: disable=C0103
+def compare_bytes(a, b, start, length):  # pylint: disable=C0103
     for offset in range(start, start + length):
         if str_to_ord(a[offset]) != str_to_ord(b[offset]):
             return False
     return True
 
 
-def int_to_ip4_addr(a): # pylint: disable=C0103
+def int_to_ip4_addr(a):  # pylint: disable=C0103
     """
     Build DHCP request string.
     """
@@ -211,13 +211,13 @@ def int_to_ip4_addr(a): # pylint: disable=C0103
                             (a) & 0xFF)
 
 
-def hexstr_to_bytearray(a): # pylint: disable=C0103
+def hexstr_to_bytearray(a):  # pylint: disable=C0103
     """
     Return hex string packed into a binary struct.
     """
-    b = b"" # pylint: disable=C0103
-    for c in range(0, len(a) // 2): # pylint: disable=C0103
-        b += struct.pack("B", int(a[c * 2:c * 2 + 2], 16)) # pylint: disable=C0103
+    b = b""  # pylint: disable=C0103
+    for c in range(0, len(a) // 2):  # pylint: disable=C0103
+        b += struct.pack("B", int(a[c * 2:c * 2 + 2], 16))  # pylint: disable=C0103
     return b
 
 
@@ -226,7 +226,7 @@ def set_ssh_config(config, name, val):
     no_match = -1
 
     match_start = no_match
-    for i in range(0, len(config)): # pylint: disable=C0200
+    for i in range(0, len(config)):  # pylint: disable=C0200
         if config[i].startswith(name) and match_start == no_match:
             config[i] = "{0} {1}".format(name, val)
             found = True
@@ -246,7 +246,7 @@ def set_ssh_config(config, name, val):
 
 def set_ini_config(config, name, val):
     notfound = True
-    nameEqual = name + '=' # pylint: disable=C0103
+    nameEqual = name + '='  # pylint: disable=C0103
     length = len(config)
     text = "{0}=\"{1}\"".format(name, val)
 
@@ -263,7 +263,7 @@ def set_ini_config(config, name, val):
 def replace_non_ascii(incoming, replace_char=''):
     outgoing = ''
     if incoming is not None:
-        for c in incoming: # pylint: disable=C0103
+        for c in incoming:  # pylint: disable=C0103
             if str_to_ord(c) > 128:
                 outgoing += replace_char
             else:
@@ -271,7 +271,7 @@ def replace_non_ascii(incoming, replace_char=''):
     return outgoing
 
 
-def remove_bom(c): # pylint: disable=C0103
+def remove_bom(c):  # pylint: disable=C0103
     """
     bom is comprised of a sequence of three chars,0xef, 0xbb, 0xbf, in case of utf-8.
     """
@@ -302,7 +302,7 @@ def get_bytes_from_pem(pem_str):
     return base64_bytes
 
 
-def compress(s): # pylint: disable=C0103
+def compress(s):  # pylint: disable=C0103
     """
     Compress a string, and return the base64 encoded result of the compression.
 
@@ -317,21 +317,21 @@ def compress(s): # pylint: disable=C0103
     return base64.b64encode(zlib.compress(s))
 
 
-def b64encode(s): # pylint: disable=C0103
+def b64encode(s):  # pylint: disable=C0103
     from azurelinuxagent.common.version import PY_VERSION_MAJOR
     if PY_VERSION_MAJOR > 2:
         return base64.b64encode(bytes(s, 'utf-8')).decode('utf-8')
     return base64.b64encode(s)
 
 
-def b64decode(s): # pylint: disable=C0103
+def b64decode(s):  # pylint: disable=C0103
     from azurelinuxagent.common.version import PY_VERSION_MAJOR
     if PY_VERSION_MAJOR > 2:
         return base64.b64decode(s).decode('utf-8')
     return base64.b64decode(s)
 
 
-def safe_shlex_split(s): # pylint: disable=C0103
+def safe_shlex_split(s):  # pylint: disable=C0103
     import shlex
     from azurelinuxagent.common.version import PY_VERSION
     if PY_VERSION[:2] == (2, 6):
@@ -339,8 +339,8 @@ def safe_shlex_split(s): # pylint: disable=C0103
     return shlex.split(s)
 
 
-def swap_hexstring(s, width=2): # pylint: disable=C0103
-    r = len(s) % width # pylint: disable=C0103
+def swap_hexstring(s, width=2):  # pylint: disable=C0103
+    r = len(s) % width  # pylint: disable=C0103
     if r != 0:
         s = ('0' * (width - (len(s) % width))) + s
 
@@ -364,11 +364,11 @@ def parse_json(json_str):
     return result
 
 
-def is_str_none_or_whitespace(s): # pylint: disable=C0103
+def is_str_none_or_whitespace(s):  # pylint: disable=C0103
     return s is None or len(s) == 0 or s.isspace()
 
 
-def is_str_empty(s): # pylint: disable=C0103
+def is_str_empty(s):  # pylint: disable=C0103
     return is_str_none_or_whitespace(s) or is_str_none_or_whitespace(s.rstrip(' \t\r\n\0'))
 
 

--- a/azurelinuxagent/common/version.py
+++ b/azurelinuxagent/common/version.py
@@ -62,10 +62,10 @@ def get_f5_platform():
     the version and product information is contained in the /VERSION file.
     """
     result = [None, None, None, None]
-    f5_version = re.compile("^Version: (\d+\.\d+\.\d+)") # pylint: disable=W1401
-    f5_product = re.compile("^Product: ([\w-]+)") # pylint: disable=W1401
+    f5_version = re.compile("^Version: (\d+\.\d+\.\d+)")  # pylint: disable=W1401
+    f5_product = re.compile("^Product: ([\w-]+)")  # pylint: disable=W1401
 
-    with open('/VERSION', 'r') as fh: # pylint: disable=C0103
+    with open('/VERSION', 'r') as fh:  # pylint: disable=C0103
         content = fh.readlines()
         for line in content:
             version_matches = f5_version.match(line)
@@ -89,10 +89,10 @@ def get_f5_platform():
 def get_checkpoint_platform():
     take = build = release = ""
     full_name = open("/etc/cp-release").read().strip()
-    with open("/etc/cloud-version") as f: # pylint: disable=C0103
+    with open("/etc/cloud-version") as f:  # pylint: disable=C0103
         for line in f:
-            k, _, v = line.partition(": ") # pylint: disable=C0103
-            v = v.strip() # pylint: disable=C0103
+            k, _, v = line.partition(": ")  # pylint: disable=C0103
+            v = v.strip()  # pylint: disable=C0103
             if k == "release":
                 release = v
             elif k == "take":
@@ -104,20 +104,20 @@ def get_checkpoint_platform():
 
 def get_distro():
     if 'FreeBSD' in platform.system():
-        release = re.sub('\-.*\Z', '', ustr(platform.release())) # pylint: disable=W1401
+        release = re.sub('\-.*\Z', '', ustr(platform.release()))  # pylint: disable=W1401
         osinfo = ['freebsd', release, '', 'freebsd']
     elif 'OpenBSD' in platform.system():
-        release = re.sub('\-.*\Z', '', ustr(platform.release())) # pylint: disable=W1401
+        release = re.sub('\-.*\Z', '', ustr(platform.release()))  # pylint: disable=W1401
         osinfo = ['openbsd', release, '', 'openbsd']
     elif 'Linux' in platform.system():
         osinfo = get_linux_distribution(0, 'alpine')
     elif 'NS-BSD' in platform.system():
-        release = re.sub('\-.*\Z', '', ustr(platform.release())) # pylint: disable=W1401
+        release = re.sub('\-.*\Z', '', ustr(platform.release()))  # pylint: disable=W1401
         osinfo = ['nsbsd', release, '', 'nsbsd']
     else:
         try:
             # dist() removed in Python 3.8
-            osinfo = list(platform.dist()) + [''] # pylint: disable=W1505,E1101
+            osinfo = list(platform.dist()) + ['']  # pylint: disable=W1505,E1101
         except Exception:
             osinfo = ['UNKNOWN', 'FFFF', '', '']
 
@@ -206,13 +206,13 @@ AGENT_PKG_GLOB = "{0}-*.zip".format(AGENT_NAME)
 
 AGENT_PATTERN = "{0}-(.*)".format(AGENT_NAME)
 AGENT_NAME_PATTERN = re.compile(AGENT_PATTERN)
-AGENT_PKG_PATTERN = re.compile(AGENT_PATTERN+"\.zip") # pylint: disable=W1401
+AGENT_PKG_PATTERN = re.compile(AGENT_PATTERN+"\.zip")  # pylint: disable=W1401
 AGENT_DIR_PATTERN = re.compile(".*/{0}".format(AGENT_PATTERN))
 
 # The execution mode of the VM - IAAS or PAAS. Linux VMs are only executed in IAAS mode.
 AGENT_EXECUTION_MODE = "IAAS"
 
-EXT_HANDLER_PATTERN = b".*/WALinuxAgent-(\d+.\d+.\d+[.\d+]*).*-run-exthandlers" # pylint: disable=W1401
+EXT_HANDLER_PATTERN = b".*/WALinuxAgent-(\d+.\d+.\d+[.\d+]*).*-run-exthandlers"  # pylint: disable=W1401
 EXT_HANDLER_REGEX = re.compile(EXT_HANDLER_PATTERN)
 
 __distro__ = get_distro()

--- a/azurelinuxagent/daemon/main.py
+++ b/azurelinuxagent/daemon/main.py
@@ -49,7 +49,7 @@ def get_daemon_handler():
     return DaemonHandler()
 
 
-class DaemonHandler(object): # pylint: disable=R0902
+class DaemonHandler(object):  # pylint: disable=R0902
     """
     Main thread of daemon. It will invoke other threads to do actual work
     """
@@ -81,7 +81,7 @@ class DaemonHandler(object): # pylint: disable=R0902
         while self.running:
             try:
                 self.daemon(child_args)
-            except Exception as e: # pylint: disable=W0612,C0103
+            except Exception as e:  # pylint: disable=W0612,C0103
                 err_msg = traceback.format_exc()
                 add_event(name=AGENT_NAME, is_success=False, message=ustr(err_msg),
                           op=WALAEventOperation.UnhandledError)
@@ -125,12 +125,12 @@ class DaemonHandler(object): # pylint: disable=R0902
     def daemon(self, child_args=None):
         logger.info("Run daemon")
 
-        self.protocol_util = get_protocol_util() # pylint: disable=W0201
-        self.scvmm_handler = get_scvmm_handler() # pylint: disable=W0201
-        self.resourcedisk_handler = get_resourcedisk_handler() # pylint: disable=W0201
-        self.rdma_handler = get_rdma_handler() # pylint: disable=W0201
-        self.provision_handler = get_provision_handler() # pylint: disable=W0201
-        self.update_handler = get_update_handler() # pylint: disable=W0201
+        self.protocol_util = get_protocol_util()  # pylint: disable=W0201
+        self.scvmm_handler = get_scvmm_handler()  # pylint: disable=W0201
+        self.resourcedisk_handler = get_resourcedisk_handler()  # pylint: disable=W0201
+        self.rdma_handler = get_rdma_handler()  # pylint: disable=W0201
+        self.provision_handler = get_provision_handler()  # pylint: disable=W0201
+        self.update_handler = get_update_handler()  # pylint: disable=W0201
 
         if conf.get_detect_scvmm_env():
             self.scvmm_handler.run()
@@ -160,13 +160,13 @@ class DaemonHandler(object): # pylint: disable=R0902
                 #   incarnation number. A forced update ensures the most
                 #   current values.
                 protocol = self.protocol_util.get_protocol()
-                if type(protocol) is not WireProtocol: # pylint: disable=C0123
+                if type(protocol) is not WireProtocol:  # pylint: disable=C0123
                     raise Exception("Attempt to setup RDMA without Wireserver")
 
                 protocol.client.update_goal_state(forced=True)
 
                 setup_rdma_device(nd_version, protocol.client.get_shared_conf())
-            except Exception as e: # pylint: disable=C0103
+            except Exception as e:  # pylint: disable=C0103
                 logger.error("Error setting up rdma device: %s" % e)
         else:
             logger.info("RDMA capabilities are not enabled, skipping")

--- a/azurelinuxagent/daemon/resourcedisk/default.py
+++ b/azurelinuxagent/daemon/resourcedisk/default.py
@@ -48,7 +48,7 @@ http://msdn.microsoft.com/en-us/library/windowsazure/jj672979.aspx
 class ResourceDiskHandler(object):
     def __init__(self):
         self.osutil = get_osutil()
-        self.fs = conf.get_resourcedisk_filesystem() # pylint: disable=C0103
+        self.fs = conf.get_resourcedisk_filesystem()  # pylint: disable=C0103
 
     def start_activate_resource_disk(self):
         disk_thread = threading.Thread(target=self.run)
@@ -71,10 +71,10 @@ class ResourceDiskHandler(object):
                                         DATALOSS_WARNING_FILE_NAME)
             try:
                 fileutil.write_file(warning_file, DATA_LOSS_WARNING)
-            except IOError as e: # pylint: disable=C0103
+            except IOError as e:  # pylint: disable=C0103
                 logger.warn("Failed to write data loss warning:{0}", e)
             return mount_point
-        except ResourceDiskError as e: # pylint: disable=C0103
+        except ResourceDiskError as e:  # pylint: disable=C0103
             logger.error("Failed to mount resource disk {0}", e)
             add_event(name=AGENT_NAME, is_success=False, message=ustr(e),
                       op=WALAEventOperation.ActivateResourceDisk)
@@ -84,7 +84,7 @@ class ResourceDiskHandler(object):
         try:
             size_mb = conf.get_resourcedisk_swap_size_mb()
             self.create_swap_space(mount_point, size_mb)
-        except ResourceDiskError as e: # pylint: disable=C0103
+        except ResourceDiskError as e:  # pylint: disable=C0103
             logger.error("Failed to enable swap {0}", e)
 
     def reread_partition_table(self, device):
@@ -92,7 +92,7 @@ class ResourceDiskHandler(object):
             shellutil.run("blockdev --rereadpt {0}".format(device),
                           chk_err=False)
 
-    def mount_resource_disk(self, mount_point): # pylint: disable=R0912
+    def mount_resource_disk(self, mount_point):  # pylint: disable=R0912
         device = self.osutil.device_for_ide_port(1)
         if device is None:
             raise ResourceDiskError("unable to detect disk topology")
@@ -250,7 +250,7 @@ class ResourceDiskHandler(object):
         return err_code, output
 
     def get_mount_string(self, mount_options, partition, mount_point):
-        if mount_options is not None: # pylint: disable=R1705
+        if mount_options is not None:  # pylint: disable=R1705
             return 'mount -t {0} -o {1} {2} {3}'.format(
                 self.fs,
                 mount_options,
@@ -303,7 +303,7 @@ class ResourceDiskHandler(object):
             raise ResourceDiskError("{0}".format(swapfile))
         logger.info("Enabled {0}KB of swap at {1}".format(size_kb, swapfile))
 
-    def mkfile(self, filename, nbytes): # pylint: disable=R0912
+    def mkfile(self, filename, nbytes):  # pylint: disable=R0912
         """
         Create a non-sparse file of that size. Deletes and replaces existing
         file.
@@ -339,14 +339,14 @@ class ResourceDiskHandler(object):
                 # Probable errors:
                 #  - OSError: Seen on Cygwin, libc notimpl?
                 #  - AttributeError: What if someone runs this under...
-                fd = None # pylint: disable=C0103
+                fd = None  # pylint: disable=C0103
 
                 try:
-                    fd = os.open( # pylint: disable=C0103
+                    fd = os.open(  # pylint: disable=C0103
                         filename,
                         os.O_CREAT | os.O_WRONLY | os.O_EXCL,
                         stat.S_IRUSR | stat.S_IWUSR)
-                    os.posix_fallocate(fd, 0, nbytes) # pylint: disable=no-member
+                    os.posix_fallocate(fd, 0, nbytes)  # pylint: disable=no-member
                     return 0
                 except BaseException:
                     # Not confident with this thing, just keep trying...

--- a/azurelinuxagent/daemon/resourcedisk/factory.py
+++ b/azurelinuxagent/daemon/resourcedisk/factory.py
@@ -23,8 +23,8 @@ from .openwrt import OpenWRTResourceDiskHandler
 
 
 def get_resourcedisk_handler(distro_name=DISTRO_NAME, 
-                             distro_version=DISTRO_VERSION, # pylint: disable=W0613
-                             distro_full_name=DISTRO_FULL_NAME): # pylint: disable=W0613
+                             distro_version=DISTRO_VERSION,  # pylint: disable=W0613
+                             distro_full_name=DISTRO_FULL_NAME):  # pylint: disable=W0613
     if distro_name == "freebsd":
         return FreeBSDResourceDiskHandler()
 

--- a/azurelinuxagent/daemon/resourcedisk/freebsd.py
+++ b/azurelinuxagent/daemon/resourcedisk/freebsd.py
@@ -38,7 +38,7 @@ class FreeBSDResourceDiskHandler(ResourceDiskHandler):
     2. GPT: The resource disk partition is /dev/da1p2, /dev/da1p1 is for reserved usage.
     """
 
-    def __init__(self): # pylint: disable=W0235
+    def __init__(self):  # pylint: disable=W0235
         super(FreeBSDResourceDiskHandler, self).__init__()
 
     @staticmethod
@@ -51,8 +51,8 @@ class FreeBSDResourceDiskHandler(ResourceDiskHandler):
                 dic[geom_name] = line[8:]
         return dic
 
-    def mount_resource_disk(self, mount_point): # pylint: disable=R0912
-        fs = self.fs # pylint: disable=C0103
+    def mount_resource_disk(self, mount_point):  # pylint: disable=R0912
+        fs = self.fs  # pylint: disable=C0103
         if fs != 'ufs':
             raise ResourceDiskError(
                 "Unsupported filesystem type:{0}, only ufs is supported.".format(fs))

--- a/azurelinuxagent/daemon/resourcedisk/openbsd.py
+++ b/azurelinuxagent/daemon/resourcedisk/openbsd.py
@@ -46,7 +46,7 @@ class OpenBSDResourceDiskHandler(ResourceDiskHandler):
                 logger.error("Failed to enable swap, error {0}", output)
 
     def mount_resource_disk(self, mount_point):
-        fs = self.fs # pylint: disable=C0103
+        fs = self.fs  # pylint: disable=C0103
         if fs != 'ffs':
             raise ResourceDiskError("Unsupported filesystem type: {0}, only "
                                     "ufs/ffs is supported.".format(fs))

--- a/azurelinuxagent/daemon/resourcedisk/openwrt.py
+++ b/azurelinuxagent/daemon/resourcedisk/openwrt.py
@@ -35,7 +35,7 @@ class OpenWRTResourceDiskHandler(ResourceDiskHandler):
             self.fs = 'ffs'
 
     def reread_partition_table(self, device):
-        ret, output = shellutil.run_get_output("hdparm -z {0}".format(device), chk_err=False) # pylint: disable=W0612
+        ret, output = shellutil.run_get_output("hdparm -z {0}".format(device), chk_err=False)  # pylint: disable=W0612
         if ret != 0:
             logger.warn("Failed refresh the partition table.")
 

--- a/azurelinuxagent/daemon/scvmm.py
+++ b/azurelinuxagent/daemon/scvmm.py
@@ -49,7 +49,7 @@ class ScvmmHandler(object):
             dvd_device = os.path.join(dev_dir, devices.group(0))
             self.osutil.mount_dvd(max_retry=1, chk_err=False, dvd_device=dvd_device, mount_point=mount_point)
             found = os.path.isfile(os.path.join(mount_point, VMM_CONF_FILE_NAME))
-            if found: # pylint: disable=R1723
+            if found:  # pylint: disable=R1723
                 self.start_scvmm_agent(mount_point=mount_point)
                 break
             else:

--- a/azurelinuxagent/ga/collect_logs.py
+++ b/azurelinuxagent/ga/collect_logs.py
@@ -127,14 +127,14 @@ class CollectLogsHandler(ThreadHandlerInterface):
 
             while not self.stopped():
                 try:
-                    for op in self._periodic_operations: # pylint: disable=C0103
+                    for op in self._periodic_operations:  # pylint: disable=C0103
                         op.run()
-                except Exception as e: # pylint: disable=C0103
+                except Exception as e:  # pylint: disable=C0103
                     logger.error("An error occurred in the log collection thread main loop; "
                                  "will skip the current iteration.\n{0}", ustr(e))
                 finally:
                     PeriodicOperation.sleep_until_next_operation(self._periodic_operations)
-        except Exception as e: # pylint: disable=C0103
+        except Exception as e:  # pylint: disable=C0103
             logger.error("An error occurred in the log collection thread; will exit the thread.\n{0}", ustr(e))
 
     def collect_and_send_logs(self):
@@ -180,11 +180,11 @@ class CollectLogsHandler(ThreadHandlerInterface):
             success = True
 
             return True
-        except Exception as e: # pylint: disable=C0103
+        except Exception as e:  # pylint: disable=C0103
             duration = elapsed_milliseconds(start_time)
 
             if isinstance(e, CommandError):
-                exception_message = ustr("[stderr] %s", e.stderr) # pylint: disable=no-member
+                exception_message = ustr("[stderr] %s", e.stderr)  # pylint: disable=no-member
             else:
                 exception_message = ustr(e)
 
@@ -205,14 +205,14 @@ class CollectLogsHandler(ThreadHandlerInterface):
         msg = None
         success = False
         try:
-            with open(COMPRESSED_ARCHIVE_PATH, "rb") as fh: # pylint: disable=C0103
+            with open(COMPRESSED_ARCHIVE_PATH, "rb") as fh:  # pylint: disable=C0103
                 archive_content = fh.read()
                 self.protocol.upload_logs(archive_content)
                 msg = "Successfully uploaded logs."
                 logger.info(msg)
 
             success = True
-        except Exception as e: # pylint: disable=C0103
+        except Exception as e:  # pylint: disable=C0103
             msg = "Failed to upload logs. Error: {0}".format(ustr(e))
             logger.warn(msg)
         finally:

--- a/azurelinuxagent/ga/collect_telemetry_events.py
+++ b/azurelinuxagent/ga/collect_telemetry_events.py
@@ -43,7 +43,7 @@ def get_collect_telemetry_events_handler(send_telemetry_events_handler):
 
 
 # too-few-public-methods<R0903> Disabled: This class is used as an Enum
-class ExtensionEventSchema(object): # pylint: disable=R0903
+class ExtensionEventSchema(object):  # pylint: disable=R0903
     """
     Class for defining the schema for Extension Events.
 

--- a/azurelinuxagent/ga/env.py
+++ b/azurelinuxagent/ga/env.py
@@ -36,9 +36,9 @@ from azurelinuxagent.common.version import AGENT_NAME, CURRENT_VERSION
 from azurelinuxagent.ga.periodic_operation import PeriodicOperation
 
 CACHE_PATTERNS = [
-    re.compile("^(.*)\.(\d+)\.(agentsManifest)$", re.IGNORECASE), # pylint: disable=W1401
-    re.compile("^(.*)\.(\d+)\.(manifest\.xml)$", re.IGNORECASE), # pylint: disable=W1401
-    re.compile("^(.*)\.(\d+)\.(xml)$", re.IGNORECASE) # pylint: disable=W1401
+    re.compile("^(.*)\.(\d+)\.(agentsManifest)$", re.IGNORECASE),  # pylint: disable=W1401
+    re.compile("^(.*)\.(\d+)\.(manifest\.xml)$", re.IGNORECASE),  # pylint: disable=W1401
+    re.compile("^(.*)\.(\d+)\.(xml)$", re.IGNORECASE)  # pylint: disable=W1401
 ]
 
 MAXIMUM_CACHED_FILES = 50
@@ -48,7 +48,7 @@ def get_env_handler():
     return EnvHandler()
 
 
-class EnvHandler(ThreadHandlerInterface): # pylint: disable=R0902
+class EnvHandler(ThreadHandlerInterface):  # pylint: disable=R0902
     """
     Monitor changes to dhcp and hostname.
     If dhcp client process re-start has occurred, reset routes, dhcp with fabric.
@@ -118,13 +118,13 @@ class EnvHandler(ThreadHandlerInterface): # pylint: disable=R0902
             self._protocol = self.protocol_util.get_protocol()
             while not self.stopped:
                 try:
-                    for op in self._periodic_operations: # pylint: disable=C0103
+                    for op in self._periodic_operations:  # pylint: disable=C0103
                         op.run()
-                except Exception as e: # pylint: disable=C0103
+                except Exception as e:  # pylint: disable=C0103
                     logger.error("An error occurred in the environment thread main loop; will skip the current iteration.\n{0}", ustr(e))
                 finally:
                     PeriodicOperation.sleep_until_next_operation(self._periodic_operations)
-        except Exception as e: # pylint: disable=C0103
+        except Exception as e:  # pylint: disable=C0103
             logger.error("An error occurred in the environment thread; will exit the thread.\n{0}", ustr(e))
 
     def _remove_persistent_net_rules_period(self):
@@ -171,7 +171,7 @@ class EnvHandler(ThreadHandlerInterface): # pylint: disable=R0902
             # the new value and the comparison should not be affected by the order of the items in the list
             pid = sorted(self.osutil.get_dhcp_pid())
 
-            if len(pid) == 0 and self.dhcp_warning_enabled: # pylint: disable=len-as-condition
+            if len(pid) == 0 and self.dhcp_warning_enabled:  # pylint: disable=len-as-condition
                 logger.warn("Dhcp client is not running.")
         except Exception as exception:
             if self.dhcp_warning_enabled:
@@ -185,7 +185,7 @@ class EnvHandler(ThreadHandlerInterface): # pylint: disable=R0902
         self.handle_dhclient_restart()
 
     def handle_dhclient_restart(self):
-        if len(self.dhcp_id_list) == 0: # pylint: disable=len-as-condition
+        if len(self.dhcp_id_list) == 0:  # pylint: disable=len-as-condition
             self.dhcp_id_list = self.get_dhcp_client_pid()
             return
 
@@ -193,7 +193,7 @@ class EnvHandler(ThreadHandlerInterface): # pylint: disable=R0902
             return
 
         new_pid = self.get_dhcp_client_pid()
-        if len(new_pid) != 0 and new_pid != self.dhcp_id_list: # pylint: disable=len-as-condition
+        if len(new_pid) != 0 and new_pid != self.dhcp_id_list:  # pylint: disable=len-as-condition
             logger.info("EnvMonitor: Detected dhcp client restart. Restoring routing table.")
             self.dhcp_handler.conf_routes()
             self.dhcp_id_list = new_pid

--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -1,4 +1,4 @@
-# Microsoft Azure Linux Agent # pylint: disable=C0302
+# Microsoft Azure Linux Agent  # pylint: disable=C0302
 #
 # Copyright Microsoft Corporation
 #
@@ -87,7 +87,7 @@ def is_extension_telemetry_pipeline_enabled():
     return _ENABLE_EXTENSION_TELEMETRY_PIPELINE
 
 
-class ValidHandlerStatus(object): # pylint: disable=R0903
+class ValidHandlerStatus(object):  # pylint: disable=R0903
     transitioning = "transitioning"
     warning = "warning"
     error = "error"
@@ -98,7 +98,7 @@ class ValidHandlerStatus(object): # pylint: disable=R0903
 _EXTENSION_TERMINAL_STATUSES = [ValidHandlerStatus.error, ValidHandlerStatus.success]
 
 
-class ExtCommandEnvVariable(object): # pylint: disable=R0903
+class ExtCommandEnvVariable(object):  # pylint: disable=R0903
     Prefix = "AZURE_GUEST_AGENT"
     DisableReturnCode = "%s_DISABLE_CMD_EXIT_CODE" % Prefix
     UninstallReturnCode = "%s_UNINSTALL_CMD_EXIT_CODE" % Prefix
@@ -108,11 +108,11 @@ class ExtCommandEnvVariable(object): # pylint: disable=R0903
     UpdatingFromVersion = "%s_UPDATING_FROM_VERSION" % Prefix
 
 
-def get_traceback(e): # pylint: disable=R1710,C0103
-    if sys.version_info[0] == 3: # pylint: disable=R1705
+def get_traceback(e):  # pylint: disable=R1710,C0103
+    if sys.version_info[0] == 3:  # pylint: disable=R1705
         return e.__traceback__
     elif sys.version_info[0] == 2:
-        ex_type, ex, tb = sys.exc_info() # pylint: disable=W0612,C0103
+        ex_type, ex, tb = sys.exc_info()  # pylint: disable=W0612,C0103
         return tb
 
 
@@ -206,13 +206,13 @@ def migrate_handler_state():
         handler = os.path.basename(handler_path)
         handler_config_path = os.path.join(conf.get_lib_dir(), handler, "config")
         if os.path.isdir(handler_config_path):
-            for file in ("State", "Status"): # pylint: disable=redefined-builtin
+            for file in ("State", "Status"):  # pylint: disable=redefined-builtin
                 from_path = os.path.join(handler_state_path, handler, file.lower())
                 to_path = os.path.join(handler_config_path, "Handler" + file)
                 if os.path.isfile(from_path) and not os.path.isfile(to_path):
                     try:
                         shutil.move(from_path, to_path)
-                    except Exception as e: # pylint: disable=C0103
+                    except Exception as e:  # pylint: disable=C0103
                         logger.warn(
                             "Exception occurred migrating {0} {1} file: {2}",
                             handler,
@@ -221,19 +221,19 @@ def migrate_handler_state():
 
     try:
         shutil.rmtree(handler_state_path)
-    except Exception as e: # pylint: disable=C0103
+    except Exception as e:  # pylint: disable=C0103
         logger.warn("Exception occurred removing {0}: {1}", handler_state_path, str(e))
     return
 
 
-class ExtHandlerState(object): # pylint: disable=R0903
+class ExtHandlerState(object):  # pylint: disable=R0903
     NotInstalled = "NotInstalled"
     Installed = "Installed"
     Enabled = "Enabled"
     FailedUpgrade = "FailedUpgrade"
 
 
-class ExtensionRequestedState(object): # pylint: disable=R0903
+class ExtensionRequestedState(object):  # pylint: disable=R0903
     """
     This is the state of the Extension as requested by the Goal State.
     CRP only supports 2 states as of now - Enabled and Uninstall
@@ -285,7 +285,7 @@ class ExtHandlersHandler(object):
 
             self.report_ext_handlers_status()
             self._cleanup_outdated_handlers()
-        except Exception as e: # pylint: disable=C0103
+        except Exception as e:  # pylint: disable=C0103
             msg = u"Exception processing extension handlers: {0}".format(ustr(e))
             detailed_msg = '{0} {1}'.format(msg, traceback.extract_tb(get_traceback(e)))
             logger.warn(msg)
@@ -306,12 +306,12 @@ class ExtHandlersHandler(object):
             # Handler in skip_handlers list, not parsing it
             return None
 
-        eh = ExtHandler(name=handler_name) # pylint: disable=C0103
+        eh = ExtHandler(name=handler_name)  # pylint: disable=C0103
         eh.properties.version = str(FlexibleVersion(name[separator + 1:]))
 
         return ExtHandlerInstance(eh, protocol)
 
-    def _cleanup_outdated_handlers(self): # pylint: disable=R0912
+    def _cleanup_outdated_handlers(self):  # pylint: disable=R0912
         handlers = []
         pkgs = []
         ext_handlers_in_gs = [ext_handler.name for ext_handler in self.ext_handlers.extHandlers]
@@ -345,7 +345,7 @@ class ExtHandlersHandler(object):
             try:
                 os.remove(pkg)
                 logger.verbose("Removed orphaned extension package {0}".format(pkg))
-            except OSError as e: # pylint: disable=C0103
+            except OSError as e:  # pylint: disable=C0103
                 logger.warn("Failed to remove orphaned package {0}: {1}".format(pkg, e.strerror))
 
         # Finally, remove the directories and packages of the orphaned handlers, i.e. Any extension directory that
@@ -357,7 +357,7 @@ class ExtHandlersHandler(object):
                 try:
                     os.remove(pkg)
                     logger.verbose("Removed extension package {0}".format(pkg))
-                except OSError as e: # pylint: disable=C0103
+                except OSError as e:  # pylint: disable=C0103
                     logger.warn("Failed to remove extension package {0}: {1}".format(pkg, e.strerror))
 
     def _extension_processing_allowed(self):
@@ -375,7 +375,7 @@ class ExtHandlersHandler(object):
 
     def handle_ext_handlers(self, etag=None):
         if self.ext_handlers.extHandlers is None or \
-                len(self.ext_handlers.extHandlers) == 0: # pylint: disable=len-as-condition
+                len(self.ext_handlers.extHandlers) == 0:  # pylint: disable=len-as-condition
             logger.verbose("No extension handler config found")
             return
 
@@ -453,7 +453,7 @@ class ExtHandlersHandler(object):
             # we should let it go through even if the installed version doesnt exist in Handler manifest (PIR) anymore.
             # If target state is enabled and version not found in manifest, do not process the extension.
             if ext_handler_i.decide_version(target_state=state) is None and state == ExtensionRequestedState.Enabled:
-                version = ext_handler_i.ext_handler.properties.version # pylint: disable=W0621
+                version = ext_handler_i.ext_handler.properties.version  # pylint: disable=W0621
                 name = ext_handler_i.ext_handler.name
                 err_msg = "Unable to find version {0} in manifest for extension {1}".format(version, name)
                 ext_handler_i.set_operation(WALAEventOperation.Download)
@@ -473,24 +473,24 @@ class ExtHandlersHandler(object):
             else:
                 message = u"Unknown ext handler state:{0}".format(state)
                 raise ExtensionError(message)
-        except ExtensionUpdateError as e: # pylint: disable=C0103
+        except ExtensionUpdateError as e:  # pylint: disable=C0103
             # Not reporting the error as it has already been reported from the old version
             self.handle_ext_handler_error(ext_handler_i, e, e.code, report_telemetry_event=False)
-        except ExtensionDownloadError as e: # pylint: disable=C0103
+        except ExtensionDownloadError as e:  # pylint: disable=C0103
             self.handle_ext_handler_download_error(ext_handler_i, e, e.code)
-        except ExtensionError as e: # pylint: disable=C0103
+        except ExtensionError as e:  # pylint: disable=C0103
             self.handle_ext_handler_error(ext_handler_i, e, e.code)
-        except Exception as e: # pylint: disable=C0103
+        except Exception as e:  # pylint: disable=C0103
             self.handle_ext_handler_error(ext_handler_i, e)
 
-    def handle_ext_handler_error(self, ext_handler_i, e, code=-1, report_telemetry_event=True): # pylint: disable=C0103
+    def handle_ext_handler_error(self, ext_handler_i, e, code=-1, report_telemetry_event=True):  # pylint: disable=C0103
         msg = ustr(e)
         ext_handler_i.set_handler_status(message=msg, code=code)
 
         if report_telemetry_event:
             ext_handler_i.report_event(message=msg, is_success=False, log_event=True)
 
-    def handle_ext_handler_download_error(self, ext_handler_i, e, code=-1): # pylint: disable=C0103
+    def handle_ext_handler_download_error(self, ext_handler_i, e, code=-1):  # pylint: disable=C0103
         msg = ustr(e)
         ext_handler_i.set_handler_status(message=msg, code=code)
 
@@ -507,7 +507,7 @@ class ExtHandlersHandler(object):
                                   handler_state.lower())
         # We go through the entire process of downloading and initializing the extension if it's either a fresh
         # extension or if it's a retry of a previously failed upgrade.
-        if handler_state == ExtHandlerState.NotInstalled or handler_state == ExtHandlerState.FailedUpgrade: # pylint: disable=R1714
+        if handler_state == ExtHandlerState.NotInstalled or handler_state == ExtHandlerState.FailedUpgrade:  # pylint: disable=R1714
             ext_handler_i.set_handler_state(ExtHandlerState.NotInstalled)
             ext_handler_i.download()
             ext_handler_i.initialize()
@@ -537,7 +537,7 @@ class ExtHandlersHandler(object):
             try:
                 continue_on_update_failure = ext_handler_i.load_manifest().is_continue_on_update_failure()
                 func()
-            except ExtensionError as e: # pylint: disable=C0103
+            except ExtensionError as e:  # pylint: disable=C0103
                 # Reporting the event with the old handler and raising a new ExtensionUpdateError to set the
                 # handler status on the new version
                 msg = "%s; ContinueOnUpdate: %s" % (ustr(e), continue_on_update_failure)
@@ -547,7 +547,7 @@ class ExtHandlersHandler(object):
 
                 exit_code = e.code
                 if isinstance(e, ExtensionOperationError):
-                    exit_code = e.exit_code # pylint: disable=E1101
+                    exit_code = e.exit_code  # pylint: disable=E1101
 
                 logger.info("Continue on Update failure flag is set, proceeding with update")
             return exit_code
@@ -557,7 +557,7 @@ class ExtHandlersHandler(object):
         # other state makes sense.
         if old_ext_handler_i.get_handler_state() == ExtHandlerState.Enabled:
             disable_exit_code = execute_old_handler_command_and_return_if_succeeds(
-                func=lambda: old_ext_handler_i.disable()) # pylint: disable=W0108
+                func=lambda: old_ext_handler_i.disable())  # pylint: disable=W0108
 
         ext_handler_i.copy_status_files(old_ext_handler_i)
         if ext_handler_i.version_gt(old_ext_handler_i):
@@ -568,7 +568,7 @@ class ExtHandlersHandler(object):
             old_ext_handler_i.update(version=updating_from_version,
                                      disable_exit_code=disable_exit_code, updating_from_version=updating_from_version)
         uninstall_exit_code = execute_old_handler_command_and_return_if_succeeds(
-            func=lambda: old_ext_handler_i.uninstall()) # pylint: disable=W0108
+            func=lambda: old_ext_handler_i.uninstall())  # pylint: disable=W0108
         old_ext_handler_i.remove_ext_handler()
         ext_handler_i.update_with_install(uninstall_exit_code=uninstall_exit_code)
         return uninstall_exit_code
@@ -593,7 +593,7 @@ class ExtHandlersHandler(object):
             # Try uninstalling the extension and swallow any exceptions in case of failures after logging them
             try:
                 ext_handler_i.uninstall()
-            except ExtensionError as e: # pylint: disable=C0103
+            except ExtensionError as e:  # pylint: disable=C0103
                 ext_handler_i.report_event(message=ustr(e), is_success=False)
 
         ext_handler_i.remove_ext_handler()
@@ -607,7 +607,7 @@ class ExtHandlersHandler(object):
             for ext_handler in self.ext_handlers.extHandlers:
                 try:
                     self.report_ext_handler_status(vm_status, ext_handler)
-                except ExtensionError as e: # pylint: disable=C0103
+                except ExtensionError as e:  # pylint: disable=C0103
                     add_event(
                         AGENT_NAME,
                         version=CURRENT_VERSION,
@@ -621,11 +621,11 @@ class ExtHandlersHandler(object):
             if self.log_report:
                 logger.verbose("Completed vm agent status report")
             self.report_status_error_state.reset()
-        except ProtocolNotFoundError as e: # pylint: disable=C0103
+        except ProtocolNotFoundError as e:  # pylint: disable=C0103
             self.report_status_error_state.incr()
             message = "Failed to report vm agent status: {0}".format(e)
             logger.verbose(message)
-        except ProtocolError as e: # pylint: disable=C0103
+        except ProtocolError as e:  # pylint: disable=C0103
             self.report_status_error_state.incr()
             message = "Failed to report vm agent status: {0}".format(e)
             add_event(AGENT_NAME,
@@ -692,20 +692,20 @@ class ExtHandlersHandler(object):
             try:
                 active_exts = ext_handler_i.report_ext_status()
                 handler_status.extensions.extend(active_exts)
-            except ExtensionError as e: # pylint: disable=C0103
+            except ExtensionError as e:  # pylint: disable=C0103
                 ext_handler_i.set_handler_status(message=ustr(e), code=e.code)
 
             try:
                 heartbeat = ext_handler_i.collect_heartbeat()
                 if heartbeat is not None:
                     handler_status.status = heartbeat.get('status')
-            except ExtensionError as e: # pylint: disable=C0103
+            except ExtensionError as e:  # pylint: disable=C0103
                 ext_handler_i.set_handler_status(message=ustr(e), code=e.code)
 
         vm_status.vmAgent.extensionHandlers.append(handler_status)
 
 
-class ExtHandlerInstance(object): # pylint: disable=R0904
+class ExtHandlerInstance(object):  # pylint: disable=R0904
     def __init__(self, ext_handler, protocol):
         self.ext_handler = ext_handler
         self.protocol = protocol
@@ -717,7 +717,7 @@ class ExtHandlerInstance(object): # pylint: disable=R0904
 
         try:
             fileutil.mkdir(self.get_log_dir(), mode=0o755)
-        except IOError as e: # pylint: disable=C0103
+        except IOError as e:  # pylint: disable=C0103
             self.logger.error(u"Failed to create extension log dir: {0}", e)
 
         log_file = os.path.join(self.get_log_dir(), "CommandExecution.log")
@@ -728,7 +728,7 @@ class ExtHandlerInstance(object): # pylint: disable=R0904
         self.logger.verbose("Decide which version to use")
         try:
             pkg_list = self.protocol.get_ext_handler_pkgs(self.ext_handler)
-        except ProtocolError as e: # pylint: disable=C0103
+        except ProtocolError as e:  # pylint: disable=C0103
             raise ExtensionError("Failed to get ext handler pkgs", e)
         except ExtensionDownloadError:
             self.set_operation(WALAEventOperation.Download)
@@ -841,7 +841,7 @@ class ExtHandlerInstance(object): # pylint: disable=R0904
                 if os.path.isfile(status_file):
                     shutil.copy2(status_file, new_ext_status_dir)
 
-    def set_operation(self, op): # pylint: disable=C0103
+    def set_operation(self, op):  # pylint: disable=C0103
         self.operation = op
 
     def report_event(self, message="", is_success=True, duration=0, log_event=True):
@@ -877,7 +877,7 @@ class ExtHandlerInstance(object): # pylint: disable=R0904
         begin_utc = datetime.datetime.utcnow()
         self.set_operation(WALAEventOperation.Download)
 
-        if self.pkg is None or self.pkg.uris is None or len(self.pkg.uris) == 0: # pylint: disable=len-as-condition
+        if self.pkg is None or self.pkg.uris is None or len(self.pkg.uris) == 0:  # pylint: disable=len-as-condition
             raise ExtensionDownloadError("No package uri found")
 
         destination = os.path.join(conf.get_lib_dir(), self.get_extension_package_zipfile_name())
@@ -925,7 +925,7 @@ class ExtHandlerInstance(object): # pylint: disable=R0904
         self.logger.info("Initializing extension {0}".format(self.get_full_name()))
 
         # Add user execute permission to all files under the base dir
-        for file in fileutil.get_all_files(self.get_base_dir()): # pylint: disable=redefined-builtin
+        for file in fileutil.get_all_files(self.get_base_dir()):  # pylint: disable=redefined-builtin
             fileutil.chmod(file, os.stat(file).st_mode | stat.S_IXUSR)
 
         # Save HandlerManifest.json
@@ -937,7 +937,7 @@ class ExtHandlerInstance(object): # pylint: disable=R0904
         try:
             man = fileutil.read_file(man_file, remove_bom=True)
             fileutil.write_file(self.get_manifest_file(), man)
-        except IOError as e: # pylint: disable=C0103
+        except IOError as e:  # pylint: disable=C0103
             fileutil.clean_ioerror(e, paths=[self.get_base_dir(), self.pkg_file])
             raise ExtensionDownloadError(u"Failed to save HandlerManifest.json", e)
 
@@ -952,7 +952,7 @@ class ExtHandlerInstance(object): # pylint: disable=R0904
             if is_extension_telemetry_pipeline_enabled():
                 fileutil.mkdir(self.get_extension_events_dir(), mode=0o700)
 
-            seq_no, status_path = self.get_status_file_path() # pylint: disable=W0612
+            seq_no, status_path = self.get_status_file_path()  # pylint: disable=W0612
             if status_path is not None:
                 now = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
                 status = [
@@ -973,7 +973,7 @@ class ExtHandlerInstance(object): # pylint: disable=R0904
                 ]
                 fileutil.write_file(status_path, json.dumps(status))
 
-        except IOError as e: # pylint: disable=C0103
+        except IOError as e:  # pylint: disable=C0103
             fileutil.clean_ioerror(e, paths=[self.get_base_dir(), self.pkg_file])
             raise ExtensionDownloadError(u"Failed to initialize extension '{0}'".format(self.get_full_name()), e)
 
@@ -1040,12 +1040,12 @@ class ExtHandlerInstance(object): # pylint: disable=R0904
                         raise exception
 
                 shutil.rmtree(base_dir, onerror=on_rmtree_error)
-        except IOError as e: # pylint: disable=C0103
+        except IOError as e:  # pylint: disable=C0103
             message = "Failed to remove extension handler directory: {0}".format(e)
             self.report_event(message=message, is_success=False)
             self.logger.warn(message)
 
-    def update(self, version=None, disable_exit_code=None, updating_from_version=None): # pylint: disable=W0621
+    def update(self, version=None, disable_exit_code=None, updating_from_version=None):  # pylint: disable=W0621
         if version is None:
             version = self.ext_handler.properties.version
 
@@ -1130,7 +1130,7 @@ class ExtHandlerInstance(object): # pylint: disable=R0904
 
         try:
             data_str, data = self._read_and_parse_json_status_file(ext_status_file)
-        except ExtensionStatusError as e: # pylint: disable=C0103
+        except ExtensionStatusError as e:  # pylint: disable=C0103
             msg = ""
             if e.code == ExtensionStatusError.CouldNotReadStatusFile:
                 ext_status.code = ExtensionErrorCodes.PluginUnknownFailure
@@ -1166,7 +1166,7 @@ class ExtHandlerInstance(object): # pylint: disable=R0904
                                            .format(ext.name, self.ext_handler.properties.version, seq_no,
                                                    ext_status_file, len(data_str), _MAX_STATUS_FILE_SIZE_IN_BYTES),
                                            code=ExtensionStatusError.MaxSizeExceeded)
-        except ExtensionStatusError as e: # pylint: disable=C0103
+        except ExtensionStatusError as e:  # pylint: disable=C0103
             msg = u"For Extension Handler {0}-{1} for the sequence number {2}, the status file {3}. " \
                   u"Encountered the following error: {4}".format(ext.name, self.ext_handler.properties.version, seq_no,
                                                                  ext_status_file, ustr(e))
@@ -1227,11 +1227,11 @@ class ExtHandlerInstance(object): # pylint: disable=R0904
                 self.protocol.report_ext_status(self.ext_handler.name, ext.name,
                                                 ext_status)
                 active_exts.append(ext.name)
-            except ProtocolError as e: # pylint: disable=C0103
+            except ProtocolError as e:  # pylint: disable=C0103
                 self.logger.error(u"Failed to report extension status: {0}", e)
         return active_exts
 
-    def collect_heartbeat(self): # pylint: disable=R1710
+    def collect_heartbeat(self):  # pylint: disable=R1710
         man = self.load_manifest()
         if not man.is_report_heartbeat():
             return
@@ -1249,9 +1249,9 @@ class ExtHandlerInstance(object): # pylint: disable=R0904
         try:
             heartbeat_json = fileutil.read_file(heartbeat_file)
             heartbeat = json.loads(heartbeat_json)[0]['heartbeat']
-        except IOError as e: # pylint: disable=C0103
+        except IOError as e:  # pylint: disable=C0103
             raise ExtensionError("Failed to get heartbeat file:{0}".format(e))
-        except (ValueError, KeyError) as e: # pylint: disable=C0103
+        except (ValueError, KeyError) as e:  # pylint: disable=C0103
             raise ExtensionError("Malformed heartbeat file: {0}".format(e))
         return heartbeat
 
@@ -1299,7 +1299,7 @@ class ExtHandlerInstance(object): # pylint: disable=R0904
                         stderr=stderr,
                         error_code=extension_error_code)
 
-                except OSError as e: # pylint: disable=C0103
+                except OSError as e:  # pylint: disable=C0103
                     raise ExtensionError("Failed to launch '{0}': {1}".format(full_path, e.strerror),
                                          code=extension_error_code)
 
@@ -1315,7 +1315,7 @@ class ExtHandlerInstance(object): # pylint: disable=R0904
         man_file = self.get_manifest_file()
         try:
             data = json.loads(fileutil.read_file(man_file))
-        except (IOError, OSError) as e: # pylint: disable=C0103
+        except (IOError, OSError) as e:  # pylint: disable=C0103
             raise ExtensionError('Failed to load manifest file ({0}): {1}'.format(man_file, e.strerror),
                                  code=ExtensionErrorCodes.PluginHandlerManifestNotFound)
         except ValueError:
@@ -1328,14 +1328,14 @@ class ExtHandlerInstance(object): # pylint: disable=R0904
         settings_file = os.path.join(self.get_conf_dir(), settings_file)
         try:
             fileutil.write_file(settings_file, settings)
-        except IOError as e: # pylint: disable=C0103
+        except IOError as e:  # pylint: disable=C0103
             fileutil.clean_ioerror(e,
                                    paths=[settings_file])
             raise ExtensionError(u"Failed to update settings file", e)
 
     def update_settings(self):
         if self.ext_handler.properties.extensions is None or \
-                len(self.ext_handler.properties.extensions) == 0: # pylint: disable=len-as-condition
+                len(self.ext_handler.properties.extensions) == 0:  # pylint: disable=len-as-condition
             # This is the behavior of waagent 2.0.x
             # The new agent has to be consistent with the old one.
             self.logger.info("Extension has no settings, write empty 0.settings")
@@ -1375,7 +1375,7 @@ class ExtHandlerInstance(object): # pylint: disable=R0904
         }]
         try:
             fileutil.write_file(self.get_env_file(), json.dumps(env))
-        except IOError as e: # pylint: disable=C0103
+        except IOError as e:  # pylint: disable=C0103
             fileutil.clean_ioerror(e,
                                    paths=[self.get_base_dir(), self.pkg_file])
             raise ExtensionDownloadError(u"Failed to save handler environment", e)
@@ -1387,7 +1387,7 @@ class ExtHandlerInstance(object): # pylint: disable=R0904
             if not os.path.exists(state_dir):
                 fileutil.mkdir(state_dir, mode=0o700)
             fileutil.write_file(state_file, handler_state)
-        except IOError as e: # pylint: disable=C0103
+        except IOError as e:  # pylint: disable=C0103
             fileutil.clean_ioerror(e, paths=[state_file])
             self.logger.error("Failed to set state: {0}", e)
 
@@ -1399,7 +1399,7 @@ class ExtHandlerInstance(object): # pylint: disable=R0904
 
         try:
             return fileutil.read_file(state_file)
-        except IOError as e: # pylint: disable=C0103
+        except IOError as e:  # pylint: disable=C0103
             self.logger.error("Failed to get state: {0}", e)
             return ExtHandlerState.NotInstalled
 
@@ -1424,7 +1424,7 @@ class ExtHandlerInstance(object): # pylint: disable=R0904
                 self.logger.error("Failed to create JSON document of handler status for {0} version {1}".format(
                     self.ext_handler.name,
                     self.ext_handler.properties.version))
-        except (IOError, ValueError, ProtocolError) as e: # pylint: disable=C0103
+        except (IOError, ValueError, ProtocolError) as e:  # pylint: disable=C0103
             fileutil.clean_ioerror(e, paths=[status_file])
             self.logger.error("Failed to save handler status: {0}, {1}", ustr(e), traceback.format_exc())
 
@@ -1441,9 +1441,9 @@ class ExtHandlerInstance(object): # pylint: disable=R0904
             handler_status = ExtHandlerStatus()
             set_properties("ExtHandlerStatus", handler_status, data)
             return handler_status
-        except (IOError, ValueError) as e: # pylint: disable=C0103
+        except (IOError, ValueError) as e:  # pylint: disable=C0103
             self.logger.error("Failed to get handler status: {0}", e)
-        except Exception as e: # pylint: disable=C0103
+        except Exception as e:  # pylint: disable=C0103
             error_msg = "Failed to get handler status message: {0}.\n Contents of file: {1}".format(
                 ustr(e), handler_status_contents).replace('"', '\'')
             add_periodic(
@@ -1492,7 +1492,7 @@ class ExtHandlerInstance(object): # pylint: disable=R0904
         runtime_settings = self.ext_handler.properties.extensions
         # If no runtime_settings available for this ext_handler, then return 0 (this is the behavior we follow
         # for update_settings)
-        if not runtime_settings or len(runtime_settings) == 0: # pylint: disable=len-as-condition
+        if not runtime_settings or len(runtime_settings) == 0:  # pylint: disable=len-as-condition
             return "0"
         # Currently for every runtime settings we use the same sequence number
         # (Check : def parse_plugin_settings(self, ext_handler, plugin_settings) in wire.py)
@@ -1507,20 +1507,20 @@ class ExtHandlerInstance(object): # pylint: disable=R0904
         data_str = None
         data = None
 
-        for attempt in range(_NUM_OF_STATUS_FILE_RETRIES): # pylint: disable=W0612
+        for attempt in range(_NUM_OF_STATUS_FILE_RETRIES):  # pylint: disable=W0612
             try:
                 data_str = fileutil.read_file(ext_status_file)
                 data = json.loads(data_str)
                 break
-            except IOError as e: # pylint: disable=C0103
+            except IOError as e:  # pylint: disable=C0103
                 failed_to_read = True
                 raised_exception = e
-            except (ValueError, TypeError) as e: # pylint: disable=C0103
+            except (ValueError, TypeError) as e:  # pylint: disable=C0103
                 failed_to_parse_json = True
                 raised_exception = e
             time.sleep(_STATUS_FILE_RETRY_DELAY)
 
-        if failed_to_read: # pylint: disable=R1720
+        if failed_to_read:  # pylint: disable=R1720
             raise ExtensionStatusError(msg=ustr(raised_exception), inner=raised_exception,
                                        code=ExtensionStatusError.CouldNotReadStatusFile)
         elif failed_to_parse_json:
@@ -1548,15 +1548,15 @@ class ExtHandlerInstance(object): # pylint: disable=R0904
         return processed_substatus
 
     @staticmethod
-    def _truncate_message(field, truncate_size=_MAX_SUBSTATUS_FIELD_LENGTH): # pylint: disable=R1710
-        if field is None: # pylint: disable=R1705
+    def _truncate_message(field, truncate_size=_MAX_SUBSTATUS_FIELD_LENGTH):  # pylint: disable=R1710
+        if field is None:  # pylint: disable=R1705
             return
         else:
             truncated_field = field if len(field) < truncate_size else field[:truncate_size] + _TRUNCATED_SUFFIX
             return truncated_field, len(truncated_field)
 
 
-class HandlerEnvironment(object): # pylint: disable=R0903
+class HandlerEnvironment(object):  # pylint: disable=R0903
     # HandlerEnvironment.json schema version
     schemaVersion = 1.0
     fileName = "HandlerEnvironment.json"
@@ -1619,5 +1619,5 @@ class ExtensionStatusError(ExtensionError):
     StatusFileMalformed = 3
     MaxSizeExceeded = 4
 
-    def __init__(self, msg=None, inner=None, code=-1): # pylint: disable=W0235
+    def __init__(self, msg=None, inner=None, code=-1):  # pylint: disable=W0235
         super(ExtensionStatusError, self).__init__(msg, inner, code)

--- a/azurelinuxagent/ga/monitor.py
+++ b/azurelinuxagent/ga/monitor.py
@@ -156,7 +156,7 @@ class ReportNetworkConfigurationChangesOperation(PeriodicOperation):
             self.last_nic_state = nic_state
 
 
-class MonitorHandler(ThreadHandlerInterface): # pylint: disable=R0902
+class MonitorHandler(ThreadHandlerInterface):  # pylint: disable=R0902
     # telemetry
     EVENT_COLLECTION_PERIOD = datetime.timedelta(minutes=1)
     # host plugin
@@ -243,14 +243,14 @@ class MonitorHandler(ThreadHandlerInterface): # pylint: disable=R0902
                 try:
                     self.protocol.update_host_plugin_from_goal_state()
 
-                    for op in self._periodic_operations: # pylint: disable=C0103
+                    for op in self._periodic_operations:  # pylint: disable=C0103
                         op.run()
 
-                except Exception as e: # pylint: disable=C0103
+                except Exception as e:  # pylint: disable=C0103
                     logger.error("An error occurred in the monitor thread main loop; will skip the current iteration.\n{0}", ustr(e))
                 finally:
                     PeriodicOperation.sleep_until_next_operation(self._periodic_operations)
-        except Exception as e: # pylint: disable=C0103
+        except Exception as e:  # pylint: disable=C0103
             logger.error("An error occurred in the monitor thread; will exit the thread.\n{0}", ustr(e))
 
     def send_imds_heartbeat(self):
@@ -271,7 +271,7 @@ class MonitorHandler(ThreadHandlerInterface): # pylint: disable=R0902
 
             self.health_service.report_imds_status(is_healthy, response)
 
-        except Exception as e: # pylint: disable=C0103
+        except Exception as e:  # pylint: disable=C0103
             msg = "Exception sending imds heartbeat: {0}".format(ustr(e))
             add_event(
                 name=AGENT_NAME,
@@ -310,7 +310,7 @@ class MonitorHandler(ThreadHandlerInterface): # pylint: disable=R0902
                     message='{0} since successful heartbeat'.format(self.host_plugin_errorstate.fail_time),
                     log_event=False)
 
-        except Exception as e: # pylint: disable=C0103
+        except Exception as e:  # pylint: disable=C0103
             msg = "Exception sending host plugin heartbeat: {0}".format(ustr(e))
             add_event(
                 name=AGENT_NAME,

--- a/azurelinuxagent/ga/periodic_operation.py
+++ b/azurelinuxagent/ga/periodic_operation.py
@@ -48,7 +48,7 @@ class PeriodicOperation(object):
                     self._operation()
                 finally:
                     self._next_run_time = datetime.datetime.utcnow() + self._period
-        except Exception as e: # pylint: disable=C0103
+        except Exception as e:  # pylint: disable=C0103
             warning = "Failed to {0}: {1} --- [NOTE: Will not log the same error for the next hour]".format(self._name, ustr(e))
             if warning != self._last_warning or self._last_warning_time is None or datetime.datetime.utcnow() >= self._last_warning_time + self._LOG_WARNING_PERIOD:
                 logger.warn(warning)

--- a/azurelinuxagent/ga/remoteaccess.py
+++ b/azurelinuxagent/ga/remoteaccess.py
@@ -42,11 +42,11 @@ def get_remote_access_handler(protocol):
     return RemoteAccessHandler(protocol)
 
 
-class RemoteAccessHandler(object): # pylint: disable=R0903
+class RemoteAccessHandler(object):  # pylint: disable=R0903
     def __init__(self, protocol):
         self._os_util = get_osutil()
         self._protocol = protocol
-        self._cryptUtil = CryptUtil(conf.get_openssl_cmd()) # pylint: disable=C0103
+        self._cryptUtil = CryptUtil(conf.get_openssl_cmd())  # pylint: disable=C0103
         self._remote_access = None
         self._incarnation = 0
         self._check_existing_jit_users = True
@@ -60,7 +60,7 @@ class RemoteAccessHandler(object): # pylint: disable=R0903
                     self._incarnation = current_incarnation
                     self._remote_access = self._protocol.client.get_remote_access()
                     self._handle_remote_access()
-        except Exception as e: # pylint: disable=C0103
+        except Exception as e:  # pylint: disable=C0103
             msg = u"Exception processing goal state for remote access users: {0} {1}".format(ustr(e), traceback.format_exc())
             add_event(AGENT_NAME,
                       version=CURRENT_VERSION,
@@ -92,7 +92,7 @@ class RemoteAccessHandler(object): # pylint: disable=R0903
                         # user account expired, delete it.
                         logger.info("Remote access user '{0}' expired.", acc.name)
                         self._remove_user(acc.name)
-                except Exception as e: # pylint: disable=C0103
+                except Exception as e:  # pylint: disable=C0103
                     logger.error("Error processing remote access user '{0}' - {1}", acc.name, ustr(e))
 
             for user in existing_jit_users:
@@ -100,7 +100,7 @@ class RemoteAccessHandler(object): # pylint: disable=R0903
                     if user not in goal_state_users:
                         # user explicitly removed
                         self._remove_user(user)
-                except Exception as e: # pylint: disable=C0103
+                except Exception as e:  # pylint: disable=C0103
                     logger.error("Error removing remote access user '{0}' - {1}", user, ustr(e))
         else:
             # There are no JIT users in the goal state; that may mean that they were removed or that they
@@ -117,7 +117,7 @@ class RemoteAccessHandler(object): # pylint: disable=R0903
                 for user in existing_jit_users:
                     try:
                         self._remove_user(user)
-                    except Exception as e: # pylint: disable=C0103
+                    except Exception as e:  # pylint: disable=C0103
                         logger.error("Error removing remote access user '{0}' - {1}", user, ustr(e))
                         remove_user_errors = True
 

--- a/azurelinuxagent/pa/deprovision/arch.py
+++ b/azurelinuxagent/pa/deprovision/arch.py
@@ -22,7 +22,7 @@ from azurelinuxagent.pa.deprovision.default import DeprovisionHandler, \
                                                    DeprovisionAction
 
 class ArchDeprovisionHandler(DeprovisionHandler):
-    def __init__(self): # pylint: disable=W0235
+    def __init__(self):  # pylint: disable=W0235
         super(ArchDeprovisionHandler, self).__init__()
 
     def setup(self, deluser):

--- a/azurelinuxagent/pa/deprovision/clearlinux.py
+++ b/azurelinuxagent/pa/deprovision/clearlinux.py
@@ -24,7 +24,7 @@ from azurelinuxagent.pa.deprovision.default import DeprovisionHandler, \
 # pylint: enable=W0611
 
 class ClearLinuxDeprovisionHandler(DeprovisionHandler):
-    def __init__(self, distro): # pylint: disable=W0231
+    def __init__(self, distro):  # pylint: disable=W0231
         self.distro = distro
 
     def setup(self, deluser):

--- a/azurelinuxagent/pa/deprovision/coreos.py
+++ b/azurelinuxagent/pa/deprovision/coreos.py
@@ -22,7 +22,7 @@ from azurelinuxagent.pa.deprovision.default import DeprovisionHandler, \
                                                    DeprovisionAction
 
 class CoreOSDeprovisionHandler(DeprovisionHandler):
-    def __init__(self): # pylint: disable=W0235
+    def __init__(self):  # pylint: disable=W0235
         super(CoreOSDeprovisionHandler, self).__init__()
 
     def setup(self, deluser):

--- a/azurelinuxagent/pa/deprovision/default.py
+++ b/azurelinuxagent/pa/deprovision/default.py
@@ -33,16 +33,16 @@ from azurelinuxagent.ga.exthandlers import HANDLER_COMPLETE_NAME_PATTERN
 
 
 def read_input(message):
-    if sys.version_info[0] >= 3: # pylint: disable=R1705
+    if sys.version_info[0] >= 3:  # pylint: disable=R1705
         return input(message)
     else:
         # This is not defined in python3, and the linter will thus 
         # throw an undefined-variable<E0602> error on this line.
         # Suppress it here.
-        return raw_input(message) # pylint: disable=E0602
+        return raw_input(message)  # pylint: disable=E0602
 
 
-class DeprovisionAction(object): # pylint: disable=R0903
+class DeprovisionAction(object):  # pylint: disable=R0903
     def __init__(self, func, args=None, kwargs=None):
         if args is None:
             args = []
@@ -93,11 +93,11 @@ class DeprovisionHandler(object):
         warnings.append("WARNING! The waagent service will be stopped.")
         actions.append(DeprovisionAction(self.osutil.stop_agent_service))
 
-    def del_dirs(self, warnings, actions): # pylint: disable=W0613
+    def del_dirs(self, warnings, actions):  # pylint: disable=W0613
         dirs = [conf.get_lib_dir(), conf.get_ext_log_dir()]
         actions.append(DeprovisionAction(fileutil.rm_dirs, dirs))
 
-    def del_files(self, warnings, actions): # pylint: disable=W0613
+    def del_files(self, warnings, actions):  # pylint: disable=W0613
         files = ['/root/.bash_history', conf.get_agent_log_file()]
         actions.append(DeprovisionAction(fileutil.rm_files, files))
 
@@ -128,7 +128,7 @@ class DeprovisionHandler(object):
         actions.append(DeprovisionAction(fileutil.rm_files,
                                          ["/var/lib/NetworkManager/dhclient-*.lease"]))
 
-    def del_ext_handler_files(self, warnings, actions): # pylint: disable=W0613
+    def del_ext_handler_files(self, warnings, actions):  # pylint: disable=W0613
         ext_dirs = [d for d in os.listdir(conf.get_lib_dir())
                     if os.path.isdir(os.path.join(conf.get_lib_dir(), d))
                     and re.match(HANDLER_COMPLETE_NAME_PATTERN, d) is not None
@@ -141,10 +141,10 @@ class DeprovisionHandler(object):
             files += glob.glob(os.path.join(ext_base, 'config', 'HandlerStatus'))
             files += glob.glob(os.path.join(ext_base, 'mrseq'))
 
-            if len(files) > 0: # pylint: disable=len-as-condition
+            if len(files) > 0:  # pylint: disable=len-as-condition
                 actions.append(DeprovisionAction(fileutil.rm_files, files))
 
-    def del_lib_dir_files(self, warnings, actions): # pylint: disable=W0613
+    def del_lib_dir_files(self, warnings, actions):  # pylint: disable=W0613
         known_files = [
             'HostingEnvironmentConfig.xml',
             'Incarnation',
@@ -163,13 +163,13 @@ class DeprovisionHandler(object):
         files = [f for f in \
                     [os.path.join(lib_dir, kf) for kf in known_files] \
                         if os.path.isfile(f)]
-        for p in known_files_glob: # pylint: disable=C0103
+        for p in known_files_glob:  # pylint: disable=C0103
             files += glob.glob(os.path.join(lib_dir, p))
 
-        if len(files) > 0: # pylint: disable=len-as-condition
+        if len(files) > 0:  # pylint: disable=len-as-condition
             actions.append(DeprovisionAction(fileutil.rm_files, files))
 
-    def reset_hostname(self, warnings, actions): # pylint: disable=W0613
+    def reset_hostname(self, warnings, actions):  # pylint: disable=W0613
         localhost = ["localhost.localdomain"]
         actions.append(DeprovisionAction(self.osutil.set_hostname, 
                                          localhost))
@@ -242,13 +242,13 @@ class DeprovisionHandler(object):
             return True
 
         confirm = read_input("Do you want to proceed (y/n)")
-        return True if confirm.lower().startswith('y') else False # pylint: disable=R1719
+        return True if confirm.lower().startswith('y') else False  # pylint: disable=R1719
     
     def do_warnings(self, warnings):
         for warning in warnings:
             print(warning)
 
-    def handle_interrupt_signal(self, signum, frame): # pylint: disable=W0613,R1711
+    def handle_interrupt_signal(self, signum, frame):  # pylint: disable=W0613,R1711
         if not self.actions_running:
             print("Deprovision is interrupted.")
             sys.exit(0)

--- a/azurelinuxagent/pa/deprovision/factory.py
+++ b/azurelinuxagent/pa/deprovision/factory.py
@@ -31,14 +31,14 @@ def get_deprovision_handler(distro_name=DISTRO_NAME,
     if distro_name == "arch":
         return ArchDeprovisionHandler()
     if distro_name == "ubuntu":
-        if Version(distro_version) >= Version('18.04'): # pylint: disable=R1705
+        if Version(distro_version) >= Version('18.04'):  # pylint: disable=R1705
             return Ubuntu1804DeprovisionHandler()
         else:
             return UbuntuDeprovisionHandler()
     if distro_name == "coreos":
         return CoreOSDeprovisionHandler()
     if "Clear Linux" in distro_full_name:
-        return ClearLinuxDeprovisionHandler() # pylint: disable=E1120
+        return ClearLinuxDeprovisionHandler()  # pylint: disable=E1120
 
     return DeprovisionHandler()
 

--- a/azurelinuxagent/pa/deprovision/ubuntu.py
+++ b/azurelinuxagent/pa/deprovision/ubuntu.py
@@ -24,7 +24,7 @@ from azurelinuxagent.pa.deprovision.default import DeprovisionHandler, \
 
 
 class UbuntuDeprovisionHandler(DeprovisionHandler):
-    def __init__(self): # pylint: disable=W0235
+    def __init__(self):  # pylint: disable=W0235
         super(UbuntuDeprovisionHandler, self).__init__()
 
     def del_resolv(self, warnings, actions):
@@ -43,7 +43,7 @@ class UbuntuDeprovisionHandler(DeprovisionHandler):
 
 
 class Ubuntu1804DeprovisionHandler(UbuntuDeprovisionHandler):
-    def __init__(self): # pylint: disable=W0235
+    def __init__(self):  # pylint: disable=W0235
         super(Ubuntu1804DeprovisionHandler, self).__init__()
 
     def del_resolv(self, warnings, actions):

--- a/azurelinuxagent/pa/provision/cloudinit.py
+++ b/azurelinuxagent/pa/provision/cloudinit.py
@@ -26,9 +26,9 @@ from datetime import datetime
 import azurelinuxagent.common.conf as conf
 import azurelinuxagent.common.logger as logger
 import azurelinuxagent.common.utils.fileutil as fileutil
-import azurelinuxagent.common.utils.shellutil as shellutil # pylint: disable=W0611
+import azurelinuxagent.common.utils.shellutil as shellutil  # pylint: disable=W0611
 
-from azurelinuxagent.common.event import elapsed_milliseconds, WALAEventOperation # pylint: disable=W0611
+from azurelinuxagent.common.event import elapsed_milliseconds, WALAEventOperation  # pylint: disable=W0611
 from azurelinuxagent.common.exception import ProvisionError, ProtocolError
 from azurelinuxagent.common.future import ustr
 from azurelinuxagent.common.protocol.util import OVF_FILE_NAME
@@ -38,7 +38,7 @@ from azurelinuxagent.pa.provision.cloudinitdetect import cloud_init_is_enabled
 
 
 class CloudInitProvisionHandler(ProvisionHandler):
-    def __init__(self): # pylint: disable=W0235
+    def __init__(self):  # pylint: disable=W0235
         super(CloudInitProvisionHandler, self).__init__()
 
     def run(self):
@@ -53,7 +53,7 @@ class CloudInitProvisionHandler(ProvisionHandler):
             self.protocol_util.get_protocol()
             self.report_not_ready("Provisioning", "Starting")
 
-            thumbprint = self.wait_for_ssh_host_key() # pylint: disable=W0612
+            thumbprint = self.wait_for_ssh_host_key()  # pylint: disable=W0612
             self.write_provisioned()
             logger.info("Finished provisioning")
 
@@ -62,7 +62,7 @@ class CloudInitProvisionHandler(ProvisionHandler):
                 is_success=True,
                 duration=elapsed_milliseconds(utc_start))
 
-        except ProvisionError as e: # pylint: disable=C0103
+        except ProvisionError as e:  # pylint: disable=C0103
             msg = "Provisioning with cloud-init failed: {0} ({1}s)".format(ustr(e), self._get_uptime_seconds())
             logger.error(msg)
             self.report_not_ready("ProvisioningFailed", ustr(e))
@@ -80,7 +80,7 @@ class CloudInitProvisionHandler(ProvisionHandler):
                     ovf_env = OvfEnv(fileutil.read_file(ovf_file_path))
                     self.handle_provision_guest_agent(ovf_env.provision_guest_agent)
                     return
-                except ProtocolError as pe: # pylint: disable=C0103
+                except ProtocolError as pe:  # pylint: disable=C0103
                     raise ProvisionError("OVF xml could not be parsed "
                                          "[{0}]: {1}".format(ovf_file_path,
                                                              ustr(pe)))
@@ -103,7 +103,7 @@ class CloudInitProvisionHandler(ProvisionHandler):
         """
         Wait for cloud-init to generate ssh host key
         """
-        keypair_type = conf.get_ssh_host_keypair_type() # pylint: disable=W0612
+        keypair_type = conf.get_ssh_host_keypair_type()  # pylint: disable=W0612
         path = conf.get_ssh_key_public_path()
         for retry in range(0, max_retry):
             if os.path.isfile(path):

--- a/azurelinuxagent/pa/provision/default.py
+++ b/azurelinuxagent/pa/provision/default.py
@@ -63,7 +63,7 @@ class ProvisionHandler(object):
 
         try:
             utc_start = datetime.utcnow()
-            thumbprint = None # pylint: disable=W0612
+            thumbprint = None  # pylint: disable=W0612
 
             if self.check_provisioned_file():
                 logger.info("Provisioning already completed, skipping.")
@@ -98,7 +98,7 @@ class ProvisionHandler(object):
             self.report_ready()
             logger.info("Provisioning complete")
 
-        except (ProtocolError, ProvisionError) as e: # pylint: disable=C0103
+        except (ProtocolError, ProvisionError) as e:  # pylint: disable=C0103
             msg = "Provisioning failed: {0} ({1}s)".format(ustr(e), self._get_uptime_seconds())
             logger.error(msg)
             self.report_not_ready("ProvisioningFailed", ustr(e))
@@ -108,10 +108,10 @@ class ProvisionHandler(object):
     @staticmethod
     def _get_uptime_seconds():
         try:
-            with open('/proc/uptime') as fh: # pylint: disable=C0103
+            with open('/proc/uptime') as fh:  # pylint: disable=C0103
                 uptime, _ = fh.readline().split()
                 return uptime
-        except: # pylint: disable=W0702
+        except:  # pylint: disable=W0702
             return 0
 
     def reg_ssh_host_key(self):
@@ -136,7 +136,7 @@ class ProvisionHandler(object):
     def get_ssh_host_key_thumbprint(self, chk_err=True):
         cmd = "ssh-keygen -lf {0}".format(conf.get_ssh_key_public_path())
         ret = shellutil.run_get_output(cmd, chk_err=chk_err)
-        if ret[0] == 0: # pylint: disable=R1705
+        if ret[0] == 0:  # pylint: disable=R1705
             return ret[1].rstrip().split()[1].replace(':', '')
         else:
             raise ProvisionError(("Failed to generate ssh host key: "
@@ -169,9 +169,9 @@ class ProvisionHandler(object):
         if not ProvisionHandler.is_provisioned():
             return False
 
-        s = fileutil.read_file(ProvisionHandler.provisioned_file_path()).strip() # pylint: disable=C0103
+        s = fileutil.read_file(ProvisionHandler.provisioned_file_path()).strip()  # pylint: disable=C0103
         if not self.osutil.is_current_instance_id(s):
-            if len(s) > 0: # pylint: disable=len-as-condition
+            if len(s) > 0:  # pylint: disable=len-as-condition
                 logger.warn("VM is provisioned, "
                             "but the VM unique identifier has changed -- "
                             "clearing cached state")
@@ -219,7 +219,7 @@ class ProvisionHandler(object):
             if conf.get_delete_root_password():
                 self.osutil.del_root_password()
 
-        except OSUtilError as e: # pylint: disable=C0103
+        except OSUtilError as e:  # pylint: disable=C0103
             raise ProvisionError("Failed to provision: {0}".format(ustr(e)))
 
     def config_user_account(self, ovfenv):
@@ -291,7 +291,7 @@ class ProvisionHandler(object):
         try:
             protocol = self.protocol_util.get_protocol()
             protocol.report_provision_status(status)
-        except ProtocolError as e: # pylint: disable=C0103
+        except ProtocolError as e:  # pylint: disable=C0103
             logger.error("Reporting NotReady failed: {0}", e)
             self.report_event(ustr(e))
 
@@ -300,6 +300,6 @@ class ProvisionHandler(object):
         try:
             protocol = self.protocol_util.get_protocol()
             protocol.report_provision_status(status)
-        except ProtocolError as e: # pylint: disable=C0103
+        except ProtocolError as e:  # pylint: disable=C0103
             logger.error("Reporting Ready failed: {0}", e)
             self.report_event(ustr(e))

--- a/azurelinuxagent/pa/provision/factory.py
+++ b/azurelinuxagent/pa/provision/factory.py
@@ -23,9 +23,9 @@ from azurelinuxagent.common.version import DISTRO_NAME, DISTRO_VERSION, \
 from .default import ProvisionHandler
 from .cloudinit import CloudInitProvisionHandler, cloud_init_is_enabled
 
-def get_provision_handler(distro_name=DISTRO_NAME, # pylint: disable=W0613
-                            distro_version=DISTRO_VERSION, # pylint: disable=W0613
-                            distro_full_name=DISTRO_FULL_NAME): # pylint: disable=W0613
+def get_provision_handler(distro_name=DISTRO_NAME,  # pylint: disable=W0613
+                            distro_version=DISTRO_VERSION,  # pylint: disable=W0613
+                            distro_full_name=DISTRO_FULL_NAME):  # pylint: disable=W0613
 
     provisioning_agent = conf.get_provisioning_agent()
 

--- a/azurelinuxagent/pa/rdma/centos.py
+++ b/azurelinuxagent/pa/rdma/centos.py
@@ -17,7 +17,7 @@
 # Requires Python 2.6+ and Openssl 1.0+
 #
 
-import glob # pylint: disable=W0611
+import glob  # pylint: disable=W0611
 import os
 import re
 import time
@@ -38,7 +38,7 @@ class CentOSRDMAHandler(RDMAHandler):
     version_minor = None
 
     def __init__(self, distro_version):
-        v = distro_version.split('.') # pylint: disable=C0103
+        v = distro_version.split('.')  # pylint: disable=C0103
         if len(v) < 2:
             raise Exception('Unexpected centos version: %s' % distro_version)
         self.version_major, self.version_minor = v[0], v[1]
@@ -68,7 +68,7 @@ class CentOSRDMAHandler(RDMAHandler):
         if installed_pkg:
             logger.info(
                 'RDMA: driver package present: {0}'.format(installed_pkg))
-            if self.is_rdma_package_up_to_date(installed_pkg, fw_version): # pylint: disable=R1705
+            if self.is_rdma_package_up_to_date(installed_pkg, fw_version):  # pylint: disable=R1705
                 logger.info('RDMA: driver package is up-to-date')
                 return
             else:
@@ -82,13 +82,13 @@ class CentOSRDMAHandler(RDMAHandler):
         # Example match (pkg name, -, followed by 3 segments, fw_version and -):
         # - pkg=microsoft-hyper-v-rdma-4.1.0.142-20160323.x86_64
         # - fw_version=142
-        pattern = '{0}-(\d+\.){{3,}}({1})-'.format(self.rdma_user_mode_package_name, fw_version) # pylint: disable=W1401
+        pattern = '{0}-(\d+\.){{3,}}({1})-'.format(self.rdma_user_mode_package_name, fw_version)  # pylint: disable=W1401
         return re.match(pattern, pkg)
 
     @staticmethod
     def get_int_rdma_version(version):
-        s = version.split('.') # pylint: disable=C0103
-        if len(s) == 0: # pylint: disable=len-as-condition
+        s = version.split('.')  # pylint: disable=C0103
+        if len(s) == 0:  # pylint: disable=len-as-condition
             raise Exception('Unexpected RDMA firmware version: "%s"' % version)
         return s[0]
 
@@ -155,7 +155,7 @@ class CentOSRDMAHandler(RDMAHandler):
 
         # Install kernel mode driver (kmod-microsoft-hyper-v-rdma-*)
         kmod_pkg = self.get_file_by_pattern(
-            pkgs, "%s-(\d+\.){3,}(%s)-\d{8}\.x86_64.rpm" % (self.rdma_kernel_mode_package_name, fw_version)) # pylint: disable=W1401
+            pkgs, "%s-(\d+\.){3,}(%s)-\d{8}\.x86_64.rpm" % (self.rdma_kernel_mode_package_name, fw_version))  # pylint: disable=W1401
         if not kmod_pkg:
             raise Exception("RDMA kernel mode package not found")
         kmod_pkg_path = os.path.join(pkg_dir, kmod_pkg)
@@ -164,7 +164,7 @@ class CentOSRDMAHandler(RDMAHandler):
 
         # Install user mode driver (microsoft-hyper-v-rdma-*)
         umod_pkg = self.get_file_by_pattern(
-            pkgs, "%s-(\d+\.){3,}(%s)-\d{8}\.x86_64.rpm" % (self.rdma_user_mode_package_name, fw_version)) # pylint: disable=W1401
+            pkgs, "%s-(\d+\.){3,}(%s)-\d{8}\.x86_64.rpm" % (self.rdma_user_mode_package_name, fw_version))  # pylint: disable=W1401
         if not umod_pkg:
             raise Exception("RDMA user mode package not found")
         umod_pkg_path = os.path.join(pkg_dir, umod_pkg)
@@ -180,7 +180,7 @@ class CentOSRDMAHandler(RDMAHandler):
 
     @staticmethod
     def get_file_by_pattern(file_list, pattern):
-        for l in file_list: # pylint: disable=C0103
+        for l in file_list:  # pylint: disable=C0103
             if re.match(pattern, l):
                 return l
         return None

--- a/azurelinuxagent/pa/rdma/factory.py
+++ b/azurelinuxagent/pa/rdma/factory.py
@@ -31,13 +31,13 @@ def get_rdma_handler(
 ):
     """Return the handler object for RDMA driver handling"""
     if (
-            (distro_full_name == 'SUSE Linux Enterprise Server' or # pylint: disable=R1714
+            (distro_full_name == 'SUSE Linux Enterprise Server' or  # pylint: disable=R1714
              distro_full_name == 'SLES') and
             Version(distro_version) > Version('11')
     ):
         return SUSERDMAHandler()
 
-    if distro_full_name == 'CentOS Linux' or distro_full_name == 'CentOS' or distro_full_name == 'Red Hat Enterprise Linux Server': # pylint: disable=R1714
+    if distro_full_name == 'CentOS Linux' or distro_full_name == 'CentOS' or distro_full_name == 'Red Hat Enterprise Linux Server':  # pylint: disable=R1714
         return CentOSRDMAHandler(distro_version)
 
     if distro_full_name == 'Ubuntu':

--- a/azurelinuxagent/pa/rdma/suse.py
+++ b/azurelinuxagent/pa/rdma/suse.py
@@ -25,7 +25,7 @@ from azurelinuxagent.common.rdma import RDMAHandler
 
 class SUSERDMAHandler(RDMAHandler):
 
-    def install_driver(self): # pylint: disable=R0912,R1710
+    def install_driver(self):  # pylint: disable=R0912,R1710
         """Install the appropriate driver package for the RDMA firmware"""
 
         fw_version = self.get_rdma_version()
@@ -43,7 +43,7 @@ class SUSERDMAHandler(RDMAHandler):
         package_name = 'dummy'
         # Figure out the kernel that is running to find the proper kmp
         cmd = 'uname -r'
-        status, kernel_release = shellutil.run_get_output(cmd) # pylint: disable=W0612
+        status, kernel_release = shellutil.run_get_output(cmd)  # pylint: disable=W0612
         if 'default' in kernel_release:
             package_name = 'msft-rdma-kmp-default'
             info_msg = 'RDMA: Detected kernel-default'
@@ -125,7 +125,7 @@ class SUSERDMAHandler(RDMAHandler):
                 if not self.load_driver_module() or requires_reboot:
                     self.reboot_system()
                 return True
-        else: # pylint: disable=W0120
+        else:  # pylint: disable=W0120
             logger.info("RDMA: No suitable match in repos. Trying local.")
             local_packages = glob.glob('/opt/microsoft/rdma/*.rpm')
             for local_package in local_packages:

--- a/azurelinuxagent/pa/rdma/ubuntu.py
+++ b/azurelinuxagent/pa/rdma/ubuntu.py
@@ -17,10 +17,10 @@
 # Requires Python 2.6+ and Openssl 1.0+
 #
 
-import glob # pylint: disable=W0611
+import glob  # pylint: disable=W0611
 import os
 import re
-import time # pylint: disable=W0611
+import time  # pylint: disable=W0611
 import azurelinuxagent.common.conf as conf
 import azurelinuxagent.common.logger as logger
 import azurelinuxagent.common.utils.shellutil as shellutil
@@ -29,7 +29,7 @@ from azurelinuxagent.common.rdma import RDMAHandler
 
 class UbuntuRDMAHandler(RDMAHandler):
 
-    def install_driver(self): # pylint: disable=R0912,R0911
+    def install_driver(self):  # pylint: disable=R0912,R0911
         #Install the appropriate driver package for the RDMA firmware
 
         nd_version = self.get_rdma_version()
@@ -37,7 +37,7 @@ class UbuntuRDMAHandler(RDMAHandler):
             logger.error("RDMA: Could not determine firmware version. No driver will be installed")
             return
         #replace . with _, we are looking for number like 144_0
-        nd_version = re.sub('\.', '_', nd_version) # pylint: disable=W1401
+        nd_version = re.sub('\.', '_', nd_version)  # pylint: disable=W1401
 
         #Check to see if we need to reconfigure driver
         status,module_name = shellutil.run_get_output('modprobe -R hv_network_direct', chk_err=False)
@@ -79,13 +79,13 @@ class UbuntuRDMAHandler(RDMAHandler):
         status,output = shellutil.run_get_output('apt-cache show --no-all-versions linux-azure')
         if status != 0:
             return
-        r = re.search('Version: (\S+)', output) # pylint: disable=W1401,C0103
+        r = re.search('Version: (\S+)', output)  # pylint: disable=W1401,C0103
         if not r:
             logger.error("RDMA: version not found in package linux-azure.")
             return
         package_version = r.groups()[0]
         #Remove the ending .<upload number> after <ABI number>
-        package_version = re.sub("\.\d+$", "", package_version) # pylint: disable=W1401
+        package_version = re.sub("\.\d+$", "", package_version)  # pylint: disable=W1401
 
         logger.info('RDMA: kernel_version=%s package_version=%s' % (kernel_version, package_version))
         kernel_version_array = [ int(x) for x in kernel_version.split('.') ]
@@ -108,15 +108,15 @@ class UbuntuRDMAHandler(RDMAHandler):
         if not os.path.isfile(modprobed_file):
             logger.info("RDMA: %s not found, it will be created" % modprobed_file)
         else:
-            f = open(modprobed_file, 'r') # pylint: disable=C0103
+            f = open(modprobed_file, 'r')  # pylint: disable=C0103
             lines = f.read()
             f.close()
-        r = re.search('alias hv_network_direct hv_network_direct_\S+', lines) # pylint: disable=W1401,C0103
+        r = re.search('alias hv_network_direct hv_network_direct_\S+', lines)  # pylint: disable=W1401,C0103
         if r:
-            lines = re.sub('alias hv_network_direct hv_network_direct_\S+', 'alias hv_network_direct hv_network_direct_%s' % nd_version, lines) # pylint: disable=W1401
+            lines = re.sub('alias hv_network_direct hv_network_direct_\S+', 'alias hv_network_direct hv_network_direct_%s' % nd_version, lines)  # pylint: disable=W1401
         else:
             lines += '\nalias hv_network_direct hv_network_direct_%s\n' % nd_version
-        f = open('/etc/modprobe.d/vmbus-rdma.conf', 'w') # pylint: disable=C0103
+        f = open('/etc/modprobe.d/vmbus-rdma.conf', 'w')  # pylint: disable=C0103
         f.write(lines)
         f.close()
         logger.info("RDMA: hv_network_direct alias updated to ND %s" % nd_version)

--- a/makepkg.py
+++ b/makepkg.py
@@ -48,22 +48,22 @@ PUBLISH_MANIFEST = '''<?xml version="1.0" encoding="utf-8" ?>
 
 PUBLISH_MANIFEST_FILE = 'manifest.xml'
 
-output_path = os.path.join(os.getcwd(), "eggs") # pylint: disable=invalid-name
-target_path = os.path.join(output_path, AGENT_LONG_VERSION) # pylint: disable=invalid-name
-bin_path = os.path.join(target_path, "bin") # pylint: disable=invalid-name
-egg_path = os.path.join(bin_path, AGENT_LONG_VERSION + ".egg") # pylint: disable=invalid-name
-manifest_path = os.path.join(target_path, AGENT_MANIFEST_FILE) # pylint: disable=invalid-name
-publish_manifest_path = os.path.join(target_path, PUBLISH_MANIFEST_FILE) # pylint: disable=invalid-name
-pkg_name = os.path.join(output_path, AGENT_LONG_VERSION + ".zip") # pylint: disable=invalid-name
+output_path = os.path.join(os.getcwd(), "eggs")  # pylint: disable=invalid-name
+target_path = os.path.join(output_path, AGENT_LONG_VERSION)  # pylint: disable=invalid-name
+bin_path = os.path.join(target_path, "bin")  # pylint: disable=invalid-name
+egg_path = os.path.join(bin_path, AGENT_LONG_VERSION + ".egg")  # pylint: disable=invalid-name
+manifest_path = os.path.join(target_path, AGENT_MANIFEST_FILE)  # pylint: disable=invalid-name
+publish_manifest_path = os.path.join(target_path, PUBLISH_MANIFEST_FILE)  # pylint: disable=invalid-name
+pkg_name = os.path.join(output_path, AGENT_LONG_VERSION + ".zip")  # pylint: disable=invalid-name
 
-family = 'Test' # pylint: disable=C0103
+family = 'Test'  # pylint: disable=C0103
 if len(sys.argv) > 1:
-    family = sys.argv[1] # pylint: disable=invalid-name
+    family = sys.argv[1]  # pylint: disable=invalid-name
 
-def do(*args): # pylint: disable=C0103,W0621
+def do(*args):  # pylint: disable=C0103,W0621
     try:
         subprocess.check_output(args, stderr=subprocess.STDOUT)
-    except subprocess.CalledProcessError as e: # pylint: disable=C0103
+    except subprocess.CalledProcessError as e:  # pylint: disable=C0103
         print("ERROR: {0}".format(str(e)))
         print("\t{0}".format(" ".join(args)))
         print(e.output)
@@ -79,12 +79,12 @@ if os.path.isfile(pkg_name):
 os.makedirs(bin_path)
 print("Created {0} directory".format(target_path))
 
-args = ["python", "setup.py", "bdist_egg", "--dist-dir={0}".format(bin_path)] # pylint: disable=invalid-name
+args = ["python", "setup.py", "bdist_egg", "--dist-dir={0}".format(bin_path)]  # pylint: disable=invalid-name
 
 print("Creating egg {0}".format(egg_path))
 do(*args)
 
-egg_name = os.path.join("bin", os.path.basename( # pylint: disable=invalid-name
+egg_name = os.path.join("bin", os.path.basename(  # pylint: disable=invalid-name
     glob.glob(os.path.join(bin_path, "*"))[0]))
 
 print("Writing {0}".format(manifest_path))
@@ -97,7 +97,7 @@ with open(publish_manifest_path, mode='w') as publish_manifest:
                                                    family))
 
 
-cwd = os.getcwd() # pylint: disable=invalid-name
+cwd = os.getcwd()  # pylint: disable=invalid-name
 os.chdir(target_path)
 print("Creating package {0}".format(pkg_name))
 do("zip", "-r", pkg_name, egg_name)

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ from azurelinuxagent.common.version import AGENT_NAME, AGENT_VERSION, \
     AGENT_DESCRIPTION, \
     DISTRO_NAME, DISTRO_VERSION, DISTRO_FULL_NAME
 
-root_dir = os.path.dirname(os.path.abspath(__file__)) # pylint: disable=invalid-name
+root_dir = os.path.dirname(os.path.abspath(__file__))  # pylint: disable=invalid-name
 os.chdir(root_dir)
 
 
@@ -88,13 +88,13 @@ def set_udev_files(data_files, dest="/etc/udev/rules.d/", src=None):
     data_files.append((dest, src))
 
 
-def get_data_files(name, version, fullname): # pylint: disable=R0912
+def get_data_files(name, version, fullname):  # pylint: disable=R0912
     """
     Determine data_files according to distro name, version and init system type
     """
     data_files = []
 
-    if name == 'redhat' or name == 'centos': # pylint: disable=R1714
+    if name == 'redhat' or name == 'centos':  # pylint: disable=R1714
         set_bin_files(data_files)
         set_conf_files(data_files)
         set_logrotate_files(data_files)
@@ -145,7 +145,7 @@ def get_data_files(name, version, fullname): # pylint: disable=R0912
             # Ubuntu15.04+ uses systemd
             set_systemd_files(data_files,
                               src=["init/ubuntu/walinuxagent.service"])
-    elif name == 'suse' or name == 'opensuse': # pylint: disable=R1714
+    elif name == 'suse' or name == 'opensuse':  # pylint: disable=R1714
         set_bin_files(data_files)
         set_conf_files(data_files, src=["config/suse/waagent.conf"])
         set_logrotate_files(data_files)
@@ -206,7 +206,7 @@ def debian_has_systemd():
         return False
 
 
-class install(_install): # pylint: disable=C0103
+class install(_install):  # pylint: disable=C0103
     user_options = _install.user_options + [
         ('lnx-distro=', None, 'target Linux distribution'),
         ('lnx-distro-version=', None, 'target Linux distribution version'),
@@ -249,11 +249,11 @@ class install(_install): # pylint: disable=C0103
 # module was deprecated. Depending on the Linux distribution the
 # implementation may be broken prior to Python 3.7 wher the functionality
 # will be removed from Python 3
-requires = [] # pylint: disable=invalid-name
+requires = []  # pylint: disable=invalid-name
 if float(sys.version[:3]) >= 3.7:
-    requires = ['distro'] # pylint: disable=invalid-name
+    requires = ['distro']  # pylint: disable=invalid-name
 
-modules = [] # pylint: disable=invalid-name
+modules = []  # pylint: disable=invalid-name
 
 if "bdist_egg" in sys.argv:
     modules.append("__main__")

--- a/tests/common/dhcp/test_dhcp.py
+++ b/tests/common/dhcp/test_dhcp.py
@@ -48,7 +48,7 @@ class TestDHCP(AgentTestCase):
                         "00FCFFFF	0	0	0   \n"
 
         with patch("os.path.exists", return_value=True):
-            mo = mock.mock_open(read_data=routing_table) # pylint: disable=invalid-name
+            mo = mock.mock_open(read_data=routing_table)  # pylint: disable=invalid-name
             with patch(open_patch(), mo):
                 self.assertTrue(dhcp_handler.wireserver_route_exists)
 

--- a/tests/common/osutil/test_bigip.py
+++ b/tests/common/osutil/test_bigip.py
@@ -30,12 +30,12 @@ from tests.tools import AgentTestCase, patch
 from .test_default import osutil_get_dhcp_pid_should_return_a_list_of_pids
 
 
-class TestBigIpOSUtil_wait_until_mcpd_is_initialized(AgentTestCase): # pylint: disable=invalid-name
+class TestBigIpOSUtil_wait_until_mcpd_is_initialized(AgentTestCase):  # pylint: disable=invalid-name
 
     @patch.object(shellutil, "run", return_value=0)
     @patch.object(logger, "info", return_value=None)
     def test_success(self, *args):
-        result = osutil.BigIpOSUtil._wait_until_mcpd_is_initialized( # pylint: disable=protected-access
+        result = osutil.BigIpOSUtil._wait_until_mcpd_is_initialized(  # pylint: disable=protected-access
             osutil.BigIpOSUtil()
         )
         self.assertEqual(result, True)
@@ -47,32 +47,32 @@ class TestBigIpOSUtil_wait_until_mcpd_is_initialized(AgentTestCase): # pylint: d
     @patch.object(shellutil, "run", return_value=1)
     @patch.object(logger, "info", return_value=None)
     @patch.object(time, "sleep", return_value=None)
-    def test_failure(self, *args): # pylint: disable=unused-argument
+    def test_failure(self, *args):  # pylint: disable=unused-argument
         self.assertRaises(
             OSUtilError,
-            osutil.BigIpOSUtil._wait_until_mcpd_is_initialized, # pylint: disable=protected-access
+            osutil.BigIpOSUtil._wait_until_mcpd_is_initialized,  # pylint: disable=protected-access
             osutil.BigIpOSUtil()
         )
 
 
-class TestBigIpOSUtil_save_sys_config(AgentTestCase): # pylint: disable=invalid-name
+class TestBigIpOSUtil_save_sys_config(AgentTestCase):  # pylint: disable=invalid-name
 
     @patch.object(shellutil, "run", return_value=0)
     @patch.object(logger, "error", return_value=None)
     def test_success(self, *args):
-        result = osutil.BigIpOSUtil._save_sys_config(osutil.BigIpOSUtil()) # pylint: disable=protected-access
+        result = osutil.BigIpOSUtil._save_sys_config(osutil.BigIpOSUtil())  # pylint: disable=protected-access
         self.assertEqual(result, 0)
         self.assertEqual(args[0].call_count, 0)
 
     @patch.object(shellutil, "run", return_value=1)
     @patch.object(logger, "error", return_value=None)
     def test_failure(self, *args):
-        result = osutil.BigIpOSUtil._save_sys_config(osutil.BigIpOSUtil()) # pylint: disable=protected-access
+        result = osutil.BigIpOSUtil._save_sys_config(osutil.BigIpOSUtil())  # pylint: disable=protected-access
         self.assertEqual(result, 1)
         self.assertEqual(args[0].call_count, 1)
 
 
-class TestBigIpOSUtil_useradd(AgentTestCase): # pylint: disable=invalid-name
+class TestBigIpOSUtil_useradd(AgentTestCase):  # pylint: disable=invalid-name
 
     @patch.object(osutil.BigIpOSUtil, 'get_userentry', return_value=None)
     @patch.object(shellutil, "run_command")
@@ -92,7 +92,7 @@ class TestBigIpOSUtil_useradd(AgentTestCase): # pylint: disable=invalid-name
         self.assertEqual(result, None)
 
     @patch.object(shellutil, "run", return_value=1)
-    def test_failure(self, *args): # pylint: disable=unused-argument
+    def test_failure(self, *args):  # pylint: disable=unused-argument
         self.assertRaises(
             OSUtilError,
             osutil.BigIpOSUtil.useradd,
@@ -100,7 +100,7 @@ class TestBigIpOSUtil_useradd(AgentTestCase): # pylint: disable=invalid-name
         )
 
 
-class TestBigIpOSUtil_chpasswd(AgentTestCase): # pylint: disable=invalid-name
+class TestBigIpOSUtil_chpasswd(AgentTestCase):  # pylint: disable=invalid-name
 
     @patch.object(shellutil, "run_command")
     @patch.object(osutil.BigIpOSUtil, 'get_userentry', return_value=True)
@@ -115,7 +115,7 @@ class TestBigIpOSUtil_chpasswd(AgentTestCase): # pylint: disable=invalid-name
         self.assertEqual(args[0].call_count, 1)
 
     @patch.object(osutil.BigIpOSUtil, 'is_sys_user', return_value=True)
-    def test_is_sys_user(self, *args): # pylint: disable=unused-argument
+    def test_is_sys_user(self, *args):  # pylint: disable=unused-argument
         self.assertRaises(
             OSUtilError,
             osutil.BigIpOSUtil.chpasswd,
@@ -124,7 +124,7 @@ class TestBigIpOSUtil_chpasswd(AgentTestCase): # pylint: disable=invalid-name
 
     @patch.object(shellutil, "run_get_output", return_value=(1, None))
     @patch.object(osutil.BigIpOSUtil, 'is_sys_user', return_value=False)
-    def test_failed_to_set_user_password(self, *args): # pylint: disable=unused-argument
+    def test_failed_to_set_user_password(self, *args):  # pylint: disable=unused-argument
         self.assertRaises(
             OSUtilError,
             osutil.BigIpOSUtil.chpasswd,
@@ -134,7 +134,7 @@ class TestBigIpOSUtil_chpasswd(AgentTestCase): # pylint: disable=invalid-name
     @patch.object(shellutil, "run_get_output", return_value=(0, None))
     @patch.object(osutil.BigIpOSUtil, 'is_sys_user', return_value=False)
     @patch.object(osutil.BigIpOSUtil, 'get_userentry', return_value=None)
-    def test_failed_to_get_user_entry(self, *args): # pylint: disable=unused-argument
+    def test_failed_to_get_user_entry(self, *args):  # pylint: disable=unused-argument
         self.assertRaises(
             OSUtilError,
             osutil.BigIpOSUtil.chpasswd,
@@ -142,17 +142,17 @@ class TestBigIpOSUtil_chpasswd(AgentTestCase): # pylint: disable=invalid-name
         )
 
 
-class TestBigIpOSUtil_get_dvd_device(AgentTestCase): # pylint: disable=invalid-name
+class TestBigIpOSUtil_get_dvd_device(AgentTestCase):  # pylint: disable=invalid-name
 
     @patch.object(os, "listdir", return_value=['tty1','cdrom0'])
-    def test_success(self, *args): # pylint: disable=unused-argument
+    def test_success(self, *args):  # pylint: disable=unused-argument
         result = osutil.BigIpOSUtil.get_dvd_device(
             osutil.BigIpOSUtil(), '/dev'
         )
         self.assertEqual(result, '/dev/cdrom0')
 
     @patch.object(os, "listdir", return_value=['foo', 'bar'])
-    def test_failure(self, *args): # pylint: disable=unused-argument
+    def test_failure(self, *args):  # pylint: disable=unused-argument
         self.assertRaises(
             OSUtilError,
             osutil.BigIpOSUtil.get_dvd_device,
@@ -160,83 +160,83 @@ class TestBigIpOSUtil_get_dvd_device(AgentTestCase): # pylint: disable=invalid-n
         )
 
 
-class TestBigIpOSUtil_restart_ssh_service(AgentTestCase): # pylint: disable=invalid-name
+class TestBigIpOSUtil_restart_ssh_service(AgentTestCase):  # pylint: disable=invalid-name
 
     @patch.object(shellutil, "run", return_value=0)
-    def test_success(self, *args): # pylint: disable=unused-argument
+    def test_success(self, *args):  # pylint: disable=unused-argument
         result = osutil.BigIpOSUtil.restart_ssh_service(
             osutil.BigIpOSUtil()
         )
         self.assertEqual(result, 0)
 
 
-class TestBigIpOSUtil_stop_agent_service(AgentTestCase): # pylint: disable=invalid-name
+class TestBigIpOSUtil_stop_agent_service(AgentTestCase):  # pylint: disable=invalid-name
 
     @patch.object(shellutil, "run", return_value=0)
-    def test_success(self, *args): # pylint: disable=unused-argument
+    def test_success(self, *args):  # pylint: disable=unused-argument
         result = osutil.BigIpOSUtil.stop_agent_service(
             osutil.BigIpOSUtil()
         )
         self.assertEqual(result, 0)
 
 
-class TestBigIpOSUtil_start_agent_service(AgentTestCase): # pylint: disable=invalid-name
+class TestBigIpOSUtil_start_agent_service(AgentTestCase):  # pylint: disable=invalid-name
 
     @patch.object(shellutil, "run", return_value=0)
-    def test_success(self, *args): # pylint: disable=unused-argument
+    def test_success(self, *args):  # pylint: disable=unused-argument
         result = osutil.BigIpOSUtil.start_agent_service(
             osutil.BigIpOSUtil()
         )
         self.assertEqual(result, 0)
 
 
-class TestBigIpOSUtil_register_agent_service(AgentTestCase): # pylint: disable=invalid-name
+class TestBigIpOSUtil_register_agent_service(AgentTestCase):  # pylint: disable=invalid-name
 
     @patch.object(shellutil, "run", return_value=0)
-    def test_success(self, *args): # pylint: disable=unused-argument
+    def test_success(self, *args):  # pylint: disable=unused-argument
         result = osutil.BigIpOSUtil.register_agent_service(
             osutil.BigIpOSUtil()
         )
         self.assertEqual(result, 0)
 
 
-class TestBigIpOSUtil_unregister_agent_service(AgentTestCase): # pylint: disable=invalid-name
+class TestBigIpOSUtil_unregister_agent_service(AgentTestCase):  # pylint: disable=invalid-name
 
     @patch.object(shellutil, "run", return_value=0)
-    def test_success(self, *args): # pylint: disable=unused-argument
+    def test_success(self, *args):  # pylint: disable=unused-argument
         result = osutil.BigIpOSUtil.unregister_agent_service(
             osutil.BigIpOSUtil()
         )
         self.assertEqual(result, 0)
 
 
-class TestBigIpOSUtil_set_hostname(AgentTestCase): # pylint: disable=invalid-name
+class TestBigIpOSUtil_set_hostname(AgentTestCase):  # pylint: disable=invalid-name
 
     @patch.object(os.path, "exists", return_value=False)
     def test_success(self, *args):
-        result = osutil.BigIpOSUtil.set_hostname( # pylint: disable=assignment-from-none
+        result = osutil.BigIpOSUtil.set_hostname(  # pylint: disable=assignment-from-none
             osutil.BigIpOSUtil(), None
         )
         self.assertEqual(args[0].call_count, 0)
         self.assertEqual(result, None)
 
 
-class TestBigIpOSUtil_set_dhcp_hostname(AgentTestCase): # pylint: disable=invalid-name
+class TestBigIpOSUtil_set_dhcp_hostname(AgentTestCase):  # pylint: disable=invalid-name
 
     @patch.object(os.path, "exists", return_value=False)
     def test_success(self, *args):
-        result = osutil.BigIpOSUtil.set_dhcp_hostname( # pylint: disable=assignment-from-none
+        result = osutil.BigIpOSUtil.set_dhcp_hostname(  # pylint: disable=assignment-from-none
             osutil.BigIpOSUtil(), None
         )
         self.assertEqual(args[0].call_count, 0)
         self.assertEqual(result, None)
 
 
-class TestBigIpOSUtil_get_first_if(AgentTestCase): # pylint: disable=invalid-name
+class TestBigIpOSUtil_get_first_if(AgentTestCase):  # pylint: disable=invalid-name
 
     @patch.object(osutil.BigIpOSUtil,
                   '_format_single_interface_name', return_value=b'eth0')
-    def test_success(self, *args): # pylint: disable=unused-argument
+    def test_success(self, *args):  # pylint: disable=unused-argument
         ifname, ipaddr = osutil.BigIpOSUtil().get_first_if()
         self.assertTrue(ifname.startswith('eth'))
         self.assertTrue(ipaddr is not None)
@@ -247,7 +247,7 @@ class TestBigIpOSUtil_get_first_if(AgentTestCase): # pylint: disable=invalid-nam
 
     @patch.object(osutil.BigIpOSUtil,
                   '_format_single_interface_name', return_value=b'loenp0s3')
-    def test_success(self, *args): # pylint: disable=unused-argument,function-redefined
+    def test_success(self, *args):  # pylint: disable=unused-argument,function-redefined
         ifname, ipaddr = osutil.BigIpOSUtil().get_first_if()
         self.assertFalse(ifname.startswith('eth'))
         self.assertTrue(ipaddr is not None)
@@ -257,7 +257,7 @@ class TestBigIpOSUtil_get_first_if(AgentTestCase): # pylint: disable=invalid-nam
             self.fail("not a valid ip address")
 
 
-class TestBigIpOSUtil_mount_dvd(AgentTestCase): # pylint: disable=invalid-name
+class TestBigIpOSUtil_mount_dvd(AgentTestCase):  # pylint: disable=invalid-name
 
     @patch.object(shellutil, "run", return_value=0)
     @patch.object(time, "sleep", return_value=None)
@@ -272,7 +272,7 @@ class TestBigIpOSUtil_mount_dvd(AgentTestCase): # pylint: disable=invalid-name
         self.assertEqual(args[1].call_count, 1)
 
 
-class TestBigIpOSUtil_route_add(AgentTestCase): # pylint: disable=invalid-name
+class TestBigIpOSUtil_route_add(AgentTestCase):  # pylint: disable=invalid-name
 
     @patch.object(shellutil, "run", return_value=0)
     def test_success(self, *args):
@@ -282,7 +282,7 @@ class TestBigIpOSUtil_route_add(AgentTestCase): # pylint: disable=invalid-name
         self.assertEqual(args[0].call_count, 1)
 
 
-class TestBigIpOSUtil_device_for_ide_port(AgentTestCase): # pylint: disable=invalid-name
+class TestBigIpOSUtil_device_for_ide_port(AgentTestCase):  # pylint: disable=invalid-name
 
     @patch.object(time, "sleep", return_value=None)
     @patch.object(os.path, "exists", return_value=False)

--- a/tests/common/osutil/test_default.py
+++ b/tests/common/osutil/test_default.py
@@ -38,14 +38,14 @@ from tests.tools import AgentTestCase, patch, open_patch, load_data, \
     running_under_travis, skip_if_predicate_true
 
 
-actual_get_proc_net_route = 'azurelinuxagent.common.osutil.default.DefaultOSUtil._get_proc_net_route' # pylint: disable=invalid-name
+actual_get_proc_net_route = 'azurelinuxagent.common.osutil.default.DefaultOSUtil._get_proc_net_route'  # pylint: disable=invalid-name
 
 
 def fake_is_loopback(_, iface):
     return iface.startswith('lo')
 
 
-class TestOSUtil(AgentTestCase): # pylint: disable=too-many-public-methods
+class TestOSUtil(AgentTestCase):  # pylint: disable=too-many-public-methods
     def setUp(self):
         AgentTestCase.setUp(self)
 
@@ -118,14 +118,14 @@ class TestOSUtil(AgentTestCase): # pylint: disable=too-many-public-methods
     def test_empty_proc_net_route(self):
         routing_table = ""
 
-        mo = mock.mock_open(read_data=routing_table) # pylint: disable=invalid-name
+        mo = mock.mock_open(read_data=routing_table)  # pylint: disable=invalid-name
         with patch(open_patch(), mo):
             self.assertEqual(len(osutil.DefaultOSUtil().read_route_table()), 0)
 
     def test_no_routes(self):
         routing_table = 'Iface\tDestination\tGateway \tFlags\tRefCnt\tUse\tMetric\tMask\t\tMTU\tWindow\tIRTT        \n'
 
-        mo = mock.mock_open(read_data=routing_table) # pylint: disable=invalid-name
+        mo = mock.mock_open(read_data=routing_table)  # pylint: disable=invalid-name
         with patch(open_patch(), mo):
             raw_route_list = osutil.DefaultOSUtil().read_route_table()
 
@@ -134,7 +134,7 @@ class TestOSUtil(AgentTestCase): # pylint: disable=too-many-public-methods
     def test_bogus_proc_net_route(self):
         routing_table = 'Iface\tDestination\tGateway \tFlags\t\tUse\tMetric\t\neth0\t00000000\t00000000\t0001\t\t0\t0\n'
 
-        mo = mock.mock_open(read_data=routing_table) # pylint: disable=invalid-name
+        mo = mock.mock_open(read_data=routing_table)  # pylint: disable=invalid-name
         with patch(open_patch(), mo):
             raw_route_list = osutil.DefaultOSUtil().read_route_table()
 
@@ -150,7 +150,7 @@ class TestOSUtil(AgentTestCase): # pylint: disable=too-many-public-methods
             'docker0\t002BA8C0\t00000000\t0001\t0\t0\t10\t00FFFFFF\t0\t0\t0    \n'
         known_sha1_hash = b'\x1e\xd1k\xae[\xf8\x9b\x1a\x13\xd0\xbbT\xa4\xe3Y\xa3\xdd\x0b\xbd\xa9'
 
-        mo = mock.mock_open(read_data=routing_table) # pylint: disable=invalid-name
+        mo = mock.mock_open(read_data=routing_table)  # pylint: disable=invalid-name
         with patch(open_patch(), mo):
             raw_route_list = osutil.DefaultOSUtil().read_route_table()
 
@@ -175,7 +175,7 @@ class TestOSUtil(AgentTestCase): # pylint: disable=too-many-public-methods
     @patch('azurelinuxagent.common.osutil.default.DefaultOSUtil.get_primary_interface', return_value='eth0')
     @patch('azurelinuxagent.common.osutil.default.DefaultOSUtil._get_all_interfaces', return_value={'eth0':'10.0.0.1'})
     @patch('azurelinuxagent.common.osutil.default.DefaultOSUtil.is_loopback', fake_is_loopback)
-    def test_get_first_if(self, get_all_interfaces_mock, get_primary_interface_mock): # pylint: disable=unused-argument
+    def test_get_first_if(self, get_all_interfaces_mock, get_primary_interface_mock):  # pylint: disable=unused-argument
         """
         Validate that the agent can find the first active non-loopback
         interface.
@@ -191,7 +191,7 @@ class TestOSUtil(AgentTestCase): # pylint: disable=too-many-public-methods
     @patch('azurelinuxagent.common.osutil.default.DefaultOSUtil.get_primary_interface', return_value='bogus0')
     @patch('azurelinuxagent.common.osutil.default.DefaultOSUtil._get_all_interfaces', return_value={'eth0':'10.0.0.1', 'lo': '127.0.0.1'})
     @patch('azurelinuxagent.common.osutil.default.DefaultOSUtil.is_loopback', fake_is_loopback)
-    def test_get_first_if_nosuchprimary(self, get_all_interfaces_mock, get_primary_interface_mock): # pylint: disable=unused-argument
+    def test_get_first_if_nosuchprimary(self, get_all_interfaces_mock, get_primary_interface_mock):  # pylint: disable=unused-argument
         ifname, ipaddr = osutil.DefaultOSUtil().get_first_if()
         self.assertTrue(ifname.startswith('eth'))
         self.assertTrue(ipaddr is not None)
@@ -210,7 +210,7 @@ class TestOSUtil(AgentTestCase): # pylint: disable=too-many-public-methods
         loopback_count = 0
         non_loopback_count = 0
 
-        for iface in osutil.DefaultOSUtil()._get_all_interfaces(): # pylint: disable=protected-access
+        for iface in osutil.DefaultOSUtil()._get_all_interfaces():  # pylint: disable=protected-access
             if iface == 'lo':
                 loopback_count += 1
             else:
@@ -220,7 +220,7 @@ class TestOSUtil(AgentTestCase): # pylint: disable=too-many-public-methods
         self.assertGreater(loopback_count, 0, 'At least 1 non-loopback network interface should exist')
 
     def test_isloopback(self):
-        for iface in osutil.DefaultOSUtil()._get_all_interfaces(): # pylint: disable=protected-access
+        for iface in osutil.DefaultOSUtil()._get_all_interfaces():  # pylint: disable=protected-access
             if iface == 'lo':
                 self.assertTrue(osutil.DefaultOSUtil().is_loopback(iface))
             else:
@@ -233,7 +233,7 @@ class TestOSUtil(AgentTestCase): # pylint: disable=too-many-public-methods
         eth0	00345B0A	00000000	0001	0	    0	5	00000000	0	0	0   \n\
         lo	    00000000	01345B0A	0003	0	    0	1	00FCFFFF	0	0	0   \n"
 
-        mo = mock.mock_open(read_data=routing_table) # pylint: disable=invalid-name
+        mo = mock.mock_open(read_data=routing_table)  # pylint: disable=invalid-name
         with patch(open_patch(), mo):
             self.assertFalse(osutil.DefaultOSUtil().is_primary_interface('lo'))
             self.assertTrue(osutil.DefaultOSUtil().is_primary_interface('eth0'))
@@ -247,7 +247,7 @@ class TestOSUtil(AgentTestCase): # pylint: disable=too-many-public-methods
         "bond0	10813FA8	0100000A	0007	0	    0	0	00000000	0	0	0   \n" \
         "bond0	FEA9FEA9	0100000A	0007	0	    0	0	00000000	0	0	0   \n"
 
-        mo = mock.mock_open(read_data=routing_table) # pylint: disable=invalid-name
+        mo = mock.mock_open(read_data=routing_table)  # pylint: disable=invalid-name
         with patch(open_patch(), mo):
             self.assertFalse(osutil.DefaultOSUtil().is_primary_interface('eth0'))
             self.assertTrue(osutil.DefaultOSUtil().is_primary_interface('bond0'))
@@ -259,7 +259,7 @@ class TestOSUtil(AgentTestCase): # pylint: disable=too-many-public-methods
         high	00000000	01345B0A	0003	0	    0	5	00000000	0	0	0   \n\
         low1	00000000	01345B0A	0003	0	    0	1	00FCFFFF	0	0	0   \n"
 
-        mo = mock.mock_open(read_data=routing_table) # pylint: disable=invalid-name
+        mo = mock.mock_open(read_data=routing_table)  # pylint: disable=invalid-name
         with patch(open_patch(), mo):
             self.assertTrue(osutil.DefaultOSUtil().is_primary_interface('low1'))
 
@@ -269,7 +269,7 @@ class TestOSUtil(AgentTestCase): # pylint: disable=too-many-public-methods
         first	00000000	01345B0A	0003	0	    0	1	00000000	0	0	0   \n\
         secnd	00000000	01345B0A	0003	0	    0	1	00FCFFFF	0	0	0   \n"
 
-        mo = mock.mock_open(read_data=routing_table) # pylint: disable=invalid-name
+        mo = mock.mock_open(read_data=routing_table)  # pylint: disable=invalid-name
         with patch(open_patch(), mo):
             self.assertTrue(osutil.DefaultOSUtil().is_primary_interface('first'))
 
@@ -279,7 +279,7 @@ class TestOSUtil(AgentTestCase): # pylint: disable=too-many-public-methods
         nflg	00000000	01345B0A	0001	0	    0	1	00000000	0	0	0   \n\
         flgs	00000000	01345B0A	0003	0	    0	1	00FCFFFF	0	0	0   \n"
 
-        mo = mock.mock_open(read_data=routing_table) # pylint: disable=invalid-name
+        mo = mock.mock_open(read_data=routing_table)  # pylint: disable=invalid-name
         with patch(open_patch(), mo):
             self.assertTrue(osutil.DefaultOSUtil().is_primary_interface('flgs'))
 
@@ -289,7 +289,7 @@ class TestOSUtil(AgentTestCase): # pylint: disable=too-many-public-methods
         ndst	00000001	01345B0A	0003	0	    0	1	00000000	0	0	0   \n\
         nflg	00000000	01345B0A	0001	0	    0	1	00FCFFFF	0	0	0   \n"
 
-        mo = mock.mock_open(read_data=routing_table) # pylint: disable=invalid-name
+        mo = mock.mock_open(read_data=routing_table)  # pylint: disable=invalid-name
         with patch(open_patch(), mo):
             self.assertFalse(osutil.DefaultOSUtil().is_primary_interface('ndst'))
             self.assertFalse(osutil.DefaultOSUtil().is_primary_interface('nflg'))
@@ -302,7 +302,7 @@ class TestOSUtil(AgentTestCase): # pylint: disable=too-many-public-methods
             patch_primary.return_value = ''
             try:
                 osutil.DefaultOSUtil().get_first_if()[0]
-            except Exception as e: # pylint: disable=unused-variable,invalid-name
+            except Exception as e:  # pylint: disable=unused-variable,invalid-name
                 print(traceback.format_exc())
                 exception = True
             self.assertFalse(exception)
@@ -313,15 +313,15 @@ class TestOSUtil(AgentTestCase): # pylint: disable=too-many-public-methods
     def test_dhcp_lease_ubuntu(self):
         with patch.object(glob, "glob", return_value=['/var/lib/dhcp/dhclient.eth0.leases']):
             with patch(open_patch(), mock.mock_open(read_data=load_data("dhcp.leases"))):
-                endpoint = get_osutil(distro_name='ubuntu', distro_version='12.04').get_dhcp_lease_endpoint() # pylint: disable=assignment-from-none
+                endpoint = get_osutil(distro_name='ubuntu', distro_version='12.04').get_dhcp_lease_endpoint()  # pylint: disable=assignment-from-none
                 self.assertTrue(endpoint is not None)
                 self.assertEqual(endpoint, "168.63.129.16")
 
-                endpoint = get_osutil(distro_name='ubuntu', distro_version='12.04').get_dhcp_lease_endpoint() # pylint: disable=assignment-from-none
+                endpoint = get_osutil(distro_name='ubuntu', distro_version='12.04').get_dhcp_lease_endpoint()  # pylint: disable=assignment-from-none
                 self.assertTrue(endpoint is not None)
                 self.assertEqual(endpoint, "168.63.129.16")
 
-                endpoint = get_osutil(distro_name='ubuntu', distro_version='14.04').get_dhcp_lease_endpoint() # pylint: disable=assignment-from-none
+                endpoint = get_osutil(distro_name='ubuntu', distro_version='14.04').get_dhcp_lease_endpoint()  # pylint: disable=assignment-from-none
                 self.assertTrue(endpoint is not None)
                 self.assertEqual(endpoint, "168.63.129.16")
 
@@ -333,13 +333,13 @@ class TestOSUtil(AgentTestCase): # pylint: disable=too-many-public-methods
         """
         with patch.object(glob, "glob", return_value=['/var/lib/dhcp/dhclient.eth0.leases']):
             with patch(open_patch(), mock.mock_open(read_data=load_data("dhcp.leases.custom.dns"))):
-                endpoint = get_osutil(distro_name='ubuntu', distro_version='14.04').get_dhcp_lease_endpoint() # pylint: disable=assignment-from-none
+                endpoint = get_osutil(distro_name='ubuntu', distro_version='14.04').get_dhcp_lease_endpoint()  # pylint: disable=assignment-from-none
                 self.assertEqual(endpoint, "168.63.129.16")
 
     def test_dhcp_lease_multi(self):
         with patch.object(glob, "glob", return_value=['/var/lib/dhcp/dhclient.eth0.leases']):
             with patch(open_patch(), mock.mock_open(read_data=load_data("dhcp.leases.multi"))):
-                endpoint = get_osutil(distro_name='ubuntu', distro_version='12.04').get_dhcp_lease_endpoint() # pylint: disable=assignment-from-none
+                endpoint = get_osutil(distro_name='ubuntu', distro_version='12.04').get_dhcp_lease_endpoint()  # pylint: disable=assignment-from-none
                 self.assertTrue(endpoint is not None)
                 self.assertEqual(endpoint, "168.63.129.2")
 
@@ -519,18 +519,18 @@ Match host 192.168.1.2\n\
         util = osutil.DefaultOSUtil()
         self.assertEqual(
             "12345678-1234-1234-1234-123456789012",
-            util._correct_instance_id("78563412-3412-3412-1234-123456789012")) # pylint: disable=protected-access
+            util._correct_instance_id("78563412-3412-3412-1234-123456789012"))  # pylint: disable=protected-access
         self.assertEqual(
             "D0DF4C54-4ECB-4A4B-9954-5BDF3ED5C3B8",
-            util._correct_instance_id("544CDFD0-CB4E-4B4A-9954-5BDF3ED5C3B8")) # pylint: disable=protected-access
+            util._correct_instance_id("544CDFD0-CB4E-4B4A-9954-5BDF3ED5C3B8"))  # pylint: disable=protected-access
         self.assertEqual(
             "d0df4c54-4ecb-4a4b-9954-5bdf3ed5c3b8",
-            util._correct_instance_id("544cdfd0-cb4e-4b4a-9954-5bdf3ed5c3b8")) # pylint: disable=protected-access
+            util._correct_instance_id("544cdfd0-cb4e-4b4a-9954-5bdf3ed5c3b8"))  # pylint: disable=protected-access
 
     @patch('os.path.isfile', return_value=True)
     @patch('azurelinuxagent.common.utils.fileutil.read_file',
             return_value="33C2F3B9-1399-429F-8EB3-BA656DF32502")
-    def test_get_instance_id_from_file(self, mock_read, mock_isfile): # pylint: disable=unused-argument
+    def test_get_instance_id_from_file(self, mock_read, mock_isfile):  # pylint: disable=unused-argument
         util = osutil.DefaultOSUtil()
         self.assertEqual(
             util.get_instance_id(),
@@ -539,7 +539,7 @@ Match host 192.168.1.2\n\
     @patch('os.path.isfile', return_value=True)
     @patch('azurelinuxagent.common.utils.fileutil.read_file',
             return_value="")
-    def test_get_instance_id_empty_from_file(self, mock_read, mock_isfile): # pylint: disable=unused-argument
+    def test_get_instance_id_empty_from_file(self, mock_read, mock_isfile):  # pylint: disable=unused-argument
         util = osutil.DefaultOSUtil()
         self.assertEqual(
             "",
@@ -548,7 +548,7 @@ Match host 192.168.1.2\n\
     @patch('os.path.isfile', return_value=True)
     @patch('azurelinuxagent.common.utils.fileutil.read_file',
             return_value="Value")
-    def test_get_instance_id_malformed_from_file(self, mock_read, mock_isfile): # pylint: disable=unused-argument
+    def test_get_instance_id_malformed_from_file(self, mock_read, mock_isfile):  # pylint: disable=unused-argument
         util = osutil.DefaultOSUtil()
         self.assertEqual(
             "Value",
@@ -557,7 +557,7 @@ Match host 192.168.1.2\n\
     @patch('os.path.isfile', return_value=False)
     @patch('azurelinuxagent.common.utils.shellutil.run_get_output',
             return_value=[0, '33C2F3B9-1399-429F-8EB3-BA656DF32502'])
-    def test_get_instance_id_from_dmidecode(self, mock_shell, mock_isfile): # pylint: disable=unused-argument
+    def test_get_instance_id_from_dmidecode(self, mock_shell, mock_isfile):  # pylint: disable=unused-argument
         util = osutil.DefaultOSUtil()
         self.assertEqual(
             util.get_instance_id(),
@@ -566,20 +566,20 @@ Match host 192.168.1.2\n\
     @patch('os.path.isfile', return_value=False)
     @patch('azurelinuxagent.common.utils.shellutil.run_get_output',
             return_value=[1, 'Error Value'])
-    def test_get_instance_id_missing(self, mock_shell, mock_isfile): # pylint: disable=unused-argument
+    def test_get_instance_id_missing(self, mock_shell, mock_isfile):  # pylint: disable=unused-argument
         util = osutil.DefaultOSUtil()
         self.assertEqual("", util.get_instance_id())
 
     @patch('os.path.isfile', return_value=False)
     @patch('azurelinuxagent.common.utils.shellutil.run_get_output',
             return_value=[0, 'Unexpected Value'])
-    def test_get_instance_id_unexpected(self, mock_shell, mock_isfile): # pylint: disable=unused-argument
+    def test_get_instance_id_unexpected(self, mock_shell, mock_isfile):  # pylint: disable=unused-argument
         util = osutil.DefaultOSUtil()
         self.assertEqual("", util.get_instance_id())
 
     @patch('os.path.isfile', return_value=True)
     @patch('azurelinuxagent.common.utils.fileutil.read_file')
-    def test_is_current_instance_id_from_file(self, mock_read, mock_isfile): # pylint: disable=unused-argument
+    def test_is_current_instance_id_from_file(self, mock_read, mock_isfile):  # pylint: disable=unused-argument
         util = osutil.DefaultOSUtil()
 
         mock_read.return_value = "11111111-2222-3333-4444-556677889900"
@@ -604,7 +604,7 @@ Match host 192.168.1.2\n\
 
     @patch('os.path.isfile', return_value=False)
     @patch('azurelinuxagent.common.utils.shellutil.run_get_output')
-    def test_is_current_instance_id_from_dmidecode(self, mock_shell, mock_isfile): # pylint: disable=unused-argument
+    def test_is_current_instance_id_from_dmidecode(self, mock_shell, mock_isfile):  # pylint: disable=unused-argument
         util = osutil.DefaultOSUtil()
 
         mock_shell.return_value = [0, 'B9F3C233-9913-9F42-8EB3-BA656DF32502']
@@ -628,7 +628,7 @@ Match host 192.168.1.2\n\
         self.assertTrue(os.path.isfile(waagent_sudoers))
 
         count = -1
-        with open(waagent_sudoers, 'r') as f: # pylint: disable=invalid-name
+        with open(waagent_sudoers, 'r') as f:  # pylint: disable=invalid-name
             count = len(f.readlines())
         self.assertEqual(1, count)
 
@@ -636,7 +636,7 @@ Match host 192.168.1.2\n\
         util.conf_sudoer("FooBar")
 
         count = -1
-        with open(waagent_sudoers, 'r') as f: # pylint: disable=invalid-name
+        with open(waagent_sudoers, 'r') as f:  # pylint: disable=invalid-name
             count = len(f.readlines())
         print("WRITING TO {0}".format(waagent_sudoers))
         self.assertEqual(1, count)
@@ -647,7 +647,7 @@ Match host 192.168.1.2\n\
 
     @staticmethod
     @contextlib.contextmanager
-    def _mock_iptables(version=osutil._IPTABLES_LOCKING_VERSION, destination='168.63.129.16'): # pylint: disable=protected-access
+    def _mock_iptables(version=osutil._IPTABLES_LOCKING_VERSION, destination='168.63.129.16'):  # pylint: disable=protected-access
         """
         Mock for the iptable commands used to set up the firewall.
 
@@ -667,26 +667,26 @@ Match host 192.168.1.2\n\
             mocked_commands[command_string] = (output.replace("'", "'\"'\"'"), exit_code)
             return command_string
 
-        wait = FlexibleVersion(version) >= osutil._IPTABLES_LOCKING_VERSION # pylint: disable=protected-access
+        wait = FlexibleVersion(version) >= osutil._IPTABLES_LOCKING_VERSION  # pylint: disable=protected-access
         uid = 42
 
-        version_command = set_command(osutil._get_iptables_version_command(), output=str(version)) # pylint: disable=protected-access
-        list_command = set_command(osutil._get_firewall_list_command(wait), output="Mock Output") # pylint: disable=protected-access
-        set_command(osutil._get_firewall_packets_command(wait)) # pylint: disable=protected-access
-        set_command(osutil._get_firewall_drop_command(wait, "-C", destination)) # pylint: disable=protected-access
-        set_command(osutil._get_firewall_drop_command(wait, "-A", destination)) # pylint: disable=protected-access
-        set_command(osutil._get_firewall_accept_command(wait, "-A", destination, uid)) # pylint: disable=protected-access
+        version_command = set_command(osutil._get_iptables_version_command(), output=str(version))  # pylint: disable=protected-access
+        list_command = set_command(osutil._get_firewall_list_command(wait), output="Mock Output")  # pylint: disable=protected-access
+        set_command(osutil._get_firewall_packets_command(wait))  # pylint: disable=protected-access
+        set_command(osutil._get_firewall_drop_command(wait, "-C", destination))  # pylint: disable=protected-access
+        set_command(osutil._get_firewall_drop_command(wait, "-A", destination))  # pylint: disable=protected-access
+        set_command(osutil._get_firewall_accept_command(wait, "-A", destination, uid))  # pylint: disable=protected-access
         # the agent assumes the rules have been deleted when these commands return 1
-        set_command(osutil._get_firewall_delete_conntrack_accept_command(wait, destination), exit_code=1) # pylint: disable=protected-access
-        set_command(osutil._get_firewall_delete_owner_accept_command(wait, destination, uid), exit_code=1) # pylint: disable=protected-access
-        set_command(osutil._get_firewall_delete_conntrack_drop_command(wait, destination), exit_code=1) # pylint: disable=protected-access
+        set_command(osutil._get_firewall_delete_conntrack_accept_command(wait, destination), exit_code=1)  # pylint: disable=protected-access
+        set_command(osutil._get_firewall_delete_owner_accept_command(wait, destination, uid), exit_code=1)  # pylint: disable=protected-access
+        set_command(osutil._get_firewall_delete_conntrack_drop_command(wait, destination), exit_code=1)  # pylint: disable=protected-access
 
         command_calls = []
 
         def mock_popen(command, *args, **kwargs):
             command_string = TestOSUtil._command_to_string(command)
             if command_string in mocked_commands:
-                if command_string != version_command and command_string != list_command: # pylint: disable=consider-using-in
+                if command_string != version_command and command_string != list_command:  # pylint: disable=consider-using-in
                     command_calls.append(command_string)
                 output, exit_code = mocked_commands[command_string]
                 command = "echo '{0}' && exit {1}".format(output, exit_code)
@@ -705,29 +705,29 @@ Match host 192.168.1.2\n\
                 yield popen_patcher
 
     def test_get_firewall_dropped_packets_returns_zero_if_firewall_disabled(self):
-        osutil._enable_firewall = False # pylint: disable=protected-access
+        osutil._enable_firewall = False  # pylint: disable=protected-access
         util = osutil.DefaultOSUtil()
 
         self.assertEqual(0, util.get_firewall_dropped_packets("not used"))
 
     def test_get_firewall_dropped_packets_returns_negative_if_error(self):
-        osutil._enable_firewall = True # pylint: disable=protected-access
+        osutil._enable_firewall = True  # pylint: disable=protected-access
 
         with TestOSUtil._mock_iptables() as mock_iptables:
-            mock_iptables.set_command(osutil._get_firewall_packets_command(mock_iptables.wait), exit_code=1) # pylint: disable=protected-access
+            mock_iptables.set_command(osutil._get_firewall_packets_command(mock_iptables.wait), exit_code=1)  # pylint: disable=protected-access
 
             self.assertEqual(-1, osutil.DefaultOSUtil().get_firewall_dropped_packets())
 
     def test_get_firewall_dropped_packets_should_ignore_transient_errors(self):
-        osutil._enable_firewall = True # pylint: disable=protected-access
+        osutil._enable_firewall = True  # pylint: disable=protected-access
 
         with TestOSUtil._mock_iptables() as mock_iptables:
-            mock_iptables.set_command(osutil._get_firewall_packets_command(mock_iptables.wait), exit_code=3, output="can't initialize iptables table `security': iptables who? (do you need to insmod?)") # pylint: disable=protected-access
+            mock_iptables.set_command(osutil._get_firewall_packets_command(mock_iptables.wait), exit_code=3, output="can't initialize iptables table `security': iptables who? (do you need to insmod?)")  # pylint: disable=protected-access
 
             self.assertEqual(0, osutil.DefaultOSUtil().get_firewall_dropped_packets())
 
     def test_get_firewall_dropped_packets(self):
-        osutil._enable_firewall = True # pylint: disable=protected-access
+        osutil._enable_firewall = True  # pylint: disable=protected-access
 
         destination = '168.63.129.16'
 
@@ -746,17 +746,17 @@ Chain OUTPUT (policy ACCEPT 104 packets, 43628 bytes)
 
 
     def test_enable_firewall_should_set_up_the_firewall(self):
-        osutil._enable_firewall = True # pylint: disable=protected-access
+        osutil._enable_firewall = True  # pylint: disable=protected-access
 
         with TestOSUtil._mock_iptables() as mock_iptables:
             # fail the rule check to force enable of the firewall
-            mock_iptables.set_command(osutil._get_firewall_drop_command(mock_iptables.wait, "-C", mock_iptables.destination), exit_code=1) # pylint: disable=protected-access
+            mock_iptables.set_command(osutil._get_firewall_drop_command(mock_iptables.wait, "-C", mock_iptables.destination), exit_code=1)  # pylint: disable=protected-access
 
             success = osutil.DefaultOSUtil().enable_firewall(dst_ip=mock_iptables.destination, uid=mock_iptables.uid)
 
-            drop_check_command = TestOSUtil._command_to_string(osutil._get_firewall_drop_command(mock_iptables.wait, "-C", mock_iptables.destination)) # pylint: disable=protected-access
-            accept_command = TestOSUtil._command_to_string(osutil._get_firewall_accept_command(mock_iptables.wait, "-A", mock_iptables.destination, mock_iptables.uid)) # pylint: disable=protected-access
-            drop_add_command = TestOSUtil._command_to_string(osutil._get_firewall_drop_command(mock_iptables.wait, "-A", mock_iptables.destination)) # pylint: disable=protected-access
+            drop_check_command = TestOSUtil._command_to_string(osutil._get_firewall_drop_command(mock_iptables.wait, "-C", mock_iptables.destination))  # pylint: disable=protected-access
+            accept_command = TestOSUtil._command_to_string(osutil._get_firewall_accept_command(mock_iptables.wait, "-A", mock_iptables.destination, mock_iptables.uid))  # pylint: disable=protected-access
+            drop_add_command = TestOSUtil._command_to_string(osutil._get_firewall_drop_command(mock_iptables.wait, "-A", mock_iptables.destination))  # pylint: disable=protected-access
 
             self.assertTrue(success, "Enabling the firewall was not successful")
             self.assertEqual(len(mock_iptables.command_calls), 3, "Incorrect number of calls to iptables: [{0}]". format(mock_iptables.command_calls))
@@ -764,14 +764,14 @@ Chain OUTPUT (policy ACCEPT 104 packets, 43628 bytes)
             self.assertEqual(mock_iptables.command_calls[1], accept_command, "The second command should add the accept rule")
             self.assertEqual(mock_iptables.command_calls[2], drop_add_command, "The third command should add the drop rule")
 
-            self.assertTrue(osutil._enable_firewall, "The firewall should not have been disabled") # pylint: disable=protected-access
+            self.assertTrue(osutil._enable_firewall, "The firewall should not have been disabled")  # pylint: disable=protected-access
 
     def test_enable_firewall_should_not_use_wait_when_iptables_does_not_support_it(self):
-        osutil._enable_firewall = True # pylint: disable=protected-access
+        osutil._enable_firewall = True  # pylint: disable=protected-access
 
-        with TestOSUtil._mock_iptables(version=osutil._IPTABLES_LOCKING_VERSION - 1) as mock_iptables: # pylint: disable=protected-access
+        with TestOSUtil._mock_iptables(version=osutil._IPTABLES_LOCKING_VERSION - 1) as mock_iptables:  # pylint: disable=protected-access
             # fail the rule check to force enable of the firewall
-            mock_iptables.set_command(osutil._get_firewall_drop_command(mock_iptables.wait, "-C", mock_iptables.destination), exit_code=1) # pylint: disable=protected-access
+            mock_iptables.set_command(osutil._get_firewall_drop_command(mock_iptables.wait, "-C", mock_iptables.destination), exit_code=1)  # pylint: disable=protected-access
 
             success = osutil.DefaultOSUtil().enable_firewall(dst_ip=mock_iptables.destination, uid=mock_iptables.uid)
 
@@ -780,13 +780,13 @@ Chain OUTPUT (policy ACCEPT 104 packets, 43628 bytes)
             for command in mock_iptables.command_calls:
                 self.assertNotIn("-w", command, "The -w option should have been used in {0}".format(command))
 
-            self.assertTrue(osutil._enable_firewall, "The firewall should not have been disabled") # pylint: disable=protected-access
+            self.assertTrue(osutil._enable_firewall, "The firewall should not have been disabled")  # pylint: disable=protected-access
 
     def test_enable_firewall_should_not_set_firewall_if_the_drop_rule_exists(self):
-        osutil._enable_firewall = True # pylint: disable=protected-access
+        osutil._enable_firewall = True  # pylint: disable=protected-access
 
         with TestOSUtil._mock_iptables() as mock_iptables:
-            drop_check_command = mock_iptables.set_command(osutil._get_firewall_drop_command(mock_iptables.wait, "-C", mock_iptables.destination), exit_code=0) # pylint: disable=protected-access
+            drop_check_command = mock_iptables.set_command(osutil._get_firewall_drop_command(mock_iptables.wait, "-C", mock_iptables.destination), exit_code=0)  # pylint: disable=protected-access
 
             success = osutil.DefaultOSUtil().enable_firewall(dst_ip=mock_iptables.destination, uid=mock_iptables.uid)
 
@@ -794,10 +794,10 @@ Chain OUTPUT (policy ACCEPT 104 packets, 43628 bytes)
             self.assertEqual(len(mock_iptables.command_calls), 1, "Incorrect number of calls to iptables: [{0}]". format(mock_iptables.command_calls))
             self.assertEqual(mock_iptables.command_calls[0], drop_check_command, "Unexpected command: {0}".format(mock_iptables.command_calls[0]))
 
-            self.assertTrue(osutil._enable_firewall) # pylint: disable=protected-access
+            self.assertTrue(osutil._enable_firewall)  # pylint: disable=protected-access
 
     def test_enable_firewall_should_check_for_invalid_iptables_options(self):
-        osutil._enable_firewall = True # pylint: disable=protected-access
+        osutil._enable_firewall = True  # pylint: disable=protected-access
 
         with TestOSUtil._mock_iptables() as mock_iptables:
             # iptables uses the following exit codes
@@ -805,13 +805,13 @@ Chain OUTPUT (policy ACCEPT 104 packets, 43628 bytes)
             #  1 - other errors
             #  2 - errors which appear to be caused by invalid or abused command
             #      line parameters
-            drop_check_command = mock_iptables.set_command(osutil._get_firewall_drop_command(mock_iptables.wait, "-C", mock_iptables.destination), exit_code=2) # pylint: disable=protected-access
+            drop_check_command = mock_iptables.set_command(osutil._get_firewall_drop_command(mock_iptables.wait, "-C", mock_iptables.destination), exit_code=2)  # pylint: disable=protected-access
 
             success = osutil.DefaultOSUtil().enable_firewall(dst_ip=mock_iptables.destination, uid=mock_iptables.uid)
 
-            delete_conntrack_accept_command = TestOSUtil._command_to_string(osutil._get_firewall_delete_conntrack_accept_command(mock_iptables.wait, mock_iptables.destination)) # pylint: disable=protected-access
-            delete_owner_accept_command = TestOSUtil._command_to_string(osutil._get_firewall_delete_owner_accept_command(mock_iptables.wait, mock_iptables.destination, mock_iptables.uid)) # pylint: disable=protected-access
-            delete_conntrack_drop_command = TestOSUtil._command_to_string(osutil._get_firewall_delete_conntrack_drop_command(mock_iptables.wait, mock_iptables.destination)) # pylint: disable=protected-access
+            delete_conntrack_accept_command = TestOSUtil._command_to_string(osutil._get_firewall_delete_conntrack_accept_command(mock_iptables.wait, mock_iptables.destination))  # pylint: disable=protected-access
+            delete_owner_accept_command = TestOSUtil._command_to_string(osutil._get_firewall_delete_owner_accept_command(mock_iptables.wait, mock_iptables.destination, mock_iptables.uid))  # pylint: disable=protected-access
+            delete_conntrack_drop_command = TestOSUtil._command_to_string(osutil._get_firewall_delete_conntrack_drop_command(mock_iptables.wait, mock_iptables.destination))  # pylint: disable=protected-access
 
             self.assertFalse(success, "Enable firewall should have failed")
             self.assertEqual(len(mock_iptables.command_calls), 4, "Incorrect number of calls to iptables: [{0}]". format(mock_iptables.command_calls))
@@ -820,10 +820,10 @@ Chain OUTPUT (policy ACCEPT 104 packets, 43628 bytes)
             self.assertEqual(mock_iptables.command_calls[2], delete_owner_accept_command, "The third command should delete the owner accept rule: {0}".format(mock_iptables.command_calls[2]))
             self.assertEqual(mock_iptables.command_calls[3], delete_conntrack_drop_command, "The fourth command should delete the conntrack accept rule : {0}".format(mock_iptables.command_calls[3]))
 
-            self.assertFalse(osutil._enable_firewall) # pylint: disable=protected-access
+            self.assertFalse(osutil._enable_firewall)  # pylint: disable=protected-access
 
     def test_enable_firewall_skips_if_disabled(self):
-        osutil._enable_firewall = False # pylint: disable=protected-access
+        osutil._enable_firewall = False  # pylint: disable=protected-access
 
         with TestOSUtil._mock_iptables() as mock_iptables:
             success = osutil.DefaultOSUtil().enable_firewall(dst_ip=mock_iptables.destination, uid=mock_iptables.uid)
@@ -831,10 +831,10 @@ Chain OUTPUT (policy ACCEPT 104 packets, 43628 bytes)
             self.assertFalse(success, "The firewall should not have been disabled")
             self.assertEqual(len(mock_iptables.command_calls), 0, "iptables should not have been invoked: [{0}]". format(mock_iptables.command_calls))
 
-            self.assertFalse(osutil._enable_firewall) # pylint: disable=protected-access
+            self.assertFalse(osutil._enable_firewall)  # pylint: disable=protected-access
 
     def test_remove_firewall(self):
-        osutil._enable_firewall = True # pylint: disable=protected-access
+        osutil._enable_firewall = True  # pylint: disable=protected-access
 
         with TestOSUtil._mock_iptables() as mock_iptables:
             delete_commands = {}
@@ -859,9 +859,9 @@ Chain OUTPUT (policy ACCEPT 104 packets, 43628 bytes)
             with patch("azurelinuxagent.common.cgroupapi.subprocess.Popen", side_effect=mock_popen):
                 success = osutil.DefaultOSUtil().remove_firewall(mock_iptables.destination, mock_iptables.uid)
 
-                delete_conntrack_accept_command = TestOSUtil._command_to_string(osutil._get_firewall_delete_conntrack_accept_command(mock_iptables.wait, mock_iptables.destination)) # pylint: disable=protected-access
-                delete_owner_accept_command = TestOSUtil._command_to_string(osutil._get_firewall_delete_owner_accept_command(mock_iptables.wait, mock_iptables.destination, mock_iptables.uid)) # pylint: disable=protected-access
-                delete_conntrack_drop_command = TestOSUtil._command_to_string(osutil._get_firewall_delete_conntrack_drop_command(mock_iptables.wait, mock_iptables.destination)) # pylint: disable=protected-access
+                delete_conntrack_accept_command = TestOSUtil._command_to_string(osutil._get_firewall_delete_conntrack_accept_command(mock_iptables.wait, mock_iptables.destination))  # pylint: disable=protected-access
+                delete_owner_accept_command = TestOSUtil._command_to_string(osutil._get_firewall_delete_owner_accept_command(mock_iptables.wait, mock_iptables.destination, mock_iptables.uid))  # pylint: disable=protected-access
+                delete_conntrack_drop_command = TestOSUtil._command_to_string(osutil._get_firewall_delete_conntrack_drop_command(mock_iptables.wait, mock_iptables.destination))  # pylint: disable=protected-access
 
                 self.assertTrue(success, "Removing the firewall should have succeeded")
                 self.assertEqual(len(delete_commands), 3, "Expected 3 delete commands: [{0}]".format(delete_commands))
@@ -874,13 +874,13 @@ Chain OUTPUT (policy ACCEPT 104 packets, 43628 bytes)
                 self.assertIn(delete_conntrack_drop_command, delete_commands, "The delete conntrack drop command was not executed")
                 self.assertEqual(delete_commands[delete_conntrack_drop_command], 2, "The delete conntrack drop command should have been executed twice")
 
-                self.assertTrue(osutil._enable_firewall) # pylint: disable=protected-access
+                self.assertTrue(osutil._enable_firewall)  # pylint: disable=protected-access
 
     def test_remove_firewall_should_not_retry_invalid_rule(self):
-        osutil._enable_firewall = True # pylint: disable=protected-access
+        osutil._enable_firewall = True  # pylint: disable=protected-access
 
         with TestOSUtil._mock_iptables() as mock_iptables:
-            command = osutil._get_firewall_delete_conntrack_accept_command(mock_iptables.wait, mock_iptables.destination) # pylint: disable=protected-access
+            command = osutil._get_firewall_delete_conntrack_accept_command(mock_iptables.wait, mock_iptables.destination)  # pylint: disable=protected-access
             # Note that the command is actually a valid rule, but we use the mock to report it as invalid (exit code 2)
             delete_conntrack_accept_command = mock_iptables.set_command(command, exit_code=2)
 
@@ -890,7 +890,7 @@ Chain OUTPUT (policy ACCEPT 104 packets, 43628 bytes)
             self.assertEqual(len(mock_iptables.command_calls), 1, "Expected a single call to iptables: [{0}]". format(mock_iptables.command_calls))
             self.assertEqual(mock_iptables.command_calls[0], delete_conntrack_accept_command, "Expected call to delete conntrack accept command: {0}".format(mock_iptables.command_calls[0]))
 
-            self.assertFalse(osutil._enable_firewall) # pylint: disable=protected-access
+            self.assertFalse(osutil._enable_firewall)  # pylint: disable=protected-access
 
     @skip_if_predicate_true(running_under_travis, "The ip command isn't available in Travis")
     def test_get_nic_state(self):
@@ -909,7 +909,7 @@ Chain OUTPUT (policy ACCEPT 104 packets, 43628 bytes)
     def test_get_dhcp_pid_should_return_an_empty_list_when_the_dhcp_client_is_not_running(self):
         original_run_command = shellutil.run_command
 
-        def mock_run_command(cmd): # pylint: disable=unused-argument
+        def mock_run_command(cmd):  # pylint: disable=unused-argument
             return original_run_command(["pidof", "non-existing-process"])
 
         with patch("azurelinuxagent.common.utils.shellutil.run_command", side_effect=mock_run_command):
@@ -923,10 +923,10 @@ Chain OUTPUT (policy ACCEPT 104 packets, 43628 bytes)
     @patch('os.path.exists', return_value=True)
     def test_device_for_ide_port_gen1_success(
             self,
-            os_path_exists, # pylint: disable=unused-argument
-            os_listdir, # pylint: disable=unused-argument
-            fileutil_read_file, # pylint: disable=unused-argument
-            os_walk): # pylint: disable=unused-argument
+            os_path_exists,  # pylint: disable=unused-argument
+            os_listdir,  # pylint: disable=unused-argument
+            fileutil_read_file,  # pylint: disable=unused-argument
+            os_walk):  # pylint: disable=unused-argument
         dev = osutil.DefaultOSUtil().device_for_ide_port(1)
         self.assertEqual(dev, 'sdb', 'The returned device should be the resource disk')
 
@@ -936,10 +936,10 @@ Chain OUTPUT (policy ACCEPT 104 packets, 43628 bytes)
     @patch('os.path.exists', return_value=True)
     def test_device_for_ide_port_gen2_success(
             self,
-            os_path_exists, # pylint: disable=unused-argument
-            os_listdir, # pylint: disable=unused-argument
-            fileutil_read_file, # pylint: disable=unused-argument
-            os_walk): # pylint: disable=unused-argument
+            os_path_exists,  # pylint: disable=unused-argument
+            os_listdir,  # pylint: disable=unused-argument
+            fileutil_read_file,  # pylint: disable=unused-argument
+            os_walk):  # pylint: disable=unused-argument
         dev = osutil.DefaultOSUtil().device_for_ide_port(1)
         self.assertEqual(dev, 'sdb', 'The returned device should be the resource disk')
 
@@ -947,8 +947,8 @@ Chain OUTPUT (policy ACCEPT 104 packets, 43628 bytes)
     @patch('os.path.exists', return_value=True)
     def test_device_for_ide_port_none(
             self,
-            os_path_exists, # pylint: disable=unused-argument
-            os_listdir): # pylint: disable=unused-argument
+            os_path_exists,  # pylint: disable=unused-argument
+            os_listdir):  # pylint: disable=unused-argument
         dev = osutil.DefaultOSUtil().device_for_ide_port(1)
         self.assertIsNone(dev, 'None should be returned if no resource disk found')
 
@@ -963,7 +963,7 @@ def osutil_get_dhcp_pid_should_return_a_list_of_pids(test_instance, osutil_insta
     """
     original_run_command = shellutil.run_command
 
-    def mock_run_command(cmd): # pylint: disable=unused-argument
+    def mock_run_command(cmd):  # pylint: disable=unused-argument
         return original_run_command(["pidof", "pidof"])
 
     with patch("azurelinuxagent.common.utils.shellutil.run_command", side_effect=mock_run_command):

--- a/tests/common/osutil/test_default_osutil.py
+++ b/tests/common/osutil/test_default_osutil.py
@@ -15,8 +15,8 @@
 # Requires Python 2.4+ and Openssl 1.0+
 #
 
-from azurelinuxagent.common.osutil.default import DefaultOSUtil, shellutil # pylint: disable=unused-import
-from tests.tools import AgentTestCase, patch # pylint: disable=unused-import
+from azurelinuxagent.common.osutil.default import DefaultOSUtil, shellutil  # pylint: disable=unused-import
+from tests.tools import AgentTestCase, patch  # pylint: disable=unused-import
 
 
 class DefaultOsUtilTestCase(AgentTestCase):

--- a/tests/common/osutil/test_factory.py
+++ b/tests/common/osutil/test_factory.py
@@ -49,7 +49,7 @@ class TestOsUtilFactory(AgentTestCase):
                           distro_code_name="",
                           distro_version="",
                           distro_full_name="")
-        self.assertTrue(type(ret) == DefaultOSUtil) # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(type(ret) == DefaultOSUtil)  # pylint: disable=unidiomatic-typecheck
         self.assertEqual(patch_logger.call_count, 1)
         self.assertEqual(ret.get_service_name(), "waagent")
 
@@ -58,49 +58,49 @@ class TestOsUtilFactory(AgentTestCase):
                           distro_code_name="",
                           distro_version="10.04",
                           distro_full_name="")
-        self.assertTrue(type(ret) == UbuntuOSUtil) # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(type(ret) == UbuntuOSUtil)  # pylint: disable=unidiomatic-typecheck
         self.assertEqual(ret.get_service_name(), "walinuxagent")
 
         ret = _get_osutil(distro_name="ubuntu",
                           distro_code_name="",
                           distro_version="12.04",
                           distro_full_name="")
-        self.assertTrue(type(ret) == Ubuntu12OSUtil) # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(type(ret) == Ubuntu12OSUtil)  # pylint: disable=unidiomatic-typecheck
         self.assertEqual(ret.get_service_name(), "walinuxagent")
 
         ret = _get_osutil(distro_name="ubuntu",
                           distro_code_name="trusty",
                           distro_version="14.04",
                           distro_full_name="")
-        self.assertTrue(type(ret) == Ubuntu14OSUtil) # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(type(ret) == Ubuntu14OSUtil)  # pylint: disable=unidiomatic-typecheck
         self.assertEqual(ret.get_service_name(), "walinuxagent")
 
         ret = _get_osutil(distro_name="ubuntu",
                           distro_code_name="xenial",
                           distro_version="16.04",
                           distro_full_name="")
-        self.assertTrue(type(ret) == Ubuntu16OSUtil) # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(type(ret) == Ubuntu16OSUtil)  # pylint: disable=unidiomatic-typecheck
         self.assertEqual(ret.get_service_name(), "walinuxagent")
 
         ret = _get_osutil(distro_name="ubuntu",
                           distro_code_name="bionic",
                           distro_version="18.04",
                           distro_full_name="")
-        self.assertTrue(type(ret) == Ubuntu18OSUtil) # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(type(ret) == Ubuntu18OSUtil)  # pylint: disable=unidiomatic-typecheck
         self.assertEqual(ret.get_service_name(), "walinuxagent")
 
         ret = _get_osutil(distro_name="ubuntu",
                           distro_code_name="focal",
                           distro_version="20.04",
                           distro_full_name="")
-        self.assertTrue(type(ret) == Ubuntu18OSUtil) # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(type(ret) == Ubuntu18OSUtil)  # pylint: disable=unidiomatic-typecheck
         self.assertEqual(ret.get_service_name(), "walinuxagent")
 
         ret = _get_osutil(distro_name="ubuntu",
                           distro_code_name="",
                           distro_version="10.04",
                           distro_full_name="Snappy Ubuntu Core")
-        self.assertTrue(type(ret) == UbuntuSnappyOSUtil) # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(type(ret) == UbuntuSnappyOSUtil)  # pylint: disable=unidiomatic-typecheck
         self.assertEqual(ret.get_service_name(), "walinuxagent")
 
     def test_get_osutil_it_should_return_arch(self):
@@ -108,7 +108,7 @@ class TestOsUtilFactory(AgentTestCase):
                           distro_code_name="",
                           distro_version="",
                           distro_full_name="")
-        self.assertTrue(type(ret) == ArchUtil) # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(type(ret) == ArchUtil)  # pylint: disable=unidiomatic-typecheck
         self.assertEqual(ret.get_service_name(), "waagent")
 
     def test_get_osutil_it_should_return_clear_linux(self):
@@ -116,7 +116,7 @@ class TestOsUtilFactory(AgentTestCase):
                           distro_code_name="",
                           distro_version="",
                           distro_full_name="Clear Linux")
-        self.assertTrue(type(ret) == ClearLinuxUtil) # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(type(ret) == ClearLinuxUtil)  # pylint: disable=unidiomatic-typecheck
         self.assertEqual(ret.get_service_name(), "waagent")
 
     def test_get_osutil_it_should_return_alpine(self):
@@ -124,7 +124,7 @@ class TestOsUtilFactory(AgentTestCase):
                           distro_code_name="",
                           distro_version="",
                           distro_full_name="")
-        self.assertTrue(type(ret) == AlpineOSUtil) # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(type(ret) == AlpineOSUtil)  # pylint: disable=unidiomatic-typecheck
         self.assertEqual(ret.get_service_name(), "waagent")
 
     def test_get_osutil_it_should_return_kali(self):
@@ -132,7 +132,7 @@ class TestOsUtilFactory(AgentTestCase):
                           distro_code_name="",
                           distro_version="",
                           distro_full_name="")
-        self.assertTrue(type(ret) == DebianOSBaseUtil) # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(type(ret) == DebianOSBaseUtil)  # pylint: disable=unidiomatic-typecheck
         self.assertEqual(ret.get_service_name(), "waagent")
 
     def test_get_osutil_it_should_return_coreos(self):
@@ -140,7 +140,7 @@ class TestOsUtilFactory(AgentTestCase):
                           distro_code_name="",
                           distro_version="",
                           distro_full_name="")
-        self.assertTrue(type(ret) == CoreOSUtil) # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(type(ret) == CoreOSUtil)  # pylint: disable=unidiomatic-typecheck
         self.assertEqual(ret.get_service_name(), "waagent")
 
     def test_get_osutil_it_should_return_suse(self):
@@ -148,21 +148,21 @@ class TestOsUtilFactory(AgentTestCase):
                           distro_code_name="",
                           distro_version="10",
                           distro_full_name="")
-        self.assertTrue(type(ret) == SUSEOSUtil) # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(type(ret) == SUSEOSUtil)  # pylint: disable=unidiomatic-typecheck
         self.assertEqual(ret.get_service_name(), "waagent")
 
         ret = _get_osutil(distro_name="suse",
                           distro_code_name="",
                           distro_full_name="SUSE Linux Enterprise Server",
                           distro_version="11")
-        self.assertTrue(type(ret) == SUSE11OSUtil) # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(type(ret) == SUSE11OSUtil)  # pylint: disable=unidiomatic-typecheck
         self.assertEqual(ret.get_service_name(), "waagent")
 
         ret = _get_osutil(distro_name="suse",
                           distro_code_name="",
                           distro_full_name="openSUSE",
                           distro_version="12")
-        self.assertTrue(type(ret) == SUSE11OSUtil) # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(type(ret) == SUSE11OSUtil)  # pylint: disable=unidiomatic-typecheck
         self.assertEqual(ret.get_service_name(), "waagent")
 
     def test_get_osutil_it_should_return_debian(self):
@@ -170,14 +170,14 @@ class TestOsUtilFactory(AgentTestCase):
                           distro_code_name="",
                           distro_full_name="",
                           distro_version="7")
-        self.assertTrue(type(ret) == DebianOSBaseUtil) # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(type(ret) == DebianOSBaseUtil)  # pylint: disable=unidiomatic-typecheck
         self.assertEqual(ret.get_service_name(), "waagent")
 
         ret = _get_osutil(distro_name="debian",
                           distro_code_name="",
                           distro_full_name="",
                           distro_version="8")
-        self.assertTrue(type(ret) == DebianOSModernUtil) # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(type(ret) == DebianOSModernUtil)  # pylint: disable=unidiomatic-typecheck
         self.assertEqual(ret.get_service_name(), "walinuxagent")
 
     def test_get_osutil_it_should_return_redhat(self):
@@ -185,42 +185,42 @@ class TestOsUtilFactory(AgentTestCase):
                           distro_code_name="",
                           distro_full_name="",
                           distro_version="6")
-        self.assertTrue(type(ret) == Redhat6xOSUtil) # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(type(ret) == Redhat6xOSUtil)  # pylint: disable=unidiomatic-typecheck
         self.assertEqual(ret.get_service_name(), "waagent")
 
         ret = _get_osutil(distro_name="centos",
                           distro_code_name="",
                           distro_full_name="",
                           distro_version="6")
-        self.assertTrue(type(ret) == Redhat6xOSUtil) # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(type(ret) == Redhat6xOSUtil)  # pylint: disable=unidiomatic-typecheck
         self.assertEqual(ret.get_service_name(), "waagent")
 
         ret = _get_osutil(distro_name="oracle",
                           distro_code_name="",
                           distro_full_name="",
                           distro_version="6")
-        self.assertTrue(type(ret) == Redhat6xOSUtil) # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(type(ret) == Redhat6xOSUtil)  # pylint: disable=unidiomatic-typecheck
         self.assertEqual(ret.get_service_name(), "waagent")
 
         ret = _get_osutil(distro_name="redhat",
                           distro_code_name="",
                           distro_full_name="",
                           distro_version="7")
-        self.assertTrue(type(ret) == RedhatOSUtil) # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(type(ret) == RedhatOSUtil)  # pylint: disable=unidiomatic-typecheck
         self.assertEqual(ret.get_service_name(), "waagent")
 
         ret = _get_osutil(distro_name="centos",
                           distro_code_name="",
                           distro_full_name="",
                           distro_version="7")
-        self.assertTrue(type(ret) == RedhatOSUtil) # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(type(ret) == RedhatOSUtil)  # pylint: disable=unidiomatic-typecheck
         self.assertEqual(ret.get_service_name(), "waagent")
 
         ret = _get_osutil(distro_name="oracle",
                           distro_code_name="",
                           distro_full_name="",
                           distro_version="7")
-        self.assertTrue(type(ret) == RedhatOSUtil) # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(type(ret) == RedhatOSUtil)  # pylint: disable=unidiomatic-typecheck
         self.assertEqual(ret.get_service_name(), "waagent")
 
     def test_get_osutil_it_should_return_euleros(self):
@@ -228,7 +228,7 @@ class TestOsUtilFactory(AgentTestCase):
                           distro_code_name="",
                           distro_version="",
                           distro_full_name="")
-        self.assertTrue(type(ret) == RedhatOSUtil) # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(type(ret) == RedhatOSUtil)  # pylint: disable=unidiomatic-typecheck
         self.assertEqual(ret.get_service_name(), "waagent")
 
     def test_get_osutil_it_should_return_freebsd(self):
@@ -236,7 +236,7 @@ class TestOsUtilFactory(AgentTestCase):
                           distro_code_name="",
                           distro_version="",
                           distro_full_name="")
-        self.assertTrue(type(ret) == FreeBSDOSUtil) # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(type(ret) == FreeBSDOSUtil)  # pylint: disable=unidiomatic-typecheck
         self.assertEqual(ret.get_service_name(), "waagent")
 
     def test_get_osutil_it_should_return_openbsd(self):
@@ -244,7 +244,7 @@ class TestOsUtilFactory(AgentTestCase):
                           distro_code_name="",
                           distro_version="",
                           distro_full_name="")
-        self.assertTrue(type(ret) == OpenBSDOSUtil) # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(type(ret) == OpenBSDOSUtil)  # pylint: disable=unidiomatic-typecheck
         self.assertEqual(ret.get_service_name(), "waagent")
 
     def test_get_osutil_it_should_return_bigip(self):
@@ -252,7 +252,7 @@ class TestOsUtilFactory(AgentTestCase):
                           distro_code_name="",
                           distro_version="",
                           distro_full_name="")
-        self.assertTrue(type(ret) == BigIpOSUtil) # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(type(ret) == BigIpOSUtil)  # pylint: disable=unidiomatic-typecheck
         self.assertEqual(ret.get_service_name(), "waagent")
 
     def test_get_osutil_it_should_return_gaia(self):
@@ -260,7 +260,7 @@ class TestOsUtilFactory(AgentTestCase):
                           distro_code_name="",
                           distro_version="",
                           distro_full_name="")
-        self.assertTrue(type(ret) == GaiaOSUtil) # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(type(ret) == GaiaOSUtil)  # pylint: disable=unidiomatic-typecheck
         self.assertEqual(ret.get_service_name(), "waagent")
 
     def test_get_osutil_it_should_return_iosxe(self):
@@ -268,7 +268,7 @@ class TestOsUtilFactory(AgentTestCase):
                           distro_code_name="",
                           distro_version="",
                           distro_full_name="")
-        self.assertTrue(type(ret) == IosxeOSUtil) # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(type(ret) == IosxeOSUtil)  # pylint: disable=unidiomatic-typecheck
         self.assertEqual(ret.get_service_name(), "waagent")
 
     def test_get_osutil_it_should_return_openwrt(self):
@@ -276,5 +276,5 @@ class TestOsUtilFactory(AgentTestCase):
                           distro_code_name="",
                           distro_version="",
                           distro_full_name="")
-        self.assertTrue(type(ret) == OpenWRTOSUtil) # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(type(ret) == OpenWRTOSUtil)  # pylint: disable=unidiomatic-typecheck
         self.assertEqual(ret.get_service_name(), "waagent")

--- a/tests/common/osutil/test_freebsd.py
+++ b/tests/common/osutil/test_freebsd.py
@@ -119,9 +119,9 @@ Destination        Gateway            Flags     Netif Expire
         with patch.object(freebsdosutil, '_get_net_info', return_value=('em0', '10.0.0.1', 'e5:f0:38:aa:da:52')):
             try:
                 freebsdosutil.get_first_if()[0]
-            except Exception as e: # pylint: disable=unused-variable,invalid-name
+            except Exception as e:  # pylint: disable=unused-variable,invalid-name
                 print(traceback.format_exc())
-                exception = True # pylint: disable=unused-variable
+                exception = True  # pylint: disable=unused-variable
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/common/osutil/test_nsbsd.py
+++ b/tests/common/osutil/test_nsbsd.py
@@ -35,12 +35,12 @@ class TestNSBSDOSUtil(AgentTestCase):
         with patch.object(NSBSDOSUtil, "resolver"):  # instantiating NSBSDOSUtil requires a resolver
             original_isfile = path.isfile
 
-            def mock_isfile(path): # pylint: disable=redefined-outer-name
+            def mock_isfile(path):  # pylint: disable=redefined-outer-name
                 return True if path == self.dhclient_pid_file else original_isfile(path)
 
             original_read_file = read_file
 
-            def mock_read_file(file, *args, **kwargs): # pylint: disable=redefined-builtin
+            def mock_read_file(file, *args, **kwargs):  # pylint: disable=redefined-builtin
                 return "123" if file == self.dhclient_pid_file else original_read_file(file, *args, **kwargs)
 
             with patch("os.path.isfile", mock_isfile):
@@ -56,7 +56,7 @@ class TestNSBSDOSUtil(AgentTestCase):
             #
             original_isfile = path.isfile
 
-            def mock_isfile(path): # pylint: disable=redefined-outer-name
+            def mock_isfile(path):  # pylint: disable=redefined-outer-name
                 return False if path == self.dhclient_pid_file else original_isfile(path)
 
             with patch("os.path.isfile", mock_isfile):
@@ -69,12 +69,12 @@ class TestNSBSDOSUtil(AgentTestCase):
             #
             original_isfile = path.isfile
 
-            def mock_isfile(path): # pylint: disable=redefined-outer-name,function-redefined
+            def mock_isfile(path):  # pylint: disable=redefined-outer-name,function-redefined
                 return True if path == self.dhclient_pid_file else original_isfile(path)
 
             original_read_file = read_file
 
-            def mock_read_file(file, *args, **kwargs): # pylint: disable=redefined-builtin
+            def mock_read_file(file, *args, **kwargs):  # pylint: disable=redefined-builtin
                 return "" if file == self.dhclient_pid_file else original_read_file(file, *args, **kwargs)
 
             with patch("os.path.isfile", mock_isfile):

--- a/tests/common/test_cgroupapi.py
+++ b/tests/common/test_cgroupapi.py
@@ -73,17 +73,17 @@ class CGroupsApiTestCase(_MockedFileSystemTestCase):
             with patch("azurelinuxagent.common.cgroupapi.get_distro", return_value=distro):
                 self.assertEqual(CGroupsApi.cgroups_supported(), supported, "cgroups_supported() failed on {0}".format(distro))
 
-    def test_create_should_return_a_SystemdCgroupsApi_on_systemd_platforms(self): # pylint: disable=invalid-name
+    def test_create_should_return_a_SystemdCgroupsApi_on_systemd_platforms(self):  # pylint: disable=invalid-name
         with patch("azurelinuxagent.common.cgroupapi.CGroupsApi.is_systemd", return_value=True):
             api = CGroupsApi.create()
 
-        self.assertTrue(type(api) == SystemdCgroupsApi) # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(type(api) == SystemdCgroupsApi)  # pylint: disable=unidiomatic-typecheck
 
-    def test_create_should_return_a_FileSystemCgroupsApi_on_non_systemd_platforms(self): # pylint: disable=invalid-name
+    def test_create_should_return_a_FileSystemCgroupsApi_on_non_systemd_platforms(self):  # pylint: disable=invalid-name
         with patch("azurelinuxagent.common.cgroupapi.CGroupsApi.is_systemd", return_value=False):
             api = CGroupsApi.create()
 
-        self.assertTrue(type(api) == FileSystemCgroupsApi) # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(type(api) == FileSystemCgroupsApi)  # pylint: disable=unidiomatic-typecheck
 
     def test_is_systemd_should_return_true_when_systemd_manages_current_process(self):
         path_exists = os.path.exists
@@ -97,7 +97,7 @@ class CGroupsApiTestCase(_MockedFileSystemTestCase):
         mock_path_exists.path_tested = False
 
         with patch("azurelinuxagent.common.cgroupapi.os.path.exists", mock_path_exists):
-            is_systemd = CGroupsApi.is_systemd() # pylint: disable=protected-access
+            is_systemd = CGroupsApi.is_systemd()  # pylint: disable=protected-access
 
         self.assertTrue(is_systemd)
 
@@ -115,7 +115,7 @@ class CGroupsApiTestCase(_MockedFileSystemTestCase):
         mock_path_exists.path_tested = False
 
         with patch("azurelinuxagent.common.cgroupapi.os.path.exists", mock_path_exists):
-            is_systemd = CGroupsApi.is_systemd() # pylint: disable=protected-access
+            is_systemd = CGroupsApi.is_systemd()  # pylint: disable=protected-access
 
         self.assertFalse(is_systemd)
 
@@ -127,7 +127,7 @@ class CGroupsApiTestCase(_MockedFileSystemTestCase):
         def controller_operation(controller):
             executed_controllers.append(controller)
 
-        CGroupsApi._foreach_controller(controller_operation, 'A dummy message') # pylint: disable=protected-access
+        CGroupsApi._foreach_controller(controller_operation, 'A dummy message')  # pylint: disable=protected-access
 
         # The setUp method mocks azurelinuxagent.common.cgroupapi.CGROUPS_FILE_SYSTEM_ROOT to have the cpu and memory controllers mounted
         self.assertIn('cpu', executed_controllers, 'The operation was not executed on the cpu controller')
@@ -144,12 +144,12 @@ class CGroupsApiTestCase(_MockedFileSystemTestCase):
             successful_controllers.append(controller)
 
         with patch("azurelinuxagent.common.cgroupapi.logger.warn") as mock_logger_warn:
-            CGroupsApi._foreach_controller(controller_operation, 'A dummy message') # pylint: disable=protected-access
+            CGroupsApi._foreach_controller(controller_operation, 'A dummy message')  # pylint: disable=protected-access
 
             self.assertIn('memory', successful_controllers, 'The operation was not executed on the memory controller')
             self.assertEqual(len(successful_controllers), 1, 'The operation was not executed on unexpected controllers: {0}'.format(successful_controllers))
 
-            args, kwargs = mock_logger_warn.call_args # pylint: disable=unused-variable
+            args, kwargs = mock_logger_warn.call_args  # pylint: disable=unused-variable
             (message_format, controller, error, message) = args
             self.assertEqual(message_format, 'Error in cgroup controller "{0}": {1}. {2}')
             self.assertEqual(controller, 'cpu')
@@ -172,7 +172,7 @@ class MountCgroupsTestCase(AgentTestCase):
     def _get_mount_commands(mock):
         mount_commands = ''
         for call_args in mock.call_args_list:
-            args, kwargs = call_args # pylint: disable=unused-variable
+            args, kwargs = call_args  # pylint: disable=unused-variable
             mount_commands += ';' + " ".join(args[0])
         return mount_commands
 
@@ -261,7 +261,7 @@ class MountCgroupsTestCase(AgentTestCase):
                 self.assertRegex(mount_commands, ';mount.* cpu,cpuacct ', 'The cpu controller was not mounted')
 
                 # A warning should have been logged for the memory controller
-                args, kwargs = mock_logger_warn.call_args # pylint: disable=unused-variable
+                args, kwargs = mock_logger_warn.call_args  # pylint: disable=unused-variable
                 self.assertIn('A test exception mounting the memory controller', args)
 
     def test_mount_cgroups_should_raise_when_the_cgroups_filesystem_fails_to_mount(self):
@@ -415,7 +415,7 @@ class FileSystemCgroupsApiTestCase(_MockedFileSystemTestCase):
             with patch("azurelinuxagent.common.cgroupapi.os.rmdir", side_effect=OSError(16, "Device or resource busy")):
                 api.remove_extension_cgroups("Microsoft.Compute.TestExtension-1.2.3")
 
-            args, kwargs = mock_logger_warn.call_args # pylint: disable=unused-variable
+            args, kwargs = mock_logger_warn.call_args  # pylint: disable=unused-variable
             message = args[0]
             self.assertIn("still has active tasks", message)
 
@@ -450,16 +450,16 @@ class FileSystemCgroupsApiTestCase(_MockedFileSystemTestCase):
 
         # The expected format of the process output is [stdout]\n{PID}\n\n\n[stderr]\n"
         pattern = re.compile(r"\[stdout\]\n(\d+)\n\n\n\[stderr\]\n")
-        m = pattern.match(process_output) # pylint: disable=invalid-name
+        m = pattern.match(process_output)  # pylint: disable=invalid-name
 
         try:
             pid_from_output = int(m.group(1))
-        except Exception as e: # pylint: disable=invalid-name
+        except Exception as e:  # pylint: disable=invalid-name
             self.fail("No PID could be extracted from the process output! Error: {0}".format(ustr(e)))
 
         for cgroup in extension_cgroups:
             cgroups_procs_path = os.path.join(cgroup.path, "cgroup.procs")
-            with open(cgroups_procs_path, "r") as f: # pylint: disable=invalid-name
+            with open(cgroups_procs_path, "r") as f:  # pylint: disable=invalid-name
                 contents = f.read()
             pid_from_cgroup = int(contents)
 
@@ -503,12 +503,12 @@ class SystemdCgroupsApiTestCase(AgentTestCase):
             self.assertEqual(cpu_accounting, "no", "Property {0} of {1} is incorrect".format("CPUAccounting", "walinuxagent.service"))
 
     def test_get_extensions_slice_root_name_should_return_the_root_slice_for_extensions(self):
-        root_slice_name = SystemdCgroupsApi()._get_extensions_slice_root_name() # pylint: disable=protected-access
+        root_slice_name = SystemdCgroupsApi()._get_extensions_slice_root_name()  # pylint: disable=protected-access
         self.assertEqual(root_slice_name, "system-walinuxagent.extensions.slice")
 
     def test_get_extension_slice_name_should_return_the_slice_for_the_given_extension(self):
         extension_name = "Microsoft.Azure.DummyExtension-1.0"
-        extension_slice_name = SystemdCgroupsApi()._get_extension_slice_name(extension_name) # pylint: disable=protected-access
+        extension_slice_name = SystemdCgroupsApi()._get_extension_slice_name(extension_name)  # pylint: disable=protected-access
         self.assertEqual(extension_slice_name, "system-walinuxagent.extensions-Microsoft.Azure.DummyExtension_1.0.slice")
 
     @attr('requires_sudo')
@@ -517,7 +517,7 @@ class SystemdCgroupsApiTestCase(AgentTestCase):
 
         SystemdCgroupsApi().create_extension_cgroups_root()
 
-        unit_name = SystemdCgroupsApi()._get_extensions_slice_root_name() # pylint: disable=protected-access
+        unit_name = SystemdCgroupsApi()._get_extensions_slice_root_name()  # pylint: disable=protected-access
         status = shellutil.run_command(["systemctl", "status", unit_name])
         self.assertIn("Loaded: loaded", status)
         self.assertIn("Active: active", status)
@@ -550,7 +550,7 @@ class SystemdCgroupsApiTestCase(AgentTestCase):
         self.assertEqual(cpu_cgroup.path, "/sys/fs/cgroup/cpu/system.slice/Microsoft.Azure.DummyExtension_1.0")
         self.assertEqual(memory_cgroup.path, "/sys/fs/cgroup/memory/system.slice/Microsoft.Azure.DummyExtension_1.0")
 
-        unit_name = SystemdCgroupsApi()._get_extension_slice_name(extension_name) # pylint: disable=protected-access
+        unit_name = SystemdCgroupsApi()._get_extension_slice_name(extension_name)  # pylint: disable=protected-access
         self.assertEqual("system-walinuxagent.extensions-Microsoft.Azure.DummyExtension_1.0.slice", unit_name)
 
         _, status = shellutil.run_get_output("systemctl status {0}".format(unit_name))
@@ -592,9 +592,9 @@ class SystemdCgroupsApiTestCase(AgentTestCase):
                 command = "echo TEST_OUTPUT"
             return original_popen(command, *args, **kwargs)
 
-        with mock_cgroup_commands() as mock_commands: # pylint: disable=unused-variable
+        with mock_cgroup_commands() as mock_commands:  # pylint: disable=unused-variable
             with tempfile.TemporaryFile(dir=self.tmp_dir, mode="w+b") as output_file:
-                with patch("azurelinuxagent.common.cgroupapi.subprocess.Popen", side_effect=mock_popen) as popen_patch: # pylint: disable=unused-variable
+                with patch("azurelinuxagent.common.cgroupapi.subprocess.Popen", side_effect=mock_popen) as popen_patch:  # pylint: disable=unused-variable
                     command_output = SystemdCgroupsApi().start_extension_command(
                         extension_name="Microsoft.Compute.TestExtension-1.2.3",
                         command="A_TEST_COMMAND",
@@ -620,7 +620,7 @@ class SystemdCgroupsApiTestCase(AgentTestCase):
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE)
 
-            tracked = CGroupsTelemetry._tracked # pylint: disable=protected-access
+            tracked = CGroupsTelemetry._tracked  # pylint: disable=protected-access
 
             self.assertTrue(
                 any(cg for cg in tracked if cg.name == 'Microsoft.Compute.TestExtension-1.2.3' and 'cpu' in cg.path),
@@ -691,7 +691,7 @@ class SystemdCgroupsApiTestCase(AgentTestCase):
                     self.assertEqual(command, extension_calls[1],
                                       "The second call to the extension should not have used systemd")
 
-                    self.assertEqual(len(CGroupsTelemetry._tracked), 0, "No cgroups should have been created") # pylint: disable=protected-access
+                    self.assertEqual(len(CGroupsTelemetry._tracked), 0, "No cgroups should have been created")  # pylint: disable=protected-access
 
                     self.assertIn("TEST_OUTPUT\n", command_output, "The test output was not captured")
 
@@ -733,7 +733,7 @@ class SystemdCgroupsApiTestCase(AgentTestCase):
                     self.assertIn("systemd-run --unit=Microsoft.Compute.TestExtension_1.2.3", extension_calls[0], "The first call to the extension should have used systemd")
                     self.assertEqual("echo 'success'", extension_calls[1], "The second call to the extension should not have used systemd")
 
-                    self.assertEqual(len(CGroupsTelemetry._tracked), 0, "No cgroups should have been created") # pylint: disable=protected-access
+                    self.assertEqual(len(CGroupsTelemetry._tracked), 0, "No cgroups should have been created")  # pylint: disable=protected-access
 
     @attr('requires_sudo')
     @patch("azurelinuxagent.common.cgroupapi.add_event")
@@ -806,7 +806,7 @@ class SystemdCgroupsApiTestCase(AgentTestCase):
 
     @attr('requires_sudo')
     @patch("azurelinuxagent.common.cgroupapi.add_event")
-    def test_start_extension_command_should_not_use_fallback_option_if_extension_times_out(self, *args): # pylint: disable=unused-argument
+    def test_start_extension_command_should_not_use_fallback_option_if_extension_times_out(self, *args):  # pylint: disable=unused-argument
         self.assertTrue(i_am_root(), "Test does not run when non-root")
 
         with tempfile.TemporaryFile(dir=self.tmp_dir, mode="w+b") as stdout:
@@ -870,7 +870,7 @@ class SystemdCgroupsApiMockedFileSystemTestCase(_MockedFileSystemTestCase):
         legacy_cpu_cgroup = CGroupsTools.create_legacy_agent_cgroup(self.cgroups_file_system_root, "cpu", '')
         legacy_memory_cgroup = CGroupsTools.create_legacy_agent_cgroup(self.cgroups_file_system_root, "memory", '')
 
-        with patch("azurelinuxagent.common.cgroupapi.add_event") as mock_add_event: # pylint: disable=unused-variable
+        with patch("azurelinuxagent.common.cgroupapi.add_event") as mock_add_event:  # pylint: disable=unused-variable
             with patch("azurelinuxagent.common.cgroupapi.get_agent_pid_file_path", return_value=daemon_pid_file):
                 legacy_cgroups = SystemdCgroupsApi().cleanup_legacy_cgroups()
 

--- a/tests/common/test_cgroups.py
+++ b/tests/common/test_cgroups.py
@@ -30,7 +30,7 @@ from tests.tools import AgentTestCase, patch, data_dir
 
 def consume_cpu_time():
     waste = 0
-    for x in range(1, 200000): # pylint: disable=unused-variable,invalid-name
+    for x in range(1, 200000):  # pylint: disable=unused-variable,invalid-name
         waste += random.random()
     return waste
 
@@ -120,8 +120,8 @@ class TestCpuCgroup(AgentTestCase):
 
         cgroup.initialize_cpu_usage()
 
-        self.assertEqual(cgroup._current_cgroup_cpu, 63763) # pylint: disable=protected-access
-        self.assertEqual(cgroup._current_system_cpu, 5496872) # pylint: disable=protected-access
+        self.assertEqual(cgroup._current_cgroup_cpu, 63763)  # pylint: disable=protected-access
+        self.assertEqual(cgroup._current_system_cpu, 5496872)  # pylint: disable=protected-access
 
     def test_get_cpu_usage_should_return_the_cpu_usage_since_its_last_invocation(self):
         osutil = get_osutil()
@@ -166,8 +166,8 @@ class TestCpuCgroup(AgentTestCase):
 
         cgroup.initialize_cpu_usage()
 
-        self.assertEqual(cgroup._current_cgroup_cpu, 0) # pylint: disable=protected-access
-        self.assertEqual(cgroup._current_system_cpu, 5496872)  # check the system usage just for test sanity # pylint: disable=protected-access
+        self.assertEqual(cgroup._current_cgroup_cpu, 0)  # pylint: disable=protected-access
+        self.assertEqual(cgroup._current_system_cpu, 5496872)  # check the system usage just for test sanity  # pylint: disable=protected-access
 
 
     def test_initialize_cpu_usage_should_raise_an_exception_when_called_more_than_once(self):
@@ -187,7 +187,7 @@ class TestCpuCgroup(AgentTestCase):
         cgroup = CpuCgroup("test", "/sys/fs/cgroup/cpu/system.slice/test")
 
         with self.assertRaises(CGroupsException):
-            cpu_usage = cgroup.get_cpu_usage() # pylint: disable=unused-variable
+            cpu_usage = cgroup.get_cpu_usage()  # pylint: disable=unused-variable
 
 
 class TestMemoryCgroup(AgentTestCase):
@@ -207,12 +207,12 @@ class TestMemoryCgroup(AgentTestCase):
     def test_get_metrics_when_files_not_present(self):
         test_mem_cg = MemoryCgroup("test_extension", os.path.join(data_dir, "cgroups"))
 
-        with self.assertRaises(IOError) as e: # pylint: disable=invalid-name
+        with self.assertRaises(IOError) as e:  # pylint: disable=invalid-name
             test_mem_cg.get_memory_usage()
 
         self.assertEqual(e.exception.errno, errno.ENOENT)
 
-        with self.assertRaises(IOError) as e: # pylint: disable=invalid-name
+        with self.assertRaises(IOError) as e:  # pylint: disable=invalid-name
             test_mem_cg.get_max_memory_usage()
 
         self.assertEqual(e.exception.errno, errno.ENOENT)

--- a/tests/common/test_cgroupstelemetry.py
+++ b/tests/common/test_cgroupstelemetry.py
@@ -27,7 +27,7 @@ from tests.tools import AgentTestCase, data_dir, patch
 
 
 def raise_ioerror(*_):
-    e = IOError() # pylint: disable=invalid-name
+    e = IOError()  # pylint: disable=invalid-name
     from errno import EIO
     e.errno = EIO
     raise e
@@ -38,7 +38,7 @@ def median(lst):
     l_len = len(data)
     if l_len < 1:
         return None
-    if l_len % 2 == 0: # pylint: disable=no-else-return
+    if l_len % 2 == 0:  # pylint: disable=no-else-return
         return (data[int((l_len - 1) / 2)] + data[int((l_len + 1) / 2)]) / 2.0
     else:
         return data[int((l_len - 1) / 2)]
@@ -54,14 +54,14 @@ def generate_metric_list(lst):
 
 def consume_cpu_time():
     waste = 0
-    for x in range(1, 200000): # pylint: disable=unused-variable,invalid-name
+    for x in range(1, 200000):  # pylint: disable=unused-variable,invalid-name
         waste += random.random()
     return waste
 
 
 def consume_memory():
     waste = []
-    for x in range(1, 3): # pylint: disable=unused-variable,invalid-name
+    for x in range(1, 3):  # pylint: disable=unused-variable,invalid-name
         waste.append([random.random()] * 10000)
         time.sleep(0.1)
         waste *= 0
@@ -135,7 +135,7 @@ class TestCGroupsTelemetry(AgentTestCase):
                 elif metric.counter == "Max Memory Usage":
                     self.assertEqual(metric.value, max_memory_metric_value)
 
-    def test_telemetry_polling_with_active_cgroups(self, *args): # pylint: disable=unused-argument
+    def test_telemetry_polling_with_active_cgroups(self, *args):  # pylint: disable=unused-argument
         num_extensions = 3
 
         self._track_new_extension_cgroups(num_extensions)
@@ -157,7 +157,7 @@ class TestCGroupsTelemetry(AgentTestCase):
                         patch_get_memory_max_usage.return_value = current_max_memory  # example 450 MB
                         num_polls = 10
 
-                        for data_count in range(1, num_polls + 1): # pylint: disable=unused-variable
+                        for data_count in range(1, num_polls + 1):  # pylint: disable=unused-variable
                             metrics = CGroupsTelemetry.poll_all_tracked()
 
                             self.assertEqual(len(metrics), num_extensions * num_of_metrics_per_extn_expected)
@@ -170,7 +170,7 @@ class TestCGroupsTelemetry(AgentTestCase):
     @patch("azurelinuxagent.common.cgroup.CGroup.is_active", return_value=False)
     def test_telemetry_polling_with_inactive_cgroups(self, *_):
         num_extensions = 5
-        no_extensions_expected = 0 # pylint: disable=unused-variable
+        no_extensions_expected = 0  # pylint: disable=unused-variable
 
         self._track_new_extension_cgroups(num_extensions)
         self._assert_cgroups_are_tracked(num_extensions)
@@ -189,15 +189,15 @@ class TestCGroupsTelemetry(AgentTestCase):
     @patch("azurelinuxagent.common.cgroup.CpuCgroup.get_cpu_usage")
     @patch("azurelinuxagent.common.cgroup.CGroup.is_active")
     @patch("azurelinuxagent.common.resourceusage.MemoryResourceUsage.get_memory_usage_from_proc_statm")
-    def test_telemetry_polling_with_changing_cgroups_state(self, patch_get_statm, patch_is_active, patch_get_cpu_usage, # pylint: disable=unused-argument,too-many-arguments
+    def test_telemetry_polling_with_changing_cgroups_state(self, patch_get_statm, patch_is_active, patch_get_cpu_usage,  # pylint: disable=unused-argument,too-many-arguments
                                                            patch_get_mem, patch_get_max_mem, *args):
         num_extensions = 5
         self._track_new_extension_cgroups(num_extensions)
 
         patch_is_active.return_value = True
 
-        no_extensions_expected = 0 # pylint: disable=unused-variable
-        expected_data_count = 1 # pylint: disable=unused-variable
+        no_extensions_expected = 0  # pylint: disable=unused-variable
+        expected_data_count = 1  # pylint: disable=unused-variable
 
         current_cpu = 30
         current_memory = 209715200
@@ -241,7 +241,7 @@ class TestCGroupsTelemetry(AgentTestCase):
 
         with patch("azurelinuxagent.common.utils.fileutil.read_file", side_effect=io_error_2):
             poll_count = 1
-            for data_count in range(poll_count, 10): # pylint: disable=unused-variable
+            for data_count in range(poll_count, 10):  # pylint: disable=unused-variable
                 CGroupsTelemetry.poll_all_tracked()
                 self.assertEqual(0, patch_periodic_warn.call_count)
 
@@ -264,7 +264,7 @@ class TestCGroupsTelemetry(AgentTestCase):
             # each collect per controller would generate a log statement, and each cgroup would invoke a
             # is active check raising an exception
 
-            for data_count in range(poll_count, 10): # pylint: disable=unused-variable
+            for data_count in range(poll_count, 10):  # pylint: disable=unused-variable
                 CGroupsTelemetry.poll_all_tracked()
                 self.assertEqual(poll_count * expected_count_per_call, patch_periodic_warn.call_count)
 
@@ -277,7 +277,7 @@ class TestCGroupsTelemetry(AgentTestCase):
         with patch("azurelinuxagent.common.utils.fileutil.read_file", return_value=''):
             with patch("azurelinuxagent.common.logger.periodic_warn") as patch_periodic_warn:
                 expected_call_count = 2  # 1 periodic warning for the cpu cgroups, and 1 for memory
-                for data_count in range(1, 10): # pylint: disable=unused-variable
+                for data_count in range(1, 10):  # pylint: disable=unused-variable
                     CGroupsTelemetry.poll_all_tracked()
                     self.assertEqual(expected_call_count, patch_periodic_warn.call_count)
 
@@ -285,7 +285,7 @@ class TestCGroupsTelemetry(AgentTestCase):
     @patch("azurelinuxagent.common.cgroup.MemoryCgroup.get_memory_usage")
     @patch("azurelinuxagent.common.cgroup.CpuCgroup.get_cpu_usage")
     @patch("azurelinuxagent.common.cgroup.CGroup.is_active")
-    def test_telemetry_calculations(self,  patch_is_active, patch_get_cpu_usage, patch_get_memory_usage, patch_get_memory_max_usage, *args): # pylint: disable=unused-argument
+    def test_telemetry_calculations(self,  patch_is_active, patch_get_cpu_usage, patch_get_memory_usage, patch_get_memory_max_usage, *args):  # pylint: disable=unused-argument
         num_polls = 10
         num_extensions = 1
 
@@ -296,7 +296,7 @@ class TestCGroupsTelemetry(AgentTestCase):
         max_memory_usage_values = [random.randint(0, 8 * 1024 ** 3) for _ in range(num_polls)]
 
         self._track_new_extension_cgroups(num_extensions)
-        self.assertEqual(2 * num_extensions, len(CGroupsTelemetry._tracked)) # pylint: disable=protected-access
+        self.assertEqual(2 * num_extensions, len(CGroupsTelemetry._tracked))  # pylint: disable=protected-access
 
         for i in range(num_polls):
             patch_is_active.return_value = True
@@ -310,14 +310,14 @@ class TestCGroupsTelemetry(AgentTestCase):
             self.assertEqual(len(metrics), 3 * num_extensions)
             self._assert_polled_metrics_equal(metrics, cpu_percent_values[i], memory_usage_values[i], max_memory_usage_values[i])
 
-    def test_cgroup_tracking(self, *args): # pylint: disable=unused-argument
+    def test_cgroup_tracking(self, *args):  # pylint: disable=unused-argument
         num_extensions = 5
         num_controllers = 2
         self._track_new_extension_cgroups(num_extensions)
         self._assert_cgroups_are_tracked(num_extensions)
-        self.assertEqual(num_extensions * num_controllers, len(CGroupsTelemetry._tracked)) # pylint: disable=protected-access
+        self.assertEqual(num_extensions * num_controllers, len(CGroupsTelemetry._tracked))  # pylint: disable=protected-access
 
-    def test_cgroup_is_tracked(self, *args): # pylint: disable=unused-argument
+    def test_cgroup_is_tracked(self, *args):  # pylint: disable=unused-argument
         num_extensions = 5
         self._track_new_extension_cgroups(num_extensions)
         self._assert_cgroups_are_tracked(num_extensions)
@@ -325,7 +325,7 @@ class TestCGroupsTelemetry(AgentTestCase):
         self.assertFalse(CGroupsTelemetry.is_tracked("not_present_memory_dummy_path"))
 
     @patch("azurelinuxagent.common.cgroup.MemoryCgroup.get_memory_usage", side_effect=raise_ioerror)
-    def test_process_cgroup_metric_with_no_memory_cgroup_mounted(self, *args): # pylint: disable=unused-argument
+    def test_process_cgroup_metric_with_no_memory_cgroup_mounted(self, *args):  # pylint: disable=unused-argument
         num_extensions = 5
         self._track_new_extension_cgroups(num_extensions)
 
@@ -338,7 +338,7 @@ class TestCGroupsTelemetry(AgentTestCase):
 
                 poll_count = 1
 
-                for data_count in range(poll_count, 10): # pylint: disable=unused-variable
+                for data_count in range(poll_count, 10):  # pylint: disable=unused-variable
                     metrics = CGroupsTelemetry.poll_all_tracked()
 
                     self.assertEqual(len(metrics), num_extensions * 1)  # Only CPU populated
@@ -346,7 +346,7 @@ class TestCGroupsTelemetry(AgentTestCase):
 
 
     @patch("azurelinuxagent.common.cgroup.CpuCgroup.get_cpu_usage", side_effect=raise_ioerror)
-    def test_process_cgroup_metric_with_no_cpu_cgroup_mounted(self, *args): # pylint: disable=unused-argument
+    def test_process_cgroup_metric_with_no_cpu_cgroup_mounted(self, *args):  # pylint: disable=unused-argument
         num_extensions = 5
 
         self._track_new_extension_cgroups(num_extensions)
@@ -362,7 +362,7 @@ class TestCGroupsTelemetry(AgentTestCase):
                     patch_get_memory_usage.return_value = current_memory  # example 200 MB
                     patch_get_memory_max_usage.return_value = current_max_memory  # example 450 MB
                     num_polls = 10
-                    for data_count in range(1, num_polls + 1): # pylint: disable=unused-variable
+                    for data_count in range(1, num_polls + 1):  # pylint: disable=unused-variable
                         metrics = CGroupsTelemetry.poll_all_tracked()
                         # Memory is only populated, CPU is not. Thus 2 metrics per cgroup.
                         self.assertEqual(len(metrics), num_extensions * 2)
@@ -371,7 +371,7 @@ class TestCGroupsTelemetry(AgentTestCase):
     @patch("azurelinuxagent.common.cgroup.MemoryCgroup.get_memory_usage", side_effect=raise_ioerror)
     @patch("azurelinuxagent.common.cgroup.MemoryCgroup.get_max_memory_usage", side_effect=raise_ioerror)
     @patch("azurelinuxagent.common.cgroup.CpuCgroup.get_cpu_usage", side_effect=raise_ioerror)
-    def test_extension_telemetry_not_sent_for_empty_perf_metrics(self, *args): # pylint: disable=unused-argument
+    def test_extension_telemetry_not_sent_for_empty_perf_metrics(self, *args):  # pylint: disable=unused-argument
         num_extensions = 5
         self._track_new_extension_cgroups(num_extensions)
 
@@ -380,7 +380,7 @@ class TestCGroupsTelemetry(AgentTestCase):
             patch_is_active.return_value = False
             poll_count = 1
 
-            for data_count in range(poll_count, 10): # pylint: disable=unused-variable
+            for data_count in range(poll_count, 10):  # pylint: disable=unused-variable
                 metrics = CGroupsTelemetry.poll_all_tracked()
                 self.assertEqual(0, len(metrics))
 

--- a/tests/common/test_conf.py
+++ b/tests/common/test_conf.py
@@ -141,30 +141,30 @@ class TestConf(AgentTestCase):
         self.assertEqual(expected_value, conf.get_cgroups_excluded(self.conf))
 
     def test_get_cgroups_excluded(self):
-        self.assert_get_cgroups_excluded(config=None, # pylint: disable=no-value-for-parameter
+        self.assert_get_cgroups_excluded(config=None,  # pylint: disable=no-value-for-parameter
                                          expected_value=[])
 
-        self.assert_get_cgroups_excluded(config='', # pylint: disable=no-value-for-parameter
+        self.assert_get_cgroups_excluded(config='',  # pylint: disable=no-value-for-parameter
                                          expected_value=[])
 
-        self.assert_get_cgroups_excluded(config='  ', # pylint: disable=no-value-for-parameter
+        self.assert_get_cgroups_excluded(config='  ',  # pylint: disable=no-value-for-parameter
                                          expected_value=[])
 
-        self.assert_get_cgroups_excluded(config='  ,  ,,  ,', # pylint: disable=no-value-for-parameter
+        self.assert_get_cgroups_excluded(config='  ,  ,,  ,',  # pylint: disable=no-value-for-parameter
                                          expected_value=[])
 
         standard_values = ['customscript', 'runcommand']
-        self.assert_get_cgroups_excluded(config='CustomScript, RunCommand', # pylint: disable=no-value-for-parameter
+        self.assert_get_cgroups_excluded(config='CustomScript, RunCommand',  # pylint: disable=no-value-for-parameter
                                          expected_value=standard_values)
 
-        self.assert_get_cgroups_excluded(config='customScript, runCommand  , , ,,', # pylint: disable=no-value-for-parameter
+        self.assert_get_cgroups_excluded(config='customScript, runCommand  , , ,,',  # pylint: disable=no-value-for-parameter
                                          expected_value=standard_values)
 
-        self.assert_get_cgroups_excluded(config='  customscript,runcommand  ', # pylint: disable=no-value-for-parameter
+        self.assert_get_cgroups_excluded(config='  customscript,runcommand  ',  # pylint: disable=no-value-for-parameter
                                          expected_value=standard_values)
 
-        self.assert_get_cgroups_excluded(config='customscript,, runcommand', # pylint: disable=no-value-for-parameter
+        self.assert_get_cgroups_excluded(config='customscript,, runcommand',  # pylint: disable=no-value-for-parameter
                                          expected_value=standard_values)
 
-        self.assert_get_cgroups_excluded(config=',,customscript ,runcommand', # pylint: disable=no-value-for-parameter
+        self.assert_get_cgroups_excluded(config=',,customscript ,runcommand',  # pylint: disable=no-value-for-parameter
                                          expected_value=standard_values)

--- a/tests/common/test_errorstate.py
+++ b/tests/common/test_errorstate.py
@@ -46,7 +46,7 @@ class TestErrorState(unittest.TestCase):
         """
         test_subject = ErrorState(timedelta(minutes=15))
 
-        for x in range(1, 10): # pylint: disable=invalid-name
+        for x in range(1, 10):  # pylint: disable=invalid-name
             mock_time.utcnow = Mock(return_value=datetime.utcnow() + timedelta(minutes=x))
 
             test_subject.incr()

--- a/tests/common/test_event.py
+++ b/tests/common/test_event.py
@@ -46,7 +46,7 @@ from tests.tools import AgentTestCase, data_dir, load_data, patch, skip_if_predi
 from tests.utils.event_logger_tools import EventLoggerTools
 
 
-class TestEvent(HttpRequestPredicates, AgentTestCase): # pylint: disable=too-many-public-methods
+class TestEvent(HttpRequestPredicates, AgentTestCase):  # pylint: disable=too-many-public-methods
     def setUp(self):
         AgentTestCase.setUp(self)
 
@@ -104,34 +104,34 @@ class TestEvent(HttpRequestPredicates, AgentTestCase): # pylint: disable=too-man
         return event_list
 
     @staticmethod
-    def _is_guest_extension_event(event): # pylint: disable=redefined-outer-name
+    def _is_guest_extension_event(event):  # pylint: disable=redefined-outer-name
         return event.eventId == TELEMETRY_EVENT_EVENT_ID and event.providerId == TELEMETRY_EVENT_PROVIDER_ID
 
     @staticmethod
-    def _is_telemetry_log_event(event): # pylint: disable=redefined-outer-name
+    def _is_telemetry_log_event(event):  # pylint: disable=redefined-outer-name
         return event.eventId == TELEMETRY_LOG_EVENT_ID and event.providerId == TELEMETRY_LOG_PROVIDER_ID
 
-    def test_parse_xml_event(self, *args): # pylint: disable=unused-argument
+    def test_parse_xml_event(self, *args):  # pylint: disable=unused-argument
         data_str = load_data('ext/event_from_extension.xml')
-        event = parse_xml_event(data_str) # pylint: disable=redefined-outer-name
+        event = parse_xml_event(data_str)  # pylint: disable=redefined-outer-name
         self.assertIsNotNone(event)
         self.assertNotEqual(0, event.parameters)
         self.assertTrue(all(param is not None for param in event.parameters))
 
-    def test_parse_json_event(self, *args): # pylint: disable=unused-argument
+    def test_parse_json_event(self, *args):  # pylint: disable=unused-argument
         data_str = load_data('ext/event.json')
-        event = parse_json_event(data_str) # pylint: disable=redefined-outer-name
+        event = parse_json_event(data_str)  # pylint: disable=redefined-outer-name
         self.assertIsNotNone(event)
         self.assertNotEqual(0, event.parameters)
         self.assertTrue(all(param is not None for param in event.parameters))
 
     def test_add_event_should_use_the_container_id_from_the_most_recent_goal_state(self):
-        def create_event_and_return_container_id(): # pylint: disable=inconsistent-return-statements
+        def create_event_and_return_container_id():  # pylint: disable=inconsistent-return-statements
             event.add_event(name='Event')
             event_list = self._collect_events()
             self.assertEqual(len(event_list), 1, "Could not find the event created by add_event")
 
-            for p in event_list[0].parameters: # pylint: disable=invalid-name
+            for p in event_list[0].parameters:  # pylint: disable=invalid-name
                 if p.name == CommonTelemetryEventSchema.ContainerId:
                     return p.value
 
@@ -167,7 +167,7 @@ class TestEvent(HttpRequestPredicates, AgentTestCase): # pylint: disable=too-man
                 self.assertIn("[EventError] Failed to create events folder", exception_message)
 
     def test_event_status_event_marked(self):
-        es = event.__event_status__ # pylint: disable=invalid-name
+        es = event.__event_status__  # pylint: disable=invalid-name
 
         self.assertFalse(es.event_marked("Foo", "1.2", "FauxOperation"))
         es.mark_event_status("Foo", "1.2", "FauxOperation", True)
@@ -175,15 +175,15 @@ class TestEvent(HttpRequestPredicates, AgentTestCase): # pylint: disable=too-man
 
         event.__event_status__ = event.EventStatus()
         event.init_event_status(self.tmp_dir)
-        es = event.__event_status__ # pylint: disable=invalid-name
+        es = event.__event_status__  # pylint: disable=invalid-name
         self.assertTrue(es.event_marked("Foo", "1.2", "FauxOperation"))
 
     def test_event_status_defaults_to_success(self):
-        es = event.__event_status__ # pylint: disable=invalid-name
+        es = event.__event_status__  # pylint: disable=invalid-name
         self.assertTrue(es.event_succeeded("Foo", "1.2", "FauxOperation"))
 
     def test_event_status_records_status(self):
-        es = event.EventStatus() # pylint: disable=invalid-name
+        es = event.EventStatus()  # pylint: disable=invalid-name
 
         es.mark_event_status("Foo", "1.2", "FauxOperation", True)
         self.assertTrue(es.event_succeeded("Foo", "1.2", "FauxOperation"))
@@ -192,14 +192,14 @@ class TestEvent(HttpRequestPredicates, AgentTestCase): # pylint: disable=too-man
         self.assertFalse(es.event_succeeded("Foo", "1.2", "FauxOperation"))
 
     def test_event_status_preserves_state(self):
-        es = event.__event_status__ # pylint: disable=invalid-name
+        es = event.__event_status__  # pylint: disable=invalid-name
 
         es.mark_event_status("Foo", "1.2", "FauxOperation", False)
         self.assertFalse(es.event_succeeded("Foo", "1.2", "FauxOperation"))
 
         event.__event_status__ = event.EventStatus()
         event.init_event_status(self.tmp_dir)
-        es = event.__event_status__ # pylint: disable=invalid-name
+        es = event.__event_status__  # pylint: disable=invalid-name
         self.assertFalse(es.event_succeeded("Foo", "1.2", "FauxOperation"))
 
     def test_should_emit_event_ignores_unknown_operations(self):
@@ -218,25 +218,25 @@ class TestEvent(HttpRequestPredicates, AgentTestCase): # pylint: disable=too-man
         event.__event_status__ = event.EventStatus()
 
         # Known operations always initially "fire"
-        for op in event.__event_status_operations__: # pylint: disable=invalid-name
+        for op in event.__event_status_operations__:  # pylint: disable=invalid-name
             self.assertTrue(event.should_emit_event("Foo", "1.2", op, True))
             self.assertTrue(event.should_emit_event("Foo", "1.2", op, False))
 
         # Note a success event...
-        for op in event.__event_status_operations__: # pylint: disable=invalid-name
+        for op in event.__event_status_operations__:  # pylint: disable=invalid-name
             event.mark_event_status("Foo", "1.2", op, True)
 
         # Subsequent success events should not fire, but failures will
-        for op in event.__event_status_operations__: # pylint: disable=invalid-name
+        for op in event.__event_status_operations__:  # pylint: disable=invalid-name
             self.assertFalse(event.should_emit_event("Foo", "1.2", op, True))
             self.assertTrue(event.should_emit_event("Foo", "1.2", op, False))
 
         # Note a failure event...
-        for op in event.__event_status_operations__: # pylint: disable=invalid-name
+        for op in event.__event_status_operations__:  # pylint: disable=invalid-name
             event.mark_event_status("Foo", "1.2", op, False)
 
         # Subsequent success events fire and failure do not
-        for op in event.__event_status_operations__: # pylint: disable=invalid-name
+        for op in event.__event_status_operations__:  # pylint: disable=invalid-name
             self.assertTrue(event.should_emit_event("Foo", "1.2", op, True))
             self.assertFalse(event.should_emit_event("Foo", "1.2", op, False))
 
@@ -329,7 +329,7 @@ class TestEvent(HttpRequestPredicates, AgentTestCase): # pylint: disable=too-man
         event.add_periodic(logger.EVERY_DAY, "FauxEvent")
         self.assertEqual(1, mock_event.call_count)
 
-        h = hash("FauxEvent"+WALAEventOperation.Unknown+ustr(True)) # pylint: disable=invalid-name
+        h = hash("FauxEvent"+WALAEventOperation.Unknown+ustr(True))  # pylint: disable=invalid-name
         event.__event_logger__.periodic_events[h] = \
             datetime.now() - logger.EVERY_DAY - logger.EVERY_HOUR
         event.add_periodic(logger.EVERY_DAY, "FauxEvent")
@@ -345,7 +345,7 @@ class TestEvent(HttpRequestPredicates, AgentTestCase): # pylint: disable=too-man
 
     @patch("azurelinuxagent.common.event.datetime")
     @patch('azurelinuxagent.common.event.EventLogger.add_event')
-    def test_periodic_forwards_args_default_values(self, mock_event, mock_datetime): # pylint: disable=unused-argument
+    def test_periodic_forwards_args_default_values(self, mock_event, mock_datetime):  # pylint: disable=unused-argument
         event.__event_logger__.reset_periodic()
         event.add_periodic(logger.EVERY_DAY, "FauxEvent", message="FauxEventMessage")
         mock_event.assert_called_once_with("FauxEvent", op=WALAEventOperation.Unknown, is_success=True, duration=0,
@@ -383,7 +383,7 @@ class TestEvent(HttpRequestPredicates, AgentTestCase): # pylint: disable=too-man
 
     @staticmethod
     def _get_event_message(evt):
-        for p in evt.parameters: # pylint: disable=invalid-name
+        for p in evt.parameters:  # pylint: disable=invalid-name
             if p.name == GuestAgentExtensionEventsSchema.Message:
                 return p.value
         return None
@@ -414,7 +414,7 @@ class TestEvent(HttpRequestPredicates, AgentTestCase): # pylint: disable=too-man
 
             invalid_events = []
             total_dropped_count = 0
-            for args, kwargs in mock_add_event.call_args_list: # pylint: disable=unused-variable
+            for args, kwargs in mock_add_event.call_args_list:  # pylint: disable=unused-variable
                 match = re.search(r"DroppedEventsCount: (\d+)", kwargs['message'])
                 if match is not None:
                     invalid_events.append(kwargs['op'])
@@ -467,7 +467,7 @@ class TestEvent(HttpRequestPredicates, AgentTestCase): # pylint: disable=too-man
     def test_save_event_cleanup(self):
         for i in range(0, 2000):
             evt = os.path.join(self.event_dir, '{0}.tld'.format(ustr(1491004920536531 + i)))
-            with open(evt, 'w') as fh: # pylint: disable=invalid-name
+            with open(evt, 'w') as fh:  # pylint: disable=invalid-name
                 fh.write('test event {0}'.format(i))
 
         events = os.listdir(self.event_dir)
@@ -502,7 +502,7 @@ class TestEvent(HttpRequestPredicates, AgentTestCase): # pylint: disable=too-man
         # which is verified using assert_timestamp()
         event_parameters = {}
         timestamp = None
-        for p in actual_event.parameters: # pylint: disable=invalid-name
+        for p in actual_event.parameters:  # pylint: disable=invalid-name
             if p.name == CommonTelemetryEventSchema.OpcodeName:  # the timestamp is stored in the opcode name
                 timestamp = p.value
             else:
@@ -514,14 +514,14 @@ class TestEvent(HttpRequestPredicates, AgentTestCase): # pylint: disable=too-man
             self.assertIsNotNone(telemetry_log_event_timestamp, "Context2 should be filled with a timestamp")
             assert_timestamp(telemetry_log_event_timestamp)
 
-        self.maxDiff = None  # the dictionary diffs can be quite large; display the whole thing # pylint: disable=invalid-name
+        self.maxDiff = None  # the dictionary diffs can be quite large; display the whole thing  # pylint: disable=invalid-name
         self.assertDictEqual(event_parameters, all_expected_parameters)
 
         self.assertIsNotNone(timestamp, "The event does not have a timestamp (Opcode)")
         assert_timestamp(timestamp)
 
     @staticmethod
-    def _datetime_to_event_timestamp(dt): # pylint: disable=invalid-name
+    def _datetime_to_event_timestamp(dt):  # pylint: disable=invalid-name
         return dt.strftime(logger.Logger.LogTimeFormatInUTC)
 
     def _test_create_event_function_should_create_events_that_have_all_the_parameters_in_the_telemetry_schema(self, create_event_function, expected_parameters):
@@ -628,7 +628,7 @@ class TestEvent(HttpRequestPredicates, AgentTestCase): # pylint: disable=too-man
         return target_file_path
 
     @staticmethod
-    def _get_file_creation_timestamp(file): # pylint: disable=redefined-builtin
+    def _get_file_creation_timestamp(file):  # pylint: disable=redefined-builtin
         return  TestEvent._datetime_to_event_timestamp(datetime.fromtimestamp(os.path.getmtime(file)))
 
     def test_collect_events_should_add_all_the_parameters_in_the_telemetry_schema_to_legacy_agent_events(self):
@@ -729,11 +729,11 @@ class TestEvent(HttpRequestPredicates, AgentTestCase): # pylint: disable=too-man
         Message we read from the event's file.
         """
         def get_event_message_from_event_file(event_file):
-            with open(event_file, "rb") as fd: # pylint: disable=invalid-name
+            with open(event_file, "rb") as fd:  # pylint: disable=invalid-name
                 event_data = fd.read().decode("utf-8")  # event files are UTF-8 encoded
             telemetry_event = json.loads(event_data)
 
-            for p in telemetry_event['parameters']: # pylint: disable=invalid-name
+            for p in telemetry_event['parameters']:  # pylint: disable=invalid-name
                 if p['name'] == GuestAgentExtensionEventsSchema.Message:
                     return p['value']
 
@@ -810,48 +810,48 @@ class TestMetrics(AgentTestCase):
     def test_cleanup_message(self):
         ev_logger = event.EventLogger()
 
-        self.assertEqual(None, ev_logger._clean_up_message(None)) # pylint: disable=protected-access
-        self.assertEqual("", ev_logger._clean_up_message("")) # pylint: disable=protected-access
-        self.assertEqual("Daemon Activate resource disk failure", ev_logger._clean_up_message( # pylint: disable=protected-access
+        self.assertEqual(None, ev_logger._clean_up_message(None))  # pylint: disable=protected-access
+        self.assertEqual("", ev_logger._clean_up_message(""))  # pylint: disable=protected-access
+        self.assertEqual("Daemon Activate resource disk failure", ev_logger._clean_up_message(  # pylint: disable=protected-access
             "Daemon Activate resource disk failure"))
-        self.assertEqual("[M.A.E.CS-2.0.7] Target handler state", ev_logger._clean_up_message( # pylint: disable=protected-access
+        self.assertEqual("[M.A.E.CS-2.0.7] Target handler state", ev_logger._clean_up_message(  # pylint: disable=protected-access
             '2019/10/07 21:54:16.629444 INFO [M.A.E.CS-2.0.7] Target handler state'))
-        self.assertEqual("[M.A.E.CS-2.0.7] Initializing extension M.A.E.CS-2.0.7", ev_logger._clean_up_message( # pylint: disable=protected-access
+        self.assertEqual("[M.A.E.CS-2.0.7] Initializing extension M.A.E.CS-2.0.7", ev_logger._clean_up_message(  # pylint: disable=protected-access
             '2019/10/07 21:54:17.284385 INFO [M.A.E.CS-2.0.7] Initializing extension M.A.E.CS-2.0.7'))
-        self.assertEqual("ExtHandler ProcessGoalState completed [incarnation 4; 4197 ms]", ev_logger._clean_up_message( # pylint: disable=protected-access
+        self.assertEqual("ExtHandler ProcessGoalState completed [incarnation 4; 4197 ms]", ev_logger._clean_up_message(  # pylint: disable=protected-access
             "2019/10/07 21:55:38.474861 INFO ExtHandler ProcessGoalState completed [incarnation 4; 4197 ms]"))
-        self.assertEqual("Daemon Azure Linux Agent Version:2.2.43", ev_logger._clean_up_message( # pylint: disable=protected-access
+        self.assertEqual("Daemon Azure Linux Agent Version:2.2.43", ev_logger._clean_up_message(  # pylint: disable=protected-access
             "2019/10/07 21:52:28.615720 INFO Daemon Azure Linux Agent Version:2.2.43"))
         self.assertEqual('Daemon Cgroup controller "memory" is not mounted. Failed to create a cgroup for the VM Agent;'
                          ' resource usage will not be tracked',
-                         ev_logger._clean_up_message('Daemon Cgroup controller "memory" is not mounted. Failed to ' # pylint: disable=protected-access
+                         ev_logger._clean_up_message('Daemon Cgroup controller "memory" is not mounted. Failed to '  # pylint: disable=protected-access
                                                      'create a cgroup for the VM Agent; resource usage will not be '
                                                      'tracked'))
         self.assertEqual('ExtHandler Root directory /sys/fs/cgroup/memory/walinuxagent.extensions does not exist.',
-                         ev_logger._clean_up_message("2019/10/08 23:45:05.691037 WARNING ExtHandler Root directory " # pylint: disable=protected-access
+                         ev_logger._clean_up_message("2019/10/08 23:45:05.691037 WARNING ExtHandler Root directory "  # pylint: disable=protected-access
                                                      "/sys/fs/cgroup/memory/walinuxagent.extensions does not exist."))
         self.assertEqual("LinuxAzureDiagnostic started to handle.",
-                         ev_logger._clean_up_message("2019/10/07 22:02:40 LinuxAzureDiagnostic started to handle.")) # pylint: disable=protected-access
+                         ev_logger._clean_up_message("2019/10/07 22:02:40 LinuxAzureDiagnostic started to handle."))  # pylint: disable=protected-access
         self.assertEqual("VMAccess started to handle.",
-                         ev_logger._clean_up_message("2019/10/07 21:56:58 VMAccess started to handle.")) # pylint: disable=protected-access
+                         ev_logger._clean_up_message("2019/10/07 21:56:58 VMAccess started to handle."))  # pylint: disable=protected-access
         self.assertEqual(
             '[PERIODIC] ExtHandler Root directory /sys/fs/cgroup/memory/walinuxagent.extensions does not exist.',
-            ev_logger._clean_up_message("2019/10/08 23:45:05.691037 WARNING [PERIODIC] ExtHandler Root directory " # pylint: disable=protected-access
+            ev_logger._clean_up_message("2019/10/08 23:45:05.691037 WARNING [PERIODIC] ExtHandler Root directory "  # pylint: disable=protected-access
                                         "/sys/fs/cgroup/memory/walinuxagent.extensions does not exist."))
-        self.assertEqual("[PERIODIC] LinuxAzureDiagnostic started to handle.", ev_logger._clean_up_message( # pylint: disable=protected-access
+        self.assertEqual("[PERIODIC] LinuxAzureDiagnostic started to handle.", ev_logger._clean_up_message(  # pylint: disable=protected-access
             "2019/10/07 22:02:40 [PERIODIC] LinuxAzureDiagnostic started to handle."))
         self.assertEqual("[PERIODIC] VMAccess started to handle.",
-                         ev_logger._clean_up_message("2019/10/07 21:56:58 [PERIODIC] VMAccess started to handle.")) # pylint: disable=protected-access
+                         ev_logger._clean_up_message("2019/10/07 21:56:58 [PERIODIC] VMAccess started to handle."))  # pylint: disable=protected-access
         self.assertEqual('[PERIODIC] Daemon Cgroup controller "memory" is not mounted. Failed to create a cgroup for '
                          'the VM Agent; resource usage will not be tracked',
-                         ev_logger._clean_up_message('[PERIODIC] Daemon Cgroup controller "memory" is not mounted. ' # pylint: disable=protected-access
+                         ev_logger._clean_up_message('[PERIODIC] Daemon Cgroup controller "memory" is not mounted. '  # pylint: disable=protected-access
                                                      'Failed to create a cgroup for the VM Agent; resource usage will '
                                                      'not be tracked'))
-        self.assertEqual('The time should be in UTC', ev_logger._clean_up_message( # pylint: disable=protected-access
+        self.assertEqual('The time should be in UTC', ev_logger._clean_up_message(  # pylint: disable=protected-access
             '2019-11-26T18:15:06.866746Z INFO The time should be in UTC'))
-        self.assertEqual('The time should be in UTC', ev_logger._clean_up_message( # pylint: disable=protected-access
+        self.assertEqual('The time should be in UTC', ev_logger._clean_up_message(  # pylint: disable=protected-access
             '2019-11-26T18:15:06.866746Z The time should be in UTC'))
-        self.assertEqual('[PERIODIC] The time should be in UTC', ev_logger._clean_up_message( # pylint: disable=protected-access
+        self.assertEqual('[PERIODIC] The time should be in UTC', ev_logger._clean_up_message(  # pylint: disable=protected-access
             '2019-11-26T18:15:06.866746Z INFO [PERIODIC] The time should be in UTC'))
-        self.assertEqual('[PERIODIC] The time should be in UTC', ev_logger._clean_up_message( # pylint: disable=protected-access
+        self.assertEqual('[PERIODIC] The time should be in UTC', ev_logger._clean_up_message(  # pylint: disable=protected-access
             '2019-11-26T18:15:06.866746Z [PERIODIC] The time should be in UTC'))

--- a/tests/common/test_logcollector.py
+++ b/tests/common/test_logcollector.py
@@ -133,7 +133,7 @@ class TestLogCollector(AgentTestCase):
         binary_descriptor = "b" if binary else ""
         data = b'0' if binary else '0'
 
-        with open(file_path, "w{0}".format(binary_descriptor)) as fh: # pylint: disable=bad-open-mode,invalid-name
+        with open(file_path, "w{0}".format(binary_descriptor)) as fh:  # pylint: disable=bad-open-mode,invalid-name
             fh.seek(file_size - 1)
             fh.write(data)
 
@@ -145,7 +145,7 @@ class TestLogCollector(AgentTestCase):
         with zipfile.ZipFile(self.compressed_archive_path, "r") as archive:
             archive_files = archive.namelist()
 
-            for file in expected_files: # pylint: disable=redefined-builtin
+            for file in expected_files:  # pylint: disable=redefined-builtin
                 if file.lstrip(os.path.sep) not in archive_files:
                     self.fail("File {0} was supposed to be collected, but is not present in the archive!".format(file))
 
@@ -153,24 +153,24 @@ class TestLogCollector(AgentTestCase):
             if "results.txt" not in archive_files:
                 self.fail("File results.txt was supposed to be collected, but is not present in the archive!")
 
-        self.assertTrue(True) # pylint: disable=redundant-unittest-assert
+        self.assertTrue(True)  # pylint: disable=redundant-unittest-assert
 
     def _assert_files_are_not_in_archive(self, unexpected_files):
         with zipfile.ZipFile(self.compressed_archive_path, "r") as archive:
             archive_files = archive.namelist()
 
-            for file in unexpected_files: # pylint: disable=redefined-builtin
+            for file in unexpected_files:  # pylint: disable=redefined-builtin
                 if file.lstrip(os.path.sep) in archive_files:
                     self.fail("File {0} wasn't supposed to be collected, but is present in the archive!".format(file))
 
-        self.assertTrue(True) # pylint: disable=redundant-unittest-assert
+        self.assertTrue(True)  # pylint: disable=redundant-unittest-assert
 
     def _assert_archive_created(self, archive):
         with open(self.output_results_file_path, "r") as out:
             error_message = out.readlines()[-1]
             self.assertTrue(archive, "Failed to collect logs, error message: {0}".format(error_message))
 
-    def _get_uncompressed_file_size(self, file): # pylint: disable=redefined-builtin
+    def _get_uncompressed_file_size(self, file):  # pylint: disable=redefined-builtin
         with zipfile.ZipFile(self.compressed_archive_path, "r") as archive:
             return archive.getinfo(file.lstrip(os.path.sep)).file_size
 
@@ -195,7 +195,7 @@ diskinfo,""".format(folder_to_list, file_to_collect)
             log_collector = LogCollector()
             archive = log_collector.collect_logs_and_get_archive()
 
-        with open(self.output_results_file_path, "r") as fh: # pylint: disable=invalid-name
+        with open(self.output_results_file_path, "r") as fh:  # pylint: disable=invalid-name
             results = fh.readlines()
 
         # Assert echo was parsed
@@ -384,7 +384,7 @@ copy,{0}
         self._assert_files_are_in_archive(expected_files)
         self._assert_files_are_not_in_archive(unexpected_files)
 
-        file = os.path.join(self.root_collect_dir, "waagent.log") # pylint: disable=redefined-builtin
+        file = os.path.join(self.root_collect_dir, "waagent.log")  # pylint: disable=redefined-builtin
         new_file_size = self._get_uncompressed_file_size(file)
         self.assertEqual(LARGE_FILE_SIZE, new_file_size, "File {0} hasn't been updated! Size in archive is {1}, but "
                                                           "should be {2}.".format(file, new_file_size, LARGE_FILE_SIZE))

--- a/tests/common/test_logger.py
+++ b/tests/common/test_logger.py
@@ -15,7 +15,7 @@
 # Requires Python 2.6+ and Openssl 1.0+
 #
 
-import json # pylint: disable=unused-import
+import json  # pylint: disable=unused-import
 import os
 import tempfile
 from datetime import datetime, timedelta
@@ -231,7 +231,7 @@ class TestLogger(AgentTestCase):
         mock.assert_not_called()
         mock.reset_mock()
 
-        for i in range(5): # pylint: disable=unused-variable
+        for i in range(5):  # pylint: disable=unused-variable
             appender.write(logger.LogLevel.ERROR, "--unit-test-ERROR--")
             appender.write(logger.LogLevel.INFO, "--unit-test-INFO--")
 
@@ -250,7 +250,7 @@ class TestLogger(AgentTestCase):
     @patch("azurelinuxagent.common.logger.ConsoleAppender.write")
     @patch("azurelinuxagent.common.logger.FileAppender.write")
     def test_add_appender(self, mock_file_write, mock_console_write, mock_telem_write, mock_stdout_write):
-        lg = logger.Logger(logger.DEFAULT_LOGGER, "TestLogger1") # pylint: disable=invalid-name
+        lg = logger.Logger(logger.DEFAULT_LOGGER, "TestLogger1")  # pylint: disable=invalid-name
 
         lg.add_appender(logger.AppenderType.FILE, logger.LogLevel.INFO, path=self.log_file)
         lg.add_appender(logger.AppenderType.TELEMETRY, logger.LogLevel.WARNING, path=add_log_event)
@@ -298,7 +298,7 @@ class TestLogger(AgentTestCase):
     @patch("azurelinuxagent.common.logger.ConsoleAppender.write")
     @patch("azurelinuxagent.common.logger.FileAppender.write")
     def test_set_prefix(self, mock_file_write, mock_console_write, mock_telem_write, mock_stdout_write):
-        lg = logger.Logger(logger.DEFAULT_LOGGER) # pylint: disable=invalid-name
+        lg = logger.Logger(logger.DEFAULT_LOGGER)  # pylint: disable=invalid-name
         prefix = "YoloLogger"
 
         lg.set_prefix(prefix)
@@ -338,7 +338,7 @@ class TestLogger(AgentTestCase):
         logger.add_logger_appender(logger.AppenderType.STDOUT, logger.LogLevel.WARNING)
         logger.set_prefix(parent_prefix)
 
-        lg = logger.Logger(logger.DEFAULT_LOGGER, child_prefix) # pylint: disable=invalid-name
+        lg = logger.Logger(logger.DEFAULT_LOGGER, child_prefix)  # pylint: disable=invalid-name
 
         lg.error("Test Log")
         self.assertEqual(1, mock_file_write.call_count)
@@ -383,8 +383,8 @@ class TestLogger(AgentTestCase):
                 logcontent = logfile.read()
                 # Checking the contents of the event file.
                 self.assertIn("Test Log - Warning", logcontent)
-        except Exception as e: # pylint: disable=invalid-name
-            self.assertFalse(True, "The log file looks like it isn't correctly setup for this test. Take a look. " # pylint: disable=redundant-unittest-assert
+        except Exception as e:  # pylint: disable=invalid-name
+            self.assertFalse(True, "The log file looks like it isn't correctly setup for this test. Take a look. "  # pylint: disable=redundant-unittest-assert
                                    "{0}".format(e))
 
     @skip_if_predicate_true(lambda: True, "Enable this test when SEND_LOGS_TO_TELEMETRY is enabled")
@@ -417,7 +417,7 @@ class TestLogger(AgentTestCase):
     @patch("azurelinuxagent.common.logger.ConsoleAppender.write")
     @patch("azurelinuxagent.common.event.send_logs_to_telemetry", return_value=True)
     @patch("azurelinuxagent.common.conf.get_lib_dir")
-    def test_telemetry_logger_check_all_file_logs_written_when_events_gt_MAX_NUMBER_OF_EVENTS(self, mock_lib_dir, *_): # pylint: disable=invalid-name
+    def test_telemetry_logger_check_all_file_logs_written_when_events_gt_MAX_NUMBER_OF_EVENTS(self, mock_lib_dir, *_):  # pylint: disable=invalid-name
         mock_lib_dir.return_value = self.lib_dir
         __event_logger__.event_dir = self.event_dir
         no_of_log_statements = MAX_NUMBER_OF_EVENTS + 100
@@ -453,8 +453,8 @@ class TestLogger(AgentTestCase):
                 self.assertRegex(logcontent[1001], r"(.*WARNING\s*{0}\s*\[PERIODIC\]\s*Too many files under:.*{1}, "
                                                    r"current count\:\s*\d+,\s*removing oldest\s*.*)".format(prefix,
                                                                                                             self.event_dir))
-        except Exception as e: # pylint: disable=invalid-name
-            self.assertFalse(True, "The log file looks like it isn't correctly setup for this test. " # pylint: disable=redundant-unittest-assert
+        except Exception as e:  # pylint: disable=invalid-name
+            self.assertFalse(True, "The log file looks like it isn't correctly setup for this test. "  # pylint: disable=redundant-unittest-assert
                                    "Take a look. {0}".format(e))
 
 

--- a/tests/common/test_resourceusage.py
+++ b/tests/common/test_resourceusage.py
@@ -23,7 +23,7 @@ from tests.tools import AgentTestCase, data_dir, patch
 
 
 def raise_ioerror(*_):
-    e = IOError() # pylint: disable=invalid-name
+    e = IOError()  # pylint: disable=invalid-name
     from errno import ENOENT
     e.errno = ENOENT
     raise e
@@ -62,12 +62,12 @@ class TestProcessInfo(AgentTestCase):
         patch_read_file.read_file.side_effect = raise_ioerror
         # No such file exists; _get_proc_cmdline throws exception.
         with self.assertRaises(IOError):
-            ProcessInfo._get_proc_cmdline(1000) # pylint: disable=protected-access
+            ProcessInfo._get_proc_cmdline(1000)  # pylint: disable=protected-access
 
         patch_read_file.read_file.side_effect = raise_exception
         # Other exception; _get_proc_cmdline throws exception.
         with self.assertRaises(ProcessInfoException):
-            ProcessInfo._get_proc_cmdline(1000) # pylint: disable=protected-access
+            ProcessInfo._get_proc_cmdline(1000)  # pylint: disable=protected-access
 
     @patch("azurelinuxagent.common.resourceusage.fileutil")
     def test_get_proc_comm(self, patch_read_file):
@@ -83,4 +83,4 @@ class TestProcessInfo(AgentTestCase):
         patch_read_file.read_file.side_effect = raise_exception
         # Other exception; _get_proc_cmdline throws exception.
         with self.assertRaises(ProcessInfoException):
-            ProcessInfo._get_proc_comm(1000) # pylint: disable=protected-access
+            ProcessInfo._get_proc_comm(1000)  # pylint: disable=protected-access

--- a/tests/common/test_singletonperthread.py
+++ b/tests/common/test_singletonperthread.py
@@ -6,7 +6,7 @@ from azurelinuxagent.common.singletonperthread import SingletonPerThread
 from tests.tools import AgentTestCase, clear_singleton_instances
 
 
-class TestClassToTestSingletonPerThread(SingletonPerThread): # pylint: disable=too-few-public-methods
+class TestClassToTestSingletonPerThread(SingletonPerThread):  # pylint: disable=too-few-public-methods
     """
     Since these tests deal with testing in a multithreaded environment,
     we employ the use of multiprocessing.Queue() to ensure that the data is consistent.
@@ -49,10 +49,10 @@ class TestSingletonPerThread(AgentTestCase):
         self.errors = Queue()
         clear_singleton_instances(TestClassToTestSingletonPerThread)
 
-    def _setup_multithread_and_execute(self, func1, args1, func2, args2, t1_name=None, t2_name=None): # pylint: disable=too-many-arguments
+    def _setup_multithread_and_execute(self, func1, args1, func2, args2, t1_name=None, t2_name=None):  # pylint: disable=too-many-arguments
 
-        t1 = Thread(target=func1, args=args1) # pylint: disable=invalid-name
-        t2 = Thread(target=func2, args=args2) # pylint: disable=invalid-name
+        t1 = Thread(target=func1, args=args1)  # pylint: disable=invalid-name
+        t2 = Thread(target=func2, args=args2)  # pylint: disable=invalid-name
         t1.setName(t1_name if t1_name else self.THREAD_NAME_1)
         t2.setName(t2_name if t2_name else self.THREAD_NAME_2)
         t1.start()
@@ -63,22 +63,22 @@ class TestSingletonPerThread(AgentTestCase):
         errs = []
         while not self.errors.empty():
             errs.append(self.errors.get())
-        if len(errs) > 0: # pylint: disable=len-as-condition
+        if len(errs) > 0:  # pylint: disable=len-as-condition
             raise Exception("Errors: %s" % ' , '.join(errs))
 
     @staticmethod
-    def _get_test_class_instance(q, err): # pylint: disable=invalid-name
+    def _get_test_class_instance(q, err):  # pylint: disable=invalid-name
         try:
             obj = TestClassToTestSingletonPerThread()
             q.put(obj)
-        except Exception as e: # pylint: disable=invalid-name
+        except Exception as e:  # pylint: disable=invalid-name
             err.put(str(e))
 
     def _parse_instances_and_return_thread_objects(self, instances, t1_name=None, t2_name=None):
         obj1, obj2 = instances.get(), instances.get()
 
         def check_obj(name):
-            if obj1.name == name: # pylint: disable=no-else-return
+            if obj1.name == name:  # pylint: disable=no-else-return
                 return obj1
             elif obj2.name == name:
                 return obj2
@@ -146,7 +146,7 @@ class TestSingletonPerThread(AgentTestCase):
                                             t1_name=t1_name,
                                             t2_name=t2_name)
 
-        singleton_instances = TestClassToTestSingletonPerThread._instances # pylint: disable=protected-access,no-member
+        singleton_instances = TestClassToTestSingletonPerThread._instances  # pylint: disable=protected-access,no-member
 
         # Assert instance names are consistent with the thread names
         self.assertIn(test_class_obj_name(t1_name), singleton_instances)

--- a/tests/common/test_telemetryevent.py
+++ b/tests/common/test_telemetryevent.py
@@ -19,7 +19,7 @@ from azurelinuxagent.common.telemetryevent import TelemetryEvent, TelemetryEvent
 from tests.tools import AgentTestCase
 
 
-def get_test_event(name="DummyExtension", op="Unknown", is_success=True, duration=0, version="foo", evt_type="", is_internal=False, # pylint: disable=invalid-name,too-many-arguments
+def get_test_event(name="DummyExtension", op="Unknown", is_success=True, duration=0, version="foo", evt_type="", is_internal=False,  # pylint: disable=invalid-name,too-many-arguments
                       message="DummyMessage", eventId=1):
     event = TelemetryEvent(eventId, "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX")
     event.parameters.append(TelemetryEventParam(GuestAgentExtensionEventsSchema.Name, name))
@@ -34,7 +34,7 @@ def get_test_event(name="DummyExtension", op="Unknown", is_success=True, duratio
 
 
 class TestTelemetryEvent(AgentTestCase):
-    def test_contains_works_for_TelemetryEvent(self): # pylint: disable=invalid-name
+    def test_contains_works_for_TelemetryEvent(self):  # pylint: disable=invalid-name
         test_event = get_test_event(message="Dummy Event")
 
         self.assertTrue(GuestAgentExtensionEventsSchema.Name in test_event)

--- a/tests/common/test_version.py
+++ b/tests/common/test_version.py
@@ -36,7 +36,7 @@ def freebsd_system():
     return ["FreeBSD"]
 
 
-def freebsd_system_release(x, y, z): # pylint: disable=unused-argument,invalid-name
+def freebsd_system_release(x, y, z):  # pylint: disable=unused-argument,invalid-name
     return "10.0"
 
 
@@ -44,7 +44,7 @@ def openbsd_system():
     return ["OpenBSD"]
 
 
-def openbsd_system_release(x, y, z): # pylint: disable=unused-argument,invalid-name
+def openbsd_system_release(x, y, z):  # pylint: disable=unused-argument,invalid-name
     return "20.0"
 
 
@@ -73,20 +73,20 @@ class TestAgentVersion(AgentTestCase):
 
     @mock.patch('platform.system', side_effect=freebsd_system)
     @mock.patch('re.sub', side_effect=freebsd_system_release)
-    def test_distro_is_correct_format_when_freebsd(self, platform_system_name, mock_variable): # pylint: disable=unused-argument
+    def test_distro_is_correct_format_when_freebsd(self, platform_system_name, mock_variable):  # pylint: disable=unused-argument
         osinfo = get_distro()
         freebsd_list = ['freebsd', "10.0", '', 'freebsd']
         self.assertListEqual(freebsd_list, osinfo)
 
     @mock.patch('platform.system', side_effect=openbsd_system)
     @mock.patch('re.sub', side_effect=openbsd_system_release)
-    def test_distro_is_correct_format_when_openbsd(self, platform_system_name, mock_variable): # pylint: disable=unused-argument
+    def test_distro_is_correct_format_when_openbsd(self, platform_system_name, mock_variable):  # pylint: disable=unused-argument
         osinfo = get_distro()
         openbsd_list = ['openbsd', "20.0", '', 'openbsd']
         self.assertListEqual(openbsd_list, osinfo)
 
     @mock.patch('platform.system', side_effect=default_system)
-    def test_distro_is_correct_format_when_default_case(self, *args): # pylint: disable=unused-argument
+    def test_distro_is_correct_format_when_default_case(self, *args):  # pylint: disable=unused-argument
         default_list = ['', '', '', '']
         unknown_list = ['unknown', 'FFFF', '', '']
 
@@ -100,7 +100,7 @@ class TestAgentVersion(AgentTestCase):
             self.assertListEqual(unknown_list, osinfo)
 
     @mock.patch('platform.system', side_effect=default_system)
-    def test_distro_is_correct_for_exception_case(self, *args): # pylint: disable=unused-argument
+    def test_distro_is_correct_for_exception_case(self, *args):  # pylint: disable=unused-argument
         default_list = ['unknown', 'FFFF', '', '']
 
         if is_platform_dist_supported():
@@ -147,13 +147,13 @@ class TestCurrentAgentName(AgentTestCase):
         AgentTestCase.setUp(self)
 
     @patch("os.getcwd", return_value="/default/install/directory")
-    def test_extract_name_finds_installed(self, mock_cwd): # pylint: disable=unused-argument
+    def test_extract_name_finds_installed(self, mock_cwd):  # pylint: disable=unused-argument
         current_agent, current_version = set_current_agent()
         self.assertEqual(AGENT_LONG_VERSION, current_agent)
         self.assertEqual(AGENT_VERSION, str(current_version))
 
     @patch("os.getcwd", return_value="/")
-    def test_extract_name_root_finds_installed(self, mock_cwd): # pylint: disable=unused-argument
+    def test_extract_name_root_finds_installed(self, mock_cwd):  # pylint: disable=unused-argument
         current_agent, current_version = set_current_agent()
         self.assertEqual(AGENT_LONG_VERSION, current_agent)
         self.assertEqual(AGENT_VERSION, str(current_version))

--- a/tests/daemon/test_daemon.py
+++ b/tests/daemon/test_daemon.py
@@ -25,7 +25,7 @@ from azurelinuxagent.pa.provision.default import ProvisionHandler
 from tests.tools import AgentTestCase, Mock, patch
 
 
-class MockDaemonCall(object): # pylint: disable=too-few-public-methods
+class MockDaemonCall(object):  # pylint: disable=too-few-public-methods
     def __init__(self, daemon_handler, count):
         self.daemon_handler = daemon_handler
         self.count = count
@@ -91,7 +91,7 @@ class TestDaemon(AgentTestCase):
     @patch('azurelinuxagent.common.conf.get_provisioning_agent', return_value='waagent')
     @patch('azurelinuxagent.ga.update.UpdateHandler.run_latest')
     @patch('azurelinuxagent.pa.provision.default.ProvisionHandler.run')
-    def test_daemon_agent_enabled(self, patch_run_provision, patch_run_latest, gpa): # pylint: disable=unused-argument
+    def test_daemon_agent_enabled(self, patch_run_provision, patch_run_latest, gpa):  # pylint: disable=unused-argument
         """
         Agent should run normally when no disable_agent is found
         """
@@ -102,7 +102,7 @@ class TestDaemon(AgentTestCase):
                 self.assertFalse(os.path.exists(conf.get_disable_agent_file_path()))
                 daemon_handler = get_daemon_handler()
 
-                def stop_daemon(child_args): # pylint: disable=unused-argument
+                def stop_daemon(child_args):  # pylint: disable=unused-argument
                     daemon_handler.running = False
 
                 patch_run_latest.side_effect = stop_daemon
@@ -114,7 +114,7 @@ class TestDaemon(AgentTestCase):
     @patch('azurelinuxagent.common.conf.get_provisioning_agent', return_value='waagent')
     @patch('azurelinuxagent.ga.update.UpdateHandler.run_latest', side_effect=AgentTestCase.fail)
     @patch('azurelinuxagent.pa.provision.default.ProvisionHandler.run', side_effect=ProvisionHandler.write_agent_disabled)
-    def test_daemon_agent_disabled(self, _, patch_run_latest, gpa): # pylint: disable=unused-argument
+    def test_daemon_agent_disabled(self, _, patch_run_latest, gpa):  # pylint: disable=unused-argument
         """
         Agent should provision, then sleep forever when disable_agent is found
         """

--- a/tests/daemon/test_resourcedisk.py
+++ b/tests/daemon/test_resourcedisk.py
@@ -47,11 +47,11 @@ class TestResourceDisk(AgentTestCase):
     @patch(
         'azurelinuxagent.daemon.resourcedisk.default.ResourceDiskHandler.check_existing_swap_file',
         return_value=False)
-    def test_create_swap_space( # pylint: disable=too-many-arguments
+    def test_create_swap_space(  # pylint: disable=too-many-arguments
             self,
-            mock_check_existing_swap_file, # pylint: disable=unused-argument
-            mock_isfile, # pylint: disable=unused-argument
-            mock_mkfile, # pylint: disable=unused-argument
+            mock_check_existing_swap_file,  # pylint: disable=unused-argument
+            mock_isfile,  # pylint: disable=unused-argument
+            mock_mkfile,  # pylint: disable=unused-argument
             mock_run,
             mock_run_get_output):
         mount_point = '/mnt/resource'
@@ -59,12 +59,12 @@ class TestResourceDisk(AgentTestCase):
 
         rdh = ResourceDiskHandler()
 
-        def rgo_side_effect(*args, **kwargs): # pylint: disable=unused-argument
+        def rgo_side_effect(*args, **kwargs):  # pylint: disable=unused-argument
             if args[0] == 'swapon -s':
                 return (0, 'Filename\t\t\t\tType\t\tSize\tUsed\tPriority\n/mnt/resource/swapfile                 \tfile    \t131068\t0\t-2\n')
             return DEFAULT
 
-        def run_side_effect(*args, **kwargs): # pylint: disable=unused-argument
+        def run_side_effect(*args, **kwargs):  # pylint: disable=unused-argument
             # We have to change the default mock behavior to return a falsey value
             # (instead of the default truthy of the mock), because we are testing
             # really for the exit code of the the swapon command to return 0.

--- a/tests/distro/test_resourceDisk.py
+++ b/tests/distro/test_resourceDisk.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Microsoft Corporation # pylint: disable=invalid-name
+# Copyright 2018 Microsoft Corporation  # pylint: disable=invalid-name
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -120,7 +120,7 @@ class TestResourceDisk(AgentTestCase):
         if os.path.exists(test_file):
             os.remove(test_file)
 
-        with open(test_file, "wb") as file: # pylint: disable=redefined-builtin
+        with open(test_file, "wb") as file:  # pylint: disable=redefined-builtin
             file.write(bytearray(file_size))
 
         os.chmod(test_file, stat.S_ISUID | stat.S_ISGID | stat.S_IRUSR |

--- a/tests/distro/test_scvmm.py
+++ b/tests/distro/test_scvmm.py
@@ -37,14 +37,14 @@ class TestSCVMM(AgentTestCase):
         scvmm_file = os.path.join(self.tmp_dir, scvmm.VMM_CONF_FILE_NAME)
         fileutil.write_file(scvmm_file, "")
 
-        with patch.object(scvmm.ScvmmHandler, 'start_scvmm_agent') as po: # pylint: disable=invalid-name
+        with patch.object(scvmm.ScvmmHandler, 'start_scvmm_agent') as po:  # pylint: disable=invalid-name
             with patch('os.listdir', return_value=["sr0", "sr1", "sr2"]):
                 with patch('time.sleep', return_value=0):
                     # execute
                     failed = False
                     try:
                         scvmm.get_scvmm_handler().run()
-                    except: # pylint: disable=bare-except
+                    except:  # pylint: disable=bare-except
                         failed = True
                     # assert
                     self.assertTrue(failed)

--- a/tests/ga/extension_emulator.py
+++ b/tests/ga/extension_emulator.py
@@ -31,7 +31,7 @@ from tests.tools import Mock, patch
 from tests.protocol.mocks import HttpRequestPredicates
 
 
-class ExtensionCommandNames(object): # pylint: disable=too-few-public-methods
+class ExtensionCommandNames(object):  # pylint: disable=too-few-public-methods
     # Linter reports too few public methods, but the use-case for this class
     # does not require any.
     INSTALL = "install"
@@ -67,7 +67,7 @@ class Actions(object):
         return return_code, fail_action
 
 
-def extension_emulator(name="OSTCExtensions.ExampleHandlerLinux", version="1.0.0", # pylint: disable=too-many-arguments
+def extension_emulator(name="OSTCExtensions.ExampleHandlerLinux", version="1.0.0",  # pylint: disable=too-many-arguments
     update_mode="UpdateWithInstall", report_heartbeat=False, continue_on_update_failure=False,
     install_action=Actions.succeed_action, uninstall_action=Actions.succeed_action, 
     enable_action=Actions.succeed_action, disable_action=Actions.succeed_action,
@@ -172,7 +172,7 @@ class ExtensionEmulator:
     A wrapper class for the possible actions and options that an extension might support.
     """
 
-    def __init__(self, name, version, # pylint: disable=too-many-arguments
+    def __init__(self, name, version,  # pylint: disable=too-many-arguments
         update_mode, report_heartbeat,
         continue_on_update_failure,
         install_action, uninstall_action,

--- a/tests/ga/test_collect_logs.py
+++ b/tests/ga/test_collect_logs.py
@@ -90,7 +90,7 @@ class TestCollectLogs(AgentTestCase, HttpRequestPredicates):
         AgentTestCase.tearDown(self)
 
     def _create_dummy_archive(self, size=1024):
-        with open(self.archive_path, "wb") as f: # pylint: disable=C0103
+        with open(self.archive_path, "wb") as f:  # pylint: disable=C0103
             f.truncate(size)
 
     def test_it_should_invoke_all_periodic_operations(self):

--- a/tests/ga/test_collect_telemetry_events.py
+++ b/tests/ga/test_collect_telemetry_events.py
@@ -80,7 +80,7 @@ class TestExtensionTelemetryHandler(AgentTestCase, HttpRequestPredicates):
             raise OSError("Test Events file {0} not found".format(test_events_file_path))
 
         try:
-            with open(test_events_file_path, "rb") as fd: # pylint: disable=invalid-name
+            with open(test_events_file_path, "rb") as fd:  # pylint: disable=invalid-name
                 event_data = fd.read().decode("utf-8")
 
             # Parse the string and get the list of events
@@ -89,7 +89,7 @@ class TestExtensionTelemetryHandler(AgentTestCase, HttpRequestPredicates):
             if not isinstance(events, list):
                 events = [events]
 
-        except Exception as e: # pylint: disable=invalid-name
+        except Exception as e:  # pylint: disable=invalid-name
             print("Error parsing json file: {0}".format(e))
             return 0
 
@@ -105,7 +105,7 @@ class TestExtensionTelemetryHandler(AgentTestCase, HttpRequestPredicates):
             test_events_paths = [events_path]
 
         extension_names = {}
-        for i in range(no_of_extensions): # pylint: disable=unused-variable
+        for i in range(no_of_extensions):  # pylint: disable=unused-variable
             ext_name = "Microsoft.OSTCExtensions.{0}".format(''.join(random.sample(string.ascii_letters, no_of_chars)))
             no_of_good_events = 0
 
@@ -128,12 +128,12 @@ class TestExtensionTelemetryHandler(AgentTestCase, HttpRequestPredicates):
     @staticmethod
     def _replace_in_file(file_path, replace_from, replace_to):
 
-        with open(file_path, 'r') as f: # pylint: disable=invalid-name
+        with open(file_path, 'r') as f:  # pylint: disable=invalid-name
             content = f.read()
 
         content = content.replace(replace_from, replace_to)
 
-        with open(file_path, 'w') as f: # pylint: disable=invalid-name
+        with open(file_path, 'w') as f:  # pylint: disable=invalid-name
             f.write(content)
 
     @staticmethod
@@ -355,7 +355,7 @@ class TestExtensionTelemetryHandler(AgentTestCase, HttpRequestPredicates):
         max_len = 100
         no_of_extensions = 2
         with patch("azurelinuxagent.ga.collect_telemetry_events._ProcessExtensionEventsPeriodicOperation._EXTENSION_EVENT_MAX_MSG_LEN", max_len):
-            handler_name_with_count, event_list = self._setup_and_assert_tests_for_max_sizes() # pylint: disable=unused-variable
+            handler_name_with_count, event_list = self._setup_and_assert_tests_for_max_sizes()  # pylint: disable=unused-variable
             context1_vals = self._get_param_value_from_event_body_if_exists(event_list,
                                                                             GuestAgentGenericLogsSchema.Context1)
             self.assertEqual(no_of_extensions, len(context1_vals),
@@ -500,7 +500,7 @@ class TestExtensionTelemetryHandler(AgentTestCase, HttpRequestPredicates):
                             ExtensionEventSchema.Message.lower(): 2,
                             ExtensionEventSchema.Version.lower(): 3
                         }
-                        for m in msg: # pylint: disable=invalid-name
+                        for m in msg:  # pylint: disable=invalid-name
                             match = re.search(patt, m)
                             self.assertIsNotNone(match, "No InvalidExtensionEventError errors reported")
                             self.assertEqual(match.group("reason").strip(), InvalidExtensionEventError.MissingKeyError,

--- a/tests/ga/test_env.py
+++ b/tests/ga/test_env.py
@@ -51,7 +51,7 @@ class TestEnvHandler(AgentTestCase):
         self.assertEqual(pids, [])
 
         self.assertEqual(mock_warn.call_count, 1)
-        args, kwargs = mock_warn.call_args # pylint: disable=unused-variable
+        args, kwargs = mock_warn.call_args  # pylint: disable=unused-variable
         message = args[0]
         self.assertEqual("Dhcp client is not running.", message)
 
@@ -63,7 +63,7 @@ class TestEnvHandler(AgentTestCase):
         self.assertEqual(pids, [])
 
         self.assertEqual(mock_error.call_count, 1)
-        args, kwargs = mock_error.call_args # pylint: disable=unused-variable
+        args, kwargs = mock_error.call_args  # pylint: disable=unused-variable
         self.assertIn("Failed to get the PID of the DHCP client", args[0])
         self.assertIn("No such file or directory", args[1])
 
@@ -75,7 +75,7 @@ class TestEnvHandler(AgentTestCase):
                 self.assertEqual(mock_warn.call_count, count)
 
                 for call_args in mock_warn.call_args_list:
-                    args, kwargs = call_args # pylint: disable=unused-variable
+                    args, kwargs = call_args  # pylint: disable=unused-variable
                     self.assertEqual("Dhcp client is not running.", args[0])
 
             with patch("azurelinuxagent.common.osutil.default.shellutil.run_command", side_effect=lambda _: self.shellutil_run_command(["pidof", "non-existing-process"])):
@@ -85,7 +85,7 @@ class TestEnvHandler(AgentTestCase):
                 assert_warnings(1)
 
                 # it should not log subsequent errors
-                for i in range(0, 3): # pylint: disable=unused-variable
+                for i in range(0, 3):  # pylint: disable=unused-variable
                     pids = env_handler.get_dhcp_client_pid()
                     self.assertEqual(pids, [])
                     self.assertEqual(mock_warn.call_count, 1)
@@ -136,7 +136,7 @@ class TestEnvHandler(AgentTestCase):
             #
             # if the process was restarted then it should reconfigure the network routes
             #
-            def mock_check_pid_alive(pid): # pylint: disable=function-redefined
+            def mock_check_pid_alive(pid):  # pylint: disable=function-redefined
                 if pid == 123:
                     return False
                 raise Exception("Unexpected PID: {0}".format(pid))
@@ -149,7 +149,7 @@ class TestEnvHandler(AgentTestCase):
             #
             # if the new dhcp client has not been restarted then it should not reconfigure the network routes
             #
-            def mock_check_pid_alive(pid): # pylint: disable=function-redefined
+            def mock_check_pid_alive(pid):  # pylint: disable=function-redefined
                 if pid in [456, 789]:
                     return True
                 raise Exception("Unexpected PID: {0}".format(pid))

--- a/tests/ga/test_extension.py
+++ b/tests/ga/test_extension.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Microsoft Corporation # pylint: disable=too-many-lines
+# Copyright 2018 Microsoft Corporation  # pylint: disable=too-many-lines
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import tempfile
 import time
 import unittest
 import uuid
-import zipfile # pylint: disable=unused-import
+import zipfile  # pylint: disable=unused-import
 
 import datetime
 
@@ -70,8 +70,8 @@ def raise_system_exception():
     raise Exception
 
 
-def raise_ioerror(*args): # pylint: disable=unused-argument
-    e = IOError() # pylint: disable=invalid-name
+def raise_ioerror(*args):  # pylint: disable=unused-argument
+    e = IOError()  # pylint: disable=invalid-name
     from errno import EIO
     e.errno = EIO
     raise e
@@ -101,7 +101,7 @@ class TestExtensionCleanup(AgentTestCase):
     def _is_extension_dir(path):
         return re.match(HANDLER_COMPLETE_NAME_PATTERN, os.path.basename(path)) is not None
 
-    def _assert_ext_handler_status(self, aggregate_status, expected_status, version, expected_ext_handler_count=0): # pylint: disable=useless-return
+    def _assert_ext_handler_status(self, aggregate_status, expected_status, version, expected_ext_handler_count=0):  # pylint: disable=useless-return
         self.assertIsNotNone(aggregate_status, "Aggregate status should not be None")
         handler_statuses = aggregate_status['aggregateStatus']['handlerAggregateStatus']
         self.assertEqual(expected_ext_handler_count, len(handler_statuses),
@@ -116,7 +116,7 @@ class TestExtensionCleanup(AgentTestCase):
     def _setup_test_env(self, test_data):
         with mock_wire_protocol(test_data) as protocol:
 
-            def mock_http_put(url, *args, **kwargs): # pylint: disable=unused-argument,inconsistent-return-statements
+            def mock_http_put(url, *args, **kwargs):  # pylint: disable=unused-argument,inconsistent-return-statements
                 if HttpRequestPredicates.is_host_plugin_status_request(url):
                     # Skip reading the HostGA request data as its encoded
                     return None
@@ -165,7 +165,7 @@ class TestExtensionCleanup(AgentTestCase):
 
             # Create random extension directories
             for i in range(no_of_orphaned_packages):
-                eh = ExtHandler(name='Random.Extension.ShouldNot.Be.There') # pylint: disable=invalid-name
+                eh = ExtHandler(name='Random.Extension.ShouldNot.Be.There')  # pylint: disable=invalid-name
                 eh.properties.version = FlexibleVersion("9.9.0") + i
                 handler = ExtHandlerInstance(eh, "unused")
                 os.mkdir(handler.get_base_dir())
@@ -181,7 +181,7 @@ class TestExtensionCleanup(AgentTestCase):
     def test_cleanup_leaves_failed_extensions(self):
         original_popen = subprocess.Popen
 
-        def mock_fail_popen(*args, **kwargs): # pylint: disable=unused-argument
+        def mock_fail_popen(*args, **kwargs):  # pylint: disable=unused-argument
             return original_popen("fail_this_command", **kwargs)
 
         with self._setup_test_env(mockwiredata.DATA_FILE_EXT_SINGLE) as (exthandlers_handler, protocol, no_of_exts):
@@ -208,7 +208,7 @@ class TestExtensionCleanup(AgentTestCase):
 
 
 class TestHandlerStateMigration(AgentTestCase):
-    def setUp(self): # pylint: disable=useless-return
+    def setUp(self):  # pylint: disable=useless-return
         AgentTestCase.setUp(self)
 
         handler_name = "Not.A.Real.Extension"
@@ -226,7 +226,7 @@ class TestHandlerStateMigration(AgentTestCase):
             message="Uninteresting message")
         return
 
-    def _prepare_handler_state(self): # pylint: disable=useless-return
+    def _prepare_handler_state(self):  # pylint: disable=useless-return
         handler_state_path = os.path.join(
             self.tmp_dir,
             "handler_state",
@@ -240,7 +240,7 @@ class TestHandlerStateMigration(AgentTestCase):
             json.dumps(get_properties(self.handler_status)))
         return
 
-    def _prepare_handler_config(self): # pylint: disable=useless-return
+    def _prepare_handler_config(self):  # pylint: disable=useless-return
         handler_config_path = os.path.join(
             self.tmp_dir,
             self.ext_handler_i.get_full_name(),
@@ -248,7 +248,7 @@ class TestHandlerStateMigration(AgentTestCase):
         os.makedirs(handler_config_path)
         return
 
-    def test_migration_migrates(self): # pylint: disable=useless-return
+    def test_migration_migrates(self):  # pylint: disable=useless-return
         self._prepare_handler_state()
         self._prepare_handler_config()
 
@@ -260,7 +260,7 @@ class TestHandlerStateMigration(AgentTestCase):
             self.handler_status.status)
         return
 
-    def test_migration_skips_if_empty(self): # pylint: disable=useless-return
+    def test_migration_skips_if_empty(self):  # pylint: disable=useless-return
         self._prepare_handler_config()
 
         migrate_handler_state()
@@ -271,7 +271,7 @@ class TestHandlerStateMigration(AgentTestCase):
             os.path.isfile(os.path.join(self.ext_handler_i.get_conf_dir(), "HandlerStatus")))
         return
 
-    def test_migration_cleans_up(self): # pylint: disable=useless-return
+    def test_migration_cleans_up(self):  # pylint: disable=useless-return
         self._prepare_handler_state()
         self._prepare_handler_config()
 
@@ -280,7 +280,7 @@ class TestHandlerStateMigration(AgentTestCase):
         self.assertFalse(os.path.isdir(os.path.join(conf.get_lib_dir(), "handler_state")))
         return
 
-    def test_migration_does_not_overwrite(self): # pylint: disable=useless-return
+    def test_migration_does_not_overwrite(self):  # pylint: disable=useless-return
         self._prepare_handler_state()
         self._prepare_handler_config()
 
@@ -320,29 +320,29 @@ class TestHandlerStateMigration(AgentTestCase):
         try:
             with patch('json.dumps', return_value=None):
                 self.ext_handler_i.set_handler_status(status=status, code=code, message=message)
-        except Exception as e: # pylint: disable=unused-variable,invalid-name
+        except Exception as e:  # pylint: disable=unused-variable,invalid-name
             self.fail("set_handler_status threw an exception")
 
     @patch("shutil.move", side_effect=Exception)
-    def test_migration_ignores_move_errors(self, shutil_mock): # pylint: disable=useless-return,unused-argument
+    def test_migration_ignores_move_errors(self, shutil_mock):  # pylint: disable=useless-return,unused-argument
         self._prepare_handler_state()
         self._prepare_handler_config()
 
         try:
             migrate_handler_state()
-        except Exception as e: # pylint: disable=invalid-name
-            self.assertTrue(False, "Unexpected exception: {0}".format(str(e))) # pylint: disable=redundant-unittest-assert
+        except Exception as e:  # pylint: disable=invalid-name
+            self.assertTrue(False, "Unexpected exception: {0}".format(str(e)))  # pylint: disable=redundant-unittest-assert
         return
 
     @patch("shutil.rmtree", side_effect=Exception)
-    def test_migration_ignores_tree_remove_errors(self, shutil_mock): # pylint: disable=useless-return,unused-argument
+    def test_migration_ignores_tree_remove_errors(self, shutil_mock):  # pylint: disable=useless-return,unused-argument
         self._prepare_handler_state()
         self._prepare_handler_config()
 
         try:
             migrate_handler_state()
-        except Exception as e: # pylint: disable=invalid-name
-            self.assertTrue(False, "Unexpected exception: {0}".format(str(e))) # pylint: disable=redundant-unittest-assert
+        except Exception as e:  # pylint: disable=invalid-name
+            self.assertTrue(False, "Unexpected exception: {0}".format(str(e)))  # pylint: disable=redundant-unittest-assert
         return
 
 
@@ -368,11 +368,11 @@ class TestExtension(ExtensionTestCase):
     def setUp(self):
         AgentTestCase.setUp(self)
 
-    def _assert_handler_status(self, report_vm_status, expected_status, # pylint: disable=useless-return,too-many-arguments
+    def _assert_handler_status(self, report_vm_status, expected_status,  # pylint: disable=useless-return,too-many-arguments
                                expected_ext_count, version,
                                expected_handler_name="OSTCExtensions.ExampleHandlerLinux"):
         self.assertTrue(report_vm_status.called)
-        args, kw = report_vm_status.call_args # pylint: disable=unused-variable,invalid-name
+        args, kw = report_vm_status.call_args  # pylint: disable=unused-variable,invalid-name
         vm_status = args[0]
         self.assertNotEqual(0, len(vm_status.vmAgent.extensionHandlers))
         handler_status = vm_status.vmAgent.extensionHandlers[0]
@@ -391,14 +391,14 @@ class TestExtension(ExtensionTestCase):
         else:
             self.assertNotIn(zip_file_format.format(extension_handler_name, extension_version), os.listdir(conf.get_lib_dir()))
 
-    def _assert_no_handler_status(self, report_vm_status): # pylint: disable=useless-return
+    def _assert_no_handler_status(self, report_vm_status):  # pylint: disable=useless-return
         self.assertTrue(report_vm_status.called)
-        args, kw = report_vm_status.call_args # pylint: disable=unused-variable,invalid-name
+        args, kw = report_vm_status.call_args  # pylint: disable=unused-variable,invalid-name
         vm_status = args[0]
         self.assertEqual(0, len(vm_status.vmAgent.extensionHandlers))
         return
 
-    def _create_mock(self, test_data, mock_http_get, MockCryptUtil, *args): # pylint: disable=unused-argument,invalid-name
+    def _create_mock(self, test_data, mock_http_get, MockCryptUtil, *args):  # pylint: disable=unused-argument,invalid-name
         # Mock protocol to return test data
         mock_http_get.side_effect = test_data.mock_http_get
         MockCryptUtil.side_effect = test_data.mock_crypt_util
@@ -421,7 +421,7 @@ class TestExtension(ExtensionTestCase):
         :return: test_data, exthandlers_handler, protocol
         """
         test_data = mockwiredata.WireProtocolData(mockwiredata.DATA_FILE_EXT_SINGLE)
-        exthandlers_handler, protocol = self._create_mock(test_data, *args) # pylint: disable=no-value-for-parameter
+        exthandlers_handler, protocol = self._create_mock(test_data, *args)  # pylint: disable=no-value-for-parameter
 
         # Ensure initial install and enable is successful
         exthandlers_handler.run()
@@ -449,7 +449,7 @@ class TestExtension(ExtensionTestCase):
     def test_ext_handler(self, *args):
         # Test enable scenario.
         test_data = mockwiredata.WireProtocolData(mockwiredata.DATA_FILE)
-        exthandlers_handler, protocol = self._create_mock(test_data, *args) # pylint: disable=no-value-for-parameter
+        exthandlers_handler, protocol = self._create_mock(test_data, *args)  # pylint: disable=no-value-for-parameter
 
         exthandlers_handler.run()
 
@@ -527,7 +527,7 @@ class TestExtension(ExtensionTestCase):
                              "We should have downloaded extension manifest {0} times".format(manifest_count))
 
         test_data = mockwiredata.WireProtocolData(mockwiredata.DATA_FILE)
-        exthandlers_handler, protocol = self._create_mock(test_data, *args) # pylint: disable=no-value-for-parameter
+        exthandlers_handler, protocol = self._create_mock(test_data, *args)  # pylint: disable=no-value-for-parameter
         exthandlers_handler.run()
         _assert_handler_status_and_manifest_download_count(protocol, test_data, 1)
 
@@ -551,7 +551,7 @@ class TestExtension(ExtensionTestCase):
     def test_ext_zip_file_packages_removed_in_update_case(self, *args):
         # Test enable scenario.
         test_data = mockwiredata.WireProtocolData(mockwiredata.DATA_FILE)
-        exthandlers_handler, protocol = self._create_mock(test_data, *args) # pylint: disable=no-value-for-parameter
+        exthandlers_handler, protocol = self._create_mock(test_data, *args)  # pylint: disable=no-value-for-parameter
 
         exthandlers_handler.run()
 
@@ -588,7 +588,7 @@ class TestExtension(ExtensionTestCase):
     def test_ext_zip_file_packages_removed_in_uninstall_case(self, *args):
         # Test enable scenario.
         test_data = mockwiredata.WireProtocolData(mockwiredata.DATA_FILE)
-        exthandlers_handler, protocol = self._create_mock(test_data, *args) # pylint: disable=no-value-for-parameter
+        exthandlers_handler, protocol = self._create_mock(test_data, *args)  # pylint: disable=no-value-for-parameter
         extension_version = "1.0.0"
 
         exthandlers_handler.run()
@@ -610,7 +610,7 @@ class TestExtension(ExtensionTestCase):
     def test_ext_zip_file_packages_removed_in_update_and_uninstall_case(self, *args):
         # Test enable scenario.
         test_data = mockwiredata.WireProtocolData(mockwiredata.DATA_FILE)
-        exthandlers_handler, protocol = self._create_mock(test_data, *args) # pylint: disable=no-value-for-parameter
+        exthandlers_handler, protocol = self._create_mock(test_data, *args)  # pylint: disable=no-value-for-parameter
 
         exthandlers_handler.run()
 
@@ -682,21 +682,21 @@ class TestExtension(ExtensionTestCase):
 
     def test_ext_handler_no_settings(self, *args):
         test_data = mockwiredata.WireProtocolData(mockwiredata.DATA_FILE_EXT_NO_SETTINGS)
-        exthandlers_handler, protocol = self._create_mock(test_data, *args) # pylint: disable=no-value-for-parameter
+        exthandlers_handler, protocol = self._create_mock(test_data, *args)  # pylint: disable=no-value-for-parameter
 
         exthandlers_handler.run()
         self._assert_handler_status(protocol.report_vm_status, "Ready", 0, "1.0.0")
 
     def test_ext_handler_no_public_settings(self, *args):
         test_data = mockwiredata.WireProtocolData(mockwiredata.DATA_FILE_EXT_NO_PUBLIC)
-        exthandlers_handler, protocol = self._create_mock(test_data, *args) # pylint: disable=no-value-for-parameter
+        exthandlers_handler, protocol = self._create_mock(test_data, *args)  # pylint: disable=no-value-for-parameter
 
         exthandlers_handler.run()
         self._assert_handler_status(protocol.report_vm_status, "Ready", 1, "1.0.0")
 
     def test_ext_handler_no_ext(self, *args):
         test_data = mockwiredata.WireProtocolData(mockwiredata.DATA_FILE_NO_EXT)
-        exthandlers_handler, protocol = self._create_mock(test_data, *args) # pylint: disable=no-value-for-parameter
+        exthandlers_handler, protocol = self._create_mock(test_data, *args)  # pylint: disable=no-value-for-parameter
 
         # Assert no extension handler status
         exthandlers_handler.run()
@@ -705,7 +705,7 @@ class TestExtension(ExtensionTestCase):
     def test_ext_handler_sequencing(self, *args):
         # Test enable scenario.
         test_data = mockwiredata.WireProtocolData(mockwiredata.DATA_FILE_EXT_SEQUENCING)
-        exthandlers_handler, protocol = self._create_mock(test_data, *args) # pylint: disable=no-value-for-parameter
+        exthandlers_handler, protocol = self._create_mock(test_data, *args)  # pylint: disable=no-value-for-parameter
 
         exthandlers_handler.run()
 
@@ -779,7 +779,7 @@ class TestExtension(ExtensionTestCase):
 
     def test_ext_handler_sequencing_default_dependency_level(self, *args):
         test_data = mockwiredata.WireProtocolData(mockwiredata.DATA_FILE)
-        exthandlers_handler, protocol = self._create_mock(test_data, *args) # pylint: disable=unused-variable,no-value-for-parameter
+        exthandlers_handler, protocol = self._create_mock(test_data, *args)  # pylint: disable=unused-variable,no-value-for-parameter
         exthandlers_handler.run()
         self.assertEqual(exthandlers_handler.ext_handlers.extHandlers[0].properties.extensions[0].dependencyLevel, 0)
         self.assertEqual(exthandlers_handler.ext_handlers.extHandlers[0].properties.extensions[0].dependencyLevel, 0)
@@ -792,7 +792,7 @@ class TestExtension(ExtensionTestCase):
                                                         "dependencyLevel=\"a6\"")
         test_data.ext_conf = test_data.ext_conf.replace("dependencyLevel=\"2\"",
                                                         "dependencyLevel=\"5b\"")
-        exthandlers_handler, protocol = self._create_mock(test_data, *args) # pylint: disable=unused-variable,no-value-for-parameter
+        exthandlers_handler, protocol = self._create_mock(test_data, *args)  # pylint: disable=unused-variable,no-value-for-parameter
 
         exthandlers_handler.run()
 
@@ -846,7 +846,7 @@ class TestExtension(ExtensionTestCase):
         expected_status_json = json.loads(expected_status)
 
         test_data = mockwiredata.WireProtocolData(mockwiredata.DATA_FILE_MULTIPLE_EXT)
-        exthandlers_handler, protocol = self._create_mock(test_data, *args) # pylint: disable=unused-variable,no-value-for-parameter
+        exthandlers_handler, protocol = self._create_mock(test_data, *args)  # pylint: disable=unused-variable,no-value-for-parameter
         exthandlers_handler.run()
 
         status_path = os.path.join(conf.get_lib_dir(), AGENT_STATUS_FILE)
@@ -857,7 +857,7 @@ class TestExtension(ExtensionTestCase):
     def test_ext_handler_rollingupgrade(self, *args):
         # Test enable scenario.
         test_data = mockwiredata.WireProtocolData(mockwiredata.DATA_FILE_EXT_ROLLINGUPGRADE)
-        exthandlers_handler, protocol = self._create_mock(test_data, *args) # pylint: disable=no-value-for-parameter
+        exthandlers_handler, protocol = self._create_mock(test_data, *args)  # pylint: disable=no-value-for-parameter
 
         exthandlers_handler.run()
 
@@ -951,10 +951,10 @@ class TestExtension(ExtensionTestCase):
 
     @patch('azurelinuxagent.ga.exthandlers.add_event')
     def test_ext_handler_download_failure_transient(self, mock_add_event, *args):
-        original_sleep = time.sleep # pylint: disable=unused-variable
+        original_sleep = time.sleep  # pylint: disable=unused-variable
 
         test_data = mockwiredata.WireProtocolData(mockwiredata.DATA_FILE)
-        exthandlers_handler, protocol = self._create_mock(test_data, *args) # pylint: disable=no-value-for-parameter
+        exthandlers_handler, protocol = self._create_mock(test_data, *args)  # pylint: disable=no-value-for-parameter
         protocol.download_ext_handler_pkg = Mock(side_effect=ProtocolError)
 
         exthandlers_handler.run()
@@ -971,7 +971,7 @@ class TestExtension(ExtensionTestCase):
                     # Create new object for each run to force re-installation of extensions as we
                     # only create handler_environment on installation
                     test_data = mockwiredata.WireProtocolData(mockwiredata.DATA_FILE_MULTIPLE_EXT)
-                    exthandlers_handler, protocol = self._create_mock(test_data, *args) # pylint: disable=no-value-for-parameter
+                    exthandlers_handler, protocol = self._create_mock(test_data, *args)  # pylint: disable=no-value-for-parameter
 
                     exthandlers_handler.run()
                     self._assert_handler_status(protocol.report_vm_status, "Ready", 1, "1.0.0")
@@ -1000,7 +1000,7 @@ class TestExtension(ExtensionTestCase):
 
     def test_it_should_not_delete_extension_events_directory_on_extension_uninstall(self, *args):
         test_data = mockwiredata.WireProtocolData(mockwiredata.DATA_FILE)
-        exthandlers_handler, protocol = self._create_mock(test_data, *args) # pylint: disable=no-value-for-parameter
+        exthandlers_handler, protocol = self._create_mock(test_data, *args)  # pylint: disable=no-value-for-parameter
 
         with patch('azurelinuxagent.ga.exthandlers.is_extension_telemetry_pipeline_enabled', return_value=True):
             exthandlers_handler.run()
@@ -1019,7 +1019,7 @@ class TestExtension(ExtensionTestCase):
 
     def test_it_should_uninstall_unregistered_extensions_properly(self, *args):
         test_data = mockwiredata.WireProtocolData(mockwiredata.DATA_FILE)
-        exthandlers_handler, protocol = self._create_mock(test_data, *args) # pylint: disable=no-value-for-parameter
+        exthandlers_handler, protocol = self._create_mock(test_data, *args)  # pylint: disable=no-value-for-parameter
         exthandlers_handler.run()
         self._assert_handler_status(protocol.report_vm_status, "Ready", 1, "1.0.0")
 
@@ -1041,13 +1041,13 @@ class TestExtension(ExtensionTestCase):
     @patch('azurelinuxagent.ga.exthandlers.add_event')
     def test_ext_handler_report_status_permanent(self, mock_add_event, mock_error_state, *args):
         test_data = mockwiredata.WireProtocolData(mockwiredata.DATA_FILE)
-        exthandlers_handler, protocol = self._create_mock(test_data, *args) # pylint: disable=no-value-for-parameter
+        exthandlers_handler, protocol = self._create_mock(test_data, *args)  # pylint: disable=no-value-for-parameter
         protocol.report_vm_status = Mock(side_effect=ProtocolError)
 
         mock_error_state.return_value = True
         exthandlers_handler.run()
         self.assertEqual(5, mock_add_event.call_count)
-        args, kw = mock_add_event.call_args # pylint: disable=invalid-name
+        args, kw = mock_add_event.call_args  # pylint: disable=invalid-name
         self.assertEqual(False, kw['is_success'])
         self.assertTrue("Failed to report vm agent status" in kw['message'])
         self.assertEqual("ReportStatusExtended", kw['op'])
@@ -1055,21 +1055,21 @@ class TestExtension(ExtensionTestCase):
     @patch('azurelinuxagent.ga.exthandlers.add_event')
     def test_ext_handler_report_status_resource_gone(self, mock_add_event, *args):
         test_data = mockwiredata.WireProtocolData(mockwiredata.DATA_FILE)
-        exthandlers_handler, protocol = self._create_mock(test_data, *args) # pylint: disable=no-value-for-parameter
+        exthandlers_handler, protocol = self._create_mock(test_data, *args)  # pylint: disable=no-value-for-parameter
         protocol.report_vm_status = Mock(side_effect=ResourceGoneError)
 
         exthandlers_handler.run()
         self.assertEqual(4, mock_add_event.call_count)
-        args, kw = mock_add_event.call_args # pylint: disable=invalid-name
+        args, kw = mock_add_event.call_args  # pylint: disable=invalid-name
         self.assertEqual(False, kw['is_success'])
         self.assertTrue("ResourceGoneError" in kw['message'])
         self.assertEqual("ExtensionProcessing", kw['op'])
 
     @patch('azurelinuxagent.common.errorstate.ErrorState.is_triggered')
     @patch('azurelinuxagent.ga.exthandlers.ExtHandlerInstance.report_event')
-    def test_ext_handler_download_failure_permanent_ProtocolError(self, mock_add_event, mock_error_state, *args): # pylint: disable=invalid-name
+    def test_ext_handler_download_failure_permanent_ProtocolError(self, mock_add_event, mock_error_state, *args):  # pylint: disable=invalid-name
         test_data = mockwiredata.WireProtocolData(mockwiredata.DATA_FILE)
-        exthandlers_handler, protocol = self._create_mock(test_data, *args) # pylint: disable=no-value-for-parameter
+        exthandlers_handler, protocol = self._create_mock(test_data, *args)  # pylint: disable=no-value-for-parameter
         protocol.get_ext_handler_pkgs = Mock(side_effect=ProtocolError)
 
         mock_error_state.return_value = True
@@ -1077,7 +1077,7 @@ class TestExtension(ExtensionTestCase):
         exthandlers_handler.run()
 
         self.assertEqual(1, mock_add_event.call_count)
-        args, kw = mock_add_event.call_args_list[0] # pylint: disable=invalid-name
+        args, kw = mock_add_event.call_args_list[0]  # pylint: disable=invalid-name
         self.assertEqual(False, kw['is_success'])
         self.assertTrue("Failed to get ext handler pkgs" in kw['message'])
         self.assertTrue("ProtocolError" in kw['message'])
@@ -1094,7 +1094,7 @@ class TestExtension(ExtensionTestCase):
                              "Incorrect Operation, all events should be a download errors")
 
         test_data = mockwiredata.WireProtocolData(mockwiredata.DATA_FILE)
-        exthandlers_handler, protocol = self._create_mock(test_data, *args) # pylint: disable=no-value-for-parameter
+        exthandlers_handler, protocol = self._create_mock(test_data, *args)  # pylint: disable=no-value-for-parameter
         unique_error_message_guid = str(uuid.uuid4())
         protocol.get_ext_handler_pkgs = Mock(side_effect=ExtensionDownloadError(unique_error_message_guid))
 
@@ -1118,56 +1118,56 @@ class TestExtension(ExtensionTestCase):
     @patch('azurelinuxagent.ga.exthandlers.fileutil')
     def test_ext_handler_io_error(self, mock_fileutil, *args):
         test_data = mockwiredata.WireProtocolData(mockwiredata.DATA_FILE)
-        exthandlers_handler, protocol = self._create_mock(test_data, *args) # pylint: disable=unused-variable,no-value-for-parameter
+        exthandlers_handler, protocol = self._create_mock(test_data, *args)  # pylint: disable=unused-variable,no-value-for-parameter
 
         mock_fileutil.write_file.return_value = IOError("Mock IO Error")
         exthandlers_handler.run()
 
-    def test_extension_processing_allowed(self, *args): # pylint: disable=unused-argument
+    def test_extension_processing_allowed(self, *args):  # pylint: disable=unused-argument
         exthandlers_handler = get_exthandlers_handler(Mock())
 
         # disable extension handling in configuration
         with patch.object(conf, 'get_extensions_enabled', return_value=False):
-            self.assertFalse(exthandlers_handler._extension_processing_allowed()) # pylint: disable=protected-access
+            self.assertFalse(exthandlers_handler._extension_processing_allowed())  # pylint: disable=protected-access
 
         # enable extension handling in configuration
         with patch.object(conf, "get_extensions_enabled", return_value=True):
             # disable overprovisioning in configuration
             with patch.object(conf, 'get_enable_overprovisioning', return_value=False):
-                self.assertTrue(exthandlers_handler._extension_processing_allowed()) # pylint: disable=protected-access
+                self.assertTrue(exthandlers_handler._extension_processing_allowed())  # pylint: disable=protected-access
 
             # enable overprovisioning in configuration
             with patch.object(conf, "get_enable_overprovisioning", return_value=True):
                 with patch.object(exthandlers_handler.protocol.get_artifacts_profile(), "is_on_hold",
                                   side_effect=[True, False]):
                     # Enable on_hold property in artifact_blob
-                    self.assertFalse(exthandlers_handler._extension_processing_allowed()) # pylint: disable=protected-access
+                    self.assertFalse(exthandlers_handler._extension_processing_allowed())  # pylint: disable=protected-access
 
                     # Disable on_hold property in artifact_blob
-                    self.assertTrue(exthandlers_handler._extension_processing_allowed()) # pylint: disable=protected-access
+                    self.assertTrue(exthandlers_handler._extension_processing_allowed())  # pylint: disable=protected-access
 
     def test_handle_ext_handlers_on_hold_true(self, *args):
         test_data = mockwiredata.WireProtocolData(mockwiredata.DATA_FILE)
-        exthandlers_handler, protocol = self._create_mock(test_data, *args) # pylint: disable=no-value-for-parameter
+        exthandlers_handler, protocol = self._create_mock(test_data, *args)  # pylint: disable=no-value-for-parameter
         exthandlers_handler.ext_handlers, exthandlers_handler.last_etag = protocol.get_ext_handlers()
         protocol.get_artifacts_profile = MagicMock()
         exthandlers_handler.protocol = protocol
 
         # Disable extension handling blocking
-        exthandlers_handler._extension_processing_allowed = Mock(return_value=False) # pylint: disable=protected-access
+        exthandlers_handler._extension_processing_allowed = Mock(return_value=False)  # pylint: disable=protected-access
         with patch.object(ExtHandlersHandler, 'handle_ext_handlers') as patch_handle_ext_handlers:
             exthandlers_handler.run()
             self.assertEqual(0, patch_handle_ext_handlers.call_count)
 
         # enable extension handling blocking
-        exthandlers_handler._extension_processing_allowed = Mock(return_value=True) # pylint: disable=protected-access
+        exthandlers_handler._extension_processing_allowed = Mock(return_value=True)  # pylint: disable=protected-access
         with patch.object(ExtHandlersHandler, 'handle_ext_handlers') as patch_handle_ext_handlers:
             exthandlers_handler.run()
             self.assertEqual(1, patch_handle_ext_handlers.call_count)
 
     def test_handle_ext_handlers_on_hold_false(self, *args):
         test_data = mockwiredata.WireProtocolData(mockwiredata.DATA_FILE)
-        exthandlers_handler, protocol = self._create_mock(test_data, *args) # pylint: disable=no-value-for-parameter
+        exthandlers_handler, protocol = self._create_mock(test_data, *args)  # pylint: disable=no-value-for-parameter
         exthandlers_handler.ext_handlers, exthandlers_handler.last_etag = protocol.get_ext_handlers()
         exthandlers_handler.protocol = protocol
 
@@ -1190,7 +1190,7 @@ class TestExtension(ExtensionTestCase):
 
     def test_last_etag_on_extension_processing(self, *args):
         test_data = mockwiredata.WireProtocolData(mockwiredata.DATA_FILE)
-        exthandlers_handler, protocol = self._create_mock(test_data, *args) # pylint: disable=no-value-for-parameter
+        exthandlers_handler, protocol = self._create_mock(test_data, *args)  # pylint: disable=no-value-for-parameter
         exthandlers_handler.ext_handlers, etag = protocol.get_ext_handlers()
         exthandlers_handler.protocol = protocol
 
@@ -1210,14 +1210,14 @@ class TestExtension(ExtensionTestCase):
     def _assert_ext_status(self, report_ext_status, expected_status,
                            expected_seq_no):
         self.assertTrue(report_ext_status.called)
-        args, kw = report_ext_status.call_args # pylint: disable=unused-variable,invalid-name
+        args, kw = report_ext_status.call_args  # pylint: disable=unused-variable,invalid-name
         ext_status = args[-1]
         self.assertEqual(expected_status, ext_status.status)
         self.assertEqual(expected_seq_no, ext_status.sequenceNumber)
 
     def test_ext_handler_no_reporting_status(self, *args):
         test_data = mockwiredata.WireProtocolData(mockwiredata.DATA_FILE)
-        exthandlers_handler, protocol = self._create_mock(test_data, *args) # pylint: disable=no-value-for-parameter
+        exthandlers_handler, protocol = self._create_mock(test_data, *args)  # pylint: disable=no-value-for-parameter
         exthandlers_handler.run()
         self._assert_handler_status(protocol.report_vm_status, "Ready", 1, "1.0.0")
 
@@ -1238,7 +1238,7 @@ class TestExtension(ExtensionTestCase):
         Expected to return True.
         '''
         test_data = mockwiredata.WireProtocolData(mockwiredata.DATA_FILE)
-        exthandlers_handler, protocol = self._create_mock(test_data, *args) # pylint: disable=unused-variable,no-value-for-parameter
+        exthandlers_handler, protocol = self._create_mock(test_data, *args)  # pylint: disable=unused-variable,no-value-for-parameter
 
         handler = ExtHandler(name="handler")
 
@@ -1266,7 +1266,7 @@ class TestExtension(ExtensionTestCase):
         Expected to return False.
         '''
         test_data = mockwiredata.WireProtocolData(mockwiredata.DATA_FILE)
-        exthandlers_handler, protocol = self._create_mock(test_data, *args) # pylint: disable=unused-variable,no-value-for-parameter
+        exthandlers_handler, protocol = self._create_mock(test_data, *args)  # pylint: disable=unused-variable,no-value-for-parameter
 
         ExtHandlerInstance.get_ext_handling_status = MagicMock(return_value=None)
         self.assertFalse(self._helper_wait_for_handler_successful_completion(exthandlers_handler))
@@ -1277,7 +1277,7 @@ class TestExtension(ExtensionTestCase):
         Expected to return True.
         '''
         test_data = mockwiredata.WireProtocolData(mockwiredata.DATA_FILE)
-        exthandlers_handler, protocol = self._create_mock(test_data, *args) # pylint: disable=unused-variable,no-value-for-parameter
+        exthandlers_handler, protocol = self._create_mock(test_data, *args)  # pylint: disable=unused-variable,no-value-for-parameter
 
         status = "success"
 
@@ -1290,7 +1290,7 @@ class TestExtension(ExtensionTestCase):
         Expected to return False.
         '''
         test_data = mockwiredata.WireProtocolData(mockwiredata.DATA_FILE)
-        exthandlers_handler, protocol = self._create_mock(test_data, *args) # pylint: disable=unused-variable,no-value-for-parameter
+        exthandlers_handler, protocol = self._create_mock(test_data, *args)  # pylint: disable=unused-variable,no-value-for-parameter
 
         status = "error"
 
@@ -1303,7 +1303,7 @@ class TestExtension(ExtensionTestCase):
         Expected to return False.
         '''
         test_data = mockwiredata.WireProtocolData(mockwiredata.DATA_FILE)
-        exthandlers_handler, protocol = self._create_mock(test_data, *args) # pylint: disable=unused-variable,no-value-for-parameter
+        exthandlers_handler, protocol = self._create_mock(test_data, *args)  # pylint: disable=unused-variable,no-value-for-parameter
 
         # Choose a non-terminal status
         status = "warning"
@@ -1317,7 +1317,7 @@ class TestExtension(ExtensionTestCase):
         verifying against the expected values
         '''
         test_data = mockwiredata.WireProtocolData(mockwiredata.DATA_FILE)
-        exthandlers_handler, protocol = self._create_mock(test_data, *args) # pylint: disable=unused-variable,no-value-for-parameter
+        exthandlers_handler, protocol = self._create_mock(test_data, *args)  # pylint: disable=unused-variable,no-value-for-parameter
 
         handler_name = "Handler"
         exthandler = ExtHandler(name=handler_name)
@@ -1360,7 +1360,7 @@ class TestExtension(ExtensionTestCase):
         verifying against the expected output values.
         """
         test_data = mockwiredata.WireProtocolData(mockwiredata.DATA_FILE)
-        exthandlers_handler, protocol = self._create_mock(test_data, *args) # pylint: disable=unused-variable,no-value-for-parameter
+        exthandlers_handler, protocol = self._create_mock(test_data, *args)  # pylint: disable=unused-variable,no-value-for-parameter
 
         handler_name = "Handler"
         exthandler = ExtHandler(name=handler_name)
@@ -1408,7 +1408,7 @@ class TestExtension(ExtensionTestCase):
                     else:
                         datafile = mockwiredata.DATA_FILE
 
-                _, protocol = self._create_mock(mockwiredata.WireProtocolData(datafile), *args) # pylint: disable=no-value-for-parameter
+                _, protocol = self._create_mock(mockwiredata.WireProtocolData(datafile), *args)  # pylint: disable=no-value-for-parameter
                 ext_handlers, _ = protocol.get_ext_handlers()
                 self.assertEqual(1, len(ext_handlers.extHandlers))
                 ext_handler = ext_handlers.extHandlers[0]
@@ -1441,7 +1441,7 @@ class TestExtension(ExtensionTestCase):
             (None, '4.1', '4.1.0.0'),
         ]
 
-        _, protocol = self._create_mock(mockwiredata.WireProtocolData(mockwiredata.DATA_FILE), *args) # pylint: disable=no-value-for-parameter
+        _, protocol = self._create_mock(mockwiredata.WireProtocolData(mockwiredata.DATA_FILE), *args)  # pylint: disable=no-value-for-parameter
         version_uri = Mock()
         version_uri.uri = 'http://mock-goal-state/Microsoft.OSTCExtensions_ExampleHandlerLinux_asiaeast_manifest.xml'
 
@@ -1462,20 +1462,20 @@ class TestExtension(ExtensionTestCase):
     def test_extensions_disabled(self, _, *args):
         # test status is reported for no extensions
         test_data = mockwiredata.WireProtocolData(mockwiredata.DATA_FILE_NO_EXT)
-        exthandlers_handler, protocol = self._create_mock(test_data, *args) # pylint: disable=no-value-for-parameter
+        exthandlers_handler, protocol = self._create_mock(test_data, *args)  # pylint: disable=no-value-for-parameter
         exthandlers_handler.run()
         self._assert_no_handler_status(protocol.report_vm_status)
 
         # test status is reported, but extensions are not processed
         test_data = mockwiredata.WireProtocolData(mockwiredata.DATA_FILE)
-        exthandlers_handler, protocol = self._create_mock(test_data, *args) # pylint: disable=no-value-for-parameter
+        exthandlers_handler, protocol = self._create_mock(test_data, *args)  # pylint: disable=no-value-for-parameter
         exthandlers_handler.run()
         self._assert_no_handler_status(protocol.report_vm_status)
 
     def test_extensions_deleted(self, *args):
         # Ensure initial enable is successful
         test_data = mockwiredata.WireProtocolData(mockwiredata.DATA_FILE_EXT_DELETION)
-        exthandlers_handler, protocol = self._create_mock(test_data, *args) # pylint: disable=no-value-for-parameter
+        exthandlers_handler, protocol = self._create_mock(test_data, *args)  # pylint: disable=no-value-for-parameter
 
         exthandlers_handler.run()
 
@@ -1502,7 +1502,7 @@ class TestExtension(ExtensionTestCase):
         When extension install fails, the operation should not be retried.
         """
         test_data = mockwiredata.WireProtocolData(mockwiredata.DATA_FILE_EXT_SINGLE)
-        exthandlers_handler, protocol = self._create_mock(test_data, *args) # pylint: disable=no-value-for-parameter
+        exthandlers_handler, protocol = self._create_mock(test_data, *args)  # pylint: disable=no-value-for-parameter
 
         # Ensure initial install is unsuccessful
         patch_get_install_command.return_value = "exit.sh 1"
@@ -1525,7 +1525,7 @@ class TestExtension(ExtensionTestCase):
         When extension install fails, the operation should be reported to our telemetry service.
         """
         test_data = mockwiredata.WireProtocolData(mockwiredata.DATA_FILE_EXT_SINGLE)
-        exthandlers_handler, protocol = self._create_mock(test_data, *args) # pylint: disable=no-value-for-parameter
+        exthandlers_handler, protocol = self._create_mock(test_data, *args)  # pylint: disable=no-value-for-parameter
 
         # Ensure install is unsuccessful
         patch_get_install_command.return_value = "exit.sh 1"
@@ -1540,7 +1540,7 @@ class TestExtension(ExtensionTestCase):
         When extension enable fails, the operation should not be retried.
         """
         test_data = mockwiredata.WireProtocolData(mockwiredata.DATA_FILE_EXT_SINGLE)
-        exthandlers_handler, protocol = self._create_mock(test_data, *args) # pylint: disable=no-value-for-parameter
+        exthandlers_handler, protocol = self._create_mock(test_data, *args)  # pylint: disable=no-value-for-parameter
 
         # Ensure initial install is successful, but enable fails
         patch_get_enable_command.call_count = 0
@@ -1563,7 +1563,7 @@ class TestExtension(ExtensionTestCase):
         When extension enable fails, the operation should be reported.
         """
         test_data = mockwiredata.WireProtocolData(mockwiredata.DATA_FILE_EXT_SINGLE)
-        exthandlers_handler, protocol = self._create_mock(test_data, *args) # pylint: disable=no-value-for-parameter
+        exthandlers_handler, protocol = self._create_mock(test_data, *args)  # pylint: disable=no-value-for-parameter
 
         # Ensure initial install is successful, but enable fails
         patch_get_enable_command.call_count = 0
@@ -1581,7 +1581,7 @@ class TestExtension(ExtensionTestCase):
         """
         # Ensure initial install and enable is successful, but disable fails
         test_data = mockwiredata.WireProtocolData(mockwiredata.DATA_FILE_EXT_SINGLE)
-        exthandlers_handler, protocol = self._create_mock(test_data, *args) # pylint: disable=no-value-for-parameter
+        exthandlers_handler, protocol = self._create_mock(test_data, *args)  # pylint: disable=no-value-for-parameter
         patch_get_disable_command.call_count = 0
         patch_get_disable_command.return_value = "exit.sh 1"
 
@@ -1619,7 +1619,7 @@ class TestExtension(ExtensionTestCase):
         """
         # Ensure initial install and enable is successful, but disable fails
         test_data = mockwiredata.WireProtocolData(mockwiredata.DATA_FILE_EXT_SINGLE)
-        exthandlers_handler, protocol = self._create_mock(test_data, *args) # pylint: disable=no-value-for-parameter
+        exthandlers_handler, protocol = self._create_mock(test_data, *args)  # pylint: disable=no-value-for-parameter
         patch_get_disable_command.call_count = 0
         patch_get_disable_command.return_value = "exit 1"
 
@@ -1648,7 +1648,7 @@ class TestExtension(ExtensionTestCase):
         """
         # Ensure initial install and enable is successful, but uninstall fails
         test_data = mockwiredata.WireProtocolData(mockwiredata.DATA_FILE_EXT_SINGLE)
-        exthandlers_handler, protocol = self._create_mock(test_data, *args) # pylint: disable=no-value-for-parameter
+        exthandlers_handler, protocol = self._create_mock(test_data, *args)  # pylint: disable=no-value-for-parameter
         patch_get_uninstall_command.call_count = 0
         patch_get_uninstall_command.return_value = "exit 1"
 
@@ -1714,7 +1714,7 @@ class TestExtension(ExtensionTestCase):
 
             # Ensure we are processing the same goal state only once
             loop_run = 5
-            for x in range(loop_run): # pylint: disable=unused-variable,invalid-name
+            for x in range(loop_run):  # pylint: disable=unused-variable,invalid-name
                 exthandlers_handler.run()
 
             update_command_count = len([extension_call for extension_call in extension_calls
@@ -1743,7 +1743,7 @@ class TestExtension(ExtensionTestCase):
 
     @patch('azurelinuxagent.ga.exthandlers.HandlerManifest.get_disable_command')
     def test_extension_upgrade_failure_when_prev_version_disable_fails(self, patch_get_disable_command, *args):
-        test_data, exthandlers_handler, protocol = self._set_up_update_test_and_update_gs(patch_get_disable_command, *args) # pylint: disable=unused-variable
+        test_data, exthandlers_handler, protocol = self._set_up_update_test_and_update_gs(patch_get_disable_command, *args)  # pylint: disable=unused-variable
 
         with patch('azurelinuxagent.ga.exthandlers.HandlerManifest.get_enable_command') as patch_get_enable_command:
             exthandlers_handler.run()
@@ -1756,7 +1756,7 @@ class TestExtension(ExtensionTestCase):
 
             # Ensure we are processing the same goal state only once
             loop_run = 5
-            for x in range(loop_run): # pylint: disable=unused-variable,invalid-name
+            for x in range(loop_run):  # pylint: disable=unused-variable,invalid-name
                 exthandlers_handler.run()
 
             self.assertEqual(1, patch_get_disable_command.call_count)
@@ -1779,7 +1779,7 @@ class TestExtension(ExtensionTestCase):
 
             # Ensure we are processing the same goal state only once
             loop_run = 5
-            for x in range(loop_run): # pylint: disable=unused-variable,invalid-name
+            for x in range(loop_run):  # pylint: disable=unused-variable,invalid-name
                 exthandlers_handler.run()
 
             self.assertEqual(1, patch_get_disable_command.call_count)
@@ -1790,7 +1790,7 @@ class TestExtension(ExtensionTestCase):
             protocol.update_goal_state()
 
             # Ensure disable won't fail by making launch_command a no-op
-            with patch('azurelinuxagent.ga.exthandlers.ExtHandlerInstance.launch_command') as patch_launch_command: # pylint: disable=unused-variable
+            with patch('azurelinuxagent.ga.exthandlers.ExtHandlerInstance.launch_command') as patch_launch_command:  # pylint: disable=unused-variable
                 exthandlers_handler.run()
                 self.assertEqual(2, patch_get_disable_command.call_count)
                 self.assertEqual(1, patch_get_enable_command.call_count)
@@ -1799,7 +1799,7 @@ class TestExtension(ExtensionTestCase):
     @patch('azurelinuxagent.ga.exthandlers.HandlerManifest.get_disable_command')
     def test_extension_upgrade_failure_when_prev_version_disable_fails_incorrect_zip(self, patch_get_disable_command,
                                                                                       *args):
-        test_data, exthandlers_handler, protocol = self._set_up_update_test_and_update_gs(patch_get_disable_command, # pylint: disable=unused-variable
+        test_data, exthandlers_handler, protocol = self._set_up_update_test_and_update_gs(patch_get_disable_command,  # pylint: disable=unused-variable
                                                                                           *args)
 
         # The download logic has retry logic that sleeps before each try - make sleep a no-op.
@@ -1818,7 +1818,7 @@ class TestExtension(ExtensionTestCase):
 
                     # Ensure we are processing the same goal state only once
                     loop_run = 5
-                    for x in range(loop_run): # pylint: disable=unused-variable,invalid-name
+                    for x in range(loop_run):  # pylint: disable=unused-variable,invalid-name
                         exthandlers_handler.run()
 
                     self.assertEqual(0, patch_get_disable_command.call_count)
@@ -1827,7 +1827,7 @@ class TestExtension(ExtensionTestCase):
     @patch('azurelinuxagent.ga.exthandlers.HandlerManifest.get_disable_command')
     def test_old_handler_reports_failure_on_disable_fail_on_update(self, patch_get_disable_command, *args):
         old_version, new_version = "1.0.0", "1.0.1"
-        test_data, exthandlers_handler, protocol = self._set_up_update_test_and_update_gs(patch_get_disable_command, # pylint: disable=unused-variable
+        test_data, exthandlers_handler, protocol = self._set_up_update_test_and_update_gs(patch_get_disable_command,  # pylint: disable=unused-variable
                                                                                           *args)
 
         with patch.object(ExtHandlerInstance, "report_event", autospec=True) as patch_report_event:
@@ -1862,7 +1862,7 @@ class TestExtension(ExtensionTestCase):
         """
         Extension upgrade failure should not be retried
         """
-        test_data, exthandlers_handler, protocol = self._set_up_update_test_and_update_gs(patch_get_update_command, # pylint: disable=unused-variable
+        test_data, exthandlers_handler, protocol = self._set_up_update_test_and_update_gs(patch_get_update_command,  # pylint: disable=unused-variable
                                                                                           *args)
 
         exthandlers_handler.run()
@@ -1872,7 +1872,7 @@ class TestExtension(ExtensionTestCase):
     @patch('azurelinuxagent.ga.exthandlers.HandlerManifest.get_disable_command')
     def test_extension_upgrade_should_pass_when_continue_on_update_failure_is_true_and_prev_version_disable_fails(
             self, patch_get_disable_command, *args):
-        test_data, exthandlers_handler, protocol = self._set_up_update_test_and_update_gs(patch_get_disable_command, # pylint: disable=unused-variable
+        test_data, exthandlers_handler, protocol = self._set_up_update_test_and_update_gs(patch_get_disable_command,  # pylint: disable=unused-variable
                                                                                           *args)
 
         with patch('azurelinuxagent.ga.exthandlers.HandlerManifest.is_continue_on_update_failure', return_value=True) \
@@ -1890,7 +1890,7 @@ class TestExtension(ExtensionTestCase):
     @patch('azurelinuxagent.ga.exthandlers.HandlerManifest.get_uninstall_command')
     def test_extension_upgrade_should_pass_when_continue_on_update_failue_is_true_and_prev_version_uninstall_fails(
             self, patch_get_uninstall_command, *args):
-        test_data, exthandlers_handler, protocol = self._set_up_update_test_and_update_gs(patch_get_uninstall_command, # pylint: disable=unused-variable
+        test_data, exthandlers_handler, protocol = self._set_up_update_test_and_update_gs(patch_get_uninstall_command,  # pylint: disable=unused-variable
                                                                                           *args)
 
         with patch('azurelinuxagent.ga.exthandlers.HandlerManifest.is_continue_on_update_failure', return_value=True) \
@@ -1908,7 +1908,7 @@ class TestExtension(ExtensionTestCase):
     @patch('azurelinuxagent.ga.exthandlers.HandlerManifest.get_disable_command')
     def test_extension_upgrade_should_fail_when_continue_on_update_failure_is_false_and_prev_version_disable_fails(
             self, patch_get_disable_command, *args):
-        test_data, exthandlers_handler, protocol = self._set_up_update_test_and_update_gs(patch_get_disable_command, # pylint: disable=unused-variable
+        test_data, exthandlers_handler, protocol = self._set_up_update_test_and_update_gs(patch_get_disable_command,  # pylint: disable=unused-variable
                                                                                           *args)
 
         with patch('azurelinuxagent.ga.exthandlers.HandlerManifest.is_continue_on_update_failure', return_value=False) \
@@ -1925,7 +1925,7 @@ class TestExtension(ExtensionTestCase):
     @patch('azurelinuxagent.ga.exthandlers.HandlerManifest.get_uninstall_command')
     def test_extension_upgrade_should_fail_when_continue_on_update_failure_is_false_and_prev_version_uninstall_fails(
             self, patch_get_uninstall_command, *args):
-        test_data, exthandlers_handler, protocol = self._set_up_update_test_and_update_gs(patch_get_uninstall_command, # pylint: disable=unused-variable
+        test_data, exthandlers_handler, protocol = self._set_up_update_test_and_update_gs(patch_get_uninstall_command,  # pylint: disable=unused-variable
                                                                                           *args)
 
         with patch('azurelinuxagent.ga.exthandlers.HandlerManifest.is_continue_on_update_failure', return_value=False) \
@@ -1942,7 +1942,7 @@ class TestExtension(ExtensionTestCase):
     @patch('azurelinuxagent.ga.exthandlers.HandlerManifest.get_disable_command')
     def test_extension_upgrade_should_fail_when_continue_on_update_failure_is_true_and_old_disable_and_new_enable_fails(
             self, patch_get_disable_command, *args):
-        test_data, exthandlers_handler, protocol = self._set_up_update_test_and_update_gs(patch_get_disable_command, # pylint: disable=unused-variable
+        test_data, exthandlers_handler, protocol = self._set_up_update_test_and_update_gs(patch_get_disable_command,  # pylint: disable=unused-variable
                                                                                           *args)
 
         with patch('azurelinuxagent.ga.exthandlers.HandlerManifest.is_continue_on_update_failure', return_value=True) \
@@ -2011,7 +2011,7 @@ class TestExtension(ExtensionTestCase):
 
     def test_ext_path_and_version_env_variables_set_for_ever_operation(self, *args):
         test_data = mockwiredata.WireProtocolData(mockwiredata.DATA_FILE_EXT_SINGLE)
-        exthandlers_handler, protocol = self._create_mock(test_data, *args) # pylint: disable=no-value-for-parameter
+        exthandlers_handler, protocol = self._create_mock(test_data, *args)  # pylint: disable=no-value-for-parameter
 
         with patch.object(CGroupConfigurator.get_instance(), "start_extension_command") as patch_start_cmd:
             exthandlers_handler.run()
@@ -2029,7 +2029,7 @@ class TestExtension(ExtensionTestCase):
     @patch("azurelinuxagent.common.cgroupconfigurator.handle_process_completion", side_effect="Process Successful")
     def test_ext_sequence_no_should_be_set_for_every_command_call(self, _, *args):
         test_data = mockwiredata.WireProtocolData(mockwiredata.DATA_FILE_MULTIPLE_EXT)
-        exthandlers_handler, protocol = self._create_mock(test_data, *args) # pylint: disable=no-value-for-parameter
+        exthandlers_handler, protocol = self._create_mock(test_data, *args)  # pylint: disable=no-value-for-parameter
 
         with patch("subprocess.Popen") as patch_popen:
             exthandlers_handler.run()
@@ -2045,7 +2045,7 @@ class TestExtension(ExtensionTestCase):
         test_data.ext_conf = test_data.ext_conf.replace('version="1.0.0"', 'version="1.0.1"')
         test_data.ext_conf = test_data.ext_conf.replace('seqNo="0"', 'seqNo="1"')
         test_data.manifest = test_data.manifest.replace('1.0.0', '1.0.1')
-        exthandlers_handler, protocol = self._create_mock(test_data, *args) # pylint: disable=no-value-for-parameter
+        exthandlers_handler, protocol = self._create_mock(test_data, *args)  # pylint: disable=no-value-for-parameter
 
         with patch("subprocess.Popen") as patch_popen:
             exthandlers_handler.run()
@@ -2080,7 +2080,7 @@ class TestExtension(ExtensionTestCase):
         self.create_script(test_file_name, test_file, base_dir)
 
         test_data = mockwiredata.WireProtocolData(mockwiredata.DATA_FILE_EXT_SINGLE)
-        exthandlers_handler, protocol = self._create_mock(test_data, *args) # pylint: disable=unused-variable,no-value-for-parameter
+        exthandlers_handler, protocol = self._create_mock(test_data, *args)  # pylint: disable=unused-variable,no-value-for-parameter
         expected_seq_no = 0
 
         with patch.object(ExtHandlerInstance, "load_manifest", return_value=manifest):
@@ -2141,7 +2141,7 @@ class TestExtension(ExtensionTestCase):
         error_dir = os.path.join(conf.get_lib_dir(), 'OSTCExtensions.ExampleHandlerLinux-1.0.0', test_error_file_name)
         self.create_script(test_error_file_name, test_error_content, error_dir)
 
-        test_data, exthandlers_handler, protocol = self._set_up_update_test_and_update_gs(Mock(), *args) # pylint: disable=unused-variable
+        test_data, exthandlers_handler, protocol = self._set_up_update_test_and_update_gs(Mock(), *args)  # pylint: disable=unused-variable
 
         base_dir = os.path.join(conf.get_lib_dir(), 'OSTCExtensions.ExampleHandlerLinux-1.0.1', test_file_name)
         self.create_script(test_file_name, test_file, base_dir)
@@ -2150,9 +2150,9 @@ class TestExtension(ExtensionTestCase):
             with patch.object(ExtHandlerInstance, 'report_event') as mock_report_event:
                 exthandlers_handler.run()
 
-                _, disable_kwargs = mock_report_event.call_args_list[1] # pylint: disable=unused-variable
+                _, disable_kwargs = mock_report_event.call_args_list[1]  # pylint: disable=unused-variable
                 _, update_kwargs = mock_report_event.call_args_list[2]
-                _, uninstall_kwargs = mock_report_event.call_args_list[3] # pylint: disable=unused-variable
+                _, uninstall_kwargs = mock_report_event.call_args_list[3]  # pylint: disable=unused-variable
                 _, install_kwargs = mock_report_event.call_args_list[4]
                 _, enable_kwargs = mock_report_event.call_args_list[5]
 
@@ -2165,7 +2165,7 @@ class TestExtension(ExtensionTestCase):
 @patch("azurelinuxagent.common.utils.restutil.http_get")
 class TestExtensionSequencing(AgentTestCase):
 
-    def _create_mock(self, mock_http_get, MockCryptUtil): # pylint: disable=invalid-name
+    def _create_mock(self, mock_http_get, MockCryptUtil):  # pylint: disable=invalid-name
         test_data = mockwiredata.WireProtocolData(mockwiredata.DATA_FILE)
 
         # Mock protocol to return test data
@@ -2182,7 +2182,7 @@ class TestExtensionSequencing(AgentTestCase):
         handler.ext_handlers, handler.last_etag = protocol.get_ext_handlers()
         conf.get_enable_overprovisioning = Mock(return_value=False)
 
-        def wait_for_handler_successful_completion(prev_handler, wait_until): # pylint: disable=unused-argument
+        def wait_for_handler_successful_completion(prev_handler, wait_until):  # pylint: disable=unused-argument
             return orig_wait_for_handler_successful_completion(prev_handler,
                                                                datetime.datetime.utcnow() + datetime.timedelta(
                                                                    seconds=5))
@@ -2197,7 +2197,7 @@ class TestExtensionSequencing(AgentTestCase):
         '''
         handler_map = dict()
         all_handlers = []
-        for h, level in dependency_levels: # pylint: disable=invalid-name
+        for h, level in dependency_levels:  # pylint: disable=invalid-name
             if handler_map.get(h) is None:
                 handler = ExtHandler(name=h)
                 extension = Extension(name=h)
@@ -2215,7 +2215,7 @@ class TestExtensionSequencing(AgentTestCase):
             exthandlers_handler.ext_handlers.extHandlers.append(handler)
 
     def _validate_extension_sequence(self, expected_sequence, exthandlers_handler):
-        installed_extensions = [a[0].name for a, k in exthandlers_handler.handle_ext_handler.call_args_list] # pylint: disable=unused-variable
+        installed_extensions = [a[0].name for a, k in exthandlers_handler.handle_ext_handler.call_args_list]  # pylint: disable=unused-variable
         self.assertListEqual(expected_sequence, installed_extensions,
                              "Expected and actual list of extensions are not equal")
 
@@ -2243,7 +2243,7 @@ class TestExtensionSequencing(AgentTestCase):
         Verifies that the sequencing is in the expected order and a failure in one extension
         skips the rest of the extensions in the sequence.
         '''
-        exthandlers_handler = self._create_mock(*args) # pylint: disable=no-value-for-parameter
+        exthandlers_handler = self._create_mock(*args)  # pylint: disable=no-value-for-parameter
 
         self._set_dependency_levels([("A", 3), ("B", 2), ("C", 2), ("D", 1), ("E", 1), ("F", 1), ("G", 1)],
                                     exthandlers_handler)
@@ -2287,7 +2287,7 @@ class TestExtensionSequencing(AgentTestCase):
         Verifies that the sequencing is in the expected order and the uninstallation takes place
         prior to all the installation/enable.
         '''
-        exthandlers_handler = self._create_mock(*args) # pylint: disable=no-value-for-parameter
+        exthandlers_handler = self._create_mock(*args)  # pylint: disable=no-value-for-parameter
 
         # "A", "D" and "F" are marked as to be uninstalled
         self._set_dependency_levels([("A", 0), ("B", 2), ("C", 2), ("D", 0), ("E", 1), ("F", 0), ("G", 1)],
@@ -2304,7 +2304,7 @@ class TestExtensionSequencing(AgentTestCase):
         When there is no dependency specified, the agent is expected to assign dependencyLevel=0 to all extension.
         Also, it is expected to install all the extension no matter if there is any failure in any of the extensions.
         '''
-        exthandlers_handler = self._create_mock(*args) # pylint: disable=no-value-for-parameter
+        exthandlers_handler = self._create_mock(*args)  # pylint: disable=no-value-for-parameter
 
         self._set_dependency_levels([("A", 1), ("B", 1), ("C", 1), ("D", 1), ("E", 1), ("F", 1), ("G", 1)],
                                     exthandlers_handler)
@@ -2692,7 +2692,7 @@ class TestCollectExtensionStatus(ExtensionTestCase):
         ExtensionTestCase.setUp(self)
         self.lib_dir = tempfile.mkdtemp()
 
-    def _setup_extension_for_validating_collect_ext_status(self, mock_lib_dir, status_file, *args): # pylint: disable=unused-argument
+    def _setup_extension_for_validating_collect_ext_status(self, mock_lib_dir, status_file, *args):  # pylint: disable=unused-argument
         handler_name = "TestHandler"
         handler_version = "1.0.0"
         mock_lib_dir.return_value = self.lib_dir
@@ -2753,7 +2753,7 @@ class TestCollectExtensionStatus(ExtensionTestCase):
         # [TRUNCATED] comes from azurelinuxagent.ga.exthandlers._TRUNCATED_SUFFIX
         self.assertRegex(ext_status.message, r"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum non "
                                              r"lacinia urna, sit .*\[TRUNCATED\]")
-        self.maxDiff = None # pylint: disable=invalid-name
+        self.maxDiff = None  # pylint: disable=invalid-name
         self.assertEqual(ext_status.status, ValidHandlerStatus.success)
         self.assertEqual(len(ext_status.substatusList), 1) # NUM OF SUBSTATUS PARSED
         for sub_status in ext_status.substatusList:
@@ -2800,17 +2800,17 @@ class TestCollectExtensionStatus(ExtensionTestCase):
                                                                                            "sample-status.json", *args)
         original_read_file = read_file
 
-        def mock_read_file(file, *args, **kwargs): # pylint: disable=redefined-builtin
+        def mock_read_file(file, *args, **kwargs):  # pylint: disable=redefined-builtin
             expected_status_file_path = os.path.join(self.lib_dir,
                                                      ext_handler_i.ext_handler.name + "-" +
                                                      ext_handler_i.ext_handler. properties.version,
                                                      "status", "0.status")
-            if file == expected_status_file_path: # pylint: disable=no-else-raise
+            if file == expected_status_file_path:  # pylint: disable=no-else-raise
                 raise IOError("No such file or directory: {0}".format(expected_status_file_path))
             else:
                 original_read_file(file, *args, **kwargs)
 
-        with patch('azurelinuxagent.common.utils.fileutil.read_file', mock_read_file) as patch_read_file: # pylint: disable=unused-variable
+        with patch('azurelinuxagent.common.utils.fileutil.read_file', mock_read_file) as patch_read_file:  # pylint: disable=unused-variable
             ext_status = ext_handler_i.collect_ext_status(extension)
 
             self.assertEqual(ext_status.code, ExtensionErrorCodes.PluginUnknownFailure)

--- a/tests/ga/test_exthandlers.py
+++ b/tests/ga/test_exthandlers.py
@@ -186,7 +186,7 @@ class TestExtHandlers(AgentTestCase):
         """
 
         # Validating empty status case
-        s = '''[]''' # pylint: disable=invalid-name
+        s = '''[]'''  # pylint: disable=invalid-name
         ext_status = ExtensionStatus(seq_no=0)
         parse_ext_status(ext_status, json.loads(s))
 
@@ -212,7 +212,7 @@ class TestExtHandlers(AgentTestCase):
 
     @patch('azurelinuxagent.common.event.EventLogger.add_event')
     @patch('azurelinuxagent.ga.exthandlers.ExtHandlerInstance._get_largest_seq_no')
-    def assert_extension_sequence_number(self, # pylint: disable=too-many-arguments
+    def assert_extension_sequence_number(self,  # pylint: disable=too-many-arguments
                                          patch_get_largest_seq,
                                          patch_add_event,
                                          goal_state_sequence_number,
@@ -238,7 +238,7 @@ class TestExtHandlers(AgentTestCase):
 
         if gs_int and gs_seq_int != disk_sequence_number:
             self.assertEqual(1, patch_add_event.call_count)
-            args, kw_args = patch_add_event.call_args # pylint: disable=unused-variable
+            args, kw_args = patch_add_event.call_args  # pylint: disable=unused-variable
             self.assertEqual('SequenceNumberMismatch', kw_args['op'])
             self.assertEqual(False, kw_args['is_success'])
             self.assertEqual('Goal state: {0}, disk: {1}'
@@ -254,19 +254,19 @@ class TestExtHandlers(AgentTestCase):
             self.assertIsNone(path)
 
     def test_extension_sequence_number(self):
-        self.assert_extension_sequence_number(goal_state_sequence_number="12", # pylint: disable=no-value-for-parameter
+        self.assert_extension_sequence_number(goal_state_sequence_number="12",  # pylint: disable=no-value-for-parameter
                                               disk_sequence_number=366,
                                               expected_sequence_number=12)
 
-        self.assert_extension_sequence_number(goal_state_sequence_number=" 12 ", # pylint: disable=no-value-for-parameter
+        self.assert_extension_sequence_number(goal_state_sequence_number=" 12 ",  # pylint: disable=no-value-for-parameter
                                               disk_sequence_number=366,
                                               expected_sequence_number=12)
 
-        self.assert_extension_sequence_number(goal_state_sequence_number=" foo", # pylint: disable=no-value-for-parameter
+        self.assert_extension_sequence_number(goal_state_sequence_number=" foo",  # pylint: disable=no-value-for-parameter
                                               disk_sequence_number=3,
                                               expected_sequence_number=3)
 
-        self.assert_extension_sequence_number(goal_state_sequence_number="-1", # pylint: disable=no-value-for-parameter
+        self.assert_extension_sequence_number(goal_state_sequence_number="-1",  # pylint: disable=no-value-for-parameter
                                               disk_sequence_number=3,
                                               expected_sequence_number=-1)
 
@@ -404,7 +404,7 @@ with open("{2}", "w") as file:
 
         start_time = time.time()
 
-        with patch("time.sleep", side_effect=sleep, autospec=True) as mock_sleep: # pylint: disable=redefined-outer-name
+        with patch("time.sleep", side_effect=sleep, autospec=True) as mock_sleep:  # pylint: disable=redefined-outer-name
 
             with self.assertRaises(ExtensionError) as context_manager:
                 self.ext_handler_instance.launch_command(command, timeout=timeout, extension_error_code=extension_error_code)
@@ -638,7 +638,7 @@ sys.stderr.write("E" * 5 * 1024 * 1024)
 
         mock_format.assert_called_once()
 
-        args, kwargs = mock_format.call_args # pylint: disable=unused-variable
+        args, kwargs = mock_format.call_args  # pylint: disable=unused-variable
         stdout, stderr = args
 
         self.assertGreaterEqual(len(stdout), 1024)
@@ -659,7 +659,7 @@ sys.stderr.write("STDERR")
         # trying to use these files.
         original_capture_process_output = read_output
 
-        def capture_process_output(stdout_file, stderr_file): # pylint: disable=unused-argument
+        def capture_process_output(stdout_file, stderr_file):  # pylint: disable=unused-argument
             return original_capture_process_output(None, None)
 
         with patch('azurelinuxagent.common.utils.extensionprocessutil.read_output', side_effect=capture_process_output):
@@ -682,7 +682,7 @@ sys.stderr.write("STDERR")
         with patch("subprocess.Popen", wraps=subprocess.Popen) as patch_popen:
             output = self.ext_handler_instance.launch_command(test_file)
 
-            args, kwagrs = patch_popen.call_args # pylint: disable=unused-variable
+            args, kwagrs = patch_popen.call_args  # pylint: disable=unused-variable
             without_os_env = dict((k, v) for (k, v) in kwagrs['env'].items() if k not in os.environ)
 
             # This check will fail if any helper environment variables are added/removed later on

--- a/tests/ga/test_exthandlers_download_extension.py
+++ b/tests/ga/test_exthandlers_download_extension.py
@@ -13,7 +13,7 @@ from azurelinuxagent.ga.exthandlers import ExtHandlerInstance, NUMBER_OF_DOWNLOA
 from tests.tools import AgentTestCase, patch, mock_sleep
 
 
-class DownloadExtensionTestCase(AgentTestCase): # pylint: disable=too-many-instance-attributes
+class DownloadExtensionTestCase(AgentTestCase):  # pylint: disable=too-many-instance-attributes
     """
     Test cases for launch_command
     """
@@ -72,7 +72,7 @@ class DownloadExtensionTestCase(AgentTestCase): # pylint: disable=too-many-insta
 
     @staticmethod
     def _create_zip_file(filename):
-        file = None # pylint: disable=redefined-builtin
+        file = None  # pylint: disable=redefined-builtin
         try:
             file = zipfile.ZipFile(filename, "w")
             info = zipfile.ZipInfo(DownloadExtensionTestCase._extension_command)
@@ -85,7 +85,7 @@ class DownloadExtensionTestCase(AgentTestCase): # pylint: disable=too-many-insta
 
     @staticmethod
     def _create_invalid_zip_file(filename):
-        with open(filename, "w") as file: # pylint: disable=redefined-builtin
+        with open(filename, "w") as file:  # pylint: disable=redefined-builtin
             file.write("An invalid ZIP file\n")
 
     def _get_extension_package_file(self):
@@ -187,7 +187,7 @@ class DownloadExtensionTestCase(AgentTestCase): # pylint: disable=too-many-insta
                          "Ensure that the state is maintained for extension HandlerState")
 
     def test_it_should_use_alternate_uris_when_download_fails(self):
-        self.download_failures = 0 # pylint: disable=attribute-defined-outside-init
+        self.download_failures = 0  # pylint: disable=attribute-defined-outside-init
 
         def download_ext_handler_pkg(_uri, destination):
             # fail a few times, then succeed
@@ -205,7 +205,7 @@ class DownloadExtensionTestCase(AgentTestCase): # pylint: disable=too-many-insta
         self._assert_download_and_expand_succeeded()
 
     def test_it_should_use_alternate_uris_when_download_raises_an_exception(self):
-        self.download_failures = 0 # pylint: disable=attribute-defined-outside-init
+        self.download_failures = 0  # pylint: disable=attribute-defined-outside-init
 
         def download_ext_handler_pkg(_uri, destination):
             # fail a few times, then succeed
@@ -223,7 +223,7 @@ class DownloadExtensionTestCase(AgentTestCase): # pylint: disable=too-many-insta
         self._assert_download_and_expand_succeeded()
 
     def test_it_should_use_alternate_uris_when_it_downloads_an_invalid_package(self):
-        self.download_failures = 0 # pylint: disable=attribute-defined-outside-init
+        self.download_failures = 0  # pylint: disable=attribute-defined-outside-init
 
         def download_ext_handler_pkg(_uri, destination):
             # fail a few times, then succeed

--- a/tests/ga/test_exthandlers_exthandlerinstance.py
+++ b/tests/ga/test_exthandlers_exthandlerinstance.py
@@ -118,7 +118,7 @@ class ExtHandlerInstanceTestCase(AgentTestCase):
 
         original_remove_api = getattr(shutil.os, remove_api_name)
 
-        def mock_remove(path, dir_fd=None): # pylint: disable=unused-argument
+        def mock_remove(path, dir_fd=None):  # pylint: disable=unused-argument
             if path.endswith("extension_file2"):
                 raise IOError("A mocked error")
             original_remove_api(path)
@@ -127,6 +127,6 @@ class ExtHandlerInstanceTestCase(AgentTestCase):
             with patch.object(self.ext_handler_instance, "report_event") as mock_report_event:
                 self.ext_handler_instance.remove_ext_handler()
 
-        args, kwargs = mock_report_event.call_args # pylint: disable=unused-variable
+        args, kwargs = mock_report_event.call_args  # pylint: disable=unused-variable
         self.assertTrue("A mocked error" in kwargs["message"])
 

--- a/tests/ga/test_monitor.py
+++ b/tests/ga/test_monitor.py
@@ -60,7 +60,7 @@ def _create_monitor_handler(enabled_operations=None, iterations=1):
         enabled_operations = []
 
     def run(self):
-        if len(enabled_operations) == 0 or self._name in enabled_operations: # pylint: disable=protected-access,len-as-condition
+        if len(enabled_operations) == 0 or self._name in enabled_operations:  # pylint: disable=protected-access,len-as-condition
             run.original_definition(self)
     run.original_definition = PeriodicOperation.run
 
@@ -182,7 +182,7 @@ class TestExtensionMetricsDataTelemetry(AgentTestCase):
     @patch('azurelinuxagent.common.event.EventLogger.add_metric')
     @patch('azurelinuxagent.common.event.EventLogger.add_event')
     @patch("azurelinuxagent.common.cgroupstelemetry.CGroupsTelemetry.poll_all_tracked")
-    def test_send_extension_metrics_telemetry(self, patch_poll_all_tracked, patch_add_event, # pylint: disable=unused-argument
+    def test_send_extension_metrics_telemetry(self, patch_poll_all_tracked, patch_add_event,  # pylint: disable=unused-argument
                                               patch_add_metric, *args):
         patch_poll_all_tracked.return_value = [MetricValue("Process", "% Processor Time", 1, 1),
                                                MetricValue("Memory", "Total Memory Usage", 1, 1),
@@ -195,7 +195,7 @@ class TestExtensionMetricsDataTelemetry(AgentTestCase):
     @patch('azurelinuxagent.common.event.EventLogger.add_metric')
     @patch('azurelinuxagent.common.event.EventLogger.add_event')
     @patch("azurelinuxagent.common.cgroupstelemetry.CGroupsTelemetry.poll_all_tracked")
-    def test_send_extension_metrics_telemetry_for_empty_cgroup(self, patch_poll_all_tracked, # pylint: disable=unused-argument
+    def test_send_extension_metrics_telemetry_for_empty_cgroup(self, patch_poll_all_tracked,  # pylint: disable=unused-argument
                                                                patch_add_event, patch_add_metric,*args):
         patch_poll_all_tracked.return_value = []
 
@@ -207,14 +207,14 @@ class TestExtensionMetricsDataTelemetry(AgentTestCase):
     @patch('azurelinuxagent.common.event.EventLogger.add_metric')
     @patch("azurelinuxagent.common.cgroup.MemoryCgroup.get_memory_usage")
     @patch('azurelinuxagent.common.logger.Logger.periodic_warn')
-    def test_send_extension_metrics_telemetry_handling_memory_cgroup_exceptions_errno2(self, patch_periodic_warn, # pylint: disable=unused-argument
+    def test_send_extension_metrics_telemetry_handling_memory_cgroup_exceptions_errno2(self, patch_periodic_warn,  # pylint: disable=unused-argument
                                                                                        patch_get_memory_usage,
                                                                                        patch_add_metric, *args):
         ioerror = IOError()
         ioerror.errno = 2
         patch_get_memory_usage.side_effect = ioerror
 
-        CGroupsTelemetry._tracked.append(MemoryCgroup("cgroup_name", "/test/path")) # pylint: disable=protected-access
+        CGroupsTelemetry._tracked.append(MemoryCgroup("cgroup_name", "/test/path"))  # pylint: disable=protected-access
 
         PollResourceUsageOperation().run()
         self.assertEqual(0, patch_periodic_warn.call_count)
@@ -223,14 +223,14 @@ class TestExtensionMetricsDataTelemetry(AgentTestCase):
     @patch('azurelinuxagent.common.event.EventLogger.add_metric')
     @patch("azurelinuxagent.common.cgroup.CpuCgroup.get_cpu_usage")
     @patch('azurelinuxagent.common.logger.Logger.periodic_warn')
-    def test_send_extension_metrics_telemetry_handling_cpu_cgroup_exceptions_errno2(self, patch_periodic_warn, # pylint: disable=unused-argument
+    def test_send_extension_metrics_telemetry_handling_cpu_cgroup_exceptions_errno2(self, patch_periodic_warn,  # pylint: disable=unused-argument
                                                                                     patch_cpu_usage, patch_add_metric,
                                                                                     *args):
         ioerror = IOError()
         ioerror.errno = 2
         patch_cpu_usage.side_effect = ioerror
 
-        CGroupsTelemetry._tracked.append(CpuCgroup("cgroup_name", "/test/path")) # pylint: disable=protected-access
+        CGroupsTelemetry._tracked.append(CpuCgroup("cgroup_name", "/test/path"))  # pylint: disable=protected-access
 
         PollResourceUsageOperation().run()
         self.assertEqual(0, patch_periodic_warn.call_count)
@@ -238,14 +238,14 @@ class TestExtensionMetricsDataTelemetry(AgentTestCase):
 
     @patch('azurelinuxagent.common.event.EventLogger.add_metric')
     @patch('azurelinuxagent.common.logger.Logger.periodic_warn')
-    def test_send_extension_metrics_telemetry_for_unsupported_cgroup(self, patch_periodic_warn, patch_add_metric, *args): # pylint: disable=unused-argument
-        CGroupsTelemetry._tracked.append(CGroup("cgroup_name", "/test/path", "io")) # pylint: disable=protected-access
+    def test_send_extension_metrics_telemetry_for_unsupported_cgroup(self, patch_periodic_warn, patch_add_metric, *args):  # pylint: disable=unused-argument
+        CGroupsTelemetry._tracked.append(CGroup("cgroup_name", "/test/path", "io"))  # pylint: disable=protected-access
 
         PollResourceUsageOperation().run()
         self.assertEqual(1, patch_periodic_warn.call_count)
         self.assertEqual(0, patch_add_metric.call_count)  # No metrics should be sent.
 
-    def test_generate_extension_metrics_telemetry_dictionary(self, *args): # pylint: disable=unused-argument
+    def test_generate_extension_metrics_telemetry_dictionary(self, *args):  # pylint: disable=unused-argument
         num_polls = 10
         num_extensions = 1
 
@@ -265,7 +265,7 @@ class TestExtensionMetricsDataTelemetry(AgentTestCase):
                                                     "dummy_extension_{0}".format(i))
                 CGroupsTelemetry.track_cgroup(dummy_memory_cgroup)
 
-        self.assertEqual(2 * num_extensions, len(CGroupsTelemetry._tracked)) # pylint: disable=protected-access
+        self.assertEqual(2 * num_extensions, len(CGroupsTelemetry._tracked))  # pylint: disable=protected-access
 
         with patch("azurelinuxagent.common.cgroup.MemoryCgroup.get_max_memory_usage") as patch_get_memory_max_usage:
             with patch("azurelinuxagent.common.cgroup.MemoryCgroup.get_memory_usage") as patch_get_memory_usage:
@@ -284,13 +284,13 @@ class PollResourceUsageOperationTestCase(AgentTestCase):
     def setUpClass(cls):
         AgentTestCase.setUpClass()
         # ensure cgroups are enabled by forcing a new instance
-        CGroupConfigurator._instance = None # pylint: disable=protected-access
+        CGroupConfigurator._instance = None  # pylint: disable=protected-access
         with mock_cgroup_commands():
             CGroupConfigurator.get_instance().initialize()
 
     @classmethod
     def tearDownClass(cls):
-        CGroupConfigurator._instance = None # pylint: disable=protected-access
+        CGroupConfigurator._instance = None  # pylint: disable=protected-access
         AgentTestCase.tearDownClass()
 
     def test_it_should_report_processes_that_do_not_belong_to_the_agent_cgroup(self):
@@ -328,7 +328,7 @@ Directory /sys/fs/cgroup/cpu/system.slice/walinuxagent.service:
                     '/bin/sh /var/lib/waagent/run-command/download/1/script.sh',
                 ]
 
-                for fp in unexpected_processes: # pylint: disable=invalid-name
+                for fp in unexpected_processes:  # pylint: disable=invalid-name
                     self.assertIn(fp, messages[0], "[{0}] was not reported as an unexpected process. Events: {1}".format(fp, messages))
 
                 # The list of processes in the message is an array of strings: "['foo', ..., 'bar']"
@@ -345,7 +345,7 @@ Directory /sys/fs/cgroup/cpu/system.slice/walinuxagent.service:
 class TestMonitorFailure(AgentTestCase):
 
     @patch("azurelinuxagent.common.protocol.healthservice.HealthService.report_host_plugin_heartbeat")
-    def test_error_heartbeat_creates_no_signal(self, patch_report_heartbeat, patch_http_get, patch_add_event, *args): # pylint: disable=unused-argument
+    def test_error_heartbeat_creates_no_signal(self, patch_report_heartbeat, patch_http_get, patch_add_event, *args):  # pylint: disable=unused-argument
 
         monitor_handler = get_monitor_handler()
         protocol = WireProtocol('endpoint')

--- a/tests/ga/test_periodic_operation.py
+++ b/tests/ga/test_periodic_operation.py
@@ -26,7 +26,7 @@ class TestPeriodicOperation(AgentTestCase):
             operation.run_time = datetime.datetime.utcnow()
         operation.run_time = None
 
-        op = PeriodicOperation("test_operation", operation, period=datetime.timedelta(hours=1)) # pylint: disable=invalid-name
+        op = PeriodicOperation("test_operation", operation, period=datetime.timedelta(hours=1))  # pylint: disable=invalid-name
         op.run()
 
         expected = operation.run_time + datetime.timedelta(hours=1)
@@ -39,7 +39,7 @@ class TestPeriodicOperation(AgentTestCase):
             operation.run_time = datetime.datetime.utcnow()
         operation.run_time = None
 
-        op = PeriodicOperation("test_operation", operation, period=3600) # pylint: disable=invalid-name
+        op = PeriodicOperation("test_operation", operation, period=3600)  # pylint: disable=invalid-name
         op.run()
 
         expected = operation.run_time + datetime.timedelta(hours=1)
@@ -116,7 +116,7 @@ class TestPeriodicOperation(AgentTestCase):
         with patch("azurelinuxagent.common.logger.warn") as warn_patcher:
             for i in range(2):
                 def operation():
-                    raise Exception("WARNING {0}".format(i)) # pylint: disable=cell-var-from-loop
+                    raise Exception("WARNING {0}".format(i))  # pylint: disable=cell-var-from-loop
 
                 pop = PeriodicOperation("test_operation", operation, period=datetime.timedelta(hours=1))
                 for _ in range(5):
@@ -133,7 +133,7 @@ class TestPeriodicOperation(AgentTestCase):
             PeriodicOperation("one", lambda: None, period=datetime.timedelta(minutes=11)),
             PeriodicOperation("one", lambda: None, period=datetime.timedelta(days=1))
         ]
-        for op in operations: # pylint: disable=invalid-name
+        for op in operations:  # pylint: disable=invalid-name
             op.run()
 
         def mock_sleep(seconds):

--- a/tests/ga/test_remoteaccess.py
+++ b/tests/ga/test_remoteaccess.py
@@ -16,8 +16,8 @@
 #
 import xml
 
-from azurelinuxagent.common.protocol.goal_state import GoalState, RemoteAccess # pylint: disable=unused-import
-from tests.tools import AgentTestCase, load_data, patch, Mock # pylint: disable=unused-import
+from azurelinuxagent.common.protocol.goal_state import GoalState, RemoteAccess  # pylint: disable=unused-import
+from tests.tools import AgentTestCase, load_data, patch, Mock  # pylint: disable=unused-import
 from tests.protocol import mockwiredata
 from tests.protocol.mocks import mock_wire_protocol
 

--- a/tests/ga/test_remoteaccess_handler.py
+++ b/tests/ga/test_remoteaccess_handler.py
@@ -28,7 +28,7 @@ from tests.protocol.mockwiredata import DATA_FILE, DATA_FILE_REMOTE_ACCESS
 
 
 class MockOSUtil(DefaultOSUtil):
-    def __init__(self): # pylint: disable=super-init-not-called
+    def __init__(self):  # pylint: disable=super-init-not-called
         self.all_users = {}
         self.sudo_users = set()
         self.jit_enabled = True
@@ -70,11 +70,11 @@ def get_user_dictionary(users):
     return user_dictionary
 
 
-def mock_add_event(name, op, is_success, version, message): # pylint: disable=invalid-name
+def mock_add_event(name, op, is_success, version, message):  # pylint: disable=invalid-name
     TestRemoteAccessHandler.eventing_data = (name, op, is_success, version, message)
 
 
-class TestRemoteAccessHandler(AgentTestCase): # pylint: disable=too-many-public-methods
+class TestRemoteAccessHandler(AgentTestCase):  # pylint: disable=too-many-public-methods
     eventing_data = [()]
 
     def setUp(self):
@@ -94,8 +94,8 @@ class TestRemoteAccessHandler(AgentTestCase): # pylint: disable=too-many-public-
             tstuser = "foobar"
             expiration_date = datetime.utcnow() + timedelta(days=1)
             pwd = tstpassword
-            rah._add_user(tstuser, pwd, expiration_date) # pylint: disable=protected-access
-            users = get_user_dictionary(rah._os_util.get_users()) # pylint: disable=protected-access
+            rah._add_user(tstuser, pwd, expiration_date)  # pylint: disable=protected-access
+            users = get_user_dictionary(rah._os_util.get_users())  # pylint: disable=protected-access
             self.assertTrue(tstuser in users, "{0} missing from users".format(tstuser))
             actual_user = users[tstuser]
             expected_expiration = (expiration_date + timedelta(days=1)).strftime("%Y-%m-%d")
@@ -111,8 +111,8 @@ class TestRemoteAccessHandler(AgentTestCase): # pylint: disable=too-many-public-
             expiration = datetime.utcnow() + timedelta(days=1)
             pwd = tstpassword
             error = "test exception for bad username"
-            self.assertRaisesRegex(Exception, error, rah._add_user, tstuser, pwd, expiration) # pylint: disable=protected-access
-            self.assertEqual(0, len(rah._os_util.get_users())) # pylint: disable=protected-access
+            self.assertRaisesRegex(Exception, error, rah._add_user, tstuser, pwd, expiration)  # pylint: disable=protected-access
+            self.assertEqual(0, len(rah._os_util.get_users()))  # pylint: disable=protected-access
 
     @patch('azurelinuxagent.common.utils.cryptutil.CryptUtil.decrypt_secret', return_value="")
     def test_add_user_bad_password_data(self, *_):
@@ -123,8 +123,8 @@ class TestRemoteAccessHandler(AgentTestCase): # pylint: disable=too-many-public-
             expiration = datetime.utcnow() + timedelta(days=1)
             pwd = tstpassword
             error = "test exception for bad password"
-            self.assertRaisesRegex(Exception, error, rah._add_user, tstuser, pwd, expiration) # pylint: disable=protected-access
-            self.assertEqual(0, len(rah._os_util.get_users())) # pylint: disable=protected-access
+            self.assertRaisesRegex(Exception, error, rah._add_user, tstuser, pwd, expiration)  # pylint: disable=protected-access
+            self.assertEqual(0, len(rah._os_util.get_users()))  # pylint: disable=protected-access
 
     @patch('azurelinuxagent.common.utils.cryptutil.CryptUtil.decrypt_secret', return_value="]aPPEv}uNg1FPnl?")
     def test_add_user_already_existing(self, _):
@@ -134,8 +134,8 @@ class TestRemoteAccessHandler(AgentTestCase): # pylint: disable=too-many-public-
             tstuser = "foobar"
             expiration_date = datetime.utcnow() + timedelta(days=1)
             pwd = tstpassword
-            rah._add_user(tstuser, pwd, expiration_date) # pylint: disable=protected-access
-            users = get_user_dictionary(rah._os_util.get_users()) # pylint: disable=protected-access
+            rah._add_user(tstuser, pwd, expiration_date)  # pylint: disable=protected-access
+            users = get_user_dictionary(rah._os_util.get_users())  # pylint: disable=protected-access
             self.assertTrue(tstuser in users, "{0} missing from users".format(tstuser))
             self.assertEqual(1, len(users.keys()))
             actual_user = users[tstuser]
@@ -144,9 +144,9 @@ class TestRemoteAccessHandler(AgentTestCase): # pylint: disable=too-many-public-
             # this does not test the user add function as that's mocked, it tests processing skips the remaining
             # calls after the initial failure
             new_user_expiration = datetime.utcnow() + timedelta(days=5)
-            self.assertRaises(Exception, rah._add_user, tstuser, pwd, new_user_expiration) # pylint: disable=protected-access
+            self.assertRaises(Exception, rah._add_user, tstuser, pwd, new_user_expiration)  # pylint: disable=protected-access
             # refresh users
-            users = get_user_dictionary(rah._os_util.get_users()) # pylint: disable=protected-access
+            users = get_user_dictionary(rah._os_util.get_users())  # pylint: disable=protected-access
             self.assertTrue(tstuser in users, "{0} missing from users after dup user attempted".format(tstuser))
             self.assertEqual(1, len(users.keys()))
             actual_user = users[tstuser]
@@ -160,14 +160,14 @@ class TestRemoteAccessHandler(AgentTestCase): # pylint: disable=too-many-public-
             tstpassword = "]aPPEv}uNg1FPnl?"
             tstuser = "foobar"
             expiration_date = datetime.utcnow() + timedelta(days=1)
-            expected_expiration = (expiration_date + timedelta(days=1)).strftime("%Y-%m-%d") # pylint: disable=unused-variable
+            expected_expiration = (expiration_date + timedelta(days=1)).strftime("%Y-%m-%d")  # pylint: disable=unused-variable
             pwd = tstpassword
-            rah._add_user(tstuser, pwd, expiration_date) # pylint: disable=protected-access
-            users = get_user_dictionary(rah._os_util.get_users()) # pylint: disable=protected-access
+            rah._add_user(tstuser, pwd, expiration_date)  # pylint: disable=protected-access
+            users = get_user_dictionary(rah._os_util.get_users())  # pylint: disable=protected-access
             self.assertTrue(tstuser in users, "{0} missing from users".format(tstuser))
-            rah._remove_user(tstuser) # pylint: disable=protected-access
+            rah._remove_user(tstuser)  # pylint: disable=protected-access
             # refresh users
-            users = get_user_dictionary(rah._os_util.get_users()) # pylint: disable=protected-access
+            users = get_user_dictionary(rah._os_util.get_users())  # pylint: disable=protected-access
             self.assertFalse(tstuser in users)
 
     @patch('azurelinuxagent.common.utils.cryptutil.CryptUtil.decrypt_secret', return_value="]aPPEv}uNg1FPnl?")
@@ -180,9 +180,9 @@ class TestRemoteAccessHandler(AgentTestCase): # pylint: disable=too-many-public-
             expiration_date = datetime.utcnow() + timedelta(days=1)
             expiration = expiration_date.strftime("%a, %d %b %Y %H:%M:%S ") + "UTC"
             remote_access.user_list.users[0].expiration = expiration
-            rah._remote_access = remote_access # pylint: disable=protected-access
-            rah._handle_remote_access() # pylint: disable=protected-access
-            users = get_user_dictionary(rah._os_util.get_users()) # pylint: disable=protected-access
+            rah._remote_access = remote_access  # pylint: disable=protected-access
+            rah._handle_remote_access()  # pylint: disable=protected-access
+            users = get_user_dictionary(rah._os_util.get_users())  # pylint: disable=protected-access
             self.assertTrue(tstuser in users, "{0} missing from users".format(tstuser))
             actual_user = users[tstuser]
             expected_expiration = (expiration_date + timedelta(days=1)).strftime("%Y-%m-%d")
@@ -196,9 +196,9 @@ class TestRemoteAccessHandler(AgentTestCase): # pylint: disable=too-many-public-
             remote_access = RemoteAccess(data_str)
             expiration = (datetime.utcnow() - timedelta(days=2)).strftime("%a, %d %b %Y %H:%M:%S ") + "UTC"
             remote_access.user_list.users[0].expiration = expiration
-            rah._remote_access = remote_access # pylint: disable=protected-access
-            rah._handle_remote_access() # pylint: disable=protected-access
-            users = get_user_dictionary(rah._os_util.get_users()) # pylint: disable=protected-access
+            rah._remote_access = remote_access  # pylint: disable=protected-access
+            rah._handle_remote_access()  # pylint: disable=protected-access
+            users = get_user_dictionary(rah._os_util.get_users())  # pylint: disable=protected-access
             self.assertFalse("testAccount" in users)
 
     def test_error_add_user(self):
@@ -208,8 +208,8 @@ class TestRemoteAccessHandler(AgentTestCase): # pylint: disable=too-many-public-
             expiration = datetime.utcnow() + timedelta(days=1)
             pwd = "bad password"
             error = r"\[CryptError\] Error decoding secret\nInner error: Incorrect padding"
-            self.assertRaisesRegex(Exception, error, rah._add_user, tstuser, pwd, expiration) # pylint: disable=protected-access
-            users = get_user_dictionary(rah._os_util.get_users()) # pylint: disable=protected-access
+            self.assertRaisesRegex(Exception, error, rah._add_user, tstuser, pwd, expiration)  # pylint: disable=protected-access
+            users = get_user_dictionary(rah._os_util.get_users())  # pylint: disable=protected-access
             self.assertEqual(0, len(users))
 
     def test_handle_remote_access_no_users(self):
@@ -217,15 +217,15 @@ class TestRemoteAccessHandler(AgentTestCase): # pylint: disable=too-many-public-
             rah = RemoteAccessHandler(Mock())
             data_str = load_data('wire/remote_access_no_accounts.xml')
             remote_access = RemoteAccess(data_str)
-            rah._remote_access = remote_access # pylint: disable=protected-access
-            rah._handle_remote_access() # pylint: disable=protected-access
-            users = get_user_dictionary(rah._os_util.get_users()) # pylint: disable=protected-access
+            rah._remote_access = remote_access  # pylint: disable=protected-access
+            rah._handle_remote_access()  # pylint: disable=protected-access
+            users = get_user_dictionary(rah._os_util.get_users())  # pylint: disable=protected-access
             self.assertEqual(0, len(users.keys()))
 
     def test_handle_remote_access_validate_jit_user_valid(self):
         rah = RemoteAccessHandler(Mock())
         comment = "JIT_Account"
-        result = rah._is_jit_user(comment) # pylint: disable=protected-access
+        result = rah._is_jit_user(comment)  # pylint: disable=protected-access
         self.assertTrue(result, "Did not identify '{0}' as a JIT_Account".format(comment))
 
     def test_handle_remote_access_validate_jit_user_invalid(self):
@@ -233,9 +233,9 @@ class TestRemoteAccessHandler(AgentTestCase): # pylint: disable=too-many-public-
         test_users = ["John Doe", None, "", " "]
         failed_results = ""
         for user in test_users:
-            if rah._is_jit_user(user): # pylint: disable=protected-access
+            if rah._is_jit_user(user):  # pylint: disable=protected-access
                 failed_results += "incorrectly identified '{0} as a JIT_Account'.  ".format(user)
-        if len(failed_results) > 0: # pylint: disable=len-as-condition
+        if len(failed_results) > 0:  # pylint: disable=len-as-condition
             self.fail(failed_results)
 
     @patch('azurelinuxagent.common.utils.cryptutil.CryptUtil.decrypt_secret', return_value="]aPPEv}uNg1FPnl?")
@@ -253,9 +253,9 @@ class TestRemoteAccessHandler(AgentTestCase): # pylint: disable=too-many-public-
                 remote_access.user_list.users[count].expiration = expiration
                 testusers.append(user)
                 count += 1
-            rah._remote_access = remote_access # pylint: disable=protected-access
-            rah._handle_remote_access() # pylint: disable=protected-access
-            users = get_user_dictionary(rah._os_util.get_users()) # pylint: disable=protected-access
+            rah._remote_access = remote_access  # pylint: disable=protected-access
+            rah._handle_remote_access()  # pylint: disable=protected-access
+            users = get_user_dictionary(rah._os_util.get_users())  # pylint: disable=protected-access
             self.assertTrue(testusers[0] in users, "{0} missing from users".format(testusers[0]))
             self.assertTrue(testusers[1] in users, "{0} missing from users".format(testusers[1]))
 
@@ -272,9 +272,9 @@ class TestRemoteAccessHandler(AgentTestCase): # pylint: disable=too-many-public-
                 user.name = "tstuser{0}".format(count)
                 expiration_date = datetime.utcnow() + timedelta(days=count)
                 user.expiration = expiration_date.strftime("%a, %d %b %Y %H:%M:%S ") + "UTC"
-            rah._remote_access = remote_access # pylint: disable=protected-access
-            rah._handle_remote_access() # pylint: disable=protected-access
-            users = get_user_dictionary(rah._os_util.get_users()) # pylint: disable=protected-access
+            rah._remote_access = remote_access  # pylint: disable=protected-access
+            rah._handle_remote_access()  # pylint: disable=protected-access
+            users = get_user_dictionary(rah._os_util.get_users())  # pylint: disable=protected-access
             self.assertEqual(10, len(users.keys()))
 
     @patch('azurelinuxagent.common.utils.cryptutil.CryptUtil.decrypt_secret', return_value="]aPPEv}uNg1FPnl?")
@@ -289,11 +289,11 @@ class TestRemoteAccessHandler(AgentTestCase): # pylint: disable=too-many-public-
                 user.name = "tstuser{0}".format(count)
                 expiration_date = datetime.utcnow() + timedelta(days=count)
                 user.expiration = expiration_date.strftime("%a, %d %b %Y %H:%M:%S ") + "UTC"
-            rah._remote_access = remote_access # pylint: disable=protected-access
-            rah._handle_remote_access() # pylint: disable=protected-access
-            users = get_user_dictionary(rah._os_util.get_users()) # pylint: disable=protected-access
+            rah._remote_access = remote_access  # pylint: disable=protected-access
+            rah._handle_remote_access()  # pylint: disable=protected-access
+            users = get_user_dictionary(rah._os_util.get_users())  # pylint: disable=protected-access
             self.assertEqual(10, len(users.keys()))
-            del rah._remote_access.user_list.users[:] # pylint: disable=protected-access
+            del rah._remote_access.user_list.users[:]  # pylint: disable=protected-access
             self.assertEqual(10, len(users.keys()))
 
     @patch('azurelinuxagent.common.utils.cryptutil.CryptUtil.decrypt_secret', return_value="]aPPEv}uNg1FPnl?")
@@ -310,9 +310,9 @@ class TestRemoteAccessHandler(AgentTestCase): # pylint: disable=too-many-public-
                     user.name = ""
                 expiration_date = datetime.utcnow() + timedelta(days=count)
                 user.expiration = expiration_date.strftime("%a, %d %b %Y %H:%M:%S ") + "UTC"
-            rah._remote_access = remote_access # pylint: disable=protected-access
-            rah._handle_remote_access() # pylint: disable=protected-access
-            users = get_user_dictionary(rah._os_util.get_users()) # pylint: disable=protected-access
+            rah._remote_access = remote_access  # pylint: disable=protected-access
+            rah._handle_remote_access()  # pylint: disable=protected-access
+            users = get_user_dictionary(rah._os_util.get_users())  # pylint: disable=protected-access
             self.assertEqual(9, len(users.keys()))
 
     @patch('azurelinuxagent.common.utils.cryptutil.CryptUtil.decrypt_secret', return_value="]aPPEv}uNg1FPnl?")
@@ -325,19 +325,19 @@ class TestRemoteAccessHandler(AgentTestCase): # pylint: disable=too-many-public-
             expiration_date = datetime.utcnow() + timedelta(days=1)
             expiration = expiration_date.strftime("%a, %d %b %Y %H:%M:%S ") + "UTC"
             remote_access.user_list.users[0].expiration = expiration
-            rah._remote_access = remote_access # pylint: disable=protected-access
-            rah._handle_remote_access() # pylint: disable=protected-access
-            users = get_user_dictionary(rah._os_util.get_users()) # pylint: disable=protected-access
+            rah._remote_access = remote_access  # pylint: disable=protected-access
+            rah._handle_remote_access()  # pylint: disable=protected-access
+            users = get_user_dictionary(rah._os_util.get_users())  # pylint: disable=protected-access
             self.assertTrue(tstuser in users, "{0} missing from users".format(tstuser))
-            os_util = rah._os_util # pylint: disable=protected-access
+            os_util = rah._os_util  # pylint: disable=protected-access
             os_util.__class__ = MockOSUtil
-            os_util.all_users.clear() # pylint: disable=no-member
+            os_util.all_users.clear()  # pylint: disable=no-member
             # refresh users
-            users = get_user_dictionary(rah._os_util.get_users()) # pylint: disable=protected-access
+            users = get_user_dictionary(rah._os_util.get_users())  # pylint: disable=protected-access
             self.assertTrue(tstuser not in users)
-            rah._handle_remote_access() # pylint: disable=protected-access
+            rah._handle_remote_access()  # pylint: disable=protected-access
             # refresh users
-            users = get_user_dictionary(rah._os_util.get_users()) # pylint: disable=protected-access
+            users = get_user_dictionary(rah._os_util.get_users())  # pylint: disable=protected-access
             self.assertTrue(tstuser in users, "{0} missing from users".format(tstuser))
 
     @patch('azurelinuxagent.common.utils.cryptutil.CryptUtil.decrypt_secret', return_value="]aPPEv}uNg1FPnl?")
@@ -352,8 +352,8 @@ class TestRemoteAccessHandler(AgentTestCase): # pylint: disable=too-many-public-
             tstuser = "foobar"
             expiration_date = datetime.utcnow() + timedelta(days=1)
             pwd = tstpassword
-            rah._add_user(tstuser, pwd, expiration_date) # pylint: disable=protected-access
-            users = get_user_dictionary(rah._os_util.get_users()) # pylint: disable=protected-access
+            rah._add_user(tstuser, pwd, expiration_date)  # pylint: disable=protected-access
+            users = get_user_dictionary(rah._os_util.get_users())  # pylint: disable=protected-access
             self.assertTrue(tstuser in users, "{0} missing from users".format(tstuser))
             rah.run()
             self.assertTrue(tstuser in users, "{0} missing from users".format(tstuser))
@@ -370,15 +370,15 @@ class TestRemoteAccessHandler(AgentTestCase): # pylint: disable=too-many-public-
                 user.name = "tstuser{0}".format(count)
                 expiration_date = datetime.utcnow() + timedelta(days=count)
                 user.expiration = expiration_date.strftime("%a, %d %b %Y %H:%M:%S ") + "UTC"
-            rah._remote_access = remote_access # pylint: disable=protected-access
-            rah._handle_remote_access() # pylint: disable=protected-access
-            users = rah._os_util.get_users() # pylint: disable=protected-access
+            rah._remote_access = remote_access  # pylint: disable=protected-access
+            rah._handle_remote_access()  # pylint: disable=protected-access
+            users = rah._os_util.get_users()  # pylint: disable=protected-access
             self.assertEqual(10, len(users))
             # now remove the user from RemoteAccess
-            deleted_user = rah._remote_access.user_list.users[3] # pylint: disable=protected-access
-            del rah._remote_access.user_list.users[3] # pylint: disable=protected-access
-            rah._handle_remote_access() # pylint: disable=protected-access
-            users = rah._os_util.get_users() # pylint: disable=protected-access
+            deleted_user = rah._remote_access.user_list.users[3]  # pylint: disable=protected-access
+            del rah._remote_access.user_list.users[3]  # pylint: disable=protected-access
+            rah._handle_remote_access()  # pylint: disable=protected-access
+            users = rah._os_util.get_users()  # pylint: disable=protected-access
             self.assertTrue(deleted_user not in users, "{0} still in users".format(deleted_user))
             self.assertEqual(9, len(users))
 
@@ -394,14 +394,14 @@ class TestRemoteAccessHandler(AgentTestCase): # pylint: disable=too-many-public-
                 user.name = "tstuser{0}".format(count)
                 expiration_date = datetime.utcnow() + timedelta(days=count)
                 user.expiration = expiration_date.strftime("%a, %d %b %Y %H:%M:%S ") + "UTC"
-            rah._remote_access = remote_access # pylint: disable=protected-access
-            rah._handle_remote_access() # pylint: disable=protected-access
-            users = rah._os_util.get_users() # pylint: disable=protected-access
+            rah._remote_access = remote_access  # pylint: disable=protected-access
+            rah._handle_remote_access()  # pylint: disable=protected-access
+            users = rah._os_util.get_users()  # pylint: disable=protected-access
             self.assertEqual(10, len(users))
             # now remove the user from RemoteAccess
-            rah._remote_access = None # pylint: disable=protected-access
-            rah._handle_remote_access() # pylint: disable=protected-access
-            users = rah._os_util.get_users() # pylint: disable=protected-access
+            rah._remote_access = None  # pylint: disable=protected-access
+            rah._handle_remote_access()  # pylint: disable=protected-access
+            users = rah._os_util.get_users()  # pylint: disable=protected-access
             self.assertEqual(0, len(users))
 
     @patch('azurelinuxagent.common.utils.cryptutil.CryptUtil.decrypt_secret', return_value="]aPPEv}uNg1FPnl?")
@@ -416,28 +416,28 @@ class TestRemoteAccessHandler(AgentTestCase): # pylint: disable=too-many-public-
                 user.name = "tstuser{0}".format(count)
                 expiration_date = datetime.utcnow() + timedelta(days=count)
                 user.expiration = expiration_date.strftime("%a, %d %b %Y %H:%M:%S ") + "UTC"
-            rah._remote_access = remote_access # pylint: disable=protected-access
-            rah._handle_remote_access() # pylint: disable=protected-access
-            users = rah._os_util.get_users() # pylint: disable=protected-access
+            rah._remote_access = remote_access  # pylint: disable=protected-access
+            rah._handle_remote_access()  # pylint: disable=protected-access
+            users = rah._os_util.get_users()  # pylint: disable=protected-access
             self.assertEqual(10, len(users))
             # now remove the user from RemoteAccess
-            rah._remote_access = None # pylint: disable=protected-access
-            rah._handle_remote_access() # pylint: disable=protected-access
-            users = rah._os_util.get_users() # pylint: disable=protected-access
+            rah._remote_access = None  # pylint: disable=protected-access
+            rah._handle_remote_access()  # pylint: disable=protected-access
+            users = rah._os_util.get_users()  # pylint: disable=protected-access
             self.assertEqual(0, len(users))
 
     def test_remove_user_error(self):
         with patch("azurelinuxagent.ga.remoteaccess.get_osutil", return_value=MockOSUtil()):
             rah = RemoteAccessHandler(Mock())
             error = "test exception, bad data"
-            self.assertRaisesRegex(Exception, error, rah._remove_user, "") # pylint: disable=protected-access
+            self.assertRaisesRegex(Exception, error, rah._remove_user, "")  # pylint: disable=protected-access
 
     def test_remove_user_not_exists(self):
         with patch("azurelinuxagent.ga.remoteaccess.get_osutil", return_value=MockOSUtil()):
             rah = RemoteAccessHandler(Mock())
             user = "bob"
             error = "test exception, user does not exist to delete"
-            self.assertRaisesRegex(Exception, error, rah._remove_user, user) # pylint: disable=protected-access
+            self.assertRaisesRegex(Exception, error, rah._remove_user, user)  # pylint: disable=protected-access
 
     @patch('azurelinuxagent.common.utils.cryptutil.CryptUtil.decrypt_secret', return_value="]aPPEv}uNg1FPnl?")
     def test_handle_remote_access_remove_and_add(self, _):
@@ -451,16 +451,16 @@ class TestRemoteAccessHandler(AgentTestCase): # pylint: disable=too-many-public-
                 user.name = "tstuser{0}".format(count)
                 expiration_date = datetime.utcnow() + timedelta(days=count)
                 user.expiration = expiration_date.strftime("%a, %d %b %Y %H:%M:%S ") + "UTC"
-            rah._remote_access = remote_access # pylint: disable=protected-access
-            rah._handle_remote_access() # pylint: disable=protected-access
-            users = rah._os_util.get_users() # pylint: disable=protected-access
+            rah._remote_access = remote_access  # pylint: disable=protected-access
+            rah._handle_remote_access()  # pylint: disable=protected-access
+            users = rah._os_util.get_users()  # pylint: disable=protected-access
             self.assertEqual(10, len(users))
             # now remove the user from RemoteAccess
             new_user = "tstuser11"
-            deleted_user = rah._remote_access.user_list.users[3] # pylint: disable=protected-access
-            rah._remote_access.user_list.users[3].name = new_user # pylint: disable=protected-access
-            rah._handle_remote_access() # pylint: disable=protected-access
-            users = rah._os_util.get_users() # pylint: disable=protected-access
+            deleted_user = rah._remote_access.user_list.users[3]  # pylint: disable=protected-access
+            rah._remote_access.user_list.users[3].name = new_user  # pylint: disable=protected-access
+            rah._handle_remote_access()  # pylint: disable=protected-access
+            users = rah._os_util.get_users()  # pylint: disable=protected-access
             self.assertTrue(deleted_user not in users, "{0} still in users".format(deleted_user))
             self.assertTrue(new_user in [u[0] for u in users], "user {0} not in users".format(new_user))
             self.assertEqual(10, len(users))

--- a/tests/ga/test_update.py
+++ b/tests/ga/test_update.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation. All rights reserved. # pylint: disable=too-many-lines
+# Copyright (c) Microsoft Corporation. All rights reserved.  # pylint: disable=too-many-lines
 # Licensed under the Apache License.
 
 from __future__ import print_function
@@ -143,14 +143,14 @@ class UpdateTestCase(AgentTestCase):
         return get_agent_pkgs(in_dir=self.tmp_dir)
 
     def agent_versions(self):
-        v = [FlexibleVersion(AGENT_DIR_PATTERN.match(a).group(1)) for a in self.agent_dirs()] # pylint: disable=invalid-name
+        v = [FlexibleVersion(AGENT_DIR_PATTERN.match(a).group(1)) for a in self.agent_dirs()]  # pylint: disable=invalid-name
         v.sort(reverse=True)
         return v
 
     def get_error_file(self, error_data=None):
         if error_data is None:
             error_data = NO_ERROR
-        fp = tempfile.NamedTemporaryFile(mode="w") # pylint: disable=invalid-name
+        fp = tempfile.NamedTemporaryFile(mode="w")  # pylint: disable=invalid-name
         json.dump(error_data if error_data is not None else NO_ERROR, fp)
         fp.seek(0)
         return fp
@@ -163,8 +163,8 @@ class UpdateTestCase(AgentTestCase):
             err.load()
             return err
 
-    def copy_agents(self, *agents): # pylint: disable=useless-return
-        if len(agents) <= 0: # pylint: disable=len-as-condition
+    def copy_agents(self, *agents):  # pylint: disable=useless-return
+        if len(agents) <= 0:  # pylint: disable=len-as-condition
             agents = get_agent_pkgs()
         for agent in agents:
             shutil.copy(agent, self.tmp_dir)
@@ -175,7 +175,7 @@ class UpdateTestCase(AgentTestCase):
             path = os.path.join(self.tmp_dir, fileutil.trim_ext(agent, "zip"))
             zipfile.ZipFile(agent).extractall(path)
 
-    def prepare_agent(self, version): # pylint: disable=useless-return
+    def prepare_agent(self, version):  # pylint: disable=useless-return
         """
         Create a download for the current agent version, copied from test data
         """
@@ -216,14 +216,14 @@ class UpdateTestCase(AgentTestCase):
             count=count - agent_count,
             is_available=is_available)
 
-    def remove_agents(self): # pylint: disable=useless-return
+    def remove_agents(self):  # pylint: disable=useless-return
         for agent in self.agent_paths():
             try:
                 if os.path.isfile(agent):
                     os.remove(agent)
                 else:
                     shutil.rmtree(agent)
-            except: # pylint: disable=bare-except
+            except:  # pylint: disable=bare-except
                 pass
         return
 
@@ -234,7 +234,7 @@ class UpdateTestCase(AgentTestCase):
                          increment=1):
         from_path = self.agent_dir(src_v)
         dst_v = FlexibleVersion(str(src_v))
-        for i in range(0, count): # pylint: disable=unused-variable
+        for i in range(0, count):  # pylint: disable=unused-variable
             dst_v += increment
             to_path = self.agent_dir(dst_v)
             shutil.copyfile(from_path + ".zip", to_path + ".zip")
@@ -246,7 +246,7 @@ class UpdateTestCase(AgentTestCase):
 
 
 class TestGuestAgentError(UpdateTestCase):
-    def test_creation(self): # pylint: disable=useless-return
+    def test_creation(self):  # pylint: disable=useless-return
         self.assertRaises(TypeError, GuestAgentError)
         self.assertRaises(UpdateError, GuestAgentError, None)
 
@@ -261,7 +261,7 @@ class TestGuestAgentError(UpdateTestCase):
         self.assertEqual(WITH_ERROR["was_fatal"], err.was_fatal)
         return
 
-    def test_clear(self): # pylint: disable=useless-return
+    def test_clear(self):  # pylint: disable=useless-return
         with self.get_error_file(error_data=WITH_ERROR) as path:
             err = GuestAgentError(path.name)
             err.load()
@@ -284,11 +284,11 @@ class TestGuestAgentError(UpdateTestCase):
         self.assertEqual(err1.failure_count, err2.failure_count)
         self.assertEqual(err1.was_fatal, err2.was_fatal)
 
-    def test_mark_failure(self): # pylint: disable=useless-return
+    def test_mark_failure(self):  # pylint: disable=useless-return
         err = self.create_error()
         self.assertFalse(err.is_blacklisted)
 
-        for i in range(0, MAX_FAILURE): # pylint: disable=unused-variable
+        for i in range(0, MAX_FAILURE):  # pylint: disable=unused-variable
             err.mark_failure()
 
         # Agent failed >= MAX_FAILURE, it should be blacklisted
@@ -296,7 +296,7 @@ class TestGuestAgentError(UpdateTestCase):
         self.assertEqual(MAX_FAILURE, err.failure_count)
         return
 
-    def test_mark_failure_permanent(self): # pylint: disable=useless-return
+    def test_mark_failure_permanent(self):  # pylint: disable=useless-return
         err = self.create_error()
 
         self.assertFalse(err.is_blacklisted)
@@ -307,16 +307,16 @@ class TestGuestAgentError(UpdateTestCase):
         self.assertTrue(err.failure_count < MAX_FAILURE)
         return
 
-    def test_str(self): # pylint: disable=useless-return
+    def test_str(self):  # pylint: disable=useless-return
         err = self.create_error(error_data=NO_ERROR)
-        s = "Last Failure: {0}, Total Failures: {1}, Fatal: {2}".format( # pylint: disable=invalid-name
+        s = "Last Failure: {0}, Total Failures: {1}, Fatal: {2}".format(  # pylint: disable=invalid-name
             NO_ERROR["last_failure"],
             NO_ERROR["failure_count"],
             NO_ERROR["was_fatal"])
         self.assertEqual(s, str(err))
 
         err = self.create_error(error_data=WITH_ERROR)
-        s = "Last Failure: {0}, Total Failures: {1}, Fatal: {2}".format( # pylint: disable=invalid-name
+        s = "Last Failure: {0}, Total Failures: {1}, Fatal: {2}".format(  # pylint: disable=invalid-name
             WITH_ERROR["last_failure"],
             WITH_ERROR["failure_count"],
             WITH_ERROR["was_fatal"])
@@ -324,7 +324,7 @@ class TestGuestAgentError(UpdateTestCase):
         return
 
 
-class TestGuestAgent(UpdateTestCase): # pylint: disable=too-many-public-methods
+class TestGuestAgent(UpdateTestCase):  # pylint: disable=too-many-public-methods
     def setUp(self):
         UpdateTestCase.setUp(self)
         self.copy_agents(get_agent_file_path())
@@ -332,7 +332,7 @@ class TestGuestAgent(UpdateTestCase): # pylint: disable=too-many-public-methods
 
     def test_creation(self):
         self.assertRaises(UpdateError, GuestAgent, "A very bad file name")
-        n = "{0}-a.bad.version".format(AGENT_NAME) # pylint: disable=invalid-name
+        n = "{0}-a.bad.version".format(AGENT_NAME)  # pylint: disable=invalid-name
         self.assertRaises(UpdateError, GuestAgent, n)
 
         self.expand_agents()
@@ -359,7 +359,7 @@ class TestGuestAgent(UpdateTestCase): # pylint: disable=too-many-public-methods
         self.assertTrue(agent.is_available)
 
     @patch("azurelinuxagent.ga.update.GuestAgent._ensure_downloaded")
-    def test_clear_error(self, mock_downloaded): # pylint: disable=unused-argument
+    def test_clear_error(self, mock_downloaded):  # pylint: disable=unused-argument
         self.expand_agents()
 
         agent = GuestAgent(path=self.agent_path)
@@ -378,11 +378,11 @@ class TestGuestAgent(UpdateTestCase): # pylint: disable=too-many-public-methods
 
     @patch("azurelinuxagent.ga.update.GuestAgent._ensure_downloaded")
     @patch("azurelinuxagent.ga.update.GuestAgent._ensure_loaded")
-    def test_is_available(self, mock_loaded, mock_downloaded): # pylint: disable=unused-argument
+    def test_is_available(self, mock_loaded, mock_downloaded):  # pylint: disable=unused-argument
         agent = GuestAgent(path=self.agent_path)
 
         self.assertFalse(agent.is_available)
-        agent._unpack() # pylint: disable=protected-access
+        agent._unpack()  # pylint: disable=protected-access
         self.assertTrue(agent.is_available)
 
         agent.mark_failure(is_fatal=True)
@@ -390,11 +390,11 @@ class TestGuestAgent(UpdateTestCase): # pylint: disable=too-many-public-methods
 
     @patch("azurelinuxagent.ga.update.GuestAgent._ensure_downloaded")
     @patch("azurelinuxagent.ga.update.GuestAgent._ensure_loaded")
-    def test_is_blacklisted(self, mock_loaded, mock_downloaded): # pylint: disable=unused-argument
+    def test_is_blacklisted(self, mock_loaded, mock_downloaded):  # pylint: disable=unused-argument
         agent = GuestAgent(path=self.agent_path)
         self.assertFalse(agent.is_blacklisted)
 
-        agent._unpack() # pylint: disable=protected-access
+        agent._unpack()  # pylint: disable=protected-access
         self.assertFalse(agent.is_blacklisted)
         self.assertEqual(agent.is_blacklisted, agent.error.is_blacklisted)
 
@@ -404,39 +404,39 @@ class TestGuestAgent(UpdateTestCase): # pylint: disable=too-many-public-methods
 
     @patch("azurelinuxagent.ga.update.GuestAgent._ensure_downloaded")
     @patch("azurelinuxagent.ga.update.GuestAgent._ensure_loaded")
-    def test_resource_gone_error_not_blacklisted(self, mock_loaded, mock_downloaded): # pylint: disable=unused-argument
+    def test_resource_gone_error_not_blacklisted(self, mock_loaded, mock_downloaded):  # pylint: disable=unused-argument
         try:
             mock_downloaded.side_effect = ResourceGoneError()
             agent = GuestAgent(path=self.agent_path)
             self.assertFalse(agent.is_blacklisted)
         except ResourceGoneError:
             pass
-        except: # pylint: disable=bare-except
+        except:  # pylint: disable=bare-except
             self.fail("Exception was not expected!")
 
     @patch("azurelinuxagent.ga.update.GuestAgent._ensure_downloaded")
     @patch("azurelinuxagent.ga.update.GuestAgent._ensure_loaded")
-    def test_ioerror_not_blacklisted(self, mock_loaded, mock_downloaded): # pylint: disable=unused-argument
+    def test_ioerror_not_blacklisted(self, mock_loaded, mock_downloaded):  # pylint: disable=unused-argument
         try:
             mock_downloaded.side_effect = IOError()
             agent = GuestAgent(path=self.agent_path)
             self.assertFalse(agent.is_blacklisted)
         except IOError:
             pass
-        except: # pylint: disable=bare-except
+        except:  # pylint: disable=bare-except
             self.fail("Exception was not expected!")
 
     @patch("azurelinuxagent.ga.update.GuestAgent._ensure_downloaded")
     @patch("azurelinuxagent.ga.update.GuestAgent._ensure_loaded")
-    def test_is_downloaded(self, mock_loaded, mock_downloaded): # pylint: disable=unused-argument
+    def test_is_downloaded(self, mock_loaded, mock_downloaded):  # pylint: disable=unused-argument
         agent = GuestAgent(path=self.agent_path)
         self.assertFalse(agent.is_downloaded)
-        agent._unpack() # pylint: disable=protected-access
+        agent._unpack()  # pylint: disable=protected-access
         self.assertTrue(agent.is_downloaded)
 
     @patch("azurelinuxagent.ga.update.GuestAgent._ensure_downloaded")
     @patch("azurelinuxagent.ga.update.GuestAgent._ensure_loaded")
-    def test_mark_failure(self, mock_loaded, mock_downloaded): # pylint: disable=unused-argument
+    def test_mark_failure(self, mock_loaded, mock_downloaded):  # pylint: disable=unused-argument
         agent = GuestAgent(path=self.agent_path)
 
         agent.mark_failure()
@@ -448,74 +448,74 @@ class TestGuestAgent(UpdateTestCase): # pylint: disable=too-many-public-methods
 
     @patch("azurelinuxagent.ga.update.GuestAgent._ensure_downloaded")
     @patch("azurelinuxagent.ga.update.GuestAgent._ensure_loaded")
-    def test_unpack(self, mock_loaded, mock_downloaded): # pylint: disable=unused-argument
+    def test_unpack(self, mock_loaded, mock_downloaded):  # pylint: disable=unused-argument
         agent = GuestAgent(path=self.agent_path)
         self.assertFalse(os.path.isdir(agent.get_agent_dir()))
-        agent._unpack() # pylint: disable=protected-access
+        agent._unpack()  # pylint: disable=protected-access
         self.assertTrue(os.path.isdir(agent.get_agent_dir()))
         self.assertTrue(os.path.isfile(agent.get_agent_manifest_path()))
 
     @patch("azurelinuxagent.ga.update.GuestAgent._ensure_downloaded")
     @patch("azurelinuxagent.ga.update.GuestAgent._ensure_loaded")
-    def test_unpack_fail(self, mock_loaded, mock_downloaded): # pylint: disable=unused-argument
+    def test_unpack_fail(self, mock_loaded, mock_downloaded):  # pylint: disable=unused-argument
         agent = GuestAgent(path=self.agent_path)
         self.assertFalse(os.path.isdir(agent.get_agent_dir()))
         os.remove(agent.get_agent_pkg_path())
-        self.assertRaises(UpdateError, agent._unpack) # pylint: disable=protected-access
+        self.assertRaises(UpdateError, agent._unpack)  # pylint: disable=protected-access
 
     @patch("azurelinuxagent.ga.update.GuestAgent._ensure_downloaded")
     @patch("azurelinuxagent.ga.update.GuestAgent._ensure_loaded")
-    def test_load_manifest(self, mock_loaded, mock_downloaded): # pylint: disable=unused-argument
+    def test_load_manifest(self, mock_loaded, mock_downloaded):  # pylint: disable=unused-argument
         agent = GuestAgent(path=self.agent_path)
-        agent._unpack() # pylint: disable=protected-access
-        agent._load_manifest() # pylint: disable=protected-access
+        agent._unpack()  # pylint: disable=protected-access
+        agent._load_manifest()  # pylint: disable=protected-access
         self.assertEqual(agent.manifest.get_enable_command(),
                          agent.get_agent_cmd())
 
     @patch("azurelinuxagent.ga.update.GuestAgent._ensure_downloaded")
     @patch("azurelinuxagent.ga.update.GuestAgent._ensure_loaded")
-    def test_load_manifest_missing(self, mock_loaded, mock_downloaded): # pylint: disable=unused-argument
+    def test_load_manifest_missing(self, mock_loaded, mock_downloaded):  # pylint: disable=unused-argument
         agent = GuestAgent(path=self.agent_path)
         self.assertFalse(os.path.isdir(agent.get_agent_dir()))
-        agent._unpack() # pylint: disable=protected-access
+        agent._unpack()  # pylint: disable=protected-access
         os.remove(agent.get_agent_manifest_path())
-        self.assertRaises(UpdateError, agent._load_manifest) # pylint: disable=protected-access
+        self.assertRaises(UpdateError, agent._load_manifest)  # pylint: disable=protected-access
 
     @patch("azurelinuxagent.ga.update.GuestAgent._ensure_downloaded")
     @patch("azurelinuxagent.ga.update.GuestAgent._ensure_loaded")
-    def test_load_manifest_is_empty(self, mock_loaded, mock_downloaded): # pylint: disable=unused-argument
+    def test_load_manifest_is_empty(self, mock_loaded, mock_downloaded):  # pylint: disable=unused-argument
         agent = GuestAgent(path=self.agent_path)
         self.assertFalse(os.path.isdir(agent.get_agent_dir()))
-        agent._unpack() # pylint: disable=protected-access
+        agent._unpack()  # pylint: disable=protected-access
         self.assertTrue(os.path.isfile(agent.get_agent_manifest_path()))
 
-        with open(agent.get_agent_manifest_path(), "w") as file: # pylint: disable=redefined-builtin
+        with open(agent.get_agent_manifest_path(), "w") as file:  # pylint: disable=redefined-builtin
             json.dump(EMPTY_MANIFEST, file)
-        self.assertRaises(UpdateError, agent._load_manifest) # pylint: disable=protected-access
+        self.assertRaises(UpdateError, agent._load_manifest)  # pylint: disable=protected-access
 
     @patch("azurelinuxagent.ga.update.GuestAgent._ensure_downloaded")
     @patch("azurelinuxagent.ga.update.GuestAgent._ensure_loaded")
-    def test_load_manifest_is_malformed(self, mock_loaded, mock_downloaded): # pylint: disable=unused-argument
+    def test_load_manifest_is_malformed(self, mock_loaded, mock_downloaded):  # pylint: disable=unused-argument
         agent = GuestAgent(path=self.agent_path)
         self.assertFalse(os.path.isdir(agent.get_agent_dir()))
-        agent._unpack() # pylint: disable=protected-access
+        agent._unpack()  # pylint: disable=protected-access
         self.assertTrue(os.path.isfile(agent.get_agent_manifest_path()))
 
-        with open(agent.get_agent_manifest_path(), "w") as file: # pylint: disable=redefined-builtin
+        with open(agent.get_agent_manifest_path(), "w") as file:  # pylint: disable=redefined-builtin
             file.write("This is not JSON data")
-        self.assertRaises(UpdateError, agent._load_manifest) # pylint: disable=protected-access
+        self.assertRaises(UpdateError, agent._load_manifest)  # pylint: disable=protected-access
 
     def test_load_error(self):
         agent = GuestAgent(path=self.agent_path)
         agent.error = None
 
-        agent._load_error() # pylint: disable=protected-access
+        agent._load_error()  # pylint: disable=protected-access
         self.assertTrue(agent.error is not None)
 
     @patch("azurelinuxagent.ga.update.GuestAgent._ensure_downloaded")
     @patch("azurelinuxagent.ga.update.GuestAgent._ensure_loaded")
     @patch("azurelinuxagent.ga.update.restutil.http_get")
-    def test_download(self, mock_http_get, mock_loaded, mock_downloaded): # pylint: disable=unused-argument
+    def test_download(self, mock_http_get, mock_loaded, mock_downloaded):  # pylint: disable=unused-argument
         self.remove_agents()
         self.assertFalse(os.path.isdir(self.agent_path))
 
@@ -525,14 +525,14 @@ class TestGuestAgent(UpdateTestCase): # pylint: disable=too-many-public-methods
         pkg = ExtHandlerPackage(version=str(get_agent_version()))
         pkg.uris.append(ExtHandlerPackageUri())
         agent = GuestAgent(pkg=pkg)
-        agent._download() # pylint: disable=protected-access
+        agent._download()  # pylint: disable=protected-access
 
         self.assertTrue(os.path.isfile(agent.get_agent_pkg_path()))
 
     @patch("azurelinuxagent.ga.update.GuestAgent._ensure_downloaded")
     @patch("azurelinuxagent.ga.update.GuestAgent._ensure_loaded")
     @patch("azurelinuxagent.ga.update.restutil.http_get")
-    def test_download_fail(self, mock_http_get, mock_loaded, mock_downloaded): # pylint: disable=unused-argument
+    def test_download_fail(self, mock_http_get, mock_loaded, mock_downloaded):  # pylint: disable=unused-argument
         self.remove_agents()
         self.assertFalse(os.path.isdir(self.agent_path))
 
@@ -542,7 +542,7 @@ class TestGuestAgent(UpdateTestCase): # pylint: disable=too-many-public-methods
         pkg.uris.append(ExtHandlerPackageUri())
         agent = GuestAgent(pkg=pkg)
 
-        self.assertRaises(UpdateError, agent._download) # pylint: disable=protected-access
+        self.assertRaises(UpdateError, agent._download)  # pylint: disable=protected-access
         self.assertFalse(os.path.isfile(agent.get_agent_pkg_path()))
         self.assertFalse(agent.is_downloaded)
 
@@ -550,7 +550,7 @@ class TestGuestAgent(UpdateTestCase): # pylint: disable=too-many-public-methods
     @patch("azurelinuxagent.ga.update.GuestAgent._ensure_loaded")
     @patch("azurelinuxagent.ga.update.restutil.http_get")
     @patch("azurelinuxagent.ga.update.restutil.http_post")
-    def test_download_fallback(self, mock_http_post, mock_http_get, mock_loaded, mock_downloaded): # pylint: disable=unused-argument
+    def test_download_fallback(self, mock_http_post, mock_http_get, mock_loaded, mock_downloaded):  # pylint: disable=unused-argument
         self.remove_agents()
         self.assertFalse(os.path.isdir(self.agent_path))
 
@@ -572,7 +572,7 @@ class TestGuestAgent(UpdateTestCase): # pylint: disable=too-many-public-methods
         agent.host = mock_host
 
         # ensure fallback fails gracefully, no http
-        self.assertRaises(UpdateError, agent._download) # pylint: disable=protected-access
+        self.assertRaises(UpdateError, agent._download)  # pylint: disable=protected-access
         self.assertEqual(mock_http_get.call_count, 2)
         self.assertEqual(mock_http_get.call_args_list[0][0][0], ext_uri)
         self.assertEqual(mock_http_get.call_args_list[1][0][0], api_uri)
@@ -581,30 +581,30 @@ class TestGuestAgent(UpdateTestCase): # pylint: disable=too-many-public-methods
         with patch.object(HostPluginProtocol,
                           "ensure_initialized",
                           return_value=True):
-            self.assertRaises(UpdateError, agent._download) # pylint: disable=protected-access
+            self.assertRaises(UpdateError, agent._download)  # pylint: disable=protected-access
             self.assertEqual(mock_http_get.call_count, 4)
 
             self.assertEqual(mock_http_get.call_args_list[2][0][0], ext_uri)
 
             self.assertEqual(mock_http_get.call_args_list[3][0][0], art_uri)
-            a, k = mock_http_get.call_args_list[3] # pylint: disable=unused-variable,invalid-name
+            a, k = mock_http_get.call_args_list[3]  # pylint: disable=unused-variable,invalid-name
             self.assertEqual(False, k['use_proxy'])
 
             # ensure fallback works as expected
             with patch.object(HostPluginProtocol,
                               "get_artifact_request",
                               return_value=[art_uri, {}]):
-                self.assertRaises(UpdateError, agent._download) # pylint: disable=protected-access
+                self.assertRaises(UpdateError, agent._download)  # pylint: disable=protected-access
                 self.assertEqual(mock_http_get.call_count, 6)
 
-                a, k = mock_http_get.call_args_list[3] # pylint: disable=invalid-name
+                a, k = mock_http_get.call_args_list[3]  # pylint: disable=invalid-name
                 self.assertEqual(False, k['use_proxy'])
 
                 self.assertEqual(mock_http_get.call_args_list[4][0][0], ext_uri)
-                a, k = mock_http_get.call_args_list[4] # pylint: disable=invalid-name
+                a, k = mock_http_get.call_args_list[4]  # pylint: disable=invalid-name
 
                 self.assertEqual(mock_http_get.call_args_list[5][0][0], art_uri)
-                a, k = mock_http_get.call_args_list[5] # pylint: disable=invalid-name
+                a, k = mock_http_get.call_args_list[5]  # pylint: disable=invalid-name
                 self.assertEqual(False, k['use_proxy'])
 
     @patch("azurelinuxagent.ga.update.restutil.http_get")
@@ -623,7 +623,7 @@ class TestGuestAgent(UpdateTestCase): # pylint: disable=too-many-public-methods
         self.assertTrue(agent.is_downloaded)
 
     @patch("azurelinuxagent.ga.update.GuestAgent._download", side_effect=UpdateError)
-    def test_ensure_downloaded_download_fails(self, mock_download): # pylint: disable=unused-argument
+    def test_ensure_downloaded_download_fails(self, mock_download):  # pylint: disable=unused-argument
         self.remove_agents()
         self.assertFalse(os.path.isdir(self.agent_path))
 
@@ -637,7 +637,7 @@ class TestGuestAgent(UpdateTestCase): # pylint: disable=too-many-public-methods
 
     @patch("azurelinuxagent.ga.update.GuestAgent._download")
     @patch("azurelinuxagent.ga.update.GuestAgent._unpack", side_effect=UpdateError)
-    def test_ensure_downloaded_unpack_fails(self, mock_unpack, mock_download): # pylint: disable=unused-argument
+    def test_ensure_downloaded_unpack_fails(self, mock_unpack, mock_download):  # pylint: disable=unused-argument
         self.assertFalse(os.path.isdir(self.agent_path))
 
         pkg = ExtHandlerPackage(version=str(get_agent_version()))
@@ -651,7 +651,7 @@ class TestGuestAgent(UpdateTestCase): # pylint: disable=too-many-public-methods
     @patch("azurelinuxagent.ga.update.GuestAgent._download")
     @patch("azurelinuxagent.ga.update.GuestAgent._unpack")
     @patch("azurelinuxagent.ga.update.GuestAgent._load_manifest", side_effect=UpdateError)
-    def test_ensure_downloaded_load_manifest_fails(self, mock_manifest, mock_unpack, mock_download): # pylint: disable=unused-argument
+    def test_ensure_downloaded_load_manifest_fails(self, mock_manifest, mock_unpack, mock_download):  # pylint: disable=unused-argument
         self.assertFalse(os.path.isdir(self.agent_path))
 
         pkg = ExtHandlerPackage(version=str(get_agent_version()))
@@ -665,7 +665,7 @@ class TestGuestAgent(UpdateTestCase): # pylint: disable=too-many-public-methods
     @patch("azurelinuxagent.ga.update.GuestAgent._download")
     @patch("azurelinuxagent.ga.update.GuestAgent._unpack")
     @patch("azurelinuxagent.ga.update.GuestAgent._load_manifest")
-    def test_ensure_download_skips_blacklisted(self, mock_manifest, mock_unpack, mock_download): # pylint: disable=unused-argument
+    def test_ensure_download_skips_blacklisted(self, mock_manifest, mock_unpack, mock_download):  # pylint: disable=unused-argument
         agent = GuestAgent(path=self.agent_path)
         self.assertEqual(0, mock_download.call_count)
 
@@ -684,7 +684,7 @@ class TestGuestAgent(UpdateTestCase): # pylint: disable=too-many-public-methods
         self.assertEqual(0, mock_unpack.call_count)
 
 
-class TestUpdate(UpdateTestCase): # pylint: disable=too-many-public-methods
+class TestUpdate(UpdateTestCase):  # pylint: disable=too-many-public-methods
     def setUp(self):
         UpdateTestCase.setUp(self)
         self.event_patch = patch('azurelinuxagent.common.event.add_event')
@@ -712,16 +712,16 @@ class TestUpdate(UpdateTestCase): # pylint: disable=too-many-public-methods
     def test_emit_restart_event_emits_event_if_not_clean_start(self):
         try:
             mock_event = self.event_patch.start()
-            self.update_handler._set_sentinel() # pylint: disable=protected-access
-            self.update_handler._emit_restart_event() # pylint: disable=protected-access
+            self.update_handler._set_sentinel()  # pylint: disable=protected-access
+            self.update_handler._emit_restart_event()  # pylint: disable=protected-access
             self.assertEqual(1, mock_event.call_count)
-        except Exception as e: # pylint: disable=unused-variable,invalid-name
+        except Exception as e:  # pylint: disable=unused-variable,invalid-name
             pass
         self.event_patch.stop()
 
     def _create_protocol(self, count=20, versions=None):
         latest_version = self.prepare_agents(count=count)
-        if versions is None or len(versions) <= 0: # pylint: disable=len-as-condition
+        if versions is None or len(versions) <= 0:  # pylint: disable=len-as-condition
             versions = [latest_version]
         return ProtocolMock(versions=versions)
 
@@ -735,18 +735,18 @@ class TestUpdate(UpdateTestCase): # pylint: disable=too-many-public-methods
             #   See http://stackoverflow.com/questions/26408941/python-nested-functions-and-variable-scope
             iterations = [0]
 
-            def iterator(*args, **kwargs): # pylint: disable=unused-argument
+            def iterator(*args, **kwargs):  # pylint: disable=unused-argument
                 iterations[0] += 1
                 return iterations[0] < invocations
 
             mock_util.check_pid_alive = Mock(side_effect=iterator)
 
-            pid_files = self.update_handler._get_pid_files() # pylint: disable=protected-access
+            pid_files = self.update_handler._get_pid_files()  # pylint: disable=protected-access
             self.assertEqual(pid_count, len(pid_files))
 
             with patch('os.getpid', return_value=42):
-                with patch('time.sleep', return_value=None) as mock_sleep: # pylint: disable=redefined-outer-name
-                    self.update_handler._ensure_no_orphans(orphan_wait_interval=interval) # pylint: disable=protected-access
+                with patch('time.sleep', return_value=None) as mock_sleep:  # pylint: disable=redefined-outer-name
+                    self.update_handler._ensure_no_orphans(orphan_wait_interval=interval)  # pylint: disable=protected-access
                     for pid_file in pid_files:
                         self.assertFalse(os.path.exists(pid_file))
                     return mock_util.check_pid_alive.call_count, mock_sleep.call_count
@@ -786,13 +786,13 @@ class TestUpdate(UpdateTestCase): # pylint: disable=too-many-public-methods
 
         self.assertFalse(os.path.exists(path))
 
-        for n in range(0, 99): # pylint: disable=invalid-name
+        for n in range(0, 99):  # pylint: disable=invalid-name
             mock_time.utcnow.return_value = Mock(microsecond=n * 10000)
 
-            self.update_handler._ensure_partition_assigned() # pylint: disable=protected-access
+            self.update_handler._ensure_partition_assigned()  # pylint: disable=protected-access
 
             self.assertTrue(os.path.exists(path))
-            s = fileutil.read_file(path) # pylint: disable=invalid-name
+            s = fileutil.read_file(path)  # pylint: disable=invalid-name
             self.assertEqual(n, int(s))
             os.remove(path)
 
@@ -809,7 +809,7 @@ class TestUpdate(UpdateTestCase): # pylint: disable=too-many-public-methods
             os.chmod(path,
                      stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH)
 
-        self.update_handler._ensure_readonly_files() # pylint: disable=protected-access
+        self.update_handler._ensure_readonly_files()  # pylint: disable=protected-access
 
         for path in test_files:
             mode = os.stat(path).st_mode
@@ -828,7 +828,7 @@ class TestUpdate(UpdateTestCase): # pylint: disable=too-many-public-methods
             os.chmod(path,
                      stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH)
 
-        self.update_handler._ensure_readonly_files() # pylint: disable=protected-access
+        self.update_handler._ensure_readonly_files()  # pylint: disable=protected-access
 
         for path in test_files:
             mode = os.stat(path).st_mode
@@ -850,10 +850,10 @@ class TestUpdate(UpdateTestCase): # pylint: disable=too-many-public-methods
         self.assertFalse(child_agent.is_blacklisted)
         self.update_handler.child_agent = child_agent
 
-        self.update_handler._evaluate_agent_health(latest_agent) # pylint: disable=protected-access
+        self.update_handler._evaluate_agent_health(latest_agent)  # pylint: disable=protected-access
 
     def test_evaluate_agent_health_ignores_installed_agent(self):
-        self.update_handler._evaluate_agent_health(None) # pylint: disable=protected-access
+        self.update_handler._evaluate_agent_health(None)  # pylint: disable=protected-access
 
     def test_evaluate_agent_health_raises_exception_for_restarting_agent(self):
         self.update_handler.child_launch_time = time.time() - (4 * 60)
@@ -879,46 +879,46 @@ class TestUpdate(UpdateTestCase): # pylint: disable=too-many-public-methods
     def test_filter_blacklisted_agents(self):
         self.prepare_agents()
 
-        self.update_handler._set_agents([GuestAgent(path=path) for path in self.agent_dirs()]) # pylint: disable=protected-access
+        self.update_handler._set_agents([GuestAgent(path=path) for path in self.agent_dirs()])  # pylint: disable=protected-access
         self.assertEqual(len(self.agent_dirs()), len(self.update_handler.agents))
 
         kept_agents = self.update_handler.agents[::2]
         blacklisted_agents = self.update_handler.agents[1::2]
         for agent in blacklisted_agents:
             agent.mark_failure(is_fatal=True)
-        self.update_handler._filter_blacklisted_agents() # pylint: disable=protected-access
+        self.update_handler._filter_blacklisted_agents()  # pylint: disable=protected-access
         self.assertEqual(kept_agents, self.update_handler.agents)
 
     def test_find_agents(self):
         self.prepare_agents()
 
         self.assertTrue(0 <= len(self.update_handler.agents))
-        self.update_handler._find_agents() # pylint: disable=protected-access
+        self.update_handler._find_agents()  # pylint: disable=protected-access
         self.assertEqual(len(get_agents(self.tmp_dir)), len(self.update_handler.agents))
 
     def test_find_agents_does_reload(self):
         self.prepare_agents()
 
-        self.update_handler._find_agents() # pylint: disable=protected-access
+        self.update_handler._find_agents()  # pylint: disable=protected-access
         agents = self.update_handler.agents
 
-        self.update_handler._find_agents() # pylint: disable=protected-access
+        self.update_handler._find_agents()  # pylint: disable=protected-access
         self.assertNotEqual(agents, self.update_handler.agents)
 
     def test_find_agents_sorts(self):
         self.prepare_agents()
-        self.update_handler._find_agents() # pylint: disable=protected-access
+        self.update_handler._find_agents()  # pylint: disable=protected-access
 
-        v = FlexibleVersion("100000") # pylint: disable=invalid-name
-        for a in self.update_handler.agents: # pylint: disable=invalid-name
+        v = FlexibleVersion("100000")  # pylint: disable=invalid-name
+        for a in self.update_handler.agents:  # pylint: disable=invalid-name
             self.assertTrue(v > a.version)
-            v = a.version # pylint: disable=invalid-name
+            v = a.version  # pylint: disable=invalid-name
 
     @patch('azurelinuxagent.common.protocol.wire.WireClient.get_host_plugin')
     def test_get_host_plugin_returns_host_for_wireserver(self, mock_get_host):
         protocol = WireProtocol('12.34.56.78')
         mock_get_host.return_value = "faux host"
-        host = self.update_handler._get_host_plugin(protocol=protocol) # pylint: disable=protected-access
+        host = self.update_handler._get_host_plugin(protocol=protocol)  # pylint: disable=protected-access
         print("mock_get_host call cound={0}".format(mock_get_host.call_count))
         self.assertEqual(1, mock_get_host.call_count)
         self.assertEqual("faux host", host)
@@ -957,77 +957,77 @@ class TestUpdate(UpdateTestCase): # pylint: disable=too-many-public-methods
         self.assertEqual(latest_agent.version, prior_agent.version)
 
     def test_get_pid_files(self):
-        pid_files = self.update_handler._get_pid_files() # pylint: disable=protected-access
+        pid_files = self.update_handler._get_pid_files()  # pylint: disable=protected-access
         self.assertEqual(0, len(pid_files))
 
     def test_get_pid_files_returns_previous(self):
-        for n in range(1250): # pylint: disable=invalid-name
+        for n in range(1250):  # pylint: disable=invalid-name
             fileutil.write_file(os.path.join(self.tmp_dir, str(n) + "_waagent.pid"), ustr(n + 1))
-        pid_files = self.update_handler._get_pid_files() # pylint: disable=protected-access
+        pid_files = self.update_handler._get_pid_files()  # pylint: disable=protected-access
         self.assertEqual(1250, len(pid_files))
 
-        pid_dir, pid_name, pid_re = self.update_handler._get_pid_parts() # pylint: disable=unused-variable,protected-access
-        for p in pid_files: # pylint: disable=invalid-name
+        pid_dir, pid_name, pid_re = self.update_handler._get_pid_parts()  # pylint: disable=unused-variable,protected-access
+        for p in pid_files:  # pylint: disable=invalid-name
             self.assertTrue(pid_re.match(os.path.basename(p)))
 
     def test_is_clean_start_returns_true_when_no_sentinel(self):
-        self.assertFalse(os.path.isfile(self.update_handler._sentinel_file_path())) # pylint: disable=protected-access
-        self.assertTrue(self.update_handler._is_clean_start) # pylint: disable=protected-access
+        self.assertFalse(os.path.isfile(self.update_handler._sentinel_file_path()))  # pylint: disable=protected-access
+        self.assertTrue(self.update_handler._is_clean_start)  # pylint: disable=protected-access
 
     def test_is_clean_start_returns_false_when_sentinel_exists(self):
-        self.update_handler._set_sentinel(agent=CURRENT_AGENT) # pylint: disable=protected-access
-        self.assertFalse(self.update_handler._is_clean_start) # pylint: disable=protected-access
+        self.update_handler._set_sentinel(agent=CURRENT_AGENT)  # pylint: disable=protected-access
+        self.assertFalse(self.update_handler._is_clean_start)  # pylint: disable=protected-access
 
     def test_is_clean_start_returns_false_for_exceptions(self):
-        self.update_handler._set_sentinel() # pylint: disable=protected-access
+        self.update_handler._set_sentinel()  # pylint: disable=protected-access
         with patch("azurelinuxagent.common.utils.fileutil.read_file", side_effect=Exception):
-            self.assertFalse(self.update_handler._is_clean_start) # pylint: disable=protected-access
+            self.assertFalse(self.update_handler._is_clean_start)  # pylint: disable=protected-access
 
     def test_is_orphaned_returns_false_if_parent_exists(self):
         fileutil.write_file(conf.get_agent_pid_file_path(), ustr(42))
         with patch('os.getppid', return_value=42):
-            self.assertFalse(self.update_handler._is_orphaned) # pylint: disable=protected-access
+            self.assertFalse(self.update_handler._is_orphaned)  # pylint: disable=protected-access
 
     def test_is_orphaned_returns_true_if_parent_is_init(self):
         with patch('os.getppid', return_value=1):
-            self.assertTrue(self.update_handler._is_orphaned) # pylint: disable=protected-access
+            self.assertTrue(self.update_handler._is_orphaned)  # pylint: disable=protected-access
 
     def test_is_orphaned_returns_true_if_parent_does_not_exist(self):
         fileutil.write_file(conf.get_agent_pid_file_path(), ustr(24))
         with patch('os.getppid', return_value=42):
-            self.assertTrue(self.update_handler._is_orphaned) # pylint: disable=protected-access
+            self.assertTrue(self.update_handler._is_orphaned)  # pylint: disable=protected-access
 
     def test_is_version_available(self):
         self.prepare_agents(is_available=True)
         self.update_handler.agents = self.agents()
 
         for agent in self.agents():
-            self.assertTrue(self.update_handler._is_version_eligible(agent.version)) # pylint: disable=protected-access
+            self.assertTrue(self.update_handler._is_version_eligible(agent.version))  # pylint: disable=protected-access
 
     @patch("azurelinuxagent.ga.update.is_current_agent_installed", return_value=False)
-    def test_is_version_available_rejects(self, mock_current): # pylint: disable=unused-argument
+    def test_is_version_available_rejects(self, mock_current):  # pylint: disable=unused-argument
         self.prepare_agents(is_available=True)
         self.update_handler.agents = self.agents()
 
         self.update_handler.agents[0].mark_failure(is_fatal=True)
-        self.assertFalse(self.update_handler._is_version_eligible(self.agents()[0].version)) # pylint: disable=protected-access
+        self.assertFalse(self.update_handler._is_version_eligible(self.agents()[0].version))  # pylint: disable=protected-access
 
     @patch("azurelinuxagent.ga.update.is_current_agent_installed", return_value=True)
-    def test_is_version_available_accepts_current(self, mock_current): # pylint: disable=unused-argument
+    def test_is_version_available_accepts_current(self, mock_current):  # pylint: disable=unused-argument
         self.update_handler.agents = []
-        self.assertTrue(self.update_handler._is_version_eligible(CURRENT_VERSION)) # pylint: disable=protected-access
+        self.assertTrue(self.update_handler._is_version_eligible(CURRENT_VERSION))  # pylint: disable=protected-access
 
     @patch("azurelinuxagent.ga.update.is_current_agent_installed", return_value=False)
-    def test_is_version_available_rejects_by_default(self, mock_current): # pylint: disable=unused-argument
+    def test_is_version_available_rejects_by_default(self, mock_current):  # pylint: disable=unused-argument
         self.prepare_agents()
         self.update_handler.agents = []
 
-        v = self.agents()[0].version # pylint: disable=invalid-name
-        self.assertFalse(self.update_handler._is_version_eligible(v)) # pylint: disable=protected-access
+        v = self.agents()[0].version  # pylint: disable=invalid-name
+        self.assertFalse(self.update_handler._is_version_eligible(v))  # pylint: disable=protected-access
 
     def test_purge_agents(self):
         self.prepare_agents()
-        self.update_handler._find_agents() # pylint: disable=protected-access
+        self.update_handler._find_agents()  # pylint: disable=protected-access
 
         # Ensure at least three agents initially exist
         self.assertTrue(2 < len(self.update_handler.agents))
@@ -1049,8 +1049,8 @@ class TestUpdate(UpdateTestCase): # pylint: disable=too-many-public-methods
 
         # Reload and assert only the kept agents remain on disk
         self.update_handler.agents = agents_to_keep
-        self.update_handler._purge_agents() # pylint: disable=protected-access
-        self.update_handler._find_agents() # pylint: disable=protected-access
+        self.update_handler._purge_agents()  # pylint: disable=protected-access
+        self.update_handler._find_agents()  # pylint: disable=protected-access
         self.assertEqual(
             [agent.version for agent in kept_agents],
             [agent.version for agent in self.update_handler.agents])
@@ -1102,8 +1102,8 @@ class TestUpdate(UpdateTestCase): # pylint: disable=too-many-public-methods
     def test_run_latest_passes_child_args(self):
         self.prepare_agents()
 
-        agent = self.update_handler.get_latest_agent() # pylint: disable=unused-variable
-        args, kwargs = self._test_run_latest(child_args="AnArgument") # pylint: disable=unused-variable
+        agent = self.update_handler.get_latest_agent()  # pylint: disable=unused-variable
+        args, kwargs = self._test_run_latest(child_args="AnArgument")  # pylint: disable=unused-variable
         args = args[0]
 
         self.assertTrue(len(args) > 1)
@@ -1132,7 +1132,7 @@ class TestUpdate(UpdateTestCase): # pylint: disable=too-many-public-methods
         self.assertEqual(0, mock_child.wait.call_count)
 
     def test_run_latest_polls_frequently_if_installed_is_latest(self):
-        mock_child = ChildMock(return_value=0) # pylint: disable=unused-variable
+        mock_child = ChildMock(return_value=0)  # pylint: disable=unused-variable
         mock_time = TimeMock(time_increment=CHILD_HEALTH_INTERVAL / 2)
         self._test_run_latest(mock_time=mock_time)
         self.assertEqual(1, mock_time.sleep_interval)
@@ -1250,7 +1250,7 @@ class TestUpdate(UpdateTestCase): # pylint: disable=too-many-public-methods
         #   See http://stackoverflow.com/questions/26408941/python-nested-functions-and-variable-scope
         iterations = [0]
 
-        def iterator(*args, **kwargs): # pylint: disable=useless-return,unused-argument
+        def iterator(*args, **kwargs):  # pylint: disable=useless-return,unused-argument
             iterations[0] += 1
             if iterations[0] >= invocations:
                 self.update_handler.running = False
@@ -1296,7 +1296,7 @@ class TestUpdate(UpdateTestCase): # pylint: disable=too-many-public-methods
         self._test_run(invocations=15, calls=[call.run()] * 15)
 
     def test_run_stops_if_update_available(self):
-        self.update_handler._upgrade_available = Mock(return_value=True) # pylint: disable=protected-access
+        self.update_handler._upgrade_available = Mock(return_value=True)  # pylint: disable=protected-access
         self._test_run(invocations=0, calls=[], enable_updates=True)
 
     def test_run_stops_if_orphaned(self):
@@ -1305,66 +1305,66 @@ class TestUpdate(UpdateTestCase): # pylint: disable=too-many-public-methods
 
     def test_run_clears_sentinel_on_successful_exit(self):
         self._test_run()
-        self.assertFalse(os.path.isfile(self.update_handler._sentinel_file_path())) # pylint: disable=protected-access
+        self.assertFalse(os.path.isfile(self.update_handler._sentinel_file_path()))  # pylint: disable=protected-access
 
     def test_run_leaves_sentinel_on_unsuccessful_exit(self):
-        self.update_handler._upgrade_available = Mock(side_effect=Exception) # pylint: disable=protected-access
+        self.update_handler._upgrade_available = Mock(side_effect=Exception)  # pylint: disable=protected-access
         self._test_run(invocations=0, calls=[], enable_updates=True)
-        self.assertTrue(os.path.isfile(self.update_handler._sentinel_file_path())) # pylint: disable=protected-access
+        self.assertTrue(os.path.isfile(self.update_handler._sentinel_file_path()))  # pylint: disable=protected-access
 
     def test_run_emits_restart_event(self):
-        self.update_handler._emit_restart_event = Mock() # pylint: disable=protected-access
+        self.update_handler._emit_restart_event = Mock()  # pylint: disable=protected-access
         self._test_run()
-        self.assertEqual(1, self.update_handler._emit_restart_event.call_count) # pylint: disable=protected-access
+        self.assertEqual(1, self.update_handler._emit_restart_event.call_count)  # pylint: disable=protected-access
 
     def test_set_agents_sets_agents(self):
         self.prepare_agents()
 
-        self.update_handler._set_agents([GuestAgent(path=path) for path in self.agent_dirs()]) # pylint: disable=protected-access
+        self.update_handler._set_agents([GuestAgent(path=path) for path in self.agent_dirs()])  # pylint: disable=protected-access
         self.assertTrue(len(self.update_handler.agents) > 0)
         self.assertEqual(len(self.agent_dirs()), len(self.update_handler.agents))
 
     def test_set_agents_sorts_agents(self):
         self.prepare_agents()
 
-        self.update_handler._set_agents([GuestAgent(path=path) for path in self.agent_dirs()]) # pylint: disable=protected-access
+        self.update_handler._set_agents([GuestAgent(path=path) for path in self.agent_dirs()])  # pylint: disable=protected-access
 
-        v = FlexibleVersion("100000") # pylint: disable=invalid-name
-        for a in self.update_handler.agents: # pylint: disable=invalid-name
+        v = FlexibleVersion("100000")  # pylint: disable=invalid-name
+        for a in self.update_handler.agents:  # pylint: disable=invalid-name
             self.assertTrue(v > a.version)
-            v = a.version # pylint: disable=invalid-name
+            v = a.version  # pylint: disable=invalid-name
 
     def test_set_sentinel(self):
-        self.assertFalse(os.path.isfile(self.update_handler._sentinel_file_path())) # pylint: disable=protected-access
-        self.update_handler._set_sentinel() # pylint: disable=protected-access
-        self.assertTrue(os.path.isfile(self.update_handler._sentinel_file_path())) # pylint: disable=protected-access
+        self.assertFalse(os.path.isfile(self.update_handler._sentinel_file_path()))  # pylint: disable=protected-access
+        self.update_handler._set_sentinel()  # pylint: disable=protected-access
+        self.assertTrue(os.path.isfile(self.update_handler._sentinel_file_path()))  # pylint: disable=protected-access
 
     def test_set_sentinel_writes_current_agent(self):
-        self.update_handler._set_sentinel() # pylint: disable=protected-access
+        self.update_handler._set_sentinel()  # pylint: disable=protected-access
         self.assertTrue(
-            fileutil.read_file(self.update_handler._sentinel_file_path()), # pylint: disable=protected-access
+            fileutil.read_file(self.update_handler._sentinel_file_path()),  # pylint: disable=protected-access
             CURRENT_AGENT)
 
     def test_shutdown(self):
-        self.update_handler._set_sentinel() # pylint: disable=protected-access
-        self.update_handler._shutdown() # pylint: disable=protected-access
+        self.update_handler._set_sentinel()  # pylint: disable=protected-access
+        self.update_handler._shutdown()  # pylint: disable=protected-access
         self.assertFalse(self.update_handler.running)
-        self.assertFalse(os.path.isfile(self.update_handler._sentinel_file_path())) # pylint: disable=protected-access
+        self.assertFalse(os.path.isfile(self.update_handler._sentinel_file_path()))  # pylint: disable=protected-access
 
     def test_shutdown_ignores_missing_sentinel_file(self):
-        self.assertFalse(os.path.isfile(self.update_handler._sentinel_file_path())) # pylint: disable=protected-access
-        self.update_handler._shutdown() # pylint: disable=protected-access
+        self.assertFalse(os.path.isfile(self.update_handler._sentinel_file_path()))  # pylint: disable=protected-access
+        self.update_handler._shutdown()  # pylint: disable=protected-access
         self.assertFalse(self.update_handler.running)
-        self.assertFalse(os.path.isfile(self.update_handler._sentinel_file_path())) # pylint: disable=protected-access
+        self.assertFalse(os.path.isfile(self.update_handler._sentinel_file_path()))  # pylint: disable=protected-access
 
     def test_shutdown_ignores_exceptions(self):
-        self.update_handler._set_sentinel() # pylint: disable=protected-access
+        self.update_handler._set_sentinel()  # pylint: disable=protected-access
 
         try:
             with patch("os.remove", side_effect=Exception):
-                self.update_handler._shutdown() # pylint: disable=protected-access
-        except Exception as e: # pylint: disable=unused-variable,invalid-name
-            self.assertTrue(False, "Unexpected exception") # pylint: disable=redundant-unittest-assert
+                self.update_handler._shutdown()  # pylint: disable=protected-access
+        except Exception as e:  # pylint: disable=unused-variable,invalid-name
+            self.assertTrue(False, "Unexpected exception")  # pylint: disable=redundant-unittest-assert
 
     def _test_upgrade_available(
             self,
@@ -1379,7 +1379,7 @@ class TestUpdate(UpdateTestCase): # pylint: disable=too-many-public-methods
         self.update_handler.protocol_util = protocol
         conf.get_autoupdate_gafamily = Mock(return_value=protocol.family)
 
-        return self.update_handler._upgrade_available(protocol, base_version=base_version) # pylint: disable=protected-access
+        return self.update_handler._upgrade_available(protocol, base_version=base_version)  # pylint: disable=protected-access
 
     def test_upgrade_available_returns_true_on_first_use(self):
         self.assertTrue(self._test_upgrade_available())
@@ -1388,11 +1388,11 @@ class TestUpdate(UpdateTestCase): # pylint: disable=too-many-public-methods
         extensions_config = ExtensionsConfig(load_data("wire/ext_conf_missing_family.xml"))
         protocol = ProtocolMock()
         protocol.family = "Prod"
-        protocol.agent_manifests = extensions_config.vmagent_manifests # pylint: disable=attribute-defined-outside-init
+        protocol.agent_manifests = extensions_config.vmagent_manifests  # pylint: disable=attribute-defined-outside-init
         self.update_handler.protocol_util = protocol
         with patch('azurelinuxagent.common.logger.warn') as mock_logger:
             with patch('tests.ga.test_update.ProtocolMock.get_vmagent_pkgs', side_effect=ProtocolError):
-                self.assertFalse(self.update_handler._upgrade_available(protocol, base_version=CURRENT_VERSION)) # pylint: disable=protected-access
+                self.assertFalse(self.update_handler._upgrade_available(protocol, base_version=CURRENT_VERSION))  # pylint: disable=protected-access
                 self.assertEqual(0, mock_logger.call_count)
 
     def test_upgrade_available_includes_old_agents(self):
@@ -1422,7 +1422,7 @@ class TestUpdate(UpdateTestCase): # pylint: disable=too-many-public-methods
         self.assertEqual(agent_versions, self.agent_versions())
 
     def test_update_available_returns_true_if_current_gets_blacklisted(self):
-        self.update_handler._is_version_eligible = Mock(return_value=False) # pylint: disable=protected-access
+        self.update_handler._is_version_eligible = Mock(return_value=False)  # pylint: disable=protected-access
         self.assertTrue(self._test_upgrade_available())
 
     def test_upgrade_available_skips_if_too_frequent(self):
@@ -1433,7 +1433,7 @@ class TestUpdate(UpdateTestCase): # pylint: disable=too-many-public-methods
     def test_upgrade_available_skips_if_when_no_new_versions(self):
         self.prepare_agents()
         base_version = self.agent_versions()[0] + 1
-        self.update_handler._is_version_eligible = lambda x: x == base_version # pylint: disable=protected-access
+        self.update_handler._is_version_eligible = lambda x: x == base_version  # pylint: disable=protected-access
         self.assertFalse(self._test_upgrade_available(base_version=base_version))
 
     def test_upgrade_available_skips_when_no_versions(self):
@@ -1447,16 +1447,16 @@ class TestUpdate(UpdateTestCase): # pylint: disable=too-many-public-methods
         self.prepare_agents()
         self._test_upgrade_available()
 
-        v = FlexibleVersion("100000") # pylint: disable=invalid-name
-        for a in self.update_handler.agents: # pylint: disable=invalid-name
+        v = FlexibleVersion("100000")  # pylint: disable=invalid-name
+        for a in self.update_handler.agents:  # pylint: disable=invalid-name
             self.assertTrue(v > a.version)
-            v = a.version # pylint: disable=invalid-name
+            v = a.version  # pylint: disable=invalid-name
 
     def test_write_pid_file(self):
-        for n in range(1112): # pylint: disable=invalid-name
+        for n in range(1112):  # pylint: disable=invalid-name
             fileutil.write_file(os.path.join(self.tmp_dir, str(n) + "_waagent.pid"), ustr(n + 1))
         with patch('os.getpid', return_value=1112):
-            pid_files, pid_file = self.update_handler._write_pid_file() # pylint: disable=protected-access
+            pid_files, pid_file = self.update_handler._write_pid_file()  # pylint: disable=protected-access
             self.assertEqual(1112, len(pid_files))
             self.assertEqual("1111_waagent.pid", os.path.basename(pid_files[-1]))
             self.assertEqual("1112_waagent.pid", os.path.basename(pid_file))
@@ -1465,7 +1465,7 @@ class TestUpdate(UpdateTestCase): # pylint: disable=too-many-public-methods
     def test_write_pid_file_ignores_exceptions(self):
         with patch('azurelinuxagent.common.utils.fileutil.write_file', side_effect=Exception):
             with patch('os.getpid', return_value=42):
-                pid_files, pid_file = self.update_handler._write_pid_file() # pylint: disable=protected-access
+                pid_files, pid_file = self.update_handler._write_pid_file()  # pylint: disable=protected-access
                 self.assertEqual(0, len(pid_files))
                 self.assertEqual(None, pid_file)
 
@@ -1476,7 +1476,7 @@ class TestUpdate(UpdateTestCase): # pylint: disable=too-many-public-methods
         before an update is found, this test attempts to ensure that
         behavior never changes.
         """
-        self.update_handler._upgrade_available = Mock(return_value=True) # pylint: disable=protected-access
+        self.update_handler._upgrade_available = Mock(return_value=True)  # pylint: disable=protected-access
         self._test_run(invocations=0, calls=[], enable_updates=True, sleep_interval=(300,))
 
     @patch('azurelinuxagent.common.conf.get_extensions_enabled', return_value=False)
@@ -1484,7 +1484,7 @@ class TestUpdate(UpdateTestCase): # pylint: disable=too-many-public-methods
         """
         When extension processing is disabled, the goal state interval should be larger.
         """
-        self.update_handler._upgrade_available = Mock(return_value=False) # pylint: disable=protected-access
+        self.update_handler._upgrade_available = Mock(return_value=False)  # pylint: disable=protected-access
         self._test_run(invocations=15, calls=[call.run()] * 15, sleep_interval=(300,))
 
     @patch("azurelinuxagent.common.logger.info")
@@ -1494,7 +1494,7 @@ class TestUpdate(UpdateTestCase): # pylint: disable=too-many-public-methods
         mock_protocol = WireProtocol("foo.bar")
 
         update_handler.last_telemetry_heartbeat = datetime.utcnow() - timedelta(hours=1)
-        update_handler._send_heartbeat_telemetry(mock_protocol) # pylint: disable=protected-access
+        update_handler._send_heartbeat_telemetry(mock_protocol)  # pylint: disable=protected-access
         self.assertEqual(1, patch_add_event.call_count)
         self.assertTrue(any(call_args[0] == "[HEARTBEAT] Agent {0} is running as the goal state agent {1}"
                             for call_args in patch_info.call_args), "The heartbeat was not written to the agent's log")
@@ -1513,12 +1513,12 @@ class TestUpdate(UpdateTestCase): # pylint: disable=too-many-public-methods
 
         def _set_iterations(iterations):
             # This will reset the current iteration and the max iterations to run for this test object.
-            update_handler._cur_iteration = 0 # pylint: disable=protected-access
-            update_handler._iterations = iterations # pylint: disable=protected-access
+            update_handler._cur_iteration = 0  # pylint: disable=protected-access
+            update_handler._iterations = iterations  # pylint: disable=protected-access
 
-        def check_running(*args, **kwargs): # pylint: disable=unused-argument
+        def check_running(*args, **kwargs):  # pylint: disable=unused-argument
             # This method will determine if the current UpdateHandler object is supposed to run or not.
-            if update_handler._cur_iteration < update_handler._iterations: # pylint: disable=protected-access
+            if update_handler._cur_iteration < update_handler._iterations:  # pylint: disable=protected-access
                 update_handler._cur_iteration += 1
                 return True
             return False
@@ -1530,9 +1530,9 @@ class TestUpdate(UpdateTestCase): # pylint: disable=too-many-public-methods
                 with patch("azurelinuxagent.common.conf.get_autoupdate_enabled", return_value=False):
                     update_handler = get_update_handler()
                     # Setup internal state for the object required for testing
-                    update_handler._cur_iteration = 0 # pylint: disable=protected-access
-                    update_handler._iterations = 0 # pylint: disable=protected-access
-                    update_handler.set_iterations = lambda i: _set_iterations(i) # pylint: disable=unnecessary-lambda
+                    update_handler._cur_iteration = 0  # pylint: disable=protected-access
+                    update_handler._iterations = 0  # pylint: disable=protected-access
+                    update_handler.set_iterations = lambda i: _set_iterations(i)  # pylint: disable=unnecessary-lambda
                     type(update_handler).running = PropertyMock(side_effect=check_running)
                     with patch("time.sleep", side_effect=lambda _: mock_sleep(0.001)):
                         with patch('sys.exit'):
@@ -1547,7 +1547,7 @@ class TestUpdate(UpdateTestCase): # pylint: disable=too-many-public-methods
 
     @staticmethod
     def _get_test_ext_handler_instance(protocol, name="OSTCExtensions.ExampleHandlerLinux", version="1.0.0"):
-        eh = ExtHandler(name=name) # pylint: disable=invalid-name
+        eh = ExtHandler(name=name)  # pylint: disable=invalid-name
         eh.properties.version = version
         return ExtHandlerInstance(eh, protocol)
 
@@ -1635,7 +1635,7 @@ class MonitorThreadTest(AgentTestCase):
     def _test_run(self, invocations=1):
         iterations = [0]
 
-        def iterator(*args, **kwargs): # pylint: disable=useless-return,unused-argument
+        def iterator(*args, **kwargs):  # pylint: disable=useless-return,unused-argument
             iterations[0] += 1
             if iterations[0] >= invocations:
                 self.update_handler.running = False
@@ -1666,7 +1666,7 @@ class MonitorThreadTest(AgentTestCase):
         return thread
 
     # too-many-arguments<R0913> Disabled: The number of arguments maps to the number of threads
-    def test_start_threads(self, mock_env, mock_monitor, mock_collect_logs, mock_telemetry_send_events, mock_telemetry_collector): # pylint: disable=too-many-arguments
+    def test_start_threads(self, mock_env, mock_monitor, mock_collect_logs, mock_telemetry_send_events, mock_telemetry_collector):  # pylint: disable=too-many-arguments
         self.assertTrue(self.update_handler.running)
 
         def _get_mock_thread():
@@ -1685,42 +1685,42 @@ class MonitorThreadTest(AgentTestCase):
             self.assertEqual(1, thread.call_count)
             self.assertEqual(1, thread().run.call_count)
 
-    def test_check_if_monitor_thread_is_alive(self, _, mock_monitor, *args): # pylint: disable=unused-argument
+    def test_check_if_monitor_thread_is_alive(self, _, mock_monitor, *args):  # pylint: disable=unused-argument
         mock_monitor_thread = self._setup_mock_thread_and_start_test_run(mock_monitor, is_alive=True, invocations=0)
         self.assertEqual(1, mock_monitor.call_count)
         self.assertEqual(1, mock_monitor_thread.run.call_count)
         self.assertEqual(1, mock_monitor_thread.is_alive.call_count)
         self.assertEqual(0, mock_monitor_thread.start.call_count)
 
-    def test_check_if_env_thread_is_alive(self, mock_env, *args): # pylint: disable=unused-argument
+    def test_check_if_env_thread_is_alive(self, mock_env, *args):  # pylint: disable=unused-argument
         mock_env_thread = self._setup_mock_thread_and_start_test_run(mock_env, is_alive=True, invocations=1)
         self.assertEqual(1, mock_env.call_count)
         self.assertEqual(1, mock_env_thread.run.call_count)
         self.assertEqual(1, mock_env_thread.is_alive.call_count)
         self.assertEqual(0, mock_env_thread.start.call_count)
 
-    def test_restart_monitor_thread_if_not_alive(self, _, mock_monitor, *args): # pylint: disable=unused-argument
+    def test_restart_monitor_thread_if_not_alive(self, _, mock_monitor, *args):  # pylint: disable=unused-argument
         mock_monitor_thread = self._setup_mock_thread_and_start_test_run(mock_monitor, is_alive=False, invocations=1)
         self.assertEqual(1, mock_monitor.call_count)
         self.assertEqual(1, mock_monitor_thread.run.call_count)
         self.assertEqual(1, mock_monitor_thread.is_alive.call_count)
         self.assertEqual(1, mock_monitor_thread.start.call_count)
 
-    def test_restart_env_thread_if_not_alive(self, mock_env, *args): # pylint: disable=unused-argument
+    def test_restart_env_thread_if_not_alive(self, mock_env, *args):  # pylint: disable=unused-argument
         mock_env_thread = self._setup_mock_thread_and_start_test_run(mock_env, is_alive=False, invocations=1)
         self.assertEqual(1, mock_env.call_count)
         self.assertEqual(1, mock_env_thread.run.call_count)
         self.assertEqual(1, mock_env_thread.is_alive.call_count)
         self.assertEqual(1, mock_env_thread.start.call_count)
 
-    def test_restart_monitor_thread(self, _, mock_monitor, *args): # pylint: disable=unused-argument
+    def test_restart_monitor_thread(self, _, mock_monitor, *args):  # pylint: disable=unused-argument
         mock_monitor_thread = self._setup_mock_thread_and_start_test_run(mock_monitor, is_alive=False, invocations=0)
         self.assertEqual(True, mock_monitor.called)
         self.assertEqual(True, mock_monitor_thread.run.called)
         self.assertEqual(True, mock_monitor_thread.is_alive.called)
         self.assertEqual(True, mock_monitor_thread.start.called)
 
-    def test_restart_env_thread(self, mock_env, *args): # pylint: disable=unused-argument
+    def test_restart_env_thread(self, mock_env, *args):  # pylint: disable=unused-argument
         mock_env_thread = self._setup_mock_thread_and_start_test_run(mock_env, is_alive=False, invocations=0)
         self.assertEqual(True, mock_env.called)
         self.assertEqual(True, mock_env_thread.run.called)
@@ -1728,7 +1728,7 @@ class MonitorThreadTest(AgentTestCase):
         self.assertEqual(True, mock_env_thread.start.called)
 
 
-class ChildMock(Mock): # pylint: disable=too-many-ancestors
+class ChildMock(Mock):  # pylint: disable=too-many-ancestors
     def __init__(self, return_value=0, side_effect=None):
         Mock.__init__(self, return_value=return_value, side_effect=side_effect)
 
@@ -1736,7 +1736,7 @@ class ChildMock(Mock): # pylint: disable=too-many-ancestors
         self.wait = Mock(return_value=return_value, side_effect=side_effect)
 
 
-class ProtocolMock(object): # pylint: disable=too-many-instance-attributes
+class ProtocolMock(object):  # pylint: disable=too-many-instance-attributes
     def __init__(self, family="TestAgent", etag=42, versions=None, client=None):
         self.family = family
         self.client = client
@@ -1756,7 +1756,7 @@ class ProtocolMock(object): # pylint: disable=too-many-instance-attributes
 
     def create_manifests(self):
         self.agent_manifests = VMAgentManifestList()
-        if len(self.versions) <= 0: # pylint: disable=len-as-condition
+        if len(self.versions) <= 0:  # pylint: disable=len-as-condition
             return
 
         if self.family is not None:
@@ -1768,7 +1768,7 @@ class ProtocolMock(object): # pylint: disable=too-many-instance-attributes
 
     def create_packages(self):
         self.agent_packages = ExtHandlerPackageList()
-        if len(self.versions) <= 0: # pylint: disable=len-as-condition
+        if len(self.versions) <= 0:  # pylint: disable=len-as-condition
             return
 
         for version in self.versions:
@@ -1788,7 +1788,7 @@ class ProtocolMock(object): # pylint: disable=too-many-instance-attributes
             raise ResourceGoneError()
         return self.agent_manifests, self.etag
 
-    def get_vmagent_pkgs(self, manifest): # pylint: disable=unused-argument
+    def get_vmagent_pkgs(self, manifest):  # pylint: disable=unused-argument
         self.call_counts["get_vmagent_pkgs"] += 1
         if self.goal_state_is_stale:
             self.goal_state_is_stale = False
@@ -1799,7 +1799,7 @@ class ProtocolMock(object): # pylint: disable=too-many-instance-attributes
         self.call_counts["update_goal_state"] += 1
 
 
-class ResponseMock(Mock): # pylint: disable=too-many-ancestors
+class ResponseMock(Mock):  # pylint: disable=too-many-ancestors
     def __init__(self, status=restutil.httpclient.OK, response=None, reason=None):
         Mock.__init__(self)
         self.status = status
@@ -1810,7 +1810,7 @@ class ResponseMock(Mock): # pylint: disable=too-many-ancestors
         return self.response
 
 
-class TimeMock(Mock): # pylint: disable=too-many-ancestors
+class TimeMock(Mock):  # pylint: disable=too-many-ancestors
     def __init__(self, time_increment=1):
         Mock.__init__(self)
         self.next_time = time.time()
@@ -1819,7 +1819,7 @@ class TimeMock(Mock): # pylint: disable=too-many-ancestors
 
         self.sleep_interval = None
 
-    def sleep(self, n): # pylint: disable=invalid-name
+    def sleep(self, n):  # pylint: disable=invalid-name
         self.sleep_interval = n
 
     def time(self):

--- a/tests/pa/test_deprovision.py
+++ b/tests/pa/test_deprovision.py
@@ -32,8 +32,8 @@ class TestDeprovision(AgentTestCase):
     @patch('azurelinuxagent.common.protocol.util.get_protocol_util')
     @patch('azurelinuxagent.pa.deprovision.default.read_input')
     def test_confirmation(self,
-            mock_read, mock_protocol, mock_util, mock_signal): # pylint: disable=unused-argument
-        dh = DeprovisionHandler() # pylint: disable=invalid-name
+            mock_read, mock_protocol, mock_util, mock_signal):  # pylint: disable=unused-argument
+        dh = DeprovisionHandler()  # pylint: disable=invalid-name
 
         dh.setup = Mock()
         dh.setup.return_value = ([], [])
@@ -88,9 +88,9 @@ class TestDeprovision(AgentTestCase):
 
         tmp = tempfile.mkdtemp()
         mock_conf.return_value = tmp
-        for d in dirs: # pylint: disable=invalid-name
+        for d in dirs:  # pylint: disable=invalid-name
             fileutil.mkdir(os.path.join(tmp, d))
-        for f in files: # pylint: disable=invalid-name
+        for f in files:  # pylint: disable=invalid-name
             fileutil.write_file(os.path.join(tmp, f), "Value")
 
         deprovision_handler = get_deprovision_handler(distro_name,
@@ -107,9 +107,9 @@ class TestDeprovision(AgentTestCase):
         self.assertEqual(fileutil.rm_files, actions[1].func)
         self.assertEqual(11, len(actions[0].args))
         self.assertEqual(3, len(actions[1].args))
-        for f in actions[0].args: # pylint: disable=invalid-name
+        for f in actions[0].args:  # pylint: disable=invalid-name
             self.assertTrue(os.path.basename(f) in files)
-        for f in actions[1].args: # pylint: disable=invalid-name
+        for f in actions[1].args:  # pylint: disable=invalid-name
             self.assertTrue(f[len(tmp)+1:] in files)
 
     @distros("redhat")
@@ -120,7 +120,7 @@ class TestDeprovision(AgentTestCase):
         deprovision_handler = get_deprovision_handler(distro_name,
                                                       distro_version,
                                                       distro_full_name)
-        warnings, actions = deprovision_handler.setup(deluser=False) # pylint: disable=unused-variable
+        warnings, actions = deprovision_handler.setup(deluser=False)  # pylint: disable=unused-variable
         assert any("/etc/resolv.conf" in w for w in warnings)
 
     @distros("ubuntu")
@@ -133,7 +133,7 @@ class TestDeprovision(AgentTestCase):
                                                       distro_full_name)
 
         with patch("os.path.realpath", return_value="/run/resolvconf/resolv.conf"):
-            warnings, actions = deprovision_handler.setup(deluser=False) # pylint: disable=unused-variable
+            warnings, actions = deprovision_handler.setup(deluser=False)  # pylint: disable=unused-variable
             assert any("/etc/resolvconf/resolv.conf.d/tail" in w for w in warnings)
 
 

--- a/tests/pa/test_provision.py
+++ b/tests/pa/test_provision.py
@@ -36,7 +36,7 @@ class TestProvision(AgentTestCase):
     @distros("redhat")
     @patch('azurelinuxagent.common.osutil.default.DefaultOSUtil.get_instance_id',
         return_value='B9F3C233-9913-9F42-8EB3-BA656DF32502')
-    def test_provision(self, mock_util, distro_name, distro_version, distro_full_name): # pylint: disable=unused-argument
+    def test_provision(self, mock_util, distro_name, distro_version, distro_full_name):  # pylint: disable=unused-argument
         provision_handler = get_provision_handler(distro_name, distro_version,
                                                   distro_full_name)
         mock_osutil = MagicMock()
@@ -60,8 +60,8 @@ class TestProvision(AgentTestCase):
 
     @patch('azurelinuxagent.common.conf.get_provision_enabled',
         return_value=False)
-    def test_provisioning_is_skipped_when_not_enabled(self, mock_conf): # pylint: disable=unused-argument
-        ph = ProvisionHandler() # pylint: disable=invalid-name
+    def test_provisioning_is_skipped_when_not_enabled(self, mock_conf):  # pylint: disable=unused-argument
+        ph = ProvisionHandler()  # pylint: disable=invalid-name
         ph.osutil = DefaultOSUtil()
         ph.osutil.get_instance_id = Mock(
                         return_value='B9F3C233-9913-9F42-8EB3-BA656DF32502')
@@ -77,8 +77,8 @@ class TestProvision(AgentTestCase):
         self.assertEqual(1, ph.write_provisioned.call_count)
 
     @patch('os.path.isfile', return_value=False)
-    def test_check_provisioned_file_not_provisioned(self, mock_isfile): # pylint: disable=unused-argument
-        ph = ProvisionHandler() # pylint: disable=invalid-name
+    def test_check_provisioned_file_not_provisioned(self, mock_isfile):  # pylint: disable=unused-argument
+        ph = ProvisionHandler()  # pylint: disable=invalid-name
         self.assertFalse(ph.check_provisioned_file())
 
     @patch('os.path.isfile', return_value=True)
@@ -86,9 +86,9 @@ class TestProvision(AgentTestCase):
             return_value="B9F3C233-9913-9F42-8EB3-BA656DF32502")
     @patch('azurelinuxagent.pa.deprovision.get_deprovision_handler')
     def test_check_provisioned_file_is_provisioned(self,
-            mock_deprovision, mock_read, mock_isfile): # pylint: disable=unused-argument
+            mock_deprovision, mock_read, mock_isfile):  # pylint: disable=unused-argument
 
-        ph = ProvisionHandler() # pylint: disable=invalid-name
+        ph = ProvisionHandler()  # pylint: disable=invalid-name
         ph.osutil = Mock()
         ph.osutil.is_current_instance_id = Mock(return_value=True)
         ph.write_provisioned = Mock()
@@ -105,9 +105,9 @@ class TestProvision(AgentTestCase):
             return_value="B9F3C233-9913-9F42-8EB3-BA656DF32502")
     @patch('azurelinuxagent.pa.deprovision.get_deprovision_handler')
     def test_check_provisioned_file_not_deprovisioned(self,
-            mock_deprovision, mock_read, mock_isfile): # pylint: disable=unused-argument
+            mock_deprovision, mock_read, mock_isfile):  # pylint: disable=unused-argument
 
-        ph = ProvisionHandler() # pylint: disable=invalid-name
+        ph = ProvisionHandler()  # pylint: disable=invalid-name
         ph.osutil = Mock()
         ph.osutil.is_current_instance_id = Mock(return_value=False)
         ph.report_ready = Mock()
@@ -129,7 +129,7 @@ class TestProvision(AgentTestCase):
         """
         ProvisionGuestAgent flag is 'false'
         """
-        self._provision_test(distro_name, # pylint: disable=no-value-for-parameter
+        self._provision_test(distro_name,  # pylint: disable=no-value-for-parameter
                              distro_version,
                              distro_full_name,
                              OVF_FILE_NAME,
@@ -145,7 +145,7 @@ class TestProvision(AgentTestCase):
         """
         ProvisionGuestAgent flag is 'true'
         """
-        self._provision_test(distro_name, # pylint: disable=no-value-for-parameter
+        self._provision_test(distro_name,  # pylint: disable=no-value-for-parameter
                              distro_version,
                              distro_full_name,
                              'ovf-env-2.xml',
@@ -161,7 +161,7 @@ class TestProvision(AgentTestCase):
         """
         ProvisionGuestAgent flag is ''
         """
-        self._provision_test(distro_name, # pylint: disable=no-value-for-parameter
+        self._provision_test(distro_name,  # pylint: disable=no-value-for-parameter
                              distro_version,
                              distro_full_name,
                              'ovf-env-3.xml',
@@ -177,7 +177,7 @@ class TestProvision(AgentTestCase):
         """
         ProvisionGuestAgent flag is 'bad data'
         """
-        self._provision_test(distro_name, # pylint: disable=no-value-for-parameter
+        self._provision_test(distro_name,  # pylint: disable=no-value-for-parameter
                              distro_version,
                              distro_full_name,
                              'ovf-env-4.xml',
@@ -188,7 +188,7 @@ class TestProvision(AgentTestCase):
            return_value='B9F3C233-9913-9F42-8EB3-BA656DF32502')
     @patch('azurelinuxagent.pa.provision.default.ProvisionHandler.write_agent_disabled')
     @patch('azurelinuxagent.pa.provision.default.cloud_init_is_enabled', return_value=False)
-    def _provision_test(self, # pylint: disable=invalid-name,too-many-arguments
+    def _provision_test(self,  # pylint: disable=invalid-name,too-many-arguments
                         distro_name,
                         distro_version,
                         distro_full_name,
@@ -206,7 +206,7 @@ class TestProvision(AgentTestCase):
          1. Provision
          2. GuestState
         """
-        ph = get_provision_handler(distro_name, # pylint: disable=invalid-name
+        ph = get_provision_handler(distro_name,  # pylint: disable=invalid-name
                                    distro_version,
                                    distro_full_name)
         ph.report_event = MagicMock()
@@ -239,7 +239,7 @@ class TestProvision(AgentTestCase):
             self.assertTrue(kw_args['message'] == provisionMessage)
             self.assertTrue(kw_args['is_success'])
 
-            expected_disabled = True if provisionMessage == 'false' else False # pylint: disable=simplifiable-if-expression
+            expected_disabled = True if provisionMessage == 'false' else False  # pylint: disable=simplifiable-if-expression
             self.assertTrue(patch_write_agent_disabled.call_count == expected_disabled)
 
         else:
@@ -270,7 +270,7 @@ class TestProvision(AgentTestCase):
 
          1. Provision
         """
-        ph = get_provision_handler(distro_name, distro_version, # pylint: disable=invalid-name
+        ph = get_provision_handler(distro_name, distro_version,  # pylint: disable=invalid-name
                                    distro_full_name)
         ph.report_event = MagicMock()
         ph.reg_ssh_host_key = MagicMock(side_effect=ProvisionError(
@@ -289,7 +289,7 @@ class TestProvision(AgentTestCase):
         fileutil.write_file(ovfenv_file, ovfenv_data)
 
         ph.run()
-        positional_args, kw_args = ph.report_event.call_args_list[0] # pylint: disable=unused-variable
+        positional_args, kw_args = ph.report_event.call_args_list[0]  # pylint: disable=unused-variable
         self.assertTrue(re.match(r'Provisioning failed: \[ProvisionError\] --unit-test-- \(\d+\.\d+s\)', positional_args[0]) is not None)
 
     @patch('azurelinuxagent.pa.provision.default.ProvisionHandler.write_agent_disabled')
@@ -299,7 +299,7 @@ class TestProvision(AgentTestCase):
                                           distro_name,
                                           distro_version,
                                           distro_full_name):
-        ph = get_provision_handler(distro_name, # pylint: disable=invalid-name
+        ph = get_provision_handler(distro_name,  # pylint: disable=invalid-name
                                    distro_version,
                                    distro_full_name)
 
@@ -342,8 +342,8 @@ class TestProvision(AgentTestCase):
     )
     def test_get_provision_handler_config_auto_no_cloudinit(
             self,
-            patch_cloud_init_is_enabled, # pylint: disable=unused-argument
-            patch_get_provisioning_agent): # pylint: disable=unused-argument
+            patch_cloud_init_is_enabled,  # pylint: disable=unused-argument
+            patch_get_provisioning_agent):  # pylint: disable=unused-argument
         provisioning_handler = get_provision_handler()
         self.assertIsInstance(provisioning_handler, ProvisionHandler, 'Auto provisioning handler should be waagent if cloud-init is not enabled')
 
@@ -357,8 +357,8 @@ class TestProvision(AgentTestCase):
     )
     def test_get_provision_handler_config_waagent(
             self,
-            patch_cloud_init_is_enabled, # pylint: disable=unused-argument
-            patch_get_provisioning_agent): # pylint: disable=unused-argument
+            patch_cloud_init_is_enabled,  # pylint: disable=unused-argument
+            patch_get_provisioning_agent):  # pylint: disable=unused-argument
         provisioning_handler = get_provision_handler()
         self.assertIsInstance(provisioning_handler, ProvisionHandler, 'Provisioning handler should be waagent if agent is set to waagent')
 
@@ -372,8 +372,8 @@ class TestProvision(AgentTestCase):
     )
     def test_get_provision_handler_config_auto_cloudinit(
             self,
-            patch_cloud_init_is_enabled, # pylint: disable=unused-argument
-            patch_get_provisioning_agent): # pylint: disable=unused-argument
+            patch_cloud_init_is_enabled,  # pylint: disable=unused-argument
+            patch_get_provisioning_agent):  # pylint: disable=unused-argument
         provisioning_handler = get_provision_handler()
         self.assertIsInstance(provisioning_handler, CloudInitProvisionHandler, 'Auto provisioning handler should be cloud-init if cloud-init is enabled')
 
@@ -383,7 +383,7 @@ class TestProvision(AgentTestCase):
     )
     def test_get_provision_handler_config_cloudinit(
             self,
-            patch_get_provisioning_agent): # pylint: disable=unused-argument
+            patch_get_provisioning_agent):  # pylint: disable=unused-argument
         provisioning_handler = get_provision_handler()
         self.assertIsInstance(provisioning_handler, CloudInitProvisionHandler, 'Provisioning handler should be cloud-init if agent is set to cloud-init')
 

--- a/tests/protocol/mocks.py
+++ b/tests/protocol/mocks.py
@@ -72,7 +72,7 @@ def mock_wire_protocol(mock_wire_data_file, http_get_handler=None, http_post_han
     #
     original_http_request = restutil.http_request
 
-    def http_request(method, url, data, **kwargs): # pylint: disable=too-many-branches
+    def http_request(method, url, data, **kwargs):  # pylint: disable=too-many-branches
         # if there is a handler for the request, use it
         handler = None
         if method == 'GET':
@@ -134,7 +134,7 @@ def mock_wire_protocol(mock_wire_data_file, http_get_handler=None, http_post_han
     protocol.mock_wire_data = mockwiredata.WireProtocolData(mock_wire_data_file)
     protocol.start = start
     protocol.stop = stop
-    protocol.track_url = lambda url: tracked_urls.append(url) # pylint: disable=unnecessary-lambda
+    protocol.track_url = lambda url: tracked_urls.append(url)  # pylint: disable=unnecessary-lambda
     protocol.get_tracked_urls = lambda: tracked_urls
     protocol.set_http_handlers = lambda http_get_handler=None, http_post_handler=None, http_put_handler=None:\
         http_handlers(get=http_get_handler, post=http_post_handler, put=http_put_handler)
@@ -209,7 +209,7 @@ class HttpRequestPredicates(object):
                                                                  restutil.HOST_PLUGIN_PORT)
 
 
-class MockHttpResponse: # pylint: disable=too-few-public-methods
+class MockHttpResponse:  # pylint: disable=too-few-public-methods
     def __init__(self, status, body=''):
         self.body = body
         self.status = status

--- a/tests/protocol/mockwiredata.py
+++ b/tests/protocol/mockwiredata.py
@@ -19,9 +19,9 @@ import re
 
 from azurelinuxagent.common.utils.textutil import parse_doc, find, findall
 from tests.tools import load_bin_data, load_data, MagicMock, Mock
-from azurelinuxagent.common.exception import HttpError, ResourceGoneError # pylint: disable=ungrouped-imports
-from azurelinuxagent.common.future import httpclient # pylint: disable=ungrouped-imports
-from azurelinuxagent.common.utils.cryptutil import CryptUtil # pylint: disable=ungrouped-imports
+from azurelinuxagent.common.exception import HttpError, ResourceGoneError  # pylint: disable=ungrouped-imports
+from azurelinuxagent.common.future import httpclient  # pylint: disable=ungrouped-imports
+from azurelinuxagent.common.utils.cryptutil import CryptUtil  # pylint: disable=ungrouped-imports
 
 DATA_FILE = {
         "version_info": "wire/version_info.xml",
@@ -94,7 +94,7 @@ DATA_FILE_PLUGIN_SETTINGS_MISMATCH = DATA_FILE.copy()
 DATA_FILE_PLUGIN_SETTINGS_MISMATCH["ext_conf"] = "wire/ext_conf_plugin_settings_version_mismatch.xml"
 
 
-class WireProtocolData(object): # pylint: disable=too-many-instance-attributes
+class WireProtocolData(object):  # pylint: disable=too-many-instance-attributes
     def __init__(self, data_files=None):
         if data_files is None:
             data_files = DATA_FILE
@@ -157,7 +157,7 @@ class WireProtocolData(object): # pylint: disable=too-many-instance-attributes
         if in_vm_artifacts_profile_file is not None:
             self.in_vm_artifacts_profile = load_data(in_vm_artifacts_profile_file)
 
-    def mock_http_get(self, url, *args, **kwargs): # pylint: disable=unused-argument,too-many-branches
+    def mock_http_get(self, url, *args, **kwargs):  # pylint: disable=unused-argument,too-many-branches
         content = None
 
         resp = MagicMock()
@@ -198,7 +198,7 @@ class WireProtocolData(object): # pylint: disable=too-many-instance-attributes
             # A stale GoalState results in a 400 from the HostPlugin
             # for which the HTTP handler in restutil raises ResourceGoneError
             if self.emulate_stale_goal_state:
-                if "extensionArtifact" in url: # pylint: disable=no-else-raise
+                if "extensionArtifact" in url:  # pylint: disable=no-else-raise
                     self.emulate_stale_goal_state = False
                     self.call_counts["extensionArtifact"] += 1
                     raise ResourceGoneError()
@@ -210,9 +210,9 @@ class WireProtocolData(object): # pylint: disable=too-many-instance-attributes
             if "extensionArtifact" in url:
                 self.call_counts["extensionArtifact"] += 1
                 if "headers" not in kwargs:
-                    raise ValueError("HostPlugin request is missing the HTTP headers: {0}", kwargs) # pylint: disable=raising-format-tuple
+                    raise ValueError("HostPlugin request is missing the HTTP headers: {0}", kwargs)  # pylint: disable=raising-format-tuple
                 if "x-ms-artifact-location" not in kwargs["headers"]:
-                    raise ValueError("HostPlugin request is missing the x-ms-artifact-location header: {0}", kwargs) # pylint: disable=raising-format-tuple
+                    raise ValueError("HostPlugin request is missing the x-ms-artifact-location header: {0}", kwargs)  # pylint: disable=raising-format-tuple
                 url = kwargs["headers"]["x-ms-artifact-location"]
 
             if "manifest.xml" in url:
@@ -235,7 +235,7 @@ class WireProtocolData(object): # pylint: disable=too-many-instance-attributes
         resp.read = Mock(return_value=content.encode("utf-8"))
         return resp
 
-    def mock_http_post(self, url, *args, **kwargs): # pylint: disable=unused-argument
+    def mock_http_post(self, url, *args, **kwargs):  # pylint: disable=unused-argument
         content = None
 
         resp = MagicMock()
@@ -250,7 +250,7 @@ class WireProtocolData(object): # pylint: disable=too-many-instance-attributes
         resp.read = Mock(return_value=content.encode("utf-8"))
         return resp
 
-    def mock_http_put(self, url, *args, **kwargs): # pylint: disable=unused-argument
+    def mock_http_put(self, url, *args, **kwargs):  # pylint: disable=unused-argument
         content = None
 
         resp = MagicMock()
@@ -300,7 +300,7 @@ class WireProtocolData(object): # pylint: disable=too-many-instance-attributes
     def replace_xml_element_value(xml_document, element_name, element_value):
         new_xml_document = re.sub(r'(?<=<{0}>).+(?=</{0}>)'.format(element_name), element_value, xml_document)
         if new_xml_document == xml_document:
-            raise Exception("Could not match element '{0}'", element_name) # pylint: disable=raising-format-tuple
+            raise Exception("Could not match element '{0}'", element_name)  # pylint: disable=raising-format-tuple
         return new_xml_document
 
     @staticmethod

--- a/tests/protocol/test_datacontract.py
+++ b/tests/protocol/test_datacontract.py
@@ -20,10 +20,10 @@ import unittest
 from azurelinuxagent.common.datacontract import get_properties, set_properties, DataContract, DataContractList
 
 
-class SampleDataContract(DataContract): # pylint: disable=too-few-public-methods
+class SampleDataContract(DataContract):  # pylint: disable=too-few-public-methods
     def __init__(self):
-        self.foo = None # pylint: disable=blacklisted-name
-        self.bar = DataContractList(int) # pylint: disable=blacklisted-name
+        self.foo = None  # pylint: disable=blacklisted-name
+        self.bar = DataContractList(int)  # pylint: disable=blacklisted-name
 
 
 class TestDataContract(unittest.TestCase):

--- a/tests/protocol/test_healthservice.py
+++ b/tests/protocol/test_healthservice.py
@@ -29,16 +29,16 @@ class TestHealthService(AgentTestCase):
         is_healthy = not restutil.request_failed_at_hostplugin(response)
         self.assertEqual(expected_healthy, is_healthy)
 
-    def assert_observation(self, call_args, name, is_healthy, value, description): # pylint: disable=too-many-arguments
+    def assert_observation(self, call_args, name, is_healthy, value, description):  # pylint: disable=too-many-arguments
         endpoint = call_args[0][0]
         content = call_args[0][1]
 
-        jo = json.loads(content) # pylint: disable=invalid-name
+        jo = json.loads(content)  # pylint: disable=invalid-name
         api = jo['Api']
         source = jo['Source']
         version = jo['Version']
         obs = jo['Observations']
-        fo = obs[0] # pylint: disable=invalid-name
+        fo = obs[0]  # pylint: disable=invalid-name
         obs_name = fo['ObservationName']
         obs_healthy = fo['IsHealthy']
         obs_value = fo['Value']
@@ -56,7 +56,7 @@ class TestHealthService(AgentTestCase):
         self.assertEqual(description, obs_description)
 
     def assert_telemetry(self, call_args, response=''):
-        args, kw_args = call_args # pylint: disable=unused-variable
+        args, kw_args = call_args  # pylint: disable=unused-variable
         self.assertFalse(kw_args['is_success'])
         self.assertEqual('HealthObservation', kw_args['op'])
         obs = json.loads(kw_args['message'])
@@ -75,12 +75,12 @@ class TestHealthService(AgentTestCase):
         except ValueError:
             pass
 
-        o = Observation(name='Name', is_healthy=True, value=None, description=None) # pylint: disable=invalid-name
+        o = Observation(name='Name', is_healthy=True, value=None, description=None)  # pylint: disable=invalid-name
         self.assertEqual('', o.value)
         self.assertEqual('', o.description)
 
         long_str = 's' * 200
-        o = Observation(name=long_str, is_healthy=True, value=long_str, description=long_str) # pylint: disable=invalid-name
+        o = Observation(name=long_str, is_healthy=True, value=long_str, description=long_str)  # pylint: disable=invalid-name
         self.assertEqual(200, len(o.name))
         self.assertEqual(200, len(o.value))
         self.assertEqual(200, len(o.description))
@@ -208,7 +208,7 @@ class TestHealthService(AgentTestCase):
 
         # make 100 observations
         for i in range(0, 100):
-            health_service._observe(is_healthy=True, name='{0}'.format(i)) # pylint: disable=protected-access
+            health_service._observe(is_healthy=True, name='{0}'.format(i))  # pylint: disable=protected-access
 
         # ensure we keep only 10
         self.assertEqual(10, len(health_service.observations))

--- a/tests/protocol/test_hostplugin.py
+++ b/tests/protocol/test_hostplugin.py
@@ -38,26 +38,26 @@ from tests.protocol.test_wire import MockResponse as TestWireMockResponse
 from tests.tools import AgentTestCase, PY_VERSION_MAJOR, Mock, patch
 
 
-hostplugin_status_url = "http://168.63.129.16:32526/status" # pylint: disable=invalid-name
-hostplugin_versions_url = "http://168.63.129.16:32526/versions" # pylint: disable=invalid-name
-health_service_url = 'http://168.63.129.16:80/HealthService' # pylint: disable=invalid-name
-hostplugin_logs_url = "http://168.63.129.16:32526/vmAgentLog" # pylint: disable=invalid-name
-sas_url = "http://sas_url" # pylint: disable=invalid-name
-wireserver_url = "168.63.129.16" # pylint: disable=invalid-name
+hostplugin_status_url = "http://168.63.129.16:32526/status"  # pylint: disable=invalid-name
+hostplugin_versions_url = "http://168.63.129.16:32526/versions"  # pylint: disable=invalid-name
+health_service_url = 'http://168.63.129.16:80/HealthService'  # pylint: disable=invalid-name
+hostplugin_logs_url = "http://168.63.129.16:32526/vmAgentLog"  # pylint: disable=invalid-name
+sas_url = "http://sas_url"  # pylint: disable=invalid-name
+wireserver_url = "168.63.129.16"  # pylint: disable=invalid-name
 
-block_blob_type = 'BlockBlob' # pylint: disable=invalid-name
-page_blob_type = 'PageBlob' # pylint: disable=invalid-name
+block_blob_type = 'BlockBlob'  # pylint: disable=invalid-name
+page_blob_type = 'PageBlob'  # pylint: disable=invalid-name
 
-api_versions = '["2015-09-01"]' # pylint: disable=invalid-name
-storage_version = "2014-02-14" # pylint: disable=invalid-name
+api_versions = '["2015-09-01"]'  # pylint: disable=invalid-name
+storage_version = "2014-02-14"  # pylint: disable=invalid-name
 
-faux_status = "{ 'dummy' : 'data' }" # pylint: disable=invalid-name
-faux_status_b64 = base64.b64encode(bytes(bytearray(faux_status, encoding='utf-8'))) # pylint: disable=invalid-name
+faux_status = "{ 'dummy' : 'data' }"  # pylint: disable=invalid-name
+faux_status_b64 = base64.b64encode(bytes(bytearray(faux_status, encoding='utf-8')))  # pylint: disable=invalid-name
 if PY_VERSION_MAJOR > 2:
-    faux_status_b64 = faux_status_b64.decode('utf-8') # pylint: disable=invalid-name
+    faux_status_b64 = faux_status_b64.decode('utf-8')  # pylint: disable=invalid-name
 
 
-class TestHostPlugin(HttpRequestPredicates, AgentTestCase): # pylint: disable=too-many-public-methods
+class TestHostPlugin(HttpRequestPredicates, AgentTestCase):  # pylint: disable=too-many-public-methods
 
     def _init_host(self):
         with mock_wire_protocol(DATA_FILE) as protocol:
@@ -95,13 +95,13 @@ class TestHostPlugin(HttpRequestPredicates, AgentTestCase): # pylint: disable=to
         expected['headers'] = self._relax_timestamp(expected['headers'])
 
         for k in iter(expected.keys()):
-            if k == 'content' or k == 'requestUri': # pylint: disable=consider-using-in
+            if k == 'content' or k == 'requestUri':  # pylint: disable=consider-using-in
                 if actual[k] != expected[k]:
                     print("Mismatch: Actual '{0}'='{1}', "
                           "Expected '{0}'='{2}'".format(k, actual[k], expected[k]))
                     return False
             elif k == 'headers':
-                for h in expected['headers']: # pylint: disable=invalid-name
+                for h in expected['headers']:  # pylint: disable=invalid-name
                     if not (h in actual['headers']):
                         print("Missing Header: '{0}'".format(h))
                         return False
@@ -123,9 +123,9 @@ class TestHostPlugin(HttpRequestPredicates, AgentTestCase): # pylint: disable=to
             'headers': headers
         }
         if not content is None:
-            s = base64.b64encode(bytes(content)) # pylint: disable=invalid-name
+            s = base64.b64encode(bytes(content))  # pylint: disable=invalid-name
             if PY_VERSION_MAJOR > 2:
-                s = s.decode('utf-8') # pylint: disable=invalid-name
+                s = s.decode('utf-8')  # pylint: disable=invalid-name
             data['content'] = s
         return data
 
@@ -137,7 +137,7 @@ class TestHostPlugin(HttpRequestPredicates, AgentTestCase): # pylint: disable=to
             'x-ms-host-config-name': goal_state.role_config_name
         }
 
-    def _validate_hostplugin_args(self, args, goal_state, exp_method, exp_url, exp_data): # pylint: disable=too-many-arguments
+    def _validate_hostplugin_args(self, args, goal_state, exp_method, exp_url, exp_data):  # pylint: disable=too-many-arguments
         args, kwargs = args
         self.assertEqual(exp_method, args[0])
         self.assertEqual(exp_url, args[1])
@@ -153,7 +153,7 @@ class TestHostPlugin(HttpRequestPredicates, AgentTestCase): # pylint: disable=to
         with mock_wire_protocol(DATA_FILE_NO_EXT) as protocol:
             # These tests use mock wire data that don't have any extensions (extension config will be empty).
             # Populate the upload blob and set an initial empty status before returning the protocol.
-            ext_conf = protocol.client._goal_state.ext_conf # pylint: disable=protected-access
+            ext_conf = protocol.client._goal_state.ext_conf  # pylint: disable=protected-access
             ext_conf.status_upload_blob = sas_url
             ext_conf.status_upload_blob_type = page_blob_type
 
@@ -168,7 +168,7 @@ class TestHostPlugin(HttpRequestPredicates, AgentTestCase): # pylint: disable=to
     @patch("azurelinuxagent.common.protocol.healthservice.HealthService.report_host_plugin_versions")
     @patch("azurelinuxagent.ga.update.restutil.http_get")
     @patch("azurelinuxagent.common.protocol.hostplugin.add_event")
-    def assert_ensure_initialized(self, patch_event, patch_http_get, patch_report_health, # pylint: disable=too-many-arguments
+    def assert_ensure_initialized(self, patch_event, patch_http_get, patch_report_health,  # pylint: disable=too-many-arguments
                                   response_body,
                                   response_status_code,
                                   should_initialize,
@@ -205,32 +205,32 @@ class TestHostPlugin(HttpRequestPredicates, AgentTestCase): # pylint: disable=to
         """
         Test calls to ensure_initialized
         """
-        self.assert_ensure_initialized(response_body=api_versions, # pylint: disable=no-value-for-parameter
+        self.assert_ensure_initialized(response_body=api_versions,  # pylint: disable=no-value-for-parameter
                                        response_status_code=200,
                                        should_initialize=True,
                                        should_report_healthy=True)
 
-        self.assert_ensure_initialized(response_body='invalid ip', # pylint: disable=no-value-for-parameter
+        self.assert_ensure_initialized(response_body='invalid ip',  # pylint: disable=no-value-for-parameter
                                        response_status_code=400,
                                        should_initialize=False,
                                        should_report_healthy=True)
 
-        self.assert_ensure_initialized(response_body='generic bad request', # pylint: disable=no-value-for-parameter
+        self.assert_ensure_initialized(response_body='generic bad request',  # pylint: disable=no-value-for-parameter
                                        response_status_code=400,
                                        should_initialize=False,
                                        should_report_healthy=True)
 
-        self.assert_ensure_initialized(response_body='resource gone', # pylint: disable=no-value-for-parameter
+        self.assert_ensure_initialized(response_body='resource gone',  # pylint: disable=no-value-for-parameter
                                        response_status_code=410,
                                        should_initialize=False,
                                        should_report_healthy=True)
 
-        self.assert_ensure_initialized(response_body='generic error', # pylint: disable=no-value-for-parameter
+        self.assert_ensure_initialized(response_body='generic error',  # pylint: disable=no-value-for-parameter
                                        response_status_code=500,
                                        should_initialize=False,
                                        should_report_healthy=False)
 
-        self.assert_ensure_initialized(response_body='upstream error', # pylint: disable=no-value-for-parameter
+        self.assert_ensure_initialized(response_body='upstream error',  # pylint: disable=no-value-for-parameter
                                        response_status_code=502,
                                        should_initialize=False,
                                        should_report_healthy=True)
@@ -384,7 +384,7 @@ class TestHostPlugin(HttpRequestPredicates, AgentTestCase): # pylint: disable=to
                         # http_put having a side effect of "put_error"
                         #
                         # The agent tries to upload using a direct connection, and that succeeds.
-                        self.assertEqual(1, wire_protocol_client.status_blob.upload.call_count) # pylint: disable=no-member
+                        self.assertEqual(1, wire_protocol_client.status_blob.upload.call_count)  # pylint: disable=no-member
                         # The agent never touches the default protocol is this code path, so no change.
                         self.assertFalse(wire.HostPluginProtocol.is_default_channel())
                         # The agent never logs telemetry event for direct fallback
@@ -397,7 +397,7 @@ class TestHostPlugin(HttpRequestPredicates, AgentTestCase): # pylint: disable=to
         """Validate correct set of data is sent to HostGAPlugin when reporting VM status"""
 
         with mock_wire_protocol(DATA_FILE) as protocol:
-            test_goal_state = protocol.client._goal_state # pylint: disable=protected-access
+            test_goal_state = protocol.client._goal_state  # pylint: disable=protected-access
             plugin = protocol.client.get_host_plugin()
 
             status_blob = protocol.client.status_blob
@@ -431,7 +431,7 @@ class TestHostPlugin(HttpRequestPredicates, AgentTestCase): # pylint: disable=to
 
     def test_validate_block_blob(self):
         with mock_wire_protocol(DATA_FILE) as protocol:
-            test_goal_state = protocol.client._goal_state # pylint: disable=protected-access
+            test_goal_state = protocol.client._goal_state  # pylint: disable=protected-access
 
             host_client = wire.HostPluginProtocol(wireserver_url,
                                                   test_goal_state.container_id,
@@ -474,7 +474,7 @@ class TestHostPlugin(HttpRequestPredicates, AgentTestCase): # pylint: disable=to
     def test_validate_page_blobs(self):
         """Validate correct set of data is sent for page blobs"""
         with mock_wire_protocol(DATA_FILE) as protocol:
-            test_goal_state = protocol.client._goal_state # pylint: disable=protected-access
+            test_goal_state = protocol.client._goal_state  # pylint: disable=protected-access
 
             host_client = wire.HostPluginProtocol(wireserver_url,
                                                   test_goal_state.container_id,
@@ -532,7 +532,7 @@ class TestHostPlugin(HttpRequestPredicates, AgentTestCase): # pylint: disable=to
                         exp_method, exp_url, exp_data)
 
     def test_validate_http_request_for_put_vm_log(self):
-        def http_put_handler(url, *args, **kwargs): # pylint: disable=inconsistent-return-statements
+        def http_put_handler(url, *args, **kwargs):  # pylint: disable=inconsistent-return-statements
             if self.is_host_plugin_put_logs_request(url):
                 http_put_handler.args, http_put_handler.kwargs = args, kwargs
                 return MockResponse(body=b'', status_code=200)
@@ -574,7 +574,7 @@ class TestHostPlugin(HttpRequestPredicates, AgentTestCase): # pylint: disable=to
             self.assertTrue(UUID_PATTERN.match(headers["x-ms-client-correlationid"]), "Correlation id is not in GUID form!")
 
     def test_put_vm_log_should_raise_an_exception_when_request_fails(self):
-        def http_put_handler(url, *args, **kwargs): # pylint: disable=inconsistent-return-statements
+        def http_put_handler(url, *args, **kwargs):  # pylint: disable=inconsistent-return-statements
             if self.is_host_plugin_put_logs_request(url):
                 http_put_handler.args, http_put_handler.kwargs = args, kwargs
                 return MockResponse(body=ustr('Gone'), status_code=410)
@@ -600,7 +600,7 @@ class TestHostPlugin(HttpRequestPredicates, AgentTestCase): # pylint: disable=to
 
     def test_validate_get_extension_artifacts(self):
         with mock_wire_protocol(DATA_FILE) as protocol:
-            test_goal_state = protocol.client._goal_state # pylint: disable=protected-access
+            test_goal_state = protocol.client._goal_state  # pylint: disable=protected-access
 
             expected_url = hostplugin.URI_FORMAT_GET_EXTENSION_ARTIFACT.format(wireserver_url, hostplugin.HOST_PLUGIN_PORT)
             expected_headers = {'x-ms-version': '2015-09-01',
@@ -615,7 +615,7 @@ class TestHostPlugin(HttpRequestPredicates, AgentTestCase): # pylint: disable=to
             self.assertTrue(host_client.api_versions is None)
             self.assertTrue(host_client.health_service is not None)
 
-            with patch.object(wire.HostPluginProtocol, "get_api_versions", return_value=api_versions) as patch_get: # pylint: disable=unused-variable
+            with patch.object(wire.HostPluginProtocol, "get_api_versions", return_value=api_versions) as patch_get:  # pylint: disable=unused-variable
                 actual_url, actual_headers = host_client.get_artifact_request(sas_url)
                 self.assertTrue(host_client.is_initialized)
                 self.assertFalse(host_client.api_versions is None)
@@ -853,7 +853,7 @@ class TestHostPlugin(HttpRequestPredicates, AgentTestCase): # pylint: disable=to
         self.assertEqual(False, actual)
 
 
-class MockResponse: # pylint: disable=too-few-public-methods
+class MockResponse:  # pylint: disable=too-few-public-methods
     def __init__(self, body, status_code, reason=''):
         self.body = body
         self.status = status_code

--- a/tests/protocol/test_imds.py
+++ b/tests/protocol/test_imds.py
@@ -88,7 +88,7 @@ class TestImds(AgentTestCase):
         test_subject = imds.ImdsClient(restutil.KNOWN_WIRESERVER_IP)
         self.assertRaises(ValueError, test_subject.get_compute)
 
-    def test_deserialize_ComputeInfo(self): # pylint: disable=invalid-name
+    def test_deserialize_ComputeInfo(self):  # pylint: disable=invalid-name
         # pylint: disable=invalid-name
         s = '''{
         "location": "westcentralus",
@@ -140,7 +140,7 @@ class TestImds(AgentTestCase):
         image_origin = self._setup_image_origin_assert("", "", "", "")
         self.assertEqual(imds.IMDS_IMAGE_ORIGIN_CUSTOM, image_origin)
 
-    def test_is_endorsed_CentOS(self): # pylint: disable=invalid-name
+    def test_is_endorsed_CentOS(self):  # pylint: disable=invalid-name
         self.assertEqual(imds.IMDS_IMAGE_ORIGIN_ENDORSED, self._setup_image_origin_assert("OpenLogic", "CentOS", "6.3", ""))
         self.assertEqual(imds.IMDS_IMAGE_ORIGIN_ENDORSED, self._setup_image_origin_assert("OpenLogic", "CentOS", "6.4", ""))
         self.assertEqual(imds.IMDS_IMAGE_ORIGIN_ENDORSED, self._setup_image_origin_assert("OpenLogic", "CentOS", "6.5", ""))
@@ -165,7 +165,7 @@ class TestImds(AgentTestCase):
         self.assertEqual(imds.IMDS_IMAGE_ORIGIN_PLATFORM, self._setup_image_origin_assert("OpenLogic", "CentOS", "6.2", ""))
         self.assertEqual(imds.IMDS_IMAGE_ORIGIN_PLATFORM, self._setup_image_origin_assert("OpenLogic", "CentOS", "6.1", ""))
 
-    def test_is_endorsed_CoreOS(self): # pylint: disable=invalid-name
+    def test_is_endorsed_CoreOS(self):  # pylint: disable=invalid-name
         self.assertEqual(imds.IMDS_IMAGE_ORIGIN_ENDORSED, self._setup_image_origin_assert("CoreOS", "CoreOS", "stable", "494.4.0"))
         self.assertEqual(imds.IMDS_IMAGE_ORIGIN_ENDORSED, self._setup_image_origin_assert("CoreOS", "CoreOS", "stable", "899.17.0"))
         self.assertEqual(imds.IMDS_IMAGE_ORIGIN_ENDORSED, self._setup_image_origin_assert("CoreOS", "CoreOS", "stable", "1688.5.3"))
@@ -174,7 +174,7 @@ class TestImds(AgentTestCase):
         self.assertEqual(imds.IMDS_IMAGE_ORIGIN_PLATFORM, self._setup_image_origin_assert("CoreOS", "CoreOS", "alpha", ""))
         self.assertEqual(imds.IMDS_IMAGE_ORIGIN_PLATFORM, self._setup_image_origin_assert("CoreOS", "CoreOS", "beta", ""))
 
-    def test_is_endorsed_Debian(self): # pylint: disable=invalid-name
+    def test_is_endorsed_Debian(self):  # pylint: disable=invalid-name
         self.assertEqual(imds.IMDS_IMAGE_ORIGIN_ENDORSED, self._setup_image_origin_assert("credativ", "Debian", "7", ""))
         self.assertEqual(imds.IMDS_IMAGE_ORIGIN_ENDORSED, self._setup_image_origin_assert("credativ", "Debian", "8", ""))
         self.assertEqual(imds.IMDS_IMAGE_ORIGIN_ENDORSED, self._setup_image_origin_assert("credativ", "Debian", "9", ""))
@@ -182,7 +182,7 @@ class TestImds(AgentTestCase):
         self.assertEqual(imds.IMDS_IMAGE_ORIGIN_PLATFORM, self._setup_image_origin_assert("credativ", "Debian", "9-DAILY", ""))
         self.assertEqual(imds.IMDS_IMAGE_ORIGIN_PLATFORM, self._setup_image_origin_assert("credativ", "Debian", "10-DAILY", ""))
 
-    def test_is_endorsed_Rhel(self): # pylint: disable=invalid-name
+    def test_is_endorsed_Rhel(self):  # pylint: disable=invalid-name
         self.assertEqual(imds.IMDS_IMAGE_ORIGIN_ENDORSED, self._setup_image_origin_assert("RedHat", "RHEL", "6.7", ""))
         self.assertEqual(imds.IMDS_IMAGE_ORIGIN_ENDORSED, self._setup_image_origin_assert("RedHat", "RHEL", "6.8", ""))
         self.assertEqual(imds.IMDS_IMAGE_ORIGIN_ENDORSED, self._setup_image_origin_assert("RedHat", "RHEL", "6.9", ""))
@@ -208,7 +208,7 @@ class TestImds(AgentTestCase):
 
         self.assertEqual(imds.IMDS_IMAGE_ORIGIN_PLATFORM, self._setup_image_origin_assert("RedHat", "RHEL", "6.6", ""))
 
-    def test_is_endorsed_SuSE(self): # pylint: disable=invalid-name
+    def test_is_endorsed_SuSE(self):  # pylint: disable=invalid-name
         self.assertEqual(imds.IMDS_IMAGE_ORIGIN_ENDORSED, self._setup_image_origin_assert("SuSE", "SLES", "11-SP4", ""))
         self.assertEqual(imds.IMDS_IMAGE_ORIGIN_ENDORSED, self._setup_image_origin_assert("SuSE", "SLES-BYOS", "11-SP4", ""))
 
@@ -232,7 +232,7 @@ class TestImds(AgentTestCase):
 
         self.assertEqual(imds.IMDS_IMAGE_ORIGIN_PLATFORM, self._setup_image_origin_assert("SuSE", "SLES", "11-SP3", ""))
 
-    def test_is_endorsed_UbuntuServer(self): # pylint: disable=invalid-name
+    def test_is_endorsed_UbuntuServer(self):  # pylint: disable=invalid-name
         self.assertEqual(imds.IMDS_IMAGE_ORIGIN_ENDORSED, self._setup_image_origin_assert("Canonical", "UbuntuServer", "14.04.0-LTS", ""))
         self.assertEqual(imds.IMDS_IMAGE_ORIGIN_ENDORSED, self._setup_image_origin_assert("Canonical", "UbuntuServer", "14.04.1-LTS", ""))
         self.assertEqual(imds.IMDS_IMAGE_ORIGIN_ENDORSED, self._setup_image_origin_assert("Canonical", "UbuntuServer", "14.04.2-LTS", ""))
@@ -347,7 +347,7 @@ class TestImds(AgentTestCase):
         if isinstance(obj, list):
             self._update_field(obj[0], fields, val)
         else:
-            f = fields[0] # pylint: disable=invalid-name
+            f = fields[0]  # pylint: disable=invalid-name
             if len(fields) == 1:
                 if val is None:
                     del obj[f]
@@ -357,9 +357,9 @@ class TestImds(AgentTestCase):
                 self._update_field(obj[f], fields[1:], val)
 
     @staticmethod
-    def _imds_response(f): # pylint: disable=invalid-name
+    def _imds_response(f):  # pylint: disable=invalid-name
         path = os.path.join(data_dir, "imds", "{0}.json".format(f))
-        with open(path, "rb") as fh: # pylint: disable=invalid-name
+        with open(path, "rb") as fh:  # pylint: disable=invalid-name
             return fh.read()
 
     def _assert_validation(self, http_status_code, http_response, expected_valid, expected_response):
@@ -399,75 +399,75 @@ class TestImds(AgentTestCase):
 
             for has_primary_ioerror in (False, True):
                 # secondary endpoint unreachable
-                test_subject._http_get = Mock(side_effect=self._mock_http_get) # pylint: disable=protected-access
+                test_subject._http_get = Mock(side_effect=self._mock_http_get)  # pylint: disable=protected-access
                 self._mock_imds_setup(primary_ioerror=has_primary_ioerror, secondary_ioerror=True)
                 result = test_subject.get_metadata(resource_path=resource_path, is_health=is_health)
-                self.assertFalse(result.success) if has_primary_ioerror else self.assertTrue(result.success) # pylint: disable=expression-not-assigned
+                self.assertFalse(result.success) if has_primary_ioerror else self.assertTrue(result.success)  # pylint: disable=expression-not-assigned
                 self.assertFalse(result.service_error)
                 if has_primary_ioerror:
                     self.assertEqual('IMDS error in /metadata/{0}: Unable to connect to endpoint'.format(resource_path), result.response)
                 else:
                     self.assertEqual('Mock success response', result.response)
-                for _, kwargs in test_subject._http_get.call_args_list: # pylint: disable=protected-access
+                for _, kwargs in test_subject._http_get.call_args_list:  # pylint: disable=protected-access
                     self.assertTrue('User-Agent' in kwargs['headers'])
                     self.assertEqual(expected_useragent, kwargs['headers']['User-Agent'])
-                self.assertEqual(2 if has_primary_ioerror else 1, test_subject._http_get.call_count) # pylint: disable=protected-access
+                self.assertEqual(2 if has_primary_ioerror else 1, test_subject._http_get.call_count)  # pylint: disable=protected-access
 
                 # IMDS success
-                test_subject._http_get = Mock(side_effect=self._mock_http_get) # pylint: disable=protected-access
+                test_subject._http_get = Mock(side_effect=self._mock_http_get)  # pylint: disable=protected-access
                 self._mock_imds_setup(primary_ioerror=has_primary_ioerror)
                 result = test_subject.get_metadata(resource_path=resource_path, is_health=is_health)
                 self.assertTrue(result.success)
                 self.assertFalse(result.service_error)
                 self.assertEqual('Mock success response', result.response)
-                for _, kwargs in test_subject._http_get.call_args_list: # pylint: disable=protected-access
+                for _, kwargs in test_subject._http_get.call_args_list:  # pylint: disable=protected-access
                     self.assertTrue('User-Agent' in kwargs['headers'])
                     self.assertEqual(expected_useragent, kwargs['headers']['User-Agent'])
-                self.assertEqual(2 if has_primary_ioerror else 1, test_subject._http_get.call_count) # pylint: disable=protected-access
+                self.assertEqual(2 if has_primary_ioerror else 1, test_subject._http_get.call_count)  # pylint: disable=protected-access
 
                 # IMDS throttled
-                test_subject._http_get = Mock(side_effect=self._mock_http_get) # pylint: disable=protected-access
+                test_subject._http_get = Mock(side_effect=self._mock_http_get)  # pylint: disable=protected-access
                 self._mock_imds_setup(primary_ioerror=has_primary_ioerror, throttled=True)
                 result = test_subject.get_metadata(resource_path=resource_path, is_health=is_health)
                 self.assertFalse(result.success)
                 self.assertFalse(result.service_error)
                 self.assertEqual('IMDS error in /metadata/{0}: Throttled'.format(resource_path), result.response)
-                for _, kwargs in test_subject._http_get.call_args_list: # pylint: disable=protected-access
+                for _, kwargs in test_subject._http_get.call_args_list:  # pylint: disable=protected-access
                     self.assertTrue('User-Agent' in kwargs['headers'])
                     self.assertEqual(expected_useragent, kwargs['headers']['User-Agent'])
-                self.assertEqual(2 if has_primary_ioerror else 1, test_subject._http_get.call_count) # pylint: disable=protected-access
+                self.assertEqual(2 if has_primary_ioerror else 1, test_subject._http_get.call_count)  # pylint: disable=protected-access
 
                 # IMDS gone error
-                test_subject._http_get = Mock(side_effect=self._mock_http_get) # pylint: disable=protected-access
+                test_subject._http_get = Mock(side_effect=self._mock_http_get)  # pylint: disable=protected-access
                 self._mock_imds_setup(primary_ioerror=has_primary_ioerror, gone_error=True)
                 result = test_subject.get_metadata(resource_path=resource_path, is_health=is_health)
                 self.assertFalse(result.success)
                 self.assertTrue(result.service_error)
                 self.assertEqual('IMDS error in /metadata/{0}: HTTP Failed with Status Code 410: Gone'.format(resource_path), result.response)
-                for _, kwargs in test_subject._http_get.call_args_list: # pylint: disable=protected-access
+                for _, kwargs in test_subject._http_get.call_args_list:  # pylint: disable=protected-access
                     self.assertTrue('User-Agent' in kwargs['headers'])
                     self.assertEqual(expected_useragent, kwargs['headers']['User-Agent'])
-                self.assertEqual(2 if has_primary_ioerror else 1, test_subject._http_get.call_count) # pylint: disable=protected-access
+                self.assertEqual(2 if has_primary_ioerror else 1, test_subject._http_get.call_count)  # pylint: disable=protected-access
 
                 # IMDS bad request
-                test_subject._http_get = Mock(side_effect=self._mock_http_get) # pylint: disable=protected-access
+                test_subject._http_get = Mock(side_effect=self._mock_http_get)  # pylint: disable=protected-access
                 self._mock_imds_setup(primary_ioerror=has_primary_ioerror, bad_request=True)
                 result = test_subject.get_metadata(resource_path=resource_path, is_health=is_health)
                 self.assertFalse(result.success)
                 self.assertFalse(result.service_error)
                 self.assertEqual('IMDS error in /metadata/{0}: [HTTP Failed] [404: reason] Mock not found'.format(resource_path), result.response)
-                for _, kwargs in test_subject._http_get.call_args_list: # pylint: disable=protected-access
+                for _, kwargs in test_subject._http_get.call_args_list:  # pylint: disable=protected-access
                     self.assertTrue('User-Agent' in kwargs['headers'])
                     self.assertEqual(expected_useragent, kwargs['headers']['User-Agent'])
-                self.assertEqual(2 if has_primary_ioerror else 1, test_subject._http_get.call_count) # pylint: disable=protected-access
+                self.assertEqual(2 if has_primary_ioerror else 1, test_subject._http_get.call_count)  # pylint: disable=protected-access
 
-    def _mock_imds_setup(self, primary_ioerror=False, secondary_ioerror=False, gone_error=False, throttled=False, bad_request=False): # pylint: disable=too-many-arguments
-        self._mock_imds_expect_fallback = primary_ioerror # pylint: disable=attribute-defined-outside-init
-        self._mock_imds_primary_ioerror = primary_ioerror # pylint: disable=attribute-defined-outside-init
-        self._mock_imds_secondary_ioerror = secondary_ioerror # pylint: disable=attribute-defined-outside-init
-        self._mock_imds_gone_error = gone_error # pylint: disable=attribute-defined-outside-init
-        self._mock_imds_throttled = throttled # pylint: disable=attribute-defined-outside-init
-        self._mock_imds_bad_request = bad_request # pylint: disable=attribute-defined-outside-init
+    def _mock_imds_setup(self, primary_ioerror=False, secondary_ioerror=False, gone_error=False, throttled=False, bad_request=False):  # pylint: disable=too-many-arguments
+        self._mock_imds_expect_fallback = primary_ioerror  # pylint: disable=attribute-defined-outside-init
+        self._mock_imds_primary_ioerror = primary_ioerror  # pylint: disable=attribute-defined-outside-init
+        self._mock_imds_secondary_ioerror = secondary_ioerror  # pylint: disable=attribute-defined-outside-init
+        self._mock_imds_gone_error = gone_error  # pylint: disable=attribute-defined-outside-init
+        self._mock_imds_throttled = throttled  # pylint: disable=attribute-defined-outside-init
+        self._mock_imds_bad_request = bad_request  # pylint: disable=attribute-defined-outside-init
 
     def _mock_http_get(self, *_, **kwargs):
         if "foo.bar" == kwargs['endpoint'] and not self._mock_imds_expect_fallback:

--- a/tests/protocol/test_metadata_server_migration_util.py
+++ b/tests/protocol/test_metadata_server_migration_util.py
@@ -19,7 +19,7 @@ import os
 import tempfile
 import unittest
 
-import azurelinuxagent.common.osutil.default as osutil # pylint: disable=unused-import
+import azurelinuxagent.common.osutil.default as osutil  # pylint: disable=unused-import
 import azurelinuxagent.common.protocol.metadata_server_migration_util as migration_util
 
 from azurelinuxagent.common.protocol.metadata_server_migration_util import _LEGACY_METADATA_SERVER_TRANSPORT_PRV_FILE_NAME, \
@@ -32,7 +32,7 @@ from tests.tools import AgentTestCase, patch, MagicMock
 class TestMetadataServerMigrationUtil(AgentTestCase):
     @patch('azurelinuxagent.common.conf.get_lib_dir')
     def test_is_metadata_server_artifact_present(self, mock_get_lib_dir):
-        dir = tempfile.gettempdir() # pylint: disable=redefined-builtin
+        dir = tempfile.gettempdir()  # pylint: disable=redefined-builtin
         metadata_server_transport_cert_file = os.path.join(dir, _LEGACY_METADATA_SERVER_TRANSPORT_CERT_FILE_NAME)
         open(metadata_server_transport_cert_file, 'w').close()
         mock_get_lib_dir.return_value = dir
@@ -48,7 +48,7 @@ class TestMetadataServerMigrationUtil(AgentTestCase):
     def test_cleanup_metadata_server_artifacts_does_not_throw_with_no_metadata_certs(self, mock_get_lib_dir, mock_enable_firewall):
         mock_get_lib_dir.return_value = tempfile.gettempdir()
         mock_enable_firewall.return_value = False
-        osutil = MagicMock() # pylint: disable=redefined-outer-name
+        osutil = MagicMock()  # pylint: disable=redefined-outer-name
         migration_util.cleanup_metadata_server_artifacts(osutil)
 
     @patch('azurelinuxagent.common.conf.enable_firewall')
@@ -56,7 +56,7 @@ class TestMetadataServerMigrationUtil(AgentTestCase):
     @patch('os.getuid')
     def test_cleanup_metadata_server_artifacts_firewall_enabled(self, mock_os_getuid, mock_get_lib_dir, mock_enable_firewall):
         # Setup Certificate Files
-        dir = tempfile.gettempdir() # pylint: disable=redefined-builtin
+        dir = tempfile.gettempdir()  # pylint: disable=redefined-builtin
         metadata_server_transport_prv_file = os.path.join(dir, _LEGACY_METADATA_SERVER_TRANSPORT_PRV_FILE_NAME)
         metadata_server_transport_cert_file = os.path.join(dir, _LEGACY_METADATA_SERVER_TRANSPORT_CERT_FILE_NAME)
         metadata_server_p7b_file = os.path.join(dir, _LEGACY_METADATA_SERVER_P7B_FILE_NAME)
@@ -69,7 +69,7 @@ class TestMetadataServerMigrationUtil(AgentTestCase):
         mock_enable_firewall.return_value = True
         fixed_uid = 0
         mock_os_getuid.return_value = fixed_uid
-        osutil = MagicMock() # pylint: disable=redefined-outer-name
+        osutil = MagicMock()  # pylint: disable=redefined-outer-name
 
         # Run
         migration_util.cleanup_metadata_server_artifacts(osutil)
@@ -88,7 +88,7 @@ class TestMetadataServerMigrationUtil(AgentTestCase):
     @patch('os.getuid')
     def test_cleanup_metadata_server_artifacts_firewall_disabled(self, mock_os_getuid, mock_get_lib_dir, mock_enable_firewall):
         # Setup Certificate Files
-        dir = tempfile.gettempdir() # pylint: disable=redefined-builtin
+        dir = tempfile.gettempdir()  # pylint: disable=redefined-builtin
         metadata_server_transport_prv_file = os.path.join(dir, _LEGACY_METADATA_SERVER_TRANSPORT_PRV_FILE_NAME)
         metadata_server_transport_cert_file = os.path.join(dir, _LEGACY_METADATA_SERVER_TRANSPORT_CERT_FILE_NAME)
         metadata_server_p7b_file = os.path.join(dir, _LEGACY_METADATA_SERVER_P7B_FILE_NAME)
@@ -101,7 +101,7 @@ class TestMetadataServerMigrationUtil(AgentTestCase):
         mock_enable_firewall.return_value = False
         fixed_uid = 0
         mock_os_getuid.return_value = fixed_uid
-        osutil = MagicMock() # pylint: disable=redefined-outer-name
+        osutil = MagicMock()  # pylint: disable=redefined-outer-name
 
         # Run
         migration_util.cleanup_metadata_server_artifacts(osutil)

--- a/tests/protocol/test_protocol_util.py
+++ b/tests/protocol/test_protocol_util.py
@@ -48,7 +48,7 @@ class TestProtocolUtil(AgentTestCase):
 
     # Cleanup certificate files, protocol file, and endpoint files
     def tearDown(self):
-        dir = tempfile.gettempdir() # pylint: disable=redefined-builtin
+        dir = tempfile.gettempdir()  # pylint: disable=redefined-builtin
         for path in [os.path.join(dir, mds_cert) for mds_cert in TestProtocolUtil.MDS_CERTIFICATES]:
             if os.path.exists(path):
                 os.remove(path)
@@ -75,11 +75,11 @@ class TestProtocolUtil(AgentTestCase):
         def get_protocol_util_instance():
             try:
                 protocol_util_instances.append(get_protocol_util())
-            except Exception as e: # pylint: disable=invalid-name
+            except Exception as e:  # pylint: disable=invalid-name
                 errors.append(e)
 
-        t1 = Thread(target=get_protocol_util_instance) # pylint: disable=invalid-name
-        t2 = Thread(target=get_protocol_util_instance) # pylint: disable=invalid-name
+        t1 = Thread(target=get_protocol_util_instance)  # pylint: disable=invalid-name
+        t2 = Thread(target=get_protocol_util_instance)  # pylint: disable=invalid-name
         t1.start()
         t2.start()
         t1.join()
@@ -89,7 +89,7 @@ class TestProtocolUtil(AgentTestCase):
         self.assertNotEqual(protocol_util_instances[0], protocol_util_instances[1], "The instances created by different threads should be different")
     
     @patch("azurelinuxagent.common.protocol.util.WireProtocol")
-    def test_detect_protocol(self, WireProtocol, _): # pylint: disable=invalid-name
+    def test_detect_protocol(self, WireProtocol, _):  # pylint: disable=invalid-name
         WireProtocol.return_value = MagicMock()
 
         protocol_util = get_protocol_util()
@@ -109,7 +109,7 @@ class TestProtocolUtil(AgentTestCase):
 
     @patch("azurelinuxagent.common.conf.get_lib_dir")
     @patch("azurelinuxagent.common.protocol.util.WireProtocol")
-    def test_detect_protocol_no_dhcp(self, WireProtocol, mock_get_lib_dir, _): # pylint: disable=invalid-name
+    def test_detect_protocol_no_dhcp(self, WireProtocol, mock_get_lib_dir, _):  # pylint: disable=invalid-name
         WireProtocol.return_value.detect = Mock()
         mock_get_lib_dir.return_value = self.tmp_dir
 
@@ -122,26 +122,26 @@ class TestProtocolUtil(AgentTestCase):
         protocol_util.dhcp_handler.endpoint = None
         protocol_util.dhcp_handler.run = Mock()
 
-        endpoint_file = protocol_util._get_wireserver_endpoint_file_path() # pylint: disable=unused-variable,protected-access
+        endpoint_file = protocol_util._get_wireserver_endpoint_file_path()  # pylint: disable=unused-variable,protected-access
 
         # Test wire protocol when no endpoint file has been written
-        protocol_util._detect_protocol() # pylint: disable=protected-access
+        protocol_util._detect_protocol()  # pylint: disable=protected-access
         self.assertEqual(KNOWN_WIRESERVER_IP, protocol_util.get_wireserver_endpoint())
 
         # Test wire protocol on dhcp failure
         protocol_util.osutil.is_dhcp_available.return_value = True
         protocol_util.dhcp_handler.run.side_effect = DhcpError()
 
-        self.assertRaises(ProtocolError, protocol_util._detect_protocol) # pylint: disable=protected-access
+        self.assertRaises(ProtocolError, protocol_util._detect_protocol)  # pylint: disable=protected-access
 
     @patch("azurelinuxagent.common.protocol.util.WireProtocol")
-    def test_get_protocol(self, WireProtocol, _): # pylint: disable=invalid-name
+    def test_get_protocol(self, WireProtocol, _):  # pylint: disable=invalid-name
         WireProtocol.return_value = MagicMock()
 
         protocol_util = get_protocol_util()
         protocol_util.get_wireserver_endpoint = Mock()
-        protocol_util._detect_protocol = MagicMock() # pylint: disable=protected-access
-        protocol_util._save_protocol("WireProtocol") # pylint: disable=protected-access
+        protocol_util._detect_protocol = MagicMock()  # pylint: disable=protected-access
+        protocol_util._save_protocol("WireProtocol")  # pylint: disable=protected-access
 
         protocol = protocol_util.get_protocol()
 
@@ -159,9 +159,9 @@ class TestProtocolUtil(AgentTestCase):
         because we already expect them to be created since we are updating from a WireServer agent.
         """
         # Setup Protocol file with WireProtocol
-        dir = tempfile.gettempdir() # pylint: disable=redefined-builtin
+        dir = tempfile.gettempdir()  # pylint: disable=redefined-builtin
         filename = os.path.join(dir, PROTOCOL_FILE_NAME)
-        with open(filename, "w") as f: # pylint: disable=invalid-name
+        with open(filename, "w") as f:  # pylint: disable=invalid-name
             f.write(WIRE_PROTOCOL_NAME)
 
         # Setup MDS Certificates
@@ -198,9 +198,9 @@ class TestProtocolUtil(AgentTestCase):
         WireServer certificates are present, and protocol/endpoint files are written to appropriately.
         """
         # Setup Protocol file with MetadataProtocol
-        dir = tempfile.gettempdir() # pylint: disable=redefined-builtin
+        dir = tempfile.gettempdir()  # pylint: disable=redefined-builtin
         protocol_filename = os.path.join(dir, PROTOCOL_FILE_NAME)
-        with open(protocol_filename, "w") as f: # pylint: disable=invalid-name
+        with open(protocol_filename, "w") as f:  # pylint: disable=invalid-name
             f.write(_METADATA_PROTOCOL_NAME)
 
         # Setup MDS Certificates
@@ -234,11 +234,11 @@ class TestProtocolUtil(AgentTestCase):
         protocol_util.osutil.enable_firewall.assert_called_once()
 
         # Check Protocol File is updated to WireProtocol
-        with open(os.path.join(dir, PROTOCOL_FILE_NAME), "r") as f: # pylint: disable=invalid-name
+        with open(os.path.join(dir, PROTOCOL_FILE_NAME), "r") as f:  # pylint: disable=invalid-name
             self.assertEqual(f.read(), WIRE_PROTOCOL_NAME)
         
         # Check Endpoint file is updated to WireServer IP
-        with open(os.path.join(dir, ENDPOINT_FILE_NAME), 'r') as f: # pylint: disable=invalid-name
+        with open(os.path.join(dir, ENDPOINT_FILE_NAME), 'r') as f:  # pylint: disable=invalid-name
             self.assertEqual(f.read(), KNOWN_WIRESERVER_IP)
 
     @patch('azurelinuxagent.common.conf.get_lib_dir')
@@ -250,7 +250,7 @@ class TestProtocolUtil(AgentTestCase):
         protocol file, and endpoint file.
         """
         # Setup mocks
-        dir = tempfile.gettempdir() # pylint: disable=redefined-builtin
+        dir = tempfile.gettempdir()  # pylint: disable=redefined-builtin
         mock_get_lib_dir.return_value = dir
         mock_enable_firewall.return_value = True
         protocol_util = get_protocol_util()
@@ -272,11 +272,11 @@ class TestProtocolUtil(AgentTestCase):
         protocol_util.osutil.enable_firewall.assert_not_called()
 
         # Check Protocol File is updated to WireProtocol
-        with open(os.path.join(dir, PROTOCOL_FILE_NAME), "r") as f: # pylint: disable=invalid-name
+        with open(os.path.join(dir, PROTOCOL_FILE_NAME), "r") as f:  # pylint: disable=invalid-name
             self.assertEqual(f.read(), WIRE_PROTOCOL_NAME)
         
         # Check Endpoint file is updated to WireServer IP
-        with open(os.path.join(dir, ENDPOINT_FILE_NAME), 'r') as f: # pylint: disable=invalid-name
+        with open(os.path.join(dir, ENDPOINT_FILE_NAME), 'r') as f:  # pylint: disable=invalid-name
             self.assertEqual(f.read(), KNOWN_WIRESERVER_IP)
 
     @patch("azurelinuxagent.common.protocol.util.fileutil")
@@ -285,52 +285,52 @@ class TestProtocolUtil(AgentTestCase):
         mock_get_lib_dir.return_value = self.tmp_dir
 
         protocol_util = get_protocol_util()
-        endpoint_file = protocol_util._get_wireserver_endpoint_file_path() # pylint: disable=protected-access
+        endpoint_file = protocol_util._get_wireserver_endpoint_file_path()  # pylint: disable=protected-access
 
         # Test get endpoint for io error
         mock_fileutil.read_file.side_effect = IOError()
 
-        ep = protocol_util.get_wireserver_endpoint() # pylint: disable=invalid-name
+        ep = protocol_util.get_wireserver_endpoint()  # pylint: disable=invalid-name
         self.assertEqual(ep, KNOWN_WIRESERVER_IP)
 
         # Test get endpoint when file not found
         mock_fileutil.read_file.side_effect = IOError(ENOENT, 'File not found')
 
-        ep = protocol_util.get_wireserver_endpoint() # pylint: disable=invalid-name
+        ep = protocol_util.get_wireserver_endpoint()  # pylint: disable=invalid-name
         self.assertEqual(ep, KNOWN_WIRESERVER_IP)
 
         # Test get endpoint for empty file
         mock_fileutil.read_file.return_value = ""
 
-        ep = protocol_util.get_wireserver_endpoint() # pylint: disable=invalid-name
+        ep = protocol_util.get_wireserver_endpoint()  # pylint: disable=invalid-name
         self.assertEqual(ep, KNOWN_WIRESERVER_IP)
 
         # Test set endpoint for io error
         mock_fileutil.write_file.side_effect = IOError()
 
-        ep = protocol_util.get_wireserver_endpoint() # pylint: disable=invalid-name
-        self.assertRaises(OSUtilError, protocol_util._set_wireserver_endpoint, 'abc') # pylint: disable=protected-access
+        ep = protocol_util.get_wireserver_endpoint()  # pylint: disable=invalid-name
+        self.assertRaises(OSUtilError, protocol_util._set_wireserver_endpoint, 'abc')  # pylint: disable=protected-access
 
         # Test clear endpoint for io error
         with open(endpoint_file, "w+") as ep_fd:
             ep_fd.write("")
 
         with patch('os.remove') as mock_remove:
-            protocol_util._clear_wireserver_endpoint() # pylint: disable=protected-access
+            protocol_util._clear_wireserver_endpoint()  # pylint: disable=protected-access
             self.assertEqual(1, mock_remove.call_count)
             self.assertEqual(endpoint_file, mock_remove.call_args_list[0][0][0])
 
         # Test clear endpoint when file not found
         with patch('os.remove') as mock_remove:
             mock_remove = Mock(side_effect=IOError(ENOENT, 'File not found'))
-            protocol_util._clear_wireserver_endpoint() # pylint: disable=protected-access
+            protocol_util._clear_wireserver_endpoint()  # pylint: disable=protected-access
             mock_remove.assert_not_called()
 
     def test_protocol_file_states(self, _):
         protocol_util = get_protocol_util()
-        protocol_util._clear_wireserver_endpoint = Mock() # pylint: disable=protected-access
+        protocol_util._clear_wireserver_endpoint = Mock()  # pylint: disable=protected-access
 
-        protocol_file = protocol_util._get_protocol_file_path() # pylint: disable=protected-access
+        protocol_file = protocol_util._get_protocol_file_path()  # pylint: disable=protected-access
 
         # Test clear protocol for io error
         with open(protocol_file, "w+") as proto_fd:
@@ -338,16 +338,16 @@ class TestProtocolUtil(AgentTestCase):
 
         with patch('os.remove') as mock_remove:
             protocol_util.clear_protocol()
-            self.assertEqual(1, protocol_util._clear_wireserver_endpoint.call_count) # pylint: disable=protected-access
+            self.assertEqual(1, protocol_util._clear_wireserver_endpoint.call_count)  # pylint: disable=protected-access
             self.assertEqual(1, mock_remove.call_count)
             self.assertEqual(protocol_file, mock_remove.call_args_list[0][0][0])
 
         # Test clear protocol when file not found
-        protocol_util._clear_wireserver_endpoint.reset_mock() # pylint: disable=protected-access
+        protocol_util._clear_wireserver_endpoint.reset_mock()  # pylint: disable=protected-access
 
         with patch('os.remove') as mock_remove:
             protocol_util.clear_protocol()
-            self.assertEqual(1, protocol_util._clear_wireserver_endpoint.call_count) # pylint: disable=protected-access
+            self.assertEqual(1, protocol_util._clear_wireserver_endpoint.call_count)  # pylint: disable=protected-access
             self.assertEqual(1, mock_remove.call_count)
             self.assertEqual(protocol_file, mock_remove.call_args_list[0][0][0])
 

--- a/tests/protocol/test_wire.py
+++ b/tests/protocol/test_wire.py
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*- # pylint: disable=too-many-lines
+# -*- encoding: utf-8 -*-  # pylint: disable=too-many-lines
 # Copyright 2018 Microsoft Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -45,13 +45,13 @@ from tests.protocol.mockwiredata import DATA_FILE_NO_EXT
 from tests.protocol.mockwiredata import WireProtocolData
 from tests.tools import Mock, patch, AgentTestCase
 
-data_with_bom = b'\xef\xbb\xbfhehe' # pylint: disable=invalid-name
-testurl = 'http://foo' # pylint: disable=invalid-name
-testtype = 'BlockBlob' # pylint: disable=invalid-name
+data_with_bom = b'\xef\xbb\xbfhehe'  # pylint: disable=invalid-name
+testurl = 'http://foo'  # pylint: disable=invalid-name
+testtype = 'BlockBlob'  # pylint: disable=invalid-name
 WIRESERVER_URL = '168.63.129.16'
 
 
-def get_event(message, duration=30000, evt_type="", is_internal=False, is_success=True, # pylint: disable=invalid-name,too-many-arguments
+def get_event(message, duration=30000, evt_type="", is_internal=False, is_success=True,  # pylint: disable=invalid-name,too-many-arguments
               name="", op="Unknown", version=CURRENT_VERSION, eventId=1):
     event = TelemetryEvent(eventId, "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX")
     event.parameters.append(TelemetryEventParam(GuestAgentExtensionEventsSchema.Name, name))
@@ -74,7 +74,7 @@ def create_mock_protocol(artifacts_profile_blob=None, status_upload_blob=None, s
         ext_conf.artifacts_profile_blob = artifacts_profile_blob
         ext_conf.status_upload_blob = status_upload_blob
         ext_conf.status_upload_blob_type = status_upload_blob_type
-        protocol.client._goal_state.ext_conf = ext_conf # pylint: disable=protected-access
+        protocol.client._goal_state.ext_conf = ext_conf  # pylint: disable=protected-access
 
         yield protocol
 
@@ -89,7 +89,7 @@ class TestWireProtocol(AgentTestCase):
         super(TestWireProtocol, self).setUp()
         HostPluginProtocol.set_default_channel(False)
 
-    def _test_getters(self, test_data, certsMustBePresent, __, MockCryptUtil, _): # pylint: disable=invalid-name
+    def _test_getters(self, test_data, certsMustBePresent, __, MockCryptUtil, _):  # pylint: disable=invalid-name
         MockCryptUtil.side_effect = test_data.mock_crypt_util
 
         with patch.object(restutil, 'http_get', test_data.mock_http_get):
@@ -97,7 +97,7 @@ class TestWireProtocol(AgentTestCase):
             protocol.detect()
             protocol.get_vminfo()
             protocol.get_certs()
-            ext_handlers, etag = protocol.get_ext_handlers() # pylint: disable=unused-variable
+            ext_handlers, etag = protocol.get_ext_handlers()  # pylint: disable=unused-variable
             for ext_handler in ext_handlers.extHandlers:
                 protocol.get_ext_handler_pkgs(ext_handler)
 
@@ -171,7 +171,7 @@ class TestWireProtocol(AgentTestCase):
         self.assertEqual(1, test_data.call_counts["hostingenvuri"])
         self.assertEqual(1, patch_report.call_count)
 
-    def test_call_storage_kwargs(self, *args): # pylint: disable=unused-argument
+    def test_call_storage_kwargs(self, *args):  # pylint: disable=unused-argument
         with patch.object(restutil, 'http_get') as http_patch:
             http_req = restutil.http_get
             url = testurl
@@ -205,10 +205,10 @@ class TestWireProtocol(AgentTestCase):
             # assert
             self.assertTrue(http_patch.call_count == 5)
             for i in range(0, 5):
-                c = http_patch.call_args_list[i][-1]['use_proxy'] # pylint: disable=invalid-name
-                self.assertTrue(c == (True if i != 3 else False)) # pylint: disable=simplifiable-if-expression
+                c = http_patch.call_args_list[i][-1]['use_proxy']  # pylint: disable=invalid-name
+                self.assertTrue(c == (True if i != 3 else False))  # pylint: disable=simplifiable-if-expression
 
-    def test_status_blob_parsing(self, *args): # pylint: disable=unused-argument
+    def test_status_blob_parsing(self, *args):  # pylint: disable=unused-argument
         with mock_wire_protocol(mockwiredata.DATA_FILE) as protocol:
             self.assertEqual(protocol.client.get_ext_conf().status_upload_blob,
                              'https://test.blob.core.windows.net/vhds/test-cs12.test-cs12.test-cs12.status?'
@@ -216,7 +216,7 @@ class TestWireProtocol(AgentTestCase):
                              'sig=hfRh7gzUE7sUtYwke78IOlZOrTRCYvkec4hGZ9zZzXo')
             self.assertEqual(protocol.client.get_ext_conf().status_upload_blob_type, u'BlockBlob')
 
-    def test_get_host_ga_plugin(self, *args): # pylint: disable=unused-argument
+    def test_get_host_ga_plugin(self, *args):  # pylint: disable=unused-argument
         with mock_wire_protocol(mockwiredata.DATA_FILE) as protocol:
             host_plugin = protocol.client.get_host_plugin()
             goal_state = protocol.client.get_goal_state()
@@ -224,7 +224,7 @@ class TestWireProtocol(AgentTestCase):
             self.assertEqual(goal_state.role_config_name, host_plugin.role_config_name)
 
     def test_upload_status_blob_should_use_the_host_channel_by_default(self, *_):
-        def http_put_handler(url, *_, **__): # pylint: disable=inconsistent-return-statements
+        def http_put_handler(url, *_, **__):  # pylint: disable=inconsistent-return-statements
             if protocol.get_endpoint() in url and url.endswith('/status'):
                 return MockResponse(body=b'', status_code=200)
 
@@ -274,7 +274,7 @@ class TestWireProtocol(AgentTestCase):
     def test_get_in_vm_artifacts_profile_blob_not_available(self, *_):
         # Test when artifacts_profile_blob is null/None
         with mock_wire_protocol(DATA_FILE_NO_EXT) as protocol:
-            protocol.client._goal_state.ext_conf = ExtensionsConfig(None) # pylint: disable=protected-access
+            protocol.client._goal_state.ext_conf = ExtensionsConfig(None)  # pylint: disable=protected-access
 
             self.assertEqual(None, protocol.client.get_artifacts_profile())
 
@@ -305,7 +305,7 @@ class TestWireProtocol(AgentTestCase):
                 host_plugin_get_artifact_url_and_headers.assert_called_with(testurl)
 
     @patch("azurelinuxagent.common.event.add_event")
-    def test_artifacts_profile_json_parsing(self, patch_event, *args): # pylint: disable=unused-argument
+    def test_artifacts_profile_json_parsing(self, patch_event, *args):  # pylint: disable=unused-argument
         with create_mock_protocol(artifacts_profile_blob=testurl) as protocol:
             # response is invalid json
             protocol.client.call_storage_service = Mock(return_value=MockResponse("invalid json".encode('utf-8'), 200))
@@ -320,7 +320,7 @@ class TestWireProtocol(AgentTestCase):
             self.assertTrue('invalid json' in patch_event.call_args[1]['message'])
             self.assertEqual('ArtifactsProfileBlob', patch_event.call_args[1]['op'])
 
-    def test_get_in_vm_artifacts_profile_default(self, *args): # pylint: disable=unused-argument
+    def test_get_in_vm_artifacts_profile_default(self, *args):  # pylint: disable=unused-argument
         with create_mock_protocol(artifacts_profile_blob=testurl) as protocol:
             protocol.client.call_storage_service = Mock(return_value=MockResponse('{"onHold": "true"}'.encode('utf-8'), 200))
             in_vm_artifacts_profile = protocol.client.get_artifacts_profile()
@@ -329,7 +329,7 @@ class TestWireProtocol(AgentTestCase):
 
     @patch("socket.gethostname", return_value="hostname")
     @patch("time.gmtime", return_value=time.localtime(1485543256))
-    def test_report_vm_status(self, *args): # pylint: disable=unused-argument
+    def test_report_vm_status(self, *args):  # pylint: disable=unused-argument
         status = 'status'
         message = 'message'
 
@@ -375,7 +375,7 @@ class TestWireProtocol(AgentTestCase):
 
         first_call = mock_http_request.call_args_list[0]
         args, kwargs = first_call
-        method, url, body_received = args # pylint: disable=unused-variable
+        method, url, body_received = args  # pylint: disable=unused-variable
         headers = kwargs['headers']
 
         # the headers should include utf-8 encoding...
@@ -384,7 +384,7 @@ class TestWireProtocol(AgentTestCase):
         self.assertIn(event_str, body_received)
 
     @patch("azurelinuxagent.common.protocol.wire.WireClient.send_event")
-    def test_report_event_small_event(self, patch_send_event, *args): # pylint: disable=unused-argument
+    def test_report_event_small_event(self, patch_send_event, *args):  # pylint: disable=unused-argument
         event_list = []
         client = WireProtocol(WIRESERVER_URL).client
 
@@ -406,7 +406,7 @@ class TestWireProtocol(AgentTestCase):
         self.assertEqual(patch_send_event.call_count, 1)
 
     @patch("azurelinuxagent.common.protocol.wire.WireClient.send_event")
-    def test_report_event_multiple_events_to_fill_buffer(self, patch_send_event, *args): # pylint: disable=unused-argument
+    def test_report_event_multiple_events_to_fill_buffer(self, patch_send_event, *args):  # pylint: disable=unused-argument
         event_list = []
         client = WireProtocol(WIRESERVER_URL).client
 
@@ -420,7 +420,7 @@ class TestWireProtocol(AgentTestCase):
         self.assertEqual(patch_send_event.call_count, 2)
 
     @patch("azurelinuxagent.common.protocol.wire.WireClient.send_event")
-    def test_report_event_large_event(self, patch_send_event, *args): # pylint: disable=unused-argument
+    def test_report_event_large_event(self, patch_send_event, *args):  # pylint: disable=unused-argument
         event_list = []
         event_str = random_generator(2 ** 18)
         event_list.append(get_event(message=event_str))
@@ -431,7 +431,7 @@ class TestWireProtocol(AgentTestCase):
 
 
 class TestWireClient(HttpRequestPredicates, AgentTestCase):
-    def test_get_ext_conf_without_extensions_should_retrieve_vmagent_manifests_info(self, *args): # pylint: disable=unused-argument
+    def test_get_ext_conf_without_extensions_should_retrieve_vmagent_manifests_info(self, *args):  # pylint: disable=unused-argument
         # Basic test for get_ext_conf() when extensions are not present in the config. The test verifies that
         # get_ext_conf() fetches the correct data by comparing the returned data with the test data provided the
         # mock_wire_protocol.
@@ -523,7 +523,7 @@ class TestWireClient(HttpRequestPredicates, AgentTestCase):
         extension_url = 'https://fake_host/fake_extension.zip'
         target_file = os.path.join(self.tmp_dir, 'fake_extension.zip')
 
-        def http_get_handler(url, *args, **kwargs): # pylint: disable=unused-argument
+        def http_get_handler(url, *args, **kwargs):  # pylint: disable=unused-argument
             if url == extension_url:
                 return HttpError("Exception to fake an error on the direct channel")
             if self.is_host_plugin_extension_request(url, kwargs, extension_url):
@@ -646,7 +646,7 @@ class TestWireClient(HttpRequestPredicates, AgentTestCase):
         def http_get_handler(url, *_, **kwargs):
             if url == manifest_url:
                 return HttpError("Exception to fake an error on the direct channel")
-            if self.is_host_plugin_extension_request(url, kwargs, manifest_url): # pylint: disable=no-else-return
+            if self.is_host_plugin_extension_request(url, kwargs, manifest_url):  # pylint: disable=no-else-return
                 # fake a stale goal state then succeed once the goal state has been refreshed
                 if http_get_handler.goal_state_requests == 0:
                     http_get_handler.goal_state_requests += 1
@@ -682,7 +682,7 @@ class TestWireClient(HttpRequestPredicates, AgentTestCase):
         manifest_url = 'https://fake_host/fake_manifest.xml'
 
         def http_get_handler(url, *_, **kwargs):
-            if url == manifest_url or self.is_host_plugin_extension_request(url, kwargs, manifest_url): # pylint: disable=no-else-return
+            if url == manifest_url or self.is_host_plugin_extension_request(url, kwargs, manifest_url):  # pylint: disable=no-else-return
                 return ResourceGoneError("Exception to fake an error on either channel")
             elif self.is_goal_state_request(url):
                 protocol.track_url(url)  # keep track of goal state requests
@@ -716,7 +716,7 @@ class TestWireClient(HttpRequestPredicates, AgentTestCase):
             self.assertEqual(HostPluginProtocol.is_default_channel(), False)
 
     def test_get_artifacts_profile_should_not_invoke_host_channel_when_direct_channel_succeeds(self):
-        def http_get_handler(url, *_, **__): # pylint: disable=useless-return
+        def http_get_handler(url, *_, **__):  # pylint: disable=useless-return
             if self.is_in_vm_artifacts_profile_request(url):
                 protocol.track_url(url)
             return None
@@ -749,7 +749,7 @@ class TestWireClient(HttpRequestPredicates, AgentTestCase):
 
                 self.assertIsNotNone(return_value, "The artifacts profile request should have succeeded")
                 self.assertIsInstance(return_value, InVMArtifactsProfile, 'The request did not return a valid artifacts profile: {0}'.format(return_value))
-                self.assertTrue(return_value.onHold, 'The OnHold property should be True') # pylint: disable=no-member
+                self.assertTrue(return_value.onHold, 'The OnHold property should be True')  # pylint: disable=no-member
                 urls = protocol.get_tracked_urls()
                 self.assertEqual(len(urls), 2, "Invalid number of requests: [{0}]".format(urls))
                 self.assertTrue(self.is_in_vm_artifacts_profile_request(urls[0]), "The first request should have been over the direct channel")
@@ -785,7 +785,7 @@ class TestWireClient(HttpRequestPredicates, AgentTestCase):
 
                 self.assertIsNotNone(return_value, "The artifacts profile request should have succeeded")
                 self.assertIsInstance(return_value, InVMArtifactsProfile, 'The request did not return a valid artifacts profile: {0}'.format(return_value))
-                self.assertTrue(return_value.onHold, 'The OnHold property should be True') # pylint: disable=no-member
+                self.assertTrue(return_value.onHold, 'The OnHold property should be True')  # pylint: disable=no-member
                 urls = protocol.get_tracked_urls()
                 self.assertEqual(len(urls), 4, "Invalid number of requests: [{0}]".format(urls))
                 self.assertTrue(self.is_in_vm_artifacts_profile_request(urls[0]), "The first request should have been over the direct channel")
@@ -826,7 +826,7 @@ class TestWireClient(HttpRequestPredicates, AgentTestCase):
             self.assertEqual(HostPluginProtocol.is_default_channel(), False, "The default channel should not have changed")
 
     def test_upload_logs_should_not_refresh_plugin_when_first_attempt_succeeds(self):
-        def http_put_handler(url, *_, **__): # pylint: disable=inconsistent-return-statements
+        def http_put_handler(url, *_, **__):  # pylint: disable=inconsistent-return-statements
             if self.is_host_plugin_put_logs_request(url):
                 return MockResponse(body=b'', status_code=200)
 
@@ -863,11 +863,11 @@ class TestWireClient(HttpRequestPredicates, AgentTestCase):
         with mock_wire_protocol(mockwiredata.DATA_FILE) as protocol:
             protocol.client.get_host_plugin().set_default_channel(False)
 
-            def direct_func(*args): # pylint: disable=unused-argument
+            def direct_func(*args):  # pylint: disable=unused-argument
                 direct_func.counter += 1
                 return 42
 
-            def host_func(*args): # pylint: disable=useless-return,unused-argument
+            def host_func(*args):  # pylint: disable=useless-return,unused-argument
                 host_func.counter += 1
                 return None
 
@@ -884,11 +884,11 @@ class TestWireClient(HttpRequestPredicates, AgentTestCase):
         with mock_wire_protocol(mockwiredata.DATA_FILE) as protocol:
             protocol.client.get_host_plugin().set_default_channel(True)
 
-            def direct_func(*args): # pylint: disable=unused-argument
+            def direct_func(*args):  # pylint: disable=unused-argument
                 direct_func.counter += 1
                 return 42
 
-            def host_func(*args): # pylint: disable=unused-argument
+            def host_func(*args):  # pylint: disable=unused-argument
                 host_func.counter += 1
                 return 43
 
@@ -906,11 +906,11 @@ class TestWireClient(HttpRequestPredicates, AgentTestCase):
             host = protocol.client.get_host_plugin()
             host.set_default_channel(False)
 
-            def direct_func(*args): # pylint: disable=unused-argument
+            def direct_func(*args):  # pylint: disable=unused-argument
                 direct_func.counter += 1
                 raise InvalidContainerError()
 
-            def host_func(*args): # pylint: disable=unused-argument
+            def host_func(*args):  # pylint: disable=unused-argument
                 host_func.counter += 1
                 return 42
 
@@ -929,11 +929,11 @@ class TestWireClient(HttpRequestPredicates, AgentTestCase):
         with mock_wire_protocol(mockwiredata.DATA_FILE) as protocol:
             protocol.client.get_host_plugin().set_default_channel(False)
 
-            def direct_func(*args): # pylint: disable=unused-argument
+            def direct_func(*args):  # pylint: disable=unused-argument
                 direct_func.counter += 1
                 raise InvalidContainerError()
 
-            def host_func(*args): # pylint: disable=unused-argument
+            def host_func(*args):  # pylint: disable=unused-argument
                 host_func.counter += 1
                 if host_func.counter == 1:
                     raise ResourceGoneError("Resource is gone")
@@ -1140,11 +1140,11 @@ class TryUpdateGoalStateTestCase(HttpRequestPredicates, AgentTestCase):
 
             calls_to_strings = lambda calls: (str(c) for c in calls)
             filter_calls = lambda calls, regex=None: (c for c in calls_to_strings(calls) if regex is None or re.match(regex, c))
-            logger_calls = lambda regex=None: [m for m in filter_calls(logger.method_calls, regex)] # pylint: disable=used-before-assignment,unnecessary-comprehension
+            logger_calls = lambda regex=None: [m for m in filter_calls(logger.method_calls, regex)]  # pylint: disable=used-before-assignment,unnecessary-comprehension
             warnings = lambda: logger_calls(r'call.warn\(.*An error occurred while retrieving the goal state.*')
             periodic_warnings = lambda: logger_calls(r'call.periodic_warn\(.*Attempts to retrieve the goal state are failing.*')
             success_messages = lambda: logger_calls(r'call.info\(.*Retrieving the goal state recovered from previous errors.*')
-            telemetry_calls = lambda regex=None: [m for m in filter_calls(add_event.mock_calls, regex)] # pylint: disable=used-before-assignment,unnecessary-comprehension
+            telemetry_calls = lambda regex=None: [m for m in filter_calls(add_event.mock_calls, regex)]  # pylint: disable=used-before-assignment,unnecessary-comprehension
             goal_state_events = lambda: telemetry_calls(r".*op='FetchGoalState'.*")
 
             #
@@ -1154,10 +1154,10 @@ class TryUpdateGoalStateTestCase(HttpRequestPredicates, AgentTestCase):
             with create_log_and_telemetry_mocks() as (logger, add_event):
                 protocol.client.try_update_goal_state()
 
-                lc = logger_calls() # pylint: disable=invalid-name
+                lc = logger_calls()  # pylint: disable=invalid-name
                 self.assertTrue(len(lc) == 0, "A successful call should not produce any log messages: [{0}]".format(lc))
 
-                tc = telemetry_calls() # pylint: disable=invalid-name
+                tc = telemetry_calls()  # pylint: disable=invalid-name
                 self.assertTrue(len(tc) == 0, "A successful call should not produce any telemetry events: [{0}]".format(tc))
 
             #
@@ -1167,12 +1167,12 @@ class TryUpdateGoalStateTestCase(HttpRequestPredicates, AgentTestCase):
             with create_log_and_telemetry_mocks() as (logger, add_event):
                 protocol.client.try_update_goal_state()
 
-                w = warnings() # pylint: disable=invalid-name
-                pw = periodic_warnings() # pylint: disable=invalid-name
+                w = warnings()  # pylint: disable=invalid-name
+                pw = periodic_warnings()  # pylint: disable=invalid-name
                 self.assertEqual(len(w), 1, "A failure should have produced a warning: [{0}]".format(w))
                 self.assertEqual(len(pw), 1, "A failure should have produced a periodic warning: [{0}]".format(pw))
 
-                gs = goal_state_events() # pylint: disable=invalid-name
+                gs = goal_state_events()  # pylint: disable=invalid-name
                 self.assertTrue(len(gs) == 1 and 'is_success=False' in gs[0], "A failure should produce a telemetry event (success=false): [{0}]".format(gs))
 
             #
@@ -1183,12 +1183,12 @@ class TryUpdateGoalStateTestCase(HttpRequestPredicates, AgentTestCase):
                 protocol.client.try_update_goal_state()
                 protocol.client.try_update_goal_state()
 
-                w = warnings() # pylint: disable=invalid-name
-                pw = periodic_warnings() # pylint: disable=invalid-name
+                w = warnings()  # pylint: disable=invalid-name
+                pw = periodic_warnings()  # pylint: disable=invalid-name
                 self.assertTrue(len(w) == 0, "Subsequent failures should not produce warnings: [{0}]".format(w))
                 self.assertEqual(len(pw), 3, "Subsequent failures should produce periodic warnings: [{0}]".format(pw))
 
-                tc = telemetry_calls() # pylint: disable=invalid-name
+                tc = telemetry_calls()  # pylint: disable=invalid-name
                 self.assertTrue(len(tc) == 0, "Subsequent failures should not produce any telemetry events: [{0}]".format(tc))
 
             #
@@ -1198,13 +1198,13 @@ class TryUpdateGoalStateTestCase(HttpRequestPredicates, AgentTestCase):
             with create_log_and_telemetry_mocks() as (logger, add_event):
                 protocol.client.try_update_goal_state()
 
-                s = success_messages() # pylint: disable=invalid-name
-                w = warnings() # pylint: disable=invalid-name
-                pw = periodic_warnings() # pylint: disable=invalid-name
+                s = success_messages()  # pylint: disable=invalid-name
+                w = warnings()  # pylint: disable=invalid-name
+                pw = periodic_warnings()  # pylint: disable=invalid-name
                 self.assertEqual(len(s), 1, "Recovering after failures should have produced an info message: [{0}]".format(s))
                 self.assertTrue(len(w) == 0 and len(pw) == 0, "Recovering after failures should have not produced any warnings: [{0}] [{1}]".format(w, pw))
 
-                gs = goal_state_events() # pylint: disable=invalid-name
+                gs = goal_state_events()  # pylint: disable=invalid-name
                 self.assertTrue(len(gs) == 1 and 'is_success=True' in gs[0], "Recovering after failures should produce a telemetry event (success=true): [{0}]".format(gs))
 
 
@@ -1245,7 +1245,7 @@ class UpdateHostPluginFromGoalStateTestCase(AgentTestCase):
                 self.assertEqual(protocol.client.get_shared_conf().xml_text, shared_conf_xml_text)
 
 
-class MockResponse: # pylint: disable=too-few-public-methods
+class MockResponse:  # pylint: disable=too-few-public-methods
     def __init__(self, body, status_code):
         self.body = body
         self.status = status_code

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -84,27 +84,27 @@ class TestAgent(AgentTestCase):
 
     def test_accepts_configuration_path(self):
         conf_path = os.path.join(data_dir, "test_waagent.conf")
-        c, f, v, d, cfp, lcm = parse_args(["-configuration-path:" + conf_path]) # pylint: disable=unused-variable,invalid-name
+        c, f, v, d, cfp, lcm = parse_args(["-configuration-path:" + conf_path])  # pylint: disable=unused-variable,invalid-name
         self.assertEqual(cfp, conf_path)
 
     @patch("os.path.exists", return_value=True)
     def test_checks_configuration_path(self, mock_exists):
         conf_path = "/foo/bar-baz/something.conf"
-        c, f, v, d, cfp, lcm = parse_args(["-configuration-path:"+conf_path]) # pylint: disable=unused-variable,invalid-name
+        c, f, v, d, cfp, lcm = parse_args(["-configuration-path:"+conf_path])  # pylint: disable=unused-variable,invalid-name
         self.assertEqual(cfp, conf_path)
         self.assertEqual(mock_exists.call_count, 1)
 
     @patch("sys.stderr")
     @patch("os.path.exists", return_value=False)
     @patch("sys.exit", side_effect=Exception)
-    def test_rejects_missing_configuration_path(self, mock_exit, mock_exists, mock_stderr): # pylint: disable=unused-argument
+    def test_rejects_missing_configuration_path(self, mock_exit, mock_exists, mock_stderr):  # pylint: disable=unused-argument
         try:
-            c, f, v, d, cfp, lcm = parse_args(["-configuration-path:/foo/bar.conf"]) # pylint: disable=unused-variable,invalid-name
+            c, f, v, d, cfp, lcm = parse_args(["-configuration-path:/foo/bar.conf"])  # pylint: disable=unused-variable,invalid-name
         except Exception:
             self.assertEqual(mock_exit.call_count, 1)
 
     def test_configuration_path_defaults_to_none(self):
-        c, f, v, d, cfp, lcm = parse_args([]) # pylint: disable=unused-variable,invalid-name
+        c, f, v, d, cfp, lcm = parse_args([])  # pylint: disable=unused-variable,invalid-name
         self.assertEqual(cfp, None)
 
     def test_agent_accepts_configuration_path(self):
@@ -151,7 +151,7 @@ class TestAgent(AgentTestCase):
         mock_dir.return_value = ext_log_dir
 
         self.assertFalse(os.path.isdir(ext_log_dir))
-        agent = Agent(False, # pylint: disable=unused-variable
+        agent = Agent(False,  # pylint: disable=unused-variable
                     conf_file_path=os.path.join(data_dir, "test_waagent.conf"))
         self.assertTrue(os.path.isdir(ext_log_dir))
 
@@ -164,7 +164,7 @@ class TestAgent(AgentTestCase):
 
         self.assertTrue(os.path.isfile(ext_log_dir))
         self.assertFalse(os.path.isdir(ext_log_dir))
-        agent = Agent(False, # pylint: disable=unused-variable
+        agent = Agent(False,  # pylint: disable=unused-variable
                       conf_file_path=os.path.join(data_dir, "test_waagent.conf"))
         self.assertTrue(os.path.isfile(ext_log_dir))
         self.assertFalse(os.path.isdir(ext_log_dir))
@@ -181,26 +181,26 @@ class TestAgent(AgentTestCase):
 
     def test_checks_log_collector_mode(self):
         # Specify full mode
-        c, f, v, d, cfp, lcm = parse_args(["-collect-logs", "-full"]) # pylint: disable=unused-variable,invalid-name
+        c, f, v, d, cfp, lcm = parse_args(["-collect-logs", "-full"])  # pylint: disable=unused-variable,invalid-name
         self.assertEqual(c, "collect-logs")
         self.assertEqual(lcm, True)
 
         # Defaults to None if mode not specified
-        c, f, v, d, cfp, lcm = parse_args(["-collect-logs"]) # pylint: disable=unused-variable,invalid-name
+        c, f, v, d, cfp, lcm = parse_args(["-collect-logs"])  # pylint: disable=unused-variable,invalid-name
         self.assertEqual(c, "collect-logs")
         self.assertEqual(lcm, False)
 
     @patch("sys.stderr")
     @patch("sys.exit", side_effect=Exception)
-    def test_rejects_invalid_log_collector_mode(self, mock_exit, mock_stderr): # pylint: disable=unused-argument
+    def test_rejects_invalid_log_collector_mode(self, mock_exit, mock_stderr):  # pylint: disable=unused-argument
         try:
-            c, f, v, d, cfp, lcm = parse_args(["-collect-logs", "-notvalid"]) # pylint: disable=unused-variable,invalid-name
+            c, f, v, d, cfp, lcm = parse_args(["-collect-logs", "-notvalid"])  # pylint: disable=unused-variable,invalid-name
         except Exception:
             self.assertEqual(mock_exit.call_count, 1)
 
     @patch("os.path.exists", return_value=True)
     @patch("azurelinuxagent.agent.LogCollector")
-    def test_calls_collect_logs_with_proper_mode(self, mock_log_collector, *args): # pylint: disable=unused-argument
+    def test_calls_collect_logs_with_proper_mode(self, mock_log_collector, *args):  # pylint: disable=unused-argument
         agent = Agent(False, conf_file_path=os.path.join(data_dir, "test_waagent.conf"))
 
         agent.collect_logs(is_full_mode=True)

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -34,25 +34,25 @@ from threading import currentThread
 import azurelinuxagent.common.conf as conf
 import azurelinuxagent.common.event as event
 import azurelinuxagent.common.logger as logger
-from azurelinuxagent.common.future import range # pylint: disable=redefined-builtin
+from azurelinuxagent.common.future import range  # pylint: disable=redefined-builtin
 from azurelinuxagent.common.cgroupapi import SYSTEMD_RUN_PATH
 from azurelinuxagent.common.utils import fileutil
 from azurelinuxagent.common.version import PY_VERSION_MAJOR
 
 try:
-    from unittest.mock import Mock, patch, MagicMock, ANY, DEFAULT, call, PropertyMock # pylint: disable=unused-import,ungrouped-imports
+    from unittest.mock import Mock, patch, MagicMock, ANY, DEFAULT, call, PropertyMock  # pylint: disable=unused-import,ungrouped-imports
 
     # Import mock module for Python2 and Python3
-    from bin.waagent2 import Agent # pylint: disable=unused-import
+    from bin.waagent2 import Agent  # pylint: disable=unused-import
 except ImportError:
     from mock import Mock, patch, MagicMock, ANY, DEFAULT, call, PropertyMock
 
-test_dir = os.path.dirname(os.path.abspath(__file__)) # pylint: disable=invalid-name
-data_dir = os.path.join(test_dir, "data") # pylint: disable=invalid-name
+test_dir = os.path.dirname(os.path.abspath(__file__))  # pylint: disable=invalid-name
+data_dir = os.path.join(test_dir, "data")  # pylint: disable=invalid-name
 
-debug = False # pylint: disable=invalid-name
+debug = False  # pylint: disable=invalid-name
 if os.environ.get('DEBUG') == '1':
-    debug = True # pylint: disable=invalid-name
+    debug = True  # pylint: disable=invalid-name
 
 # Enable verbose logger to stdout
 if debug:
@@ -132,13 +132,13 @@ def is_python_version_26():
 
 class AgentTestCase(unittest.TestCase):
     @classmethod
-    def setUpClass(cls): # pylint: disable=too-many-branches
+    def setUpClass(cls):  # pylint: disable=too-many-branches
         # Setup newer unittest assertions missing in prior versions of Python
 
         if not hasattr(cls, "assertRegex"):
             cls.assertRegex = cls.assertRegexpMatches if hasattr(cls, "assertRegexpMatches") else cls.emulate_assertRegexpMatches
         if not hasattr(cls, "assertNotRegex"):
-            cls.assertNotRegex = cls.assertNotRegexpMatches if hasattr(cls, "assertNotRegexpMatches") else cls.emulate_assertNotRegexpMatches # pylint: disable=no-member
+            cls.assertNotRegex = cls.assertNotRegexpMatches if hasattr(cls, "assertNotRegexpMatches") else cls.emulate_assertNotRegexpMatches  # pylint: disable=no-member
         if not hasattr(cls, "assertIn"):
             cls.assertIn = cls.emulate_assertIn
         if not hasattr(cls, "assertNotIn"):
@@ -195,53 +195,53 @@ class AgentTestCase(unittest.TestCase):
         if not debug and self.tmp_dir is not None:
             shutil.rmtree(self.tmp_dir)
 
-    def emulate_assertIn(self, a, b, msg=None): # pylint: disable=invalid-name
+    def emulate_assertIn(self, a, b, msg=None):  # pylint: disable=invalid-name
         if a not in b:
             msg = msg if msg is not None else "{0} not found in {1}".format(_safe_repr(a), _safe_repr(b))
             self.fail(msg)
 
-    def emulate_assertNotIn(self, a, b, msg=None): # pylint: disable=invalid-name
+    def emulate_assertNotIn(self, a, b, msg=None):  # pylint: disable=invalid-name
         if a in b:
             msg = msg if msg is not None else "{0} unexpectedly found in {1}".format(_safe_repr(a), _safe_repr(b))
             self.fail(msg)
 
-    def emulate_assertGreater(self, a, b, msg=None): # pylint: disable=invalid-name
+    def emulate_assertGreater(self, a, b, msg=None):  # pylint: disable=invalid-name
         if not a > b:
             msg = msg if msg is not None else '{0} not greater than {1}'.format(_safe_repr(a), _safe_repr(b))
             self.fail(msg)
 
-    def emulate_assertGreaterEqual(self, a, b, msg=None): # pylint: disable=invalid-name
+    def emulate_assertGreaterEqual(self, a, b, msg=None):  # pylint: disable=invalid-name
         if not a >= b:
             msg = msg if msg is not None else '{0} not greater or equal to {1}'.format(_safe_repr(a), _safe_repr(b))
             self.fail(msg)
 
-    def emulate_assertLess(self, a, b, msg=None): # pylint: disable=invalid-name
+    def emulate_assertLess(self, a, b, msg=None):  # pylint: disable=invalid-name
         if not a < b:
             msg = msg if msg is not None else '{0} not less than {1}'.format(_safe_repr(a), _safe_repr(b))
             self.fail(msg)
 
-    def emulate_assertLessEqual(self, a, b, msg=None): # pylint: disable=invalid-name
+    def emulate_assertLessEqual(self, a, b, msg=None):  # pylint: disable=invalid-name
         if not a <= b:
             msg = msg if msg is not None else '{0} not less or equal to {1}'.format(_safe_repr(a), _safe_repr(b))
             self.fail(msg)
 
-    def emulate_assertIsNone(self, x, msg=None): # pylint: disable=invalid-name
+    def emulate_assertIsNone(self, x, msg=None):  # pylint: disable=invalid-name
         if x is not None:
             msg = msg if msg is not None else '{0} is not None'.format(_safe_repr(x))
             self.fail(msg)
 
-    def emulate_assertIsNotNone(self, x, msg=None): # pylint: disable=invalid-name
+    def emulate_assertIsNotNone(self, x, msg=None):  # pylint: disable=invalid-name
         if x is None:
             msg = msg if msg is not None else '{0} is None'.format(_safe_repr(x))
             self.fail(msg)
 
-    def emulate_assertRegexpMatches(self, text, regexp, msg=None): # pylint: disable=invalid-name
+    def emulate_assertRegexpMatches(self, text, regexp, msg=None):  # pylint: disable=invalid-name
         if re.search(regexp, text) is not None:
             return
         msg = msg if msg is not None else "'{0}' does not match '{1}'.".format(text, regexp)
         self.fail(msg)
 
-    def emulate_assertNotRegexpMatches(self, text, regexp, msg=None): # pylint: disable=invalid-name
+    def emulate_assertNotRegexpMatches(self, text, regexp, msg=None):  # pylint: disable=invalid-name
         if re.search(regexp, text, flags=1) is None:
             return
         msg = msg if msg is not None else "'{0}' should not match '{1}'.".format(text, regexp)
@@ -256,22 +256,22 @@ class AgentTestCase(unittest.TestCase):
             return self
 
         @staticmethod
-        def _get_type_name(type): # pylint: disable=redefined-builtin
+        def _get_type_name(type):  # pylint: disable=redefined-builtin
             return type.__name__ if hasattr(type, "__name__") else str(type)
 
         def __exit__(self, exception_type, exception, *_):
             if exception_type is None:
-                expected = AgentTestCase._AssertRaisesContextManager._get_type_name(self._expected_exception_type) # pylint: disable=protected-access
+                expected = AgentTestCase._AssertRaisesContextManager._get_type_name(self._expected_exception_type)  # pylint: disable=protected-access
                 self._test_case.fail("Did not raise an exception; expected '{0}'".format(expected))
             if not issubclass(exception_type, self._expected_exception_type):
-                raised = AgentTestCase._AssertRaisesContextManager._get_type_name(exception_type) # pylint: disable=protected-access
-                expected = AgentTestCase._AssertRaisesContextManager._get_type_name(self._expected_exception_type) # pylint: disable=protected-access
+                raised = AgentTestCase._AssertRaisesContextManager._get_type_name(exception_type)  # pylint: disable=protected-access
+                expected = AgentTestCase._AssertRaisesContextManager._get_type_name(self._expected_exception_type)  # pylint: disable=protected-access
                 self._test_case.fail("Raised '{0}', but expected '{1}'".format(raised, expected))
 
-            self.exception = exception # pylint: disable=attribute-defined-outside-init
+            self.exception = exception  # pylint: disable=attribute-defined-outside-init
             return True
 
-    def emulate_assertRaises(self, exception_type, function=None, *args, **kwargs): # pylint: disable=invalid-name,keyword-arg-before-vararg
+    def emulate_assertRaises(self, exception_type, function=None, *args, **kwargs):  # pylint: disable=invalid-name,keyword-arg-before-vararg
         # return a context manager only when function is not provided; otherwise use the original assertRaises
         if function is None:
             return AgentTestCase._AssertRaisesContextManager(exception_type, self)
@@ -283,15 +283,15 @@ class AgentTestCase(unittest.TestCase):
     def emulate_raises_regex(self, exception_type, regex, function, *args, **kwargs):
         try:
             function(*args, **kwargs)
-        except Exception as e: # pylint: disable=invalid-name
-            if re.search(regex, str(e), flags=1) is not None: # pylint: disable=no-else-return
+        except Exception as e:  # pylint: disable=invalid-name
+            if re.search(regex, str(e), flags=1) is not None:  # pylint: disable=no-else-return
                 return
             else:
                 self.fail("Expected exception {0} matching {1}.  Actual: {2}".format(
                     exception_type, regex, str(e)))
         self.fail("No exception was thrown.  Expected exception {0} matching {1}".format(exception_type, regex))
 
-    def emulate_assertDictEqual(self, first, second, msg=None): # pylint: disable=invalid-name
+    def emulate_assertDictEqual(self, first, second, msg=None):  # pylint: disable=invalid-name
         def fail(message):
             self.fail(self._formatMessage(msg, message))
 
@@ -305,7 +305,7 @@ class AgentTestCase(unittest.TestCase):
             if k not in first:
                 fail("'{0}' is missing from first".format(k))
 
-    def emulate_assertListEqual(self, seq1, seq2, msg=None, seq_type=None): # pylint: disable=too-many-branches,invalid-name
+    def emulate_assertListEqual(self, seq1, seq2, msg=None, seq_type=None):  # pylint: disable=too-many-branches,invalid-name
         """An equality assertion for ordered sequences (like lists and tuples).
 
         For the purposes of this function, a valid ordered sequence type is one
@@ -378,7 +378,7 @@ class AgentTestCase(unittest.TestCase):
                     break
             else:
                 if (len1 == len2 and seq_type is None and
-                    type(seq1) != type(seq2)): # pylint: disable=unidiomatic-typecheck
+                    type(seq1) != type(seq2)):  # pylint: disable=unidiomatic-typecheck
                     # The sequences are the same, but have differing types.
                     return
 
@@ -400,15 +400,15 @@ class AgentTestCase(unittest.TestCase):
                 except (TypeError, IndexError, NotImplementedError):
                     differing += ('Unable to index element %d '
                                   'of second %s\n' % (len1, seq_type_name))
-        standardMsg = differing # pylint: disable=invalid-name
-        diffMsg = '\n' + '\n'.join( # pylint: disable=invalid-name
+        standardMsg = differing  # pylint: disable=invalid-name
+        diffMsg = '\n' + '\n'.join(  # pylint: disable=invalid-name
             difflib.ndiff(pprint.pformat(seq1).splitlines(),
                           pprint.pformat(seq2).splitlines()))
-        standardMsg = self._truncateMessage(standardMsg, diffMsg) # pylint: disable=invalid-name
+        standardMsg = self._truncateMessage(standardMsg, diffMsg)  # pylint: disable=invalid-name
         msg = self._formatMessage(msg, standardMsg)
         self.fail(msg)
 
-    def emulate_assertIsInstance(self, obj, object_type, msg=None): # pylint: disable=invalid-name
+    def emulate_assertIsInstance(self, obj, object_type, msg=None):  # pylint: disable=invalid-name
         if not isinstance(obj, object_type):
             msg = msg if msg is not None else '{0} is not an instance of {1}'.format(_safe_repr(obj),
                                                                                      _safe_repr(object_type))
@@ -417,7 +417,7 @@ class AgentTestCase(unittest.TestCase):
     @staticmethod
     def _create_files(tmp_dir, prefix, suffix, count, with_sleep=0):
         for i in range(count):
-            f = os.path.join(tmp_dir, '.'.join((prefix, str(i), suffix))) # pylint: disable=invalid-name
+            f = os.path.join(tmp_dir, '.'.join((prefix, str(i), suffix)))  # pylint: disable=invalid-name
             fileutil.write_file(f, "faux content")
             time.sleep(with_sleep)
 
@@ -463,7 +463,7 @@ def load_bin_data(name):
         return data_file.read()
 
 
-supported_distro = [ # pylint: disable=invalid-name
+supported_distro = [  # pylint: disable=invalid-name
     ["ubuntu", "12.04", ""],
     ["ubuntu", "14.04", ""],
     ["ubuntu", "14.10", ""],
@@ -518,7 +518,7 @@ def distros(distro_name=".*", distro_version=".*", distro_full_name=".*"):
 
 def clear_singleton_instances(cls):
     # Adding this lock to avoid any race conditions
-    with cls._lock: # pylint: disable=protected-access
+    with cls._lock:  # pylint: disable=protected-access
         obj_name = "%s__%s" % (cls.__name__, currentThread().getName())  # Object Name = className__threadName
-        if obj_name in cls._instances: # pylint: disable=protected-access
-            del cls._instances[obj_name] # pylint: disable=protected-access
+        if obj_name in cls._instances:  # pylint: disable=protected-access
+            del cls._instances[obj_name]  # pylint: disable=protected-access

--- a/tests/utils/test_archive.py
+++ b/tests/utils/test_archive.py
@@ -11,9 +11,9 @@ from azurelinuxagent.common.utils import fileutil
 from azurelinuxagent.common.utils.archive import StateFlusher, StateArchiver, _MAX_ARCHIVED_STATES
 from tests.tools import AgentTestCase, patch
 
-debug = False # pylint: disable=invalid-name
+debug = False  # pylint: disable=invalid-name
 if os.environ.get('DEBUG') == '1':
-    debug = True # pylint: disable=invalid-name
+    debug = True  # pylint: disable=invalid-name
 
 # Enable verbose logger to stdout
 if debug:

--- a/tests/utils/test_crypt_util.py
+++ b/tests/utils/test_crypt_util.py
@@ -29,7 +29,7 @@ class TestCryptoUtilOperations(AgentTestCase):
     def test_decrypt_encrypted_text(self):
         encrypted_string = load_data("wire/encrypted.enc")
         prv_key = os.path.join(self.tmp_dir, "TransportPrivate.pem") 
-        with open(prv_key, 'w+') as c: # pylint: disable=invalid-name
+        with open(prv_key, 'w+') as c:  # pylint: disable=invalid-name
             c.write(load_data("wire/sample.pem"))
         secret = ']aPPEv}uNg1FPnl?'
         crypto = CryptUtil(conf.get_openssl_cmd())
@@ -46,7 +46,7 @@ class TestCryptoUtilOperations(AgentTestCase):
     def test_decrypt_encrypted_text_wrong_private_key(self):
         encrypted_string = load_data("wire/encrypted.enc")
         prv_key = os.path.join(self.tmp_dir, "wrong.pem")
-        with open(prv_key, 'w+') as c: # pylint: disable=invalid-name
+        with open(prv_key, 'w+') as c:  # pylint: disable=invalid-name
             c.write(load_data("wire/trans_prv"))
         crypto = CryptUtil(conf.get_openssl_cmd())
         self.assertRaises(CryptError, crypto.decrypt_secret, encrypted_string, prv_key)
@@ -54,7 +54,7 @@ class TestCryptoUtilOperations(AgentTestCase):
     def test_decrypt_encrypted_text_text_not_encrypted(self):
         encrypted_string = "abc@123"
         prv_key = os.path.join(self.tmp_dir, "TransportPrivate.pem")
-        with open(prv_key, 'w+') as c: # pylint: disable=invalid-name
+        with open(prv_key, 'w+') as c:  # pylint: disable=invalid-name
             c.write(load_data("wire/sample.pem"))
         crypto = CryptUtil(conf.get_openssl_cmd())
         self.assertRaises(CryptError, crypto.decrypt_secret, encrypted_string, prv_key)
@@ -64,7 +64,7 @@ class TestCryptoUtilOperations(AgentTestCase):
         prv_key = os.path.join(data_dir, "wire", "trans_prv")
         expected_pub_key = os.path.join(data_dir, "wire", "trans_pub")
 
-        with open(expected_pub_key) as fh: # pylint: disable=invalid-name
+        with open(expected_pub_key) as fh:  # pylint: disable=invalid-name
             self.assertEqual(fh.read(), crypto.get_pubkey_from_prv(prv_key))
 
     def test_get_pubkey_from_crt_invalid_file(self):

--- a/tests/utils/test_extension_process_util.py
+++ b/tests/utils/test_extension_process_util.py
@@ -55,7 +55,7 @@ class TestProcessUtils(AgentTestCase):
 
     def test_wait_for_process_completion_or_timeout_should_kill_process_on_timeout(self):
         timeout = 5
-        process = subprocess.Popen( # pylint: disable=subprocess-popen-preexec-fn
+        process = subprocess.Popen(  # pylint: disable=subprocess-popen-preexec-fn
             "sleep 1m",
             shell=True,
             cwd=self.tmp_dir,
@@ -94,7 +94,7 @@ class TestProcessUtils(AgentTestCase):
         command = "echo 'dummy stdout' && 1>&2 echo 'dummy stderr'"
         with tempfile.TemporaryFile(dir=self.tmp_dir, mode="w+b") as stdout:
             with tempfile.TemporaryFile(dir=self.tmp_dir, mode="w+b") as stderr:
-                process = subprocess.Popen(command, # pylint: disable=subprocess-popen-preexec-fn
+                process = subprocess.Popen(command,  # pylint: disable=subprocess-popen-preexec-fn
                                            shell=True,
                                            cwd=self.tmp_dir,
                                            env={},
@@ -119,7 +119,7 @@ class TestProcessUtils(AgentTestCase):
             with tempfile.TemporaryFile(dir=self.tmp_dir, mode="w+b") as stderr:
                 with patch('time.sleep') as mock_sleep:
                     with self.assertRaises(ExtensionError) as context_manager:
-                        process = subprocess.Popen(command, # pylint: disable=subprocess-popen-preexec-fn
+                        process = subprocess.Popen(command,  # pylint: disable=subprocess-popen-preexec-fn
                                                    shell=True,
                                                    cwd=self.tmp_dir,
                                                    env={},
@@ -149,7 +149,7 @@ class TestProcessUtils(AgentTestCase):
         with tempfile.TemporaryFile(dir=self.tmp_dir, mode="w+b") as stdout:
             with tempfile.TemporaryFile(dir=self.tmp_dir, mode="w+b") as stderr:
                 with self.assertRaises(ExtensionError) as context_manager:
-                    process = subprocess.Popen(command, # pylint: disable=subprocess-popen-preexec-fn
+                    process = subprocess.Popen(command,  # pylint: disable=subprocess-popen-preexec-fn
                                                shell=True,
                                                cwd=self.tmp_dir,
                                                env={},

--- a/tests/utils/test_file_util.py
+++ b/tests/utils/test_file_util.py
@@ -41,7 +41,7 @@ class TestFileOperations(AgentTestCase):
         self.assertEqual(content, content_read)
         os.remove(test_file)
 
-    def test_write_file_content_is_None(self): # pylint: disable=invalid-name
+    def test_write_file_content_is_None(self):  # pylint: disable=invalid-name
         """
         write_file throws when content is None. No file is created.
         """
@@ -50,7 +50,7 @@ class TestFileOperations(AgentTestCase):
             fileutil.write_file(test_file, None)
 
             self.fail("expected write_file to throw an exception")
-        except: # pylint: disable=bare-except
+        except:  # pylint: disable=bare-except
             self.assertEqual(False, os.path.exists(test_file))
 
     def test_rw_utf8_file(self):
@@ -80,8 +80,8 @@ class TestFileOperations(AgentTestCase):
         os.remove(test_file)
 
     def test_findre_in_file(self):
-        fp = tempfile.mktemp() # pylint: disable=invalid-name
-        with open(fp, 'w') as f: # pylint: disable=invalid-name
+        fp = tempfile.mktemp()  # pylint: disable=invalid-name
+        with open(fp, 'w') as f:  # pylint: disable=invalid-name
             f.write(
 '''
 First line
@@ -107,8 +107,8 @@ Third line with more words
             fileutil.findre_in_file(fp, "^Do not match.*"))
 
     def test_findstr_in_file(self):
-        fp = tempfile.mktemp() # pylint: disable=invalid-name
-        with open(fp, 'w') as f: # pylint: disable=invalid-name
+        fp = tempfile.mktemp()  # pylint: disable=invalid-name
+        with open(fp, 'w') as f:  # pylint: disable=invalid-name
             f.write(
 '''
 First line
@@ -140,7 +140,7 @@ Third line with more words
         test_file2 = os.path.join(self.tmp_dir, 'another_file')
         test_files = [test_file + random_word() for _ in range(5)] + \
                      [test_file2 + random_word() for _ in range(5)]
-        for file in test_files: # pylint: disable=redefined-builtin
+        for file in test_files:  # pylint: disable=redefined-builtin
             open(file, 'a').close()
 
         #Remove files using fileutil.rm_files
@@ -153,22 +153,22 @@ Third line with more words
 
     def test_remove_dirs(self):
         dirs = []
-        for n in range(0,5): # pylint: disable=invalid-name
+        for n in range(0,5):  # pylint: disable=invalid-name
             dirs.append(tempfile.mkdtemp())
-        for d in dirs: # pylint: disable=invalid-name
-            for n in range(0, random.choice(range(0,10))): # pylint: disable=invalid-name
+        for d in dirs:  # pylint: disable=invalid-name
+            for n in range(0, random.choice(range(0,10))):  # pylint: disable=invalid-name
                 fileutil.write_file(os.path.join(d, "test"+str(n)), "content")
-            for n in range(0, random.choice(range(0,10))): # pylint: disable=invalid-name
-                dd = os.path.join(d, "testd"+str(n)) # pylint: disable=invalid-name
+            for n in range(0, random.choice(range(0,10))):  # pylint: disable=invalid-name
+                dd = os.path.join(d, "testd"+str(n))  # pylint: disable=invalid-name
                 os.mkdir(dd)
-                for nn in range(0, random.choice(range(0,10))): # pylint: disable=invalid-name
+                for nn in range(0, random.choice(range(0,10))):  # pylint: disable=invalid-name
                     os.symlink(dd, os.path.join(dd, "sym"+str(nn)))
-            for n in range(0, random.choice(range(0,10))): # pylint: disable=invalid-name
+            for n in range(0, random.choice(range(0,10))):  # pylint: disable=invalid-name
                 os.symlink(d, os.path.join(d, "sym"+str(n)))
 
         fileutil.rm_dirs(*dirs)
 
-        for d in dirs: # pylint: disable=invalid-name
+        for d in dirs:  # pylint: disable=invalid-name
             self.assertEqual(len(os.listdir(d)), 0)
 
     def test_get_all_files(self):
@@ -187,7 +187,7 @@ Third line with more words
         expected_files.extend([test_file_in_subdir + random_word() for _ in range(5)] + \
                      [test_file_in_subdir2 + random_word() for _ in range(5)])
 
-        for file in expected_files: # pylint: disable=redefined-builtin
+        for file in expected_files:  # pylint: disable=redefined-builtin
             open(file, 'a').close()
 
         # Get All files using fileutil.get_all_files
@@ -257,7 +257,7 @@ DHCP_HOSTNAME=test\n"
                 patch_write.assert_called_once_with(path, updated_file)
 
     def test_clean_ioerror_ignores_missing(self):
-        e = IOError() # pylint: disable=invalid-name
+        e = IOError()  # pylint: disable=invalid-name
         e.errno = errno.ENOSPC
 
         # Send no paths
@@ -268,19 +268,19 @@ DHCP_HOSTNAME=test\n"
 
     def test_clean_ioerror_ignores_unless_ioerror(self):
         try:
-            d = tempfile.mkdtemp() # pylint: disable=invalid-name
-            fd, f = tempfile.mkstemp() # pylint: disable=invalid-name
+            d = tempfile.mkdtemp()  # pylint: disable=invalid-name
+            fd, f = tempfile.mkstemp()  # pylint: disable=invalid-name
             os.close(fd)
             fileutil.write_file(f, 'Not empty')
 
             # Send non-IOError exception
-            e = Exception() # pylint: disable=invalid-name
+            e = Exception()  # pylint: disable=invalid-name
             fileutil.clean_ioerror(e, paths=[d, f])
             self.assertTrue(os.path.isdir(d))
             self.assertTrue(os.path.isfile(f))
 
             # Send unrecognized IOError
-            e = IOError() # pylint: disable=invalid-name
+            e = IOError()  # pylint: disable=invalid-name
             e.errno = errno.EFAULT
             self.assertFalse(e.errno in fileutil.KNOWN_IOERRORS)
             fileutil.clean_ioerror(e, paths=[d, f])
@@ -292,23 +292,23 @@ DHCP_HOSTNAME=test\n"
             os.remove(f)
 
     def test_clean_ioerror_removes_files(self):
-        fd, f = tempfile.mkstemp() # pylint: disable=invalid-name
+        fd, f = tempfile.mkstemp()  # pylint: disable=invalid-name
         os.close(fd)
         fileutil.write_file(f, 'Not empty')
 
-        e = IOError() # pylint: disable=invalid-name
+        e = IOError()  # pylint: disable=invalid-name
         e.errno = errno.ENOSPC
         fileutil.clean_ioerror(e, paths=[f])
         self.assertFalse(os.path.isdir(f))
         self.assertFalse(os.path.isfile(f))
 
     def test_clean_ioerror_removes_directories(self):
-        d1 = tempfile.mkdtemp() # pylint: disable=invalid-name
-        d2 = tempfile.mkdtemp() # pylint: disable=invalid-name
-        for n in ['foo', 'bar']: # pylint: disable=invalid-name
+        d1 = tempfile.mkdtemp()  # pylint: disable=invalid-name
+        d2 = tempfile.mkdtemp()  # pylint: disable=invalid-name
+        for n in ['foo', 'bar']:  # pylint: disable=invalid-name
             fileutil.write_file(os.path.join(d2, n), 'Not empty')
 
-        e = IOError() # pylint: disable=invalid-name
+        e = IOError()  # pylint: disable=invalid-name
         e.errno = errno.ENOSPC
         fileutil.clean_ioerror(e, paths=[d1, d2])
         self.assertFalse(os.path.isdir(d1))
@@ -318,10 +318,10 @@ DHCP_HOSTNAME=test\n"
 
     def test_clean_ioerror_handles_a_range_of_errors(self):
         for err in fileutil.KNOWN_IOERRORS:
-            e = IOError() # pylint: disable=invalid-name
+            e = IOError()  # pylint: disable=invalid-name
             e.errno = err
 
-            d = tempfile.mkdtemp() # pylint: disable=invalid-name
+            d = tempfile.mkdtemp()  # pylint: disable=invalid-name
             fileutil.clean_ioerror(e, paths=[d])
             self.assertFalse(os.path.isdir(d))
             self.assertFalse(os.path.isfile(d))

--- a/tests/utils/test_flexible_version.py
+++ b/tests/utils/test_flexible_version.py
@@ -1,4 +1,4 @@
-import random # pylint: disable=unused-import
+import random  # pylint: disable=unused-import
 import re
 import unittest
 
@@ -7,23 +7,23 @@ from azurelinuxagent.common.utils.flexible_version import FlexibleVersion
 class TestFlexibleVersion(unittest.TestCase):
 
     def setUp(self):
-        self.v = FlexibleVersion() # pylint: disable=invalid-name
+        self.v = FlexibleVersion()  # pylint: disable=invalid-name
 
-    def test_compile_separator(self): # pylint: disable=useless-return
+    def test_compile_separator(self):  # pylint: disable=useless-return
         tests = [
             '.',
             '',
             '-'
         ]
-        for t in tests: # pylint: disable=invalid-name
+        for t in tests:  # pylint: disable=invalid-name
             t_escaped = re.escape(t)
             t_re = re.compile(t_escaped)
-            self.assertEqual((t_escaped, t_re), self.v._compile_separator(t)) # pylint: disable=protected-access
-        self.assertEqual(('', re.compile('')),  self.v._compile_separator(None)) # pylint: disable=protected-access
+            self.assertEqual((t_escaped, t_re), self.v._compile_separator(t))  # pylint: disable=protected-access
+        self.assertEqual(('', re.compile('')),  self.v._compile_separator(None))  # pylint: disable=protected-access
         return
 
-    def test_compile_pattern(self): # pylint: disable=useless-return
-        self.v._compile_pattern() # pylint: disable=protected-access
+    def test_compile_pattern(self):  # pylint: disable=useless-return
+        self.v._compile_pattern()  # pylint: disable=protected-access
         tests = {
             '1': True,
             '1.2': True,
@@ -85,9 +85,9 @@ class TestFlexibleVersion(unittest.TestCase):
                 "test: {0} expected: {1} ".format(test, expectation))
         return
 
-    def test_compile_pattern_sep(self): # pylint: disable=useless-return
+    def test_compile_pattern_sep(self):  # pylint: disable=useless-return
         self.v.sep = '-'
-        self.v._compile_pattern() # pylint: disable=protected-access
+        self.v._compile_pattern()  # pylint: disable=protected-access
         tests = { 
             '1': True,
             '1-2': True,
@@ -143,9 +143,9 @@ class TestFlexibleVersion(unittest.TestCase):
                 "test: {0} expected: {1} ".format(test, expectation))
         return
 
-    def test_compile_pattern_prerel(self): # pylint: disable=useless-return
+    def test_compile_pattern_prerel(self):  # pylint: disable=useless-return
         self.v.prerel_tags = ('a', 'b', 'c')
-        self.v._compile_pattern() # pylint: disable=protected-access
+        self.v._compile_pattern()  # pylint: disable=protected-access
         tests = {
             '1': True,
             '1.2': True,
@@ -208,71 +208,71 @@ class TestFlexibleVersion(unittest.TestCase):
                 "test: {0} expected: {1} ".format(test, expectation))
         return
 
-    def test_ensure_compatible_separators(self): # pylint: disable=useless-return
-        v1 = FlexibleVersion('1.2.3') # pylint: disable=invalid-name
-        v2 = FlexibleVersion('1-2-3', sep='-') # pylint: disable=invalid-name
+    def test_ensure_compatible_separators(self):  # pylint: disable=useless-return
+        v1 = FlexibleVersion('1.2.3')  # pylint: disable=invalid-name
+        v2 = FlexibleVersion('1-2-3', sep='-')  # pylint: disable=invalid-name
         try:
-            v1 == v2 # pylint: disable=pointless-statement
-            self.assertTrue(False, "Incompatible separators failed to raise an exception") # pylint: disable=redundant-unittest-assert
+            v1 == v2  # pylint: disable=pointless-statement
+            self.assertTrue(False, "Incompatible separators failed to raise an exception")  # pylint: disable=redundant-unittest-assert
         except ValueError:
             pass
-        except Exception as e: # pylint: disable=invalid-name
-            t = e.__class__.__name__ # pylint: disable=invalid-name
+        except Exception as e:  # pylint: disable=invalid-name
+            t = e.__class__.__name__  # pylint: disable=invalid-name
             # pylint: disable=redundant-unittest-assert
             self.assertTrue(False, "Incompatible separators raised an unexpected exception: {0}" \
                 .format(t))
             # pylint: enable=redundant-unittest-assert
         return
 
-    def test_ensure_compatible_prerel(self): # pylint: disable=useless-return
-        v1 = FlexibleVersion('1.2.3', prerel_tags=('alpha', 'beta', 'rc')) # pylint: disable=invalid-name
-        v2 = FlexibleVersion('1.2.3', prerel_tags=('a', 'b', 'c')) # pylint: disable=invalid-name
+    def test_ensure_compatible_prerel(self):  # pylint: disable=useless-return
+        v1 = FlexibleVersion('1.2.3', prerel_tags=('alpha', 'beta', 'rc'))  # pylint: disable=invalid-name
+        v2 = FlexibleVersion('1.2.3', prerel_tags=('a', 'b', 'c'))  # pylint: disable=invalid-name
         try:
-            v1 == v2 # pylint: disable=pointless-statement
-            self.assertTrue(False, "Incompatible prerel_tags failed to raise an exception") # pylint: disable=redundant-unittest-assert
+            v1 == v2  # pylint: disable=pointless-statement
+            self.assertTrue(False, "Incompatible prerel_tags failed to raise an exception")  # pylint: disable=redundant-unittest-assert
         except ValueError:
             pass
-        except Exception as e: # pylint: disable=invalid-name
-            t = e.__class__.__name__ # pylint: disable=invalid-name
+        except Exception as e:  # pylint: disable=invalid-name
+            t = e.__class__.__name__  # pylint: disable=invalid-name
             # pylint: disable=redundant-unittest-assert
             self.assertTrue(False, "Incompatible prerel_tags raised an unexpected exception: {0}" \
                 .format(t))
             # pylint: enable=redundant-unittest-assert
         return
 
-    def test_ensure_compatible_prerel_length(self): # pylint: disable=useless-return
-        v1 = FlexibleVersion('1.2.3', prerel_tags=('a', 'b', 'c')) # pylint: disable=invalid-name
-        v2 = FlexibleVersion('1.2.3', prerel_tags=('a', 'b')) # pylint: disable=invalid-name
+    def test_ensure_compatible_prerel_length(self):  # pylint: disable=useless-return
+        v1 = FlexibleVersion('1.2.3', prerel_tags=('a', 'b', 'c'))  # pylint: disable=invalid-name
+        v2 = FlexibleVersion('1.2.3', prerel_tags=('a', 'b'))  # pylint: disable=invalid-name
         try:
-            v1 == v2 # pylint: disable=pointless-statement
-            self.assertTrue(False, "Incompatible prerel_tags failed to raise an exception") # pylint: disable=redundant-unittest-assert
+            v1 == v2  # pylint: disable=pointless-statement
+            self.assertTrue(False, "Incompatible prerel_tags failed to raise an exception")  # pylint: disable=redundant-unittest-assert
         except ValueError:
             pass
-        except Exception as e: # pylint: disable=invalid-name
-            t = e.__class__.__name__ # pylint: disable=invalid-name
+        except Exception as e:  # pylint: disable=invalid-name
+            t = e.__class__.__name__  # pylint: disable=invalid-name
             # pylint: disable=redundant-unittest-assert
             self.assertTrue(False, "Incompatible prerel_tags raised an unexpected exception: {0}" \
                 .format(t))
             # pylint: enable=redundant-unittest-assert
         return
 
-    def test_ensure_compatible_prerel_order(self): # pylint: disable=useless-return
-        v1 = FlexibleVersion('1.2.3', prerel_tags=('a', 'b')) # pylint: disable=invalid-name
-        v2 = FlexibleVersion('1.2.3', prerel_tags=('b', 'a')) # pylint: disable=invalid-name
+    def test_ensure_compatible_prerel_order(self):  # pylint: disable=useless-return
+        v1 = FlexibleVersion('1.2.3', prerel_tags=('a', 'b'))  # pylint: disable=invalid-name
+        v2 = FlexibleVersion('1.2.3', prerel_tags=('b', 'a'))  # pylint: disable=invalid-name
         try:
-            v1 == v2 # pylint: disable=pointless-statement
-            self.assertTrue(False, "Incompatible prerel_tags failed to raise an exception") # pylint: disable=redundant-unittest-assert
+            v1 == v2  # pylint: disable=pointless-statement
+            self.assertTrue(False, "Incompatible prerel_tags failed to raise an exception")  # pylint: disable=redundant-unittest-assert
         except ValueError:
             pass
-        except Exception as e: # pylint: disable=invalid-name
-            t = e.__class__.__name__ # pylint: disable=invalid-name
+        except Exception as e:  # pylint: disable=invalid-name
+            t = e.__class__.__name__  # pylint: disable=invalid-name
             # pylint: disable=redundant-unittest-assert
             self.assertTrue(False, "Incompatible prerel_tags raised an unexpected exception: {0}" \
                 .format(t))
             # pylint: enable=redundant-unittest-assert
         return
 
-    def test_major(self): # pylint: disable=useless-return
+    def test_major(self):  # pylint: disable=useless-return
         tests = {
             '1' : 1,
             '1.2' : 1,
@@ -286,7 +286,7 @@ class TestFlexibleVersion(unittest.TestCase):
                 FlexibleVersion(test).major)
         return
 
-    def test_minor(self): # pylint: disable=useless-return
+    def test_minor(self):  # pylint: disable=useless-return
         tests = {
             '1' : 0,
             '1.2' : 2,
@@ -300,7 +300,7 @@ class TestFlexibleVersion(unittest.TestCase):
                 FlexibleVersion(test).minor)
         return
 
-    def test_patch(self): # pylint: disable=useless-return
+    def test_patch(self):  # pylint: disable=useless-return
         tests = {
             '1' : 0,
             '1.2' : 0,
@@ -314,7 +314,7 @@ class TestFlexibleVersion(unittest.TestCase):
                 FlexibleVersion(test).patch)
         return
 
-    def test_parse(self): # pylint: disable=useless-return
+    def test_parse(self):  # pylint: disable=useless-return
         tests = {
             "1.2.3.4": ((1, 2, 3, 4), None),
             "1.2.3.4alpha5": ((1, 2, 3, 4), ('alpha', 5)),
@@ -323,11 +323,11 @@ class TestFlexibleVersion(unittest.TestCase):
         }
         for test in iter(tests):
             expectation = tests[test]
-            self.v._parse(test) # pylint: disable=protected-access
+            self.v._parse(test)  # pylint: disable=protected-access
             self.assertEqual(expectation, (self.v.version, self.v.prerelease))
         return
 
-    def test_decrement(self): # pylint: disable=useless-return
+    def test_decrement(self):  # pylint: disable=useless-return
         src_v = FlexibleVersion('1.0.0.0.10')
         dst_v = FlexibleVersion(str(src_v))
         for i in range(1,10):
@@ -335,18 +335,18 @@ class TestFlexibleVersion(unittest.TestCase):
             self.assertEqual(i, src_v.version[-1] - dst_v.version[-1])
         return
 
-    def test_decrement_disallows_below_zero(self): # pylint: disable=useless-return
+    def test_decrement_disallows_below_zero(self):  # pylint: disable=useless-return
         try:
-            FlexibleVersion('1.0') - 1 # pylint: disable=expression-not-assigned
-            self.assertTrue(False, "Decrement failed to raise an exception") # pylint: disable=redundant-unittest-assert
+            FlexibleVersion('1.0') - 1  # pylint: disable=expression-not-assigned
+            self.assertTrue(False, "Decrement failed to raise an exception")  # pylint: disable=redundant-unittest-assert
         except ArithmeticError:
             pass
-        except Exception as e: # pylint: disable=invalid-name
-            t = e.__class__.__name__ # pylint: disable=invalid-name
-            self.assertTrue(False, "Decrement raised an unexpected exception: {0}".format(t)) # pylint: disable=redundant-unittest-assert
+        except Exception as e:  # pylint: disable=invalid-name
+            t = e.__class__.__name__  # pylint: disable=invalid-name
+            self.assertTrue(False, "Decrement raised an unexpected exception: {0}".format(t))  # pylint: disable=redundant-unittest-assert
         return
 
-    def test_increment(self): # pylint: disable=useless-return
+    def test_increment(self):  # pylint: disable=useless-return
         src_v = FlexibleVersion('1.0.0.0.0')
         dst_v = FlexibleVersion(str(src_v))
         for i in range(1,10):
@@ -354,7 +354,7 @@ class TestFlexibleVersion(unittest.TestCase):
             self.assertEqual(i, dst_v.version[-1] - src_v.version[-1])
         return
 
-    def test_str(self): # pylint: disable=useless-return
+    def test_str(self):  # pylint: disable=useless-return
         tests = [
             '1',
             '1.2',
@@ -407,7 +407,7 @@ class TestFlexibleVersion(unittest.TestCase):
             self.assertEqual(test, str(FlexibleVersion(test)))
         return
 
-    def test_creation_from_flexible_version(self): # pylint: disable=useless-return
+    def test_creation_from_flexible_version(self):  # pylint: disable=useless-return
         tests = [
             '1',
             '1.2',
@@ -457,16 +457,16 @@ class TestFlexibleVersion(unittest.TestCase):
             '1.2.3.4alpha5',
         ]
         for test in tests:
-            v = FlexibleVersion(test) # pylint: disable=invalid-name
+            v = FlexibleVersion(test)  # pylint: disable=invalid-name
             self.assertEqual(test, str(FlexibleVersion(v)))
         return
 
     def test_repr(self):
-        v = FlexibleVersion('1,2,3rc4', ',', ['lol', 'rc']) # pylint: disable=invalid-name
+        v = FlexibleVersion('1,2,3rc4', ',', ['lol', 'rc'])  # pylint: disable=invalid-name
         expected = "FlexibleVersion ('1,2,3rc4', ',', ('lol', 'rc'))"
         self.assertEqual(expected, repr(v))
 
-    def test_order(self): # pylint: disable=useless-return
+    def test_order(self):  # pylint: disable=useless-return
         test0 = ["1.7.0", "1.7.0rc0", "1.11.0"]
         expected0 = ['1.7.0rc0', '1.7.0', '1.11.0']
         self.assertEqual(expected0, list(map(str, sorted([FlexibleVersion(v) for v in test0]))))

--- a/tests/utils/test_rest_util.py
+++ b/tests/utils/test_rest_util.py
@@ -83,35 +83,35 @@ class TestIOErrorCounter(AgentTestCase):
         self.assertEqual(2, counts.get("other"))
         self.assertEqual(
            {"hostplugin":0, "protocol":0, "other":0},
-            restutil.IOErrorCounter._counts) # pylint: disable=protected-access
+            restutil.IOErrorCounter._counts)  # pylint: disable=protected-access
 
 
-class TestHttpOperations(AgentTestCase): # pylint: disable=too-many-public-methods
+class TestHttpOperations(AgentTestCase):  # pylint: disable=too-many-public-methods
     def test_parse_url(self):
         test_uri = "http://abc.def/ghi#hash?jkl=mn"
-        host, port, secure, rel_uri = restutil._parse_url(test_uri) # pylint: disable=unused-variable,protected-access
+        host, port, secure, rel_uri = restutil._parse_url(test_uri)  # pylint: disable=unused-variable,protected-access
         self.assertEqual("abc.def", host) 
         self.assertEqual("/ghi#hash?jkl=mn", rel_uri) 
 
         test_uri = "http://abc.def/"
-        host, port, secure, rel_uri = restutil._parse_url(test_uri) # pylint: disable=protected-access
+        host, port, secure, rel_uri = restutil._parse_url(test_uri)  # pylint: disable=protected-access
         self.assertEqual("abc.def", host) 
         self.assertEqual("/", rel_uri) 
         self.assertEqual(False, secure) 
 
         test_uri = "https://abc.def/ghi?jkl=mn"
-        host, port, secure, rel_uri = restutil._parse_url(test_uri) # pylint: disable=protected-access
+        host, port, secure, rel_uri = restutil._parse_url(test_uri)  # pylint: disable=protected-access
         self.assertEqual(True, secure) 
 
         test_uri = "http://abc.def:80/"
-        host, port, secure, rel_uri = restutil._parse_url(test_uri) # pylint: disable=protected-access
+        host, port, secure, rel_uri = restutil._parse_url(test_uri)  # pylint: disable=protected-access
         self.assertEqual("abc.def", host) 
 
-        host, port, secure, rel_uri = restutil._parse_url("") # pylint: disable=protected-access
+        host, port, secure, rel_uri = restutil._parse_url("")  # pylint: disable=protected-access
         self.assertEqual(None, host) 
         self.assertEqual(rel_uri, "") 
 
-        host, port, secure, rel_uri = restutil._parse_url("None") # pylint: disable=protected-access
+        host, port, secure, rel_uri = restutil._parse_url("None")  # pylint: disable=protected-access
         self.assertEqual(None, host) 
         self.assertEqual(rel_uri, "None") 
 
@@ -174,7 +174,7 @@ class TestHttpOperations(AgentTestCase): # pylint: disable=too-many-public-metho
                         "=" + restutil.REDACTED_TEXT)
                        ]
 
-        for x in urls_tuples: # pylint: disable=invalid-name
+        for x in urls_tuples:  # pylint: disable=invalid-name
             self.assertEqual(restutil.redact_sas_tokens_in_urls(x[0]), x[1]) 
 
     @patch('azurelinuxagent.common.conf.get_httpproxy_port')
@@ -182,7 +182,7 @@ class TestHttpOperations(AgentTestCase): # pylint: disable=too-many-public-metho
     def test_get_http_proxy_none_is_default(self, mock_host, mock_port):
         mock_host.return_value = None
         mock_port.return_value = None
-        h, p = restutil._get_http_proxy() # pylint: disable=protected-access,invalid-name
+        h, p = restutil._get_http_proxy()  # pylint: disable=protected-access,invalid-name
         self.assertEqual(None, h)
         self.assertEqual(None, p)
 
@@ -191,7 +191,7 @@ class TestHttpOperations(AgentTestCase): # pylint: disable=too-many-public-metho
     def test_get_http_proxy_configuration_overrides_env(self, mock_host, mock_port):
         mock_host.return_value = "host"
         mock_port.return_value = None
-        h, p = restutil._get_http_proxy() # pylint: disable=protected-access,invalid-name
+        h, p = restutil._get_http_proxy()  # pylint: disable=protected-access,invalid-name
         self.assertEqual("host", h)
         self.assertEqual(None, p)
         self.assertEqual(1, mock_host.call_count)
@@ -202,7 +202,7 @@ class TestHttpOperations(AgentTestCase): # pylint: disable=too-many-public-metho
     def test_get_http_proxy_configuration_requires_host(self, mock_host, mock_port):
         mock_host.return_value = None
         mock_port.return_value = None
-        h, p = restutil._get_http_proxy() # pylint: disable=protected-access,invalid-name
+        h, p = restutil._get_http_proxy()  # pylint: disable=protected-access,invalid-name
         self.assertEqual(None, h)
         self.assertEqual(None, p)
         self.assertEqual(1, mock_host.call_count)
@@ -215,7 +215,7 @@ class TestHttpOperations(AgentTestCase): # pylint: disable=too-many-public-metho
                                     'http_proxy' : 'http://foo.com:80',
                                     'https_proxy' : 'https://bar.com:443'
                                 }):
-            h, p = restutil._get_http_proxy() # pylint: disable=protected-access,invalid-name
+            h, p = restutil._get_http_proxy()  # pylint: disable=protected-access,invalid-name
             self.assertEqual("foo.com", h)
             self.assertEqual(80, p)
 
@@ -226,7 +226,7 @@ class TestHttpOperations(AgentTestCase): # pylint: disable=too-many-public-metho
                                     'http_proxy' : 'http://foo.com:80',
                                     'https_proxy' : 'https://bar.com:443'
                                 }):
-            h, p = restutil._get_http_proxy(secure=True) # pylint: disable=protected-access,invalid-name
+            h, p = restutil._get_http_proxy(secure=True)  # pylint: disable=protected-access,invalid-name
             self.assertEqual("bar.com", h)
             self.assertEqual(443, p)
 
@@ -236,7 +236,7 @@ class TestHttpOperations(AgentTestCase): # pylint: disable=too-many-public-metho
         with patch.dict(os.environ, {
                                     'http_proxy' : 'http://user:pw@foo.com:80'
                                 }):
-            h, p = restutil._get_http_proxy() # pylint: disable=protected-access,invalid-name
+            h, p = restutil._get_http_proxy()  # pylint: disable=protected-access,invalid-name
             self.assertEqual("foo.com", h)
             self.assertEqual(80, p)
 
@@ -325,7 +325,7 @@ class TestHttpOperations(AgentTestCase): # pylint: disable=too-many-public-metho
 
     @patch("azurelinuxagent.common.future.httpclient.HTTPSConnection")
     @patch("azurelinuxagent.common.future.httpclient.HTTPConnection")
-    def test_http_request_direct(self, HTTPConnection, HTTPSConnection): # pylint: disable=invalid-name
+    def test_http_request_direct(self, HTTPConnection, HTTPSConnection):  # pylint: disable=invalid-name
         mock_conn = \
             MagicMock(getresponse=\
                 Mock(return_value=\
@@ -333,7 +333,7 @@ class TestHttpOperations(AgentTestCase): # pylint: disable=too-many-public-metho
 
         HTTPConnection.return_value = mock_conn
 
-        resp = restutil._http_request("GET", "foo", "/bar") # pylint: disable=protected-access
+        resp = restutil._http_request("GET", "foo", "/bar")  # pylint: disable=protected-access
 
         HTTPConnection.assert_has_calls([
             call("foo", 80, timeout=10)
@@ -348,7 +348,7 @@ class TestHttpOperations(AgentTestCase): # pylint: disable=too-many-public-metho
 
     @patch("azurelinuxagent.common.future.httpclient.HTTPSConnection")
     @patch("azurelinuxagent.common.future.httpclient.HTTPConnection")
-    def test_http_request_direct_secure(self, HTTPConnection, HTTPSConnection): # pylint: disable=invalid-name
+    def test_http_request_direct_secure(self, HTTPConnection, HTTPSConnection):  # pylint: disable=invalid-name
         mock_conn = \
             MagicMock(getresponse=\
                 Mock(return_value=\
@@ -356,7 +356,7 @@ class TestHttpOperations(AgentTestCase): # pylint: disable=too-many-public-metho
 
         HTTPSConnection.return_value = mock_conn
 
-        resp = restutil._http_request("GET", "foo", "/bar", secure=True) # pylint: disable=protected-access
+        resp = restutil._http_request("GET", "foo", "/bar", secure=True)  # pylint: disable=protected-access
 
         HTTPConnection.assert_not_called()
         HTTPSConnection.assert_has_calls([
@@ -371,7 +371,7 @@ class TestHttpOperations(AgentTestCase): # pylint: disable=too-many-public-metho
 
     @patch("azurelinuxagent.common.future.httpclient.HTTPSConnection")
     @patch("azurelinuxagent.common.future.httpclient.HTTPConnection")
-    def test_http_request_proxy(self, HTTPConnection, HTTPSConnection): # pylint: disable=invalid-name
+    def test_http_request_proxy(self, HTTPConnection, HTTPSConnection):  # pylint: disable=invalid-name
         mock_conn = \
             MagicMock(getresponse=\
                 Mock(return_value=\
@@ -379,7 +379,7 @@ class TestHttpOperations(AgentTestCase): # pylint: disable=too-many-public-metho
 
         HTTPConnection.return_value = mock_conn
 
-        resp = restutil._http_request("GET", "foo", "/bar", # pylint: disable=protected-access
+        resp = restutil._http_request("GET", "foo", "/bar",  # pylint: disable=protected-access
                             proxy_host="foo.bar", proxy_port=23333)
 
         HTTPConnection.assert_has_calls([
@@ -396,7 +396,7 @@ class TestHttpOperations(AgentTestCase): # pylint: disable=too-many-public-metho
     @patch("azurelinuxagent.common.utils.restutil._get_http_proxy")
     @patch("time.sleep")
     @patch("azurelinuxagent.common.utils.restutil._http_request")
-    def test_http_request_proxy_with_no_proxy_check(self, _http_request, sleep, mock_get_http_proxy): # pylint: disable=unused-argument
+    def test_http_request_proxy_with_no_proxy_check(self, _http_request, sleep, mock_get_http_proxy):  # pylint: disable=unused-argument
         mock_http_resp = MagicMock()
         mock_http_resp.read = Mock(return_value="hehe")
         _http_request.return_value = mock_http_resp
@@ -503,7 +503,7 @@ class TestHttpOperations(AgentTestCase): # pylint: disable=too-many-public-metho
 
     @patch("azurelinuxagent.common.future.httpclient.HTTPSConnection")
     @patch("azurelinuxagent.common.future.httpclient.HTTPConnection")
-    def test_http_request_proxy_secure(self, HTTPConnection, HTTPSConnection): # pylint: disable=invalid-name
+    def test_http_request_proxy_secure(self, HTTPConnection, HTTPSConnection):  # pylint: disable=invalid-name
         mock_conn = \
             MagicMock(getresponse=\
                 Mock(return_value=\
@@ -511,7 +511,7 @@ class TestHttpOperations(AgentTestCase): # pylint: disable=too-many-public-metho
 
         HTTPSConnection.return_value = mock_conn
 
-        resp = restutil._http_request("GET", "foo", "/bar", # pylint: disable=protected-access
+        resp = restutil._http_request("GET", "foo", "/bar",  # pylint: disable=protected-access
                             proxy_host="foo.bar", proxy_port=23333,
                             secure=True)
 
@@ -528,7 +528,7 @@ class TestHttpOperations(AgentTestCase): # pylint: disable=too-many-public-metho
 
     @patch("time.sleep")
     @patch("azurelinuxagent.common.utils.restutil._http_request")
-    def test_http_request_with_retry(self, _http_request, sleep): # pylint: disable=unused-argument
+    def test_http_request_with_retry(self, _http_request, sleep):  # pylint: disable=unused-argument
         mock_http_resp = MagicMock()
         mock_http_resp.read = Mock(return_value="hehe")
         _http_request.return_value = mock_http_resp
@@ -608,7 +608,7 @@ class TestHttpOperations(AgentTestCase): # pylint: disable=too-many-public-metho
 
         _http_request.side_effect = [
                 Mock(status=httpclient.SERVICE_UNAVAILABLE)
-                    for i in range(restutil.DEFAULT_RETRIES) # pylint: disable=unused-variable
+                    for i in range(restutil.DEFAULT_RETRIES)  # pylint: disable=unused-variable
             ] + [Mock(status=httpclient.OK)]
 
         restutil.http_get("https://foo.bar",
@@ -628,7 +628,7 @@ class TestHttpOperations(AgentTestCase): # pylint: disable=too-many-public-metho
 
         _http_request.side_effect = [
                 Mock(status=httpclient.SERVICE_UNAVAILABLE)
-                    for i in range(restutil.THROTTLE_RETRIES-1) # pylint: disable=unused-variable
+                    for i in range(restutil.THROTTLE_RETRIES-1)  # pylint: disable=unused-variable
             ] + [Mock(status=httpclient.OK)]
 
         restutil.http_get("https://foo.bar",
@@ -754,7 +754,7 @@ class TestHttpOperations(AgentTestCase): # pylint: disable=too-many-public-metho
         response.status = 'status'
         response.reason = 'reason'
         with patch.object(response, 'read') as patch_response:
-            for s in responses: # pylint: disable=invalid-name
+            for s in responses:  # pylint: disable=invalid-name
                 patch_response.return_value = s
                 result = restutil.read_response_error(response)
                 print("RESPONSE: {0}".format(s))
@@ -800,7 +800,7 @@ class TestHttpOperations(AgentTestCase): # pylint: disable=too-many-public-metho
             self.assertEqual(result, expected_response)
             try:
                 raise HttpError("{0}".format(result))
-            except HttpError as e: # pylint: disable=invalid-name
+            except HttpError as e:  # pylint: disable=invalid-name
                 self.assertTrue(result in ustr(e))
 
 

--- a/tests/utils/test_shell_util.py
+++ b/tests/utils/test_shell_util.py
@@ -65,7 +65,7 @@ class RunGetOutputTestCase(AgentTestCase):
 
         self.assertEqual(mock_logger.verbose.call_count, 1)
 
-        args, kwargs = mock_logger.verbose.call_args # pylint: disable=unused-variable
+        args, kwargs = mock_logger.verbose.call_args  # pylint: disable=unused-variable
         command_in_message = args[1]
         self.assertEqual(command_in_message, command)
 
@@ -78,7 +78,7 @@ class RunGetOutputTestCase(AgentTestCase):
 
         self.assertEqual(mock_logger.error.call_count, 1)
 
-        args, kwargs = mock_logger.error.call_args # pylint: disable=unused-variable
+        args, kwargs = mock_logger.error.call_args  # pylint: disable=unused-variable
 
         message = args[0]  # message is similar to "Command: [exit 99], return code: [99], result: []"
         self.assertIn("[{0}]".format(command), message)
@@ -97,7 +97,7 @@ class RunGetOutputTestCase(AgentTestCase):
 
         self.assertEqual(mock_logger.info.call_count, 1)
 
-        args, kwargs = mock_logger.info.call_args # pylint: disable=unused-variable
+        args, kwargs = mock_logger.info.call_args  # pylint: disable=unused-variable
 
         message = args[0]  # message is similar to "Command: [exit 99], return code: [99], result: []"
         self.assertIn("[{0}]".format(command), message)
@@ -116,7 +116,7 @@ class RunGetOutputTestCase(AgentTestCase):
 
         self.assertEqual(mock_logger.error.call_count, 1)
 
-        args, kwargs = mock_logger.error.call_args # pylint: disable=unused-variable
+        args, kwargs = mock_logger.error.call_args  # pylint: disable=unused-variable
 
         message = args[0]  # message is similar to "Command: [exit 99], return code: [99], result: []"
         self.assertIn("[{0}]".format(command), message)
@@ -161,7 +161,7 @@ class RunCommandTestCase(AgentTestCase):
         def assert_no_message_logged(command):
             try:
                 shellutil.run_command(command)
-            except: # pylint: disable=bare-except
+            except:  # pylint: disable=bare-except
                 pass
 
             self.assertEqual(mock_logger.info.call_count, 0)
@@ -178,12 +178,12 @@ class RunCommandTestCase(AgentTestCase):
         with patch("azurelinuxagent.common.utils.shellutil.logger.error") as mock_log_error:
             try:
                 shellutil.run_command(command, log_error=True)
-            except: # pylint: disable=bare-except
+            except:  # pylint: disable=bare-except
                 pass
 
             self.assertEqual(mock_log_error.call_count, 1)
 
-            args, kwargs = mock_log_error.call_args # pylint: disable=unused-variable
+            args, kwargs = mock_log_error.call_args  # pylint: disable=unused-variable
             self.assertIn("ls -d /etc nonexistent_file", args, msg="The command was not logged")
             self.assertIn(2, args, msg="The command's return code was not logged")
             self.assertIn("/etc\n", args, msg="The command's stdout was not logged")
@@ -194,7 +194,7 @@ class RunCommandTestCase(AgentTestCase):
         with patch("azurelinuxagent.common.utils.shellutil.logger.error") as mock_log_error:
             try:
                 shellutil.run_command(command, log_error=True)
-            except: # pylint: disable=bare-except
+            except:  # pylint: disable=bare-except
                 pass
 
             self.assertEqual(mock_log_error.call_count, 1)
@@ -209,7 +209,7 @@ class RunCommandTestCase(AgentTestCase):
         random_hash = ''.join(random.choice('0123456789ABCDEF') for _ in range(16))
         try:
             output = shellutil.run_command(command, cmd_input=random_hash)
-        except: # pylint: disable=bare-except
+        except:  # pylint: disable=bare-except
             self.fail("No exception should've been thrown when trying to read from stdin in run_command")
 
         self.assertEqual(output, random_hash, "We're reading from stdin and printing it shell, output should match")

--- a/tests/utils/test_text_util.py
+++ b/tests/utils/test_text_util.py
@@ -137,7 +137,7 @@ class TestTextUtil(AgentTestCase):
             ['aBcdEf12', 4, 'Ef12aBcd']
         ]
 
-        for t in data: # pylint: disable=invalid-name
+        for t in data:  # pylint: disable=invalid-name
             self.assertEqual(t[2], textutil.swap_hexstring(t[0], width=t[1]))
 
     def test_compress(self):


### PR DESCRIPTION
Inline pylint suppressions (as other inline comments) should be preceded by 2 spaces.

Updated files using
```
find . -name '*.py' -exec sed -i  's/\([^ ]\) \(# pylint:\)/\1  \2/' {} \;
```