### PR TITLE
Refresh host ga plugin in periodic task

### DIFF
--- a/azurelinuxagent/ga/monitor.py
+++ b/azurelinuxagent/ga/monitor.py
@@ -144,6 +144,8 @@ class SendHostPluginHeartbeatOperation(PeriodicOperation):
         try:
             host_plugin = self.protocol.client.get_host_plugin()
             host_plugin.ensure_initialized()
+            self.protocol.update_host_plugin_from_goal_state()
+
             is_currently_healthy = host_plugin.get_health()
 
             if is_currently_healthy:
@@ -270,8 +272,6 @@ class MonitorHandler(ThreadHandlerInterface):
 
             while not self.stopped():
                 try:
-                    protocol.update_host_plugin_from_goal_state()
-
                     for op in periodic_operations:
                         op.run()
 


### PR DESCRIPTION
Refreshing the goal state for the Host GA Plugin doesn't need to be done in the main method of the monitor thread. Moved it to the periodic task for the plugin.