### PR TITLE
Fix distro resolution for RedHat

### DIFF
--- a/azurelinuxagent/common/osutil/factory.py
+++ b/azurelinuxagent/common/osutil/factory.py
@@ -59,7 +59,7 @@ def _get_osutil(distro_name, distro_code_name, distro_version, distro_full_name)
         return ClearLinuxUtil()
 
     if distro_name == "ubuntu":
-        if Version(distro_version) in [Version("12.04"), Version("12.10")]:  # pylint: disable=R1705
+        if Version(distro_version) in [Version("12.04"), Version("12.10")]:
             return Ubuntu12OSUtil()
         elif Version(distro_version) in [Version("14.04"), Version("14.10")]:
             return Ubuntu14OSUtil()
@@ -71,8 +71,8 @@ def _get_osutil(distro_name, distro_code_name, distro_version, distro_full_name)
             return Ubuntu18OSUtil()
         elif distro_full_name == "Snappy Ubuntu Core":
             return UbuntuSnappyOSUtil()
-        else:
-            return UbuntuOSUtil()
+
+        return UbuntuOSUtil()
 
     if distro_name == "alpine":
         return AlpineOSUtil()
@@ -84,28 +84,23 @@ def _get_osutil(distro_name, distro_code_name, distro_version, distro_full_name)
         return CoreOSUtil()
 
     if distro_name in ("suse", "sles", "opensuse"):
-        # pylint: disable=R1705
-        if distro_full_name == 'SUSE Linux Enterprise Server' \
-                and Version(distro_version) < Version('12') \
+        if distro_full_name == 'SUSE Linux Enterprise Server' and Version(distro_version) < Version('12') \
                 or distro_full_name == 'openSUSE' and Version(distro_version) < Version('13.2'):
             return SUSE11OSUtil()
-        else:
-            return SUSEOSUtil()
+
+        return SUSEOSUtil()
 
     if distro_name == "debian":
-        if "sid" in distro_version or Version(distro_version) > Version("7"):  # pylint: disable=R1705
+        if "sid" in distro_version or Version(distro_version) > Version("7"):
             return DebianOSModernUtil()
-        else:
-            return DebianOSBaseUtil()
 
-    # pylint: disable=R1714
-    if distro_name == "redhat" \
-            or distro_name == "centos" \
-            or distro_name == "oracle":
-        if Version(distro_version) < Version("7"):  # pylint: disable=R1705
+        return DebianOSBaseUtil()
+
+    if distro_name in ("redhat", "rhel", "centos", "oracle"):
+        if Version(distro_version) < Version("7"):
             return Redhat6xOSUtil()
-        else:
-            return RedhatOSUtil()
+
+        return RedhatOSUtil()
 
     if distro_name == "euleros":
         return RedhatOSUtil()
@@ -128,11 +123,8 @@ def _get_osutil(distro_name, distro_code_name, distro_version, distro_full_name)
     if distro_name == "nsbsd":
         return NSBSDOSUtil()
 
-    if distro_name == "openwrt":  # pylint: disable=R1705
+    if distro_name == "openwrt":
         return OpenWRTOSUtil()
 
-    else:
-        logger.warn("Unable to load distro implementation for {0}. Using "
-                    "default distro implementation instead.",
-                    distro_name)
-        return DefaultOSUtil()
+    logger.warn("Unable to load distro implementation for {0}. Using default distro implementation instead.", distro_name)
+    return DefaultOSUtil()

--- a/azurelinuxagent/common/osutil/factory.py
+++ b/azurelinuxagent/common/osutil/factory.py
@@ -61,15 +61,15 @@ def _get_osutil(distro_name, distro_code_name, distro_version, distro_full_name)
     if distro_name == "ubuntu":
         if Version(distro_version) in [Version("12.04"), Version("12.10")]:
             return Ubuntu12OSUtil()
-        elif Version(distro_version) in [Version("14.04"), Version("14.10")]:
+        if Version(distro_version) in [Version("14.04"), Version("14.10")]:
             return Ubuntu14OSUtil()
-        elif Version(distro_version) in [Version('16.04'), Version('16.10'), Version('17.04')]:
+        if Version(distro_version) in [Version('16.04'), Version('16.10'), Version('17.04')]:
             return Ubuntu16OSUtil()
-        elif Version(distro_version) in [Version('18.04'), Version('18.10'),
+        if Version(distro_version) in [Version('18.04'), Version('18.10'),
                                          Version('19.04'), Version('19.10'),
                                          Version('20.04')]:
             return Ubuntu18OSUtil()
-        elif distro_full_name == "Snappy Ubuntu Core":
+        if distro_full_name == "Snappy Ubuntu Core":
             return UbuntuSnappyOSUtil()
 
         return UbuntuOSUtil()

--- a/tests/common/osutil/test_factory.py
+++ b/tests/common/osutil/test_factory.py
@@ -15,23 +15,23 @@
 # Requires Python 2.4+ and Openssl 1.0+
 #
 
-from azurelinuxagent.common.osutil.factory import _get_osutil
-from azurelinuxagent.common.osutil.default import DefaultOSUtil
+from azurelinuxagent.common.osutil.alpine import AlpineOSUtil
 from azurelinuxagent.common.osutil.arch import ArchUtil
+from azurelinuxagent.common.osutil.bigip import BigIpOSUtil
 from azurelinuxagent.common.osutil.clearlinux import ClearLinuxUtil
 from azurelinuxagent.common.osutil.coreos import CoreOSUtil
 from azurelinuxagent.common.osutil.debian import DebianOSBaseUtil, DebianOSModernUtil
+from azurelinuxagent.common.osutil.default import DefaultOSUtil
+from azurelinuxagent.common.osutil.factory import _get_osutil
 from azurelinuxagent.common.osutil.freebsd import FreeBSDOSUtil
+from azurelinuxagent.common.osutil.gaia import GaiaOSUtil
+from azurelinuxagent.common.osutil.iosxe import IosxeOSUtil
 from azurelinuxagent.common.osutil.openbsd import OpenBSDOSUtil
+from azurelinuxagent.common.osutil.openwrt import OpenWRTOSUtil
 from azurelinuxagent.common.osutil.redhat import RedhatOSUtil, Redhat6xOSUtil
 from azurelinuxagent.common.osutil.suse import SUSEOSUtil, SUSE11OSUtil
 from azurelinuxagent.common.osutil.ubuntu import UbuntuOSUtil, Ubuntu12OSUtil, Ubuntu14OSUtil, \
     UbuntuSnappyOSUtil, Ubuntu16OSUtil, Ubuntu18OSUtil
-from azurelinuxagent.common.osutil.alpine import AlpineOSUtil
-from azurelinuxagent.common.osutil.bigip import BigIpOSUtil
-from azurelinuxagent.common.osutil.gaia import GaiaOSUtil
-from azurelinuxagent.common.osutil.iosxe import IosxeOSUtil
-from azurelinuxagent.common.osutil.openwrt import OpenWRTOSUtil
 from tests.tools import AgentTestCase, patch
 
 
@@ -49,7 +49,7 @@ class TestOsUtilFactory(AgentTestCase):
                           distro_code_name="",
                           distro_version="",
                           distro_full_name="")
-        self.assertTrue(type(ret) == DefaultOSUtil)  # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(isinstance(ret, DefaultOSUtil))
         self.assertEqual(patch_logger.call_count, 1)
         self.assertEqual(ret.get_service_name(), "waagent")
 
@@ -58,49 +58,49 @@ class TestOsUtilFactory(AgentTestCase):
                           distro_code_name="",
                           distro_version="10.04",
                           distro_full_name="")
-        self.assertTrue(type(ret) == UbuntuOSUtil)  # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(isinstance(ret, UbuntuOSUtil))
         self.assertEqual(ret.get_service_name(), "walinuxagent")
 
         ret = _get_osutil(distro_name="ubuntu",
                           distro_code_name="",
                           distro_version="12.04",
                           distro_full_name="")
-        self.assertTrue(type(ret) == Ubuntu12OSUtil)  # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(isinstance(ret, Ubuntu12OSUtil))
         self.assertEqual(ret.get_service_name(), "walinuxagent")
 
         ret = _get_osutil(distro_name="ubuntu",
                           distro_code_name="trusty",
                           distro_version="14.04",
                           distro_full_name="")
-        self.assertTrue(type(ret) == Ubuntu14OSUtil)  # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(isinstance(ret, Ubuntu14OSUtil))
         self.assertEqual(ret.get_service_name(), "walinuxagent")
 
         ret = _get_osutil(distro_name="ubuntu",
                           distro_code_name="xenial",
                           distro_version="16.04",
                           distro_full_name="")
-        self.assertTrue(type(ret) == Ubuntu16OSUtil)  # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(isinstance(ret, Ubuntu16OSUtil))
         self.assertEqual(ret.get_service_name(), "walinuxagent")
 
         ret = _get_osutil(distro_name="ubuntu",
                           distro_code_name="bionic",
                           distro_version="18.04",
                           distro_full_name="")
-        self.assertTrue(type(ret) == Ubuntu18OSUtil)  # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(isinstance(ret, Ubuntu18OSUtil))
         self.assertEqual(ret.get_service_name(), "walinuxagent")
 
         ret = _get_osutil(distro_name="ubuntu",
                           distro_code_name="focal",
                           distro_version="20.04",
                           distro_full_name="")
-        self.assertTrue(type(ret) == Ubuntu18OSUtil)  # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(isinstance(ret, Ubuntu18OSUtil))
         self.assertEqual(ret.get_service_name(), "walinuxagent")
 
         ret = _get_osutil(distro_name="ubuntu",
                           distro_code_name="",
                           distro_version="10.04",
                           distro_full_name="Snappy Ubuntu Core")
-        self.assertTrue(type(ret) == UbuntuSnappyOSUtil)  # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(isinstance(ret, UbuntuSnappyOSUtil))
         self.assertEqual(ret.get_service_name(), "walinuxagent")
 
     def test_get_osutil_it_should_return_arch(self):
@@ -108,7 +108,7 @@ class TestOsUtilFactory(AgentTestCase):
                           distro_code_name="",
                           distro_version="",
                           distro_full_name="")
-        self.assertTrue(type(ret) == ArchUtil)  # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(isinstance(ret, ArchUtil))
         self.assertEqual(ret.get_service_name(), "waagent")
 
     def test_get_osutil_it_should_return_clear_linux(self):
@@ -116,7 +116,7 @@ class TestOsUtilFactory(AgentTestCase):
                           distro_code_name="",
                           distro_version="",
                           distro_full_name="Clear Linux")
-        self.assertTrue(type(ret) == ClearLinuxUtil)  # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(isinstance(ret, ClearLinuxUtil))
         self.assertEqual(ret.get_service_name(), "waagent")
 
     def test_get_osutil_it_should_return_alpine(self):
@@ -124,7 +124,7 @@ class TestOsUtilFactory(AgentTestCase):
                           distro_code_name="",
                           distro_version="",
                           distro_full_name="")
-        self.assertTrue(type(ret) == AlpineOSUtil)  # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(isinstance(ret, AlpineOSUtil))
         self.assertEqual(ret.get_service_name(), "waagent")
 
     def test_get_osutil_it_should_return_kali(self):
@@ -132,7 +132,7 @@ class TestOsUtilFactory(AgentTestCase):
                           distro_code_name="",
                           distro_version="",
                           distro_full_name="")
-        self.assertTrue(type(ret) == DebianOSBaseUtil)  # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(isinstance(ret, DebianOSBaseUtil))
         self.assertEqual(ret.get_service_name(), "waagent")
 
     def test_get_osutil_it_should_return_coreos(self):
@@ -140,7 +140,7 @@ class TestOsUtilFactory(AgentTestCase):
                           distro_code_name="",
                           distro_version="",
                           distro_full_name="")
-        self.assertTrue(type(ret) == CoreOSUtil)  # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(isinstance(ret, CoreOSUtil))
         self.assertEqual(ret.get_service_name(), "waagent")
 
     def test_get_osutil_it_should_return_suse(self):
@@ -148,21 +148,21 @@ class TestOsUtilFactory(AgentTestCase):
                           distro_code_name="",
                           distro_version="10",
                           distro_full_name="")
-        self.assertTrue(type(ret) == SUSEOSUtil)  # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(isinstance(ret, SUSEOSUtil))
         self.assertEqual(ret.get_service_name(), "waagent")
 
         ret = _get_osutil(distro_name="suse",
                           distro_code_name="",
                           distro_full_name="SUSE Linux Enterprise Server",
                           distro_version="11")
-        self.assertTrue(type(ret) == SUSE11OSUtil)  # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(isinstance(ret, SUSE11OSUtil))
         self.assertEqual(ret.get_service_name(), "waagent")
 
         ret = _get_osutil(distro_name="suse",
                           distro_code_name="",
                           distro_full_name="openSUSE",
                           distro_version="12")
-        self.assertTrue(type(ret) == SUSE11OSUtil)  # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(isinstance(ret, SUSE11OSUtil))
         self.assertEqual(ret.get_service_name(), "waagent")
 
     def test_get_osutil_it_should_return_debian(self):
@@ -170,14 +170,14 @@ class TestOsUtilFactory(AgentTestCase):
                           distro_code_name="",
                           distro_full_name="",
                           distro_version="7")
-        self.assertTrue(type(ret) == DebianOSBaseUtil)  # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(isinstance(ret, DebianOSBaseUtil))
         self.assertEqual(ret.get_service_name(), "waagent")
 
         ret = _get_osutil(distro_name="debian",
                           distro_code_name="",
                           distro_full_name="",
                           distro_version="8")
-        self.assertTrue(type(ret) == DebianOSModernUtil)  # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(isinstance(ret, DebianOSModernUtil))
         self.assertEqual(ret.get_service_name(), "walinuxagent")
 
     def test_get_osutil_it_should_return_redhat(self):
@@ -185,42 +185,56 @@ class TestOsUtilFactory(AgentTestCase):
                           distro_code_name="",
                           distro_full_name="",
                           distro_version="6")
-        self.assertTrue(type(ret) == Redhat6xOSUtil)  # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(isinstance(ret, Redhat6xOSUtil))
+        self.assertEqual(ret.get_service_name(), "waagent")
+
+        ret = _get_osutil(distro_name="rhel",
+                          distro_code_name="",
+                          distro_full_name="",
+                          distro_version="6")
+        self.assertTrue(isinstance(ret, Redhat6xOSUtil))
         self.assertEqual(ret.get_service_name(), "waagent")
 
         ret = _get_osutil(distro_name="centos",
                           distro_code_name="",
                           distro_full_name="",
                           distro_version="6")
-        self.assertTrue(type(ret) == Redhat6xOSUtil)  # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(isinstance(ret, Redhat6xOSUtil))
         self.assertEqual(ret.get_service_name(), "waagent")
 
         ret = _get_osutil(distro_name="oracle",
                           distro_code_name="",
                           distro_full_name="",
                           distro_version="6")
-        self.assertTrue(type(ret) == Redhat6xOSUtil)  # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(isinstance(ret, Redhat6xOSUtil))
         self.assertEqual(ret.get_service_name(), "waagent")
 
         ret = _get_osutil(distro_name="redhat",
                           distro_code_name="",
                           distro_full_name="",
                           distro_version="7")
-        self.assertTrue(type(ret) == RedhatOSUtil)  # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(isinstance(ret, RedhatOSUtil))
+        self.assertEqual(ret.get_service_name(), "waagent")
+
+        ret = _get_osutil(distro_name="rhel",
+                          distro_code_name="",
+                          distro_full_name="",
+                          distro_version="7")
+        self.assertTrue(isinstance(ret, RedhatOSUtil))
         self.assertEqual(ret.get_service_name(), "waagent")
 
         ret = _get_osutil(distro_name="centos",
                           distro_code_name="",
                           distro_full_name="",
                           distro_version="7")
-        self.assertTrue(type(ret) == RedhatOSUtil)  # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(isinstance(ret, RedhatOSUtil))
         self.assertEqual(ret.get_service_name(), "waagent")
 
         ret = _get_osutil(distro_name="oracle",
                           distro_code_name="",
                           distro_full_name="",
                           distro_version="7")
-        self.assertTrue(type(ret) == RedhatOSUtil)  # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(isinstance(ret, RedhatOSUtil))
         self.assertEqual(ret.get_service_name(), "waagent")
 
     def test_get_osutil_it_should_return_euleros(self):
@@ -228,7 +242,7 @@ class TestOsUtilFactory(AgentTestCase):
                           distro_code_name="",
                           distro_version="",
                           distro_full_name="")
-        self.assertTrue(type(ret) == RedhatOSUtil)  # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(isinstance(ret, RedhatOSUtil))
         self.assertEqual(ret.get_service_name(), "waagent")
 
     def test_get_osutil_it_should_return_freebsd(self):
@@ -236,7 +250,7 @@ class TestOsUtilFactory(AgentTestCase):
                           distro_code_name="",
                           distro_version="",
                           distro_full_name="")
-        self.assertTrue(type(ret) == FreeBSDOSUtil)  # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(isinstance(ret, FreeBSDOSUtil))
         self.assertEqual(ret.get_service_name(), "waagent")
 
     def test_get_osutil_it_should_return_openbsd(self):
@@ -244,7 +258,7 @@ class TestOsUtilFactory(AgentTestCase):
                           distro_code_name="",
                           distro_version="",
                           distro_full_name="")
-        self.assertTrue(type(ret) == OpenBSDOSUtil)  # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(isinstance(ret, OpenBSDOSUtil))
         self.assertEqual(ret.get_service_name(), "waagent")
 
     def test_get_osutil_it_should_return_bigip(self):
@@ -252,7 +266,7 @@ class TestOsUtilFactory(AgentTestCase):
                           distro_code_name="",
                           distro_version="",
                           distro_full_name="")
-        self.assertTrue(type(ret) == BigIpOSUtil)  # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(isinstance(ret, BigIpOSUtil))
         self.assertEqual(ret.get_service_name(), "waagent")
 
     def test_get_osutil_it_should_return_gaia(self):
@@ -260,7 +274,7 @@ class TestOsUtilFactory(AgentTestCase):
                           distro_code_name="",
                           distro_version="",
                           distro_full_name="")
-        self.assertTrue(type(ret) == GaiaOSUtil)  # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(isinstance(ret, GaiaOSUtil))
         self.assertEqual(ret.get_service_name(), "waagent")
 
     def test_get_osutil_it_should_return_iosxe(self):
@@ -268,7 +282,7 @@ class TestOsUtilFactory(AgentTestCase):
                           distro_code_name="",
                           distro_version="",
                           distro_full_name="")
-        self.assertTrue(type(ret) == IosxeOSUtil)  # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(isinstance(ret, IosxeOSUtil))
         self.assertEqual(ret.get_service_name(), "waagent")
 
     def test_get_osutil_it_should_return_openwrt(self):
@@ -276,5 +290,5 @@ class TestOsUtilFactory(AgentTestCase):
                           distro_code_name="",
                           distro_version="",
                           distro_full_name="")
-        self.assertTrue(type(ret) == OpenWRTOSUtil)  # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(isinstance(ret, OpenWRTOSUtil))
         self.assertEqual(ret.get_service_name(), "waagent")


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

When we are resolving distros, we call either:
1) `platform.linux_distribution(full_distribution_name=False)` which returns "redhat", or
2) `distro.linux_distribution(full_distribution_name=False)` returns "rhel". See [here](https://distro.readthedocs.io/en/latest/#distro.id).

Option 2) was actually never invoked since `platform` is the primary choice. Starting Python 3.9, `platform` is deprecated, so we fall back to using `distro` which returns a slightly different value. This PR updates the possible return values and fixes pylint warnings of prod and test code.


<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).