### PR TITLE
fix removed alias tostring() of tobytes() method in python 3.9

### DIFF
--- a/azurelinuxagent/common/osutil/bigip.py
+++ b/azurelinuxagent/common/osutil/bigip.py
@@ -287,7 +287,7 @@ class BigIpOSUtil(DefaultOSUtil):
         if retsize == (expected * struct_size):
             logger.warn(('SIOCGIFCONF returned more than {0} up '
                          'network interfaces.'), expected)
-        sock = buff.tostring()
+        sock = buff.tobytes()
         for i in range(0, struct_size * expected, struct_size):
             iface = self._format_single_interface_name(sock, i)
 

--- a/azurelinuxagent/common/osutil/default.py
+++ b/azurelinuxagent/common/osutil/default.py
@@ -804,7 +804,7 @@ class DefaultOSUtil(object):  # pylint: disable=R0904
             logger.warn(('SIOCGIFCONF returned more than {0} up '
                          'network interfaces.'), expected)
 
-        ifconf_buff = buff.tostring()
+        ifconf_buff = buff.tobytes()
 
         ifaces = {}
         for i in range(0, array_size, struct_size):

--- a/bin/waagent2.0
+++ b/bin/waagent2.0
@@ -2669,7 +2669,7 @@ def GetFirstActiveNetworkInterfaceNonLoopback():
     retsize=(struct.unpack('iL', fcntl.ioctl(s.fileno(), 0x8912, struct.pack('iL',expected*struct_size,buff.buffer_info()[0]))))[0]
     if retsize == (expected*struct_size) :
         Warn('SIOCGIFCONF returned more than ' + str(expected) + ' up network interfaces.')
-    s=buff.tostring()
+    s=buff.tobytes()
     preferred_nic = Config.get("Network.Interface")
     for i in range(0,struct_size*expected,struct_size):
         iface=s[i:i+16].split(b'\0', 1)[0]


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Issue # <!-- if any -->

the agent fails in python 3.9 with non existent method array.array tostring(). 
replaced tostring alias with tobytes method. 

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).