### PR TITLE
Remove unnecessary unit test

### DIFF
--- a/tests/ga/test_collect_logs.py
+++ b/tests/ga/test_collect_logs.py
@@ -21,8 +21,7 @@ from azurelinuxagent.common import logger
 from azurelinuxagent.common.cgroupapi import SYSTEMD_RUN_PATH
 from azurelinuxagent.common.logger import Logger
 from azurelinuxagent.common.protocol.util import ProtocolUtil
-from azurelinuxagent.ga.collect_logs import get_collect_logs_handler, CollectLogsHandler, is_log_collection_allowed
-from azurelinuxagent.ga.periodic_operation import PeriodicOperation
+from azurelinuxagent.ga.collect_logs import get_collect_logs_handler, is_log_collection_allowed
 from tests.protocol.mocks import mock_wire_protocol, HttpRequestPredicates, MockHttpResponse
 from tests.protocol.mockwiredata import DATA_FILE
 from tests.tools import Mock, MagicMock, patch, AgentTestCase, clear_singleton_instances, skip_if_predicate_true, \

--- a/tests/ga/test_collect_logs.py
+++ b/tests/ga/test_collect_logs.py
@@ -93,21 +93,6 @@ class TestCollectLogs(AgentTestCase, HttpRequestPredicates):
         with open(self.archive_path, "wb") as f:
             f.truncate(size)
 
-    def test_it_should_invoke_all_periodic_operations(self):
-        invoked_operations = []
-
-        with _create_collect_logs_handler() as collect_logs_handler:
-            def mock_run(self):
-                invoked_operations.append(self._name)
-
-            with patch.object(PeriodicOperation, "run", side_effect=mock_run, spec=CollectLogsHandler.run):
-                collect_logs_handler.run_and_wait()
-
-                expected_operations = ["collect_and_send_logs"]
-
-                self.assertEqual(invoked_operations.sort(), expected_operations.sort(),
-                                 "The collect logs thread did not invoke the expected operations")
-
     def test_it_should_only_collect_logs_if_conditions_are_met(self):
         # In order to collect logs, three conditions have to be met:
         # 1) the flag must be set to true in the conf file


### PR DESCRIPTION
The test was probably copy and pasted from the unit tests for the MonitorHandler; while it makes sense in that class, it doesn't here.