### PR TITLE
Fix for invalid gs createdOnTicks values

### DIFF
--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -278,15 +278,29 @@ class ExtHandlersHandler(object):
         :return: Tuple (activity_id, correlation_id, gs_created_timestamp) or "NA" for any property that's not available
         """
 
-        def check_empty(value): return value if value not in (None, "") else "NA"
+        def parse_value(parse_fn, value):
+
+            try:
+                if value not in (None, ""):
+                    return parse_fn(value)
+            except Exception as e:
+                # A failure here isn't a fatal error, because the info we're
+                # trying to retrieve is debug only on linux.
+                error_msg = u"Couldn't parse debug metadata value: {0}".format(e)
+                logger.verbose(error_msg)
+            
+            return "NA"
+        
+        fmt_time = lambda time: time.strftime(logger.Logger.LogTimeFormatInUTC)
+        identity = lambda value: value
 
         in_vm_gs_metadata = self.protocol.get_in_vm_gs_metadata()
-        gs_creation_time = check_empty(in_vm_gs_metadata.created_on_ticks)
-        gs_creation_time = gs_creation_time.strftime(
-            logger.Logger.LogTimeFormatInUTC) if gs_creation_time != "NA" else gs_creation_time
 
-        return check_empty(in_vm_gs_metadata.activity_id), check_empty(
-            in_vm_gs_metadata.correlation_id), gs_creation_time
+        gs_creation_time = parse_value(fmt_time, in_vm_gs_metadata.created_on_ticks)
+        activity_id = parse_value(identity, in_vm_gs_metadata.activity_id)
+        correlation_id = parse_value(identity, in_vm_gs_metadata.correlation_id)
+
+        return activity_id, correlation_id, gs_creation_time
 
     def run(self):
 

--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -278,7 +278,7 @@ class ExtHandlersHandler(object):
         :return: Tuple (activity_id, correlation_id, gs_created_timestamp) or "NA" for any property that's not available
         """
 
-        def parse_value(parse_fn, value):
+        def format_value(parse_fn, value):
 
             try:
                 if value not in (None, ""):
@@ -291,14 +291,14 @@ class ExtHandlersHandler(object):
             
             return "NA"
         
-        fmt_time = lambda time: time.strftime(logger.Logger.LogTimeFormatInUTC)
+        to_utc = lambda time: time.strftime(logger.Logger.LogTimeFormatInUTC)
         identity = lambda value: value
 
         in_vm_gs_metadata = self.protocol.get_in_vm_gs_metadata()
 
-        gs_creation_time = parse_value(fmt_time, in_vm_gs_metadata.created_on_ticks)
-        activity_id = parse_value(identity, in_vm_gs_metadata.activity_id)
-        correlation_id = parse_value(identity, in_vm_gs_metadata.correlation_id)
+        gs_creation_time = format_value(to_utc, in_vm_gs_metadata.created_on_ticks)
+        activity_id = format_value(identity, in_vm_gs_metadata.activity_id)
+        correlation_id = format_value(identity, in_vm_gs_metadata.correlation_id)
 
         return activity_id, correlation_id, gs_creation_time
 

--- a/tests/data/wire/ext_conf_invalid_vm_metadata.xml
+++ b/tests/data/wire/ext_conf_invalid_vm_metadata.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Extensions version="1.0.0.0" goalStateIncarnation="9">
+   <GuestAgentExtension xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+      <GAFamilies>
+         <GAFamily>
+            <Name>Prod</Name>
+            <Uris>
+               <Uri>http://mock-goal-state/manifest_of_ga.xml</Uri>
+            </Uris>
+         </GAFamily>
+         <GAFamily>
+            <Name>Test</Name>
+            <Uris>
+               <Uri>http://mock-goal-state/manifest_of_ga.xml</Uri>
+            </Uris>
+         </GAFamily>
+      </GAFamilies>
+   </GuestAgentExtension>
+   <Plugins>
+      <Plugin name="OSTCExtensions.ExampleHandlerLinux" version="1.0.0" location="http://mock-goal-state/rdfepirv2hknprdstr03.blob.core.windows.net/b01058962be54ceca550a390fa5ff064/Microsoft.OSTCExtensions_ExampleHandlerLinux_asiaeast_manifest.xml" config="" state="enabled" autoUpgrade="false" failoverlocation="http://mock-goal-state/rdfepirv2hknprdstr04.blob.core.windows.net/b01058962be54ceca550a390fa5ff064/Microsoft.OSTCExtensions_ExampleHandlerLinux_asiaeast_manifest.xml" runAsStartupTask="false" isJson="true" />
+   </Plugins>
+   <PluginSettings>
+      <Plugin name="OSTCExtensions.ExampleHandlerLinux" version="1.0.0">
+         <RuntimeSettings seqNo="0">{"runtimeSettings":[{"handlerSettings":{"protectedSettingsCertThumbprint":"4037FBF5F1F3014F99B5D6C7799E9B20E6871CB3","protectedSettings":"MIICWgYJK","publicSettings":{"foo":"bar"}}}]}</RuntimeSettings>
+      </Plugin>
+   </PluginSettings>
+   <StatusUploadBlob statusBlobType="BlockBlob">https://test.blob.core.windows.net/vhds/test-cs12.test-cs12.test-cs12.status?sr=b&amp;sp=rw&amp;se=9999-01-01&amp;sk=key1&amp;sv=2014-02-14&amp;sig=hfRh7gzUE7sUtYwke78IOlZOrTRCYvkec4hGZ9zZzXo</StatusUploadBlob>
+   <InVMGoalStateMetaData inSvdSeqNo="2" createdOnTicks="0" activityId="555e551c-600e-4fb4-90ba-8ab8ec28eccc" correlationId="400de90b-522e-491f-9d89-ec944661f531" />
+</Extensions>

--- a/tests/ga/test_extension.py
+++ b/tests/ga/test_extension.py
@@ -1337,7 +1337,7 @@ class TestExtension(ExtensionTestCase):
             self.assertEqual(etag, exthandlers_handler.last_etag,
                              "Last etag and etag should be same if extension processing is enabled")
 
-    def test_it_should_parse_in_vm_metadata_properly(self, mock_get, mock_crypt, *args):
+    def test_it_should_parse_valid_in_vm_metadata_properly(self, mock_get, mock_crypt, *args):
 
         test_data = mockwiredata.WireProtocolData(mockwiredata.DATA_FILE_IN_VM_META_DATA)
         exthandlers_handler, protocol = self._create_mock(test_data, mock_get, mock_crypt, *args)
@@ -1349,6 +1349,8 @@ class TestExtension(ExtensionTestCase):
         self.assertEqual(correlation_id, "400de90b-522e-491f-9d89-ec944661f531", "Incorrect correlation Id")
         self.assertEqual(gs_creation_time, '2020-11-09T17:48:50.412125Z', "Incorrect GS Creation time")
 
+    def test_it_should_parse_missing_in_vm_metadata_properly(self, mock_get, mock_crypt, *args):
+
         # If the data is not provided in ExtensionConfig, it should just be None
         test_data = mockwiredata.WireProtocolData(mockwiredata.DATA_FILE)
         exthandlers_handler, protocol = self._create_mock(test_data, mock_get, mock_crypt, *args)
@@ -1359,6 +1361,14 @@ class TestExtension(ExtensionTestCase):
         self.assertEqual(activity_id, "NA", "Activity Id should be NA")
         self.assertEqual(correlation_id, "NA", "Correlation Id should be NA")
         self.assertEqual(gs_creation_time, "NA", "GS Creation time should be NA")
+    
+    def test_it_should_parse_invalid_in_vm_metadata_properly(self, mock_get, mock_crypt, *args):
+
+        test_data = mockwiredata.WireProtocolData(mockwiredata.DATA_FILE_INVALID_VM_META_DATA)
+        exthandlers_handler, protocol = self._create_mock(test_data, mock_get, mock_crypt, *args)
+
+        exthandlers_handler.run()
+        self._assert_handler_status(protocol.report_vm_status, "Ready", 1, "1.0.0")
 
     def _assert_ext_status(self, report_ext_status, expected_status,
                            expected_seq_no):

--- a/tests/ga/test_extension.py
+++ b/tests/ga/test_extension.py
@@ -1349,7 +1349,7 @@ class TestExtension(ExtensionTestCase):
         self.assertEqual(correlation_id, "400de90b-522e-491f-9d89-ec944661f531", "Incorrect correlation Id")
         self.assertEqual(gs_creation_time, '2020-11-09T17:48:50.412125Z', "Incorrect GS Creation time")
 
-    def test_it_should_parse_missing_in_vm_metadata_properly(self, mock_get, mock_crypt, *args):
+    def test_it_should_process_goal_state_even_if_metadata_missing(self, mock_get, mock_crypt, *args):
 
         # If the data is not provided in ExtensionConfig, it should just be None
         test_data = mockwiredata.WireProtocolData(mockwiredata.DATA_FILE)
@@ -1362,7 +1362,7 @@ class TestExtension(ExtensionTestCase):
         self.assertEqual(correlation_id, "NA", "Correlation Id should be NA")
         self.assertEqual(gs_creation_time, "NA", "GS Creation time should be NA")
     
-    def test_it_should_parse_invalid_in_vm_metadata_properly(self, mock_get, mock_crypt, *args):
+    def test_it_should_process_goal_state_even_if_metadata_invalid(self, mock_get, mock_crypt, *args):
 
         test_data = mockwiredata.WireProtocolData(mockwiredata.DATA_FILE_INVALID_VM_META_DATA)
         exthandlers_handler, protocol = self._create_mock(test_data, mock_get, mock_crypt, *args)

--- a/tests/protocol/mockwiredata.py
+++ b/tests/protocol/mockwiredata.py
@@ -46,6 +46,9 @@ DATA_FILE_IN_VM_ARTIFACTS_PROFILE["in_vm_artifacts_profile"] = "wire/in_vm_artif
 DATA_FILE_IN_VM_META_DATA = DATA_FILE.copy()
 DATA_FILE_IN_VM_META_DATA["ext_conf"] = "wire/ext_conf_in_vm_metadata.xml"
 
+DATA_FILE_INVALID_VM_META_DATA = DATA_FILE.copy()
+DATA_FILE_INVALID_VM_META_DATA["ext_conf"] = "wire/ext_conf_invalid_vm_metadata.xml"
+
 DATA_FILE_NO_EXT = DATA_FILE.copy()
 DATA_FILE_NO_EXT["goal_state"] = "wire/goal_state_no_ext.xml"
 DATA_FILE_NO_EXT["ext_conf"] = None


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

CRP sometimes sends an extension config file with the `createdOnTicks` attribute of the `InVmGoalStateMetaData` node set to `0`. This isn't a fatal error, as this info is just debug information for linux as of now. This PR adds logic to ignore invalid data like this and process the goal state anyway.

<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).