### PR TITLE
Change Iterative approach to Binet's Formula for Calculating Nth Fibonacci Term for Retry Delay

### DIFF
--- a/azurelinuxagent/common/utils/restutil.py
+++ b/azurelinuxagent/common/utils/restutil.py
@@ -17,6 +17,7 @@
 # Requires Python 2.6+ and Openssl 1.0+
 #
 
+import math
 import os
 import re
 import threading
@@ -136,10 +137,11 @@ class IOErrorCounter(object):
 
 
 def _compute_delay(retry_attempt=1, delay=DELAY_IN_SECONDS):
-    fib = (1, 1)
-    for _ in range(retry_attempt):
-        fib = (fib[1], fib[0]+fib[1])
-    return delay*fib[1]
+    # Binet's Formula for Nth Fibonacci Term:
+    # https://artofproblemsolving.com/wiki/index.php/Binet%27s_Formula
+    sqrt5 = math.sqrt(5)
+    fib_n = int((( (1 + sqrt5) ** retry_attempt - (1 - sqrt5) ** retry_attempt ) / ( 2 ** retry_attempt * sqrt5 )))
+    return delay*fib_n
 
 
 def _is_retry_status(status, retry_codes=None):

--- a/azurelinuxagent/common/utils/restutil.py
+++ b/azurelinuxagent/common/utils/restutil.py
@@ -140,8 +140,9 @@ def _compute_delay(retry_attempt=1, delay=DELAY_IN_SECONDS):
     # Binet's Formula for Nth Fibonacci Term:
     # https://artofproblemsolving.com/wiki/index.php/Binet%27s_Formula
     sqrt5 = math.sqrt(5)
-    fib_n = int((( (1 + sqrt5) ** retry_attempt - (1 - sqrt5) ** retry_attempt ) / ( 2 ** retry_attempt * sqrt5 )))
-    return delay*fib_n
+    fib_n = int(round((( (1 + sqrt5) ** retry_attempt - (1 - sqrt5) ** retry_attempt ) / ( 2 ** retry_attempt * sqrt5 ))))
+    # Add 2 to be equivalent with previous iterative approach indexing
+    return delay * (fib_n + 2)
 
 
 def _is_retry_status(status, retry_codes=None):

--- a/azurelinuxagent/common/utils/restutil.py
+++ b/azurelinuxagent/common/utils/restutil.py
@@ -140,9 +140,10 @@ def _compute_delay(retry_attempt=1, delay=DELAY_IN_SECONDS):
     # Binet's Formula for Nth Fibonacci Term:
     # https://artofproblemsolving.com/wiki/index.php/Binet%27s_Formula
     sqrt5 = math.sqrt(5)
+    # Add 2 to be consistent with previous iterative approach indexing
+    n = retry_attempt + 2
     fib_n = int(round((( (1 + sqrt5) ** retry_attempt - (1 - sqrt5) ** retry_attempt ) / ( 2 ** retry_attempt * sqrt5 ))))
-    # Add 2 to be equivalent with previous iterative approach indexing
-    return delay * (fib_n + 2)
+    return delay * fib_n
 
 
 def _is_retry_status(status, retry_codes=None):

--- a/azurelinuxagent/common/utils/restutil.py
+++ b/azurelinuxagent/common/utils/restutil.py
@@ -142,7 +142,7 @@ def _compute_delay(retry_attempt=1, delay=DELAY_IN_SECONDS):
     sqrt5 = math.sqrt(5)
     # Add 2 to be consistent with previous iterative approach indexing
     n = retry_attempt + 2
-    fib_n = int(round((( (1 + sqrt5) ** retry_attempt - (1 - sqrt5) ** retry_attempt ) / ( 2 ** retry_attempt * sqrt5 ))))
+    fib_n = int(round((( (1 + sqrt5) ** n - (1 - sqrt5) ** n ) / ( 2 ** n * sqrt5 ))))
     return delay * fib_n
 
 


### PR DESCRIPTION
Change Iterative approach to Binet's Formula for Calculating Nth Fibonacci Term for Retry Delay

<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->
The current calculation for retry delay involves calculating Nth fibonacci term iteratively. We can use Binet's formula to find Nth fibonacci term in O(1).

---

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] If applicable, the PR references the bug/issue that it fixes in the description.
- [x] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [x] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).