### PR TITLE
Always create status file placeholder for extensions

### DIFF
--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -1144,14 +1144,8 @@ class ExtHandlerInstance(object):
 
         if extension is not None and extension.sequenceNumber is not None:
             try:
-                gs_seq_no = int(extension.sequenceNumber)
-
-                if gs_seq_no != seq_no:
-                    add_event(AGENT_NAME, version=CURRENT_VERSION, op=WALAEventOperation.SequenceNumberMismatch,
-                              is_success=False, message="Goal state: {0}, disk: {1}".format(gs_seq_no, seq_no),
-                              log_event=False)
-
-                seq_no = gs_seq_no
+                # Always get the sequence number from the goal state, don't rely on the sequence number on disk
+                seq_no = int(extension.sequenceNumber)
             except ValueError:
                 logger.error('Sequence number [{0}] does not appear to be valid'.format(extension.sequenceNumber))
 


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Updating the dead code that should always create a status file placeholder on extension enable. The main change is removing the dependency on the filesystem extension sequence number and instead always using the sequence number from the goal state.

<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).