### PR TITLE
Gha pylint update fix

### DIFF
--- a/azurelinuxagent/common/dhcp.py
+++ b/azurelinuxagent/common/dhcp.py
@@ -86,7 +86,7 @@ class DhcpHandler(object):
         logger.info("Test for route to {0}".format(KNOWN_WIRESERVER_IP))
         try:
             route_table = self.osutil.read_route_table()
-            if any([(KNOWN_WIRESERVER_IP_ENTRY in route) for route in route_table]):
+            if any((KNOWN_WIRESERVER_IP_ENTRY in route) for route in route_table):
                 # reset self.gateway and self.routes
                 # we do not need to alter the routing table
                 self.endpoint = KNOWN_WIRESERVER_IP

--- a/azurelinuxagent/daemon/resourcedisk/default.py
+++ b/azurelinuxagent/daemon/resourcedisk/default.py
@@ -78,6 +78,7 @@ class ResourceDiskHandler(object):
             logger.error("Failed to mount resource disk {0}", e)
             add_event(name=AGENT_NAME, is_success=False, message=ustr(e),
                       op=WALAEventOperation.ActivateResourceDisk)
+        return None
 
     def enable_swap(self, mount_point):
         logger.info("Enable swap")

--- a/ci/3.6.pylintrc
+++ b/ci/3.6.pylintrc
@@ -29,6 +29,7 @@ disable=C, # (C) convention, for programming standard violation
     too-many-statements, # (R0915): *Too many statements (%s/%s)*
     useless-object-inheritance, # (R0205): *Class %r inherits from object, can be safely removed from bases in python3*
     useless-return, # (R1711): *Useless return at end of function or method*
+    use-a-generator, # (R1729): *Use a generator instead '%s(%s)'*
     broad-except, # (W0703): *Catching too general exception %s*
     raise-missing-from, # (W0707): *Consider explicitly re-raising using the 'from' keyword*
     fixme, # Used when a warning note as FIXME or TODO is detected

--- a/tests/common/test_logcollector.py
+++ b/tests/common/test_logcollector.py
@@ -199,11 +199,11 @@ diskinfo,""".format(folder_to_list, file_to_collect)
             results = fh.readlines()
 
         # Assert echo was parsed
-        self.assertTrue(any([line.endswith("### Test header ###\n") for line in results]))
+        self.assertTrue(any(line.endswith("### Test header ###\n") for line in results))
         # Assert unknown command was reported
-        self.assertTrue(any([line.endswith("ERROR Couldn\'t parse \"unknown command\"\n") for line in results]))
+        self.assertTrue(any(line.endswith("ERROR Couldn\'t parse \"unknown command\"\n") for line in results))
         # Assert ll was parsed
-        self.assertTrue(any(["ls -alF {0}".format(folder_to_list) in line for line in results]))
+        self.assertTrue(any("ls -alF {0}".format(folder_to_list) in line for line in results))
         # Assert copy was parsed
         self._assert_archive_created(archive)
         self._assert_files_are_in_archive(expected_files=[file_to_collect])

--- a/tests/common/test_persist_firewall_rules.py
+++ b/tests/common/test_persist_firewall_rules.py
@@ -157,7 +157,7 @@ class TestPersistFirewallRulesHandler(AgentTestCase):
         # Assert no commands for adding rules using firewall-cmd were called
         self.__assert_firewall_called(cmd=FirewallCmdDirectCommands.PassThrough, validate_command_called=False)
         # Assert no commands for systemctl were called
-        self.assertFalse(any(["systemctl" in cmd for cmd in self.__executed_commands]), "Systemctl shouldn't be called")
+        self.assertFalse(any("systemctl" in cmd for cmd in self.__executed_commands), "Systemctl shouldn't be called")
 
     def test_it_should_skip_setup_if_agent_network_setup_service_already_enabled(self):
         self.__replace_popen_cmd = TestPersistFirewallRulesHandler.__mock_network_setup_service_enabled
@@ -218,7 +218,7 @@ class TestPersistFirewallRulesHandler(AgentTestCase):
                 return True, ["echo", "running"]
             # This is to fail the check if firewalld-rules are already applied
             cmds_to_fail = ["firewall-cmd", FirewallCmdDirectCommands.QueryPassThrough, "conntrack"]
-            if all([cmd_to_fail in cmd for cmd_to_fail in cmds_to_fail]):
+            if all(cmd_to_fail in cmd for cmd_to_fail in cmds_to_fail):
                 return True, ["exit", "1"]
             if "firewall-cmd" in cmd:
                 return True, ["echo", "enabled"]
@@ -231,7 +231,7 @@ class TestPersistFirewallRulesHandler(AgentTestCase):
         self.__assert_firewall_cmd_running_called(validate_command_called=True)
         self.__assert_firewall_called(cmd=FirewallCmdDirectCommands.QueryPassThrough, validate_command_called=True)
         self.__assert_firewall_called(cmd=FirewallCmdDirectCommands.PassThrough, validate_command_called=True)
-        self.assertFalse(any(["systemctl" in cmd for cmd in self.__executed_commands]), "Systemctl shouldn't be called")
+        self.assertFalse(any("systemctl" in cmd for cmd in self.__executed_commands), "Systemctl shouldn't be called")
 
     def test_it_should_set_up_custom_service_if_no_firewalld(self):
         self.__replace_popen_cmd = TestPersistFirewallRulesHandler.__mock_network_setup_service_disabled

--- a/tests/ga/test_extension.py
+++ b/tests/ga/test_extension.py
@@ -1172,7 +1172,7 @@ class TestExtension(AgentTestCase):
             event_occurrences = [kw for _, kw in mock_add_event.call_args_list if
                           "Failed to download artifacts: [ExtensionDownloadError] {0}".format(err_msg_guid) in kw['message']]
             self.assertEqual(expected_download_failed_event_count, len(event_occurrences), "Call count do not match")
-            self.assertFalse(any([kw['is_success'] for kw in event_occurrences]), "The events should have failed")
+            self.assertFalse(any(kw['is_success'] for kw in event_occurrences), "The events should have failed")
             self.assertEqual(expected_download_failed_event_count, len([kw['op'] for kw in event_occurrences]),
                              "Incorrect Operation, all events should be a download errors")
 


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

An update to pylint stable on python3 added a `use-a-generator` warning, and (presumably) better checking for `inconsistent-return-statements`. This PR disables the `use-a-generator` warning and fixes all warnings reported by the new pylint version.

<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).