### PR TITLE
Reduce the number of retries when downloading manifests and zips

### DIFF
--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -160,11 +160,11 @@ class WireProtocol(DataContract):
     def _download_ext_handler_pkg_through_host(self, uri, destination):
         host = self.client.get_host_plugin()
         uri, headers = host.get_artifact_request(uri, host.manifest_uri)
-        success = self.client.stream(uri, destination, headers=headers, use_proxy=False)
+        success = self.client.stream(uri, destination, headers=headers, use_proxy=False, max_retry=1)
         return success
 
     def download_ext_handler_pkg(self, uri, destination, headers=None, use_proxy=True):  # pylint: disable=W0613
-        direct_func = lambda: self.client.stream(uri, destination, headers=None, use_proxy=True)
+        direct_func = lambda: self.client.stream(uri, destination, headers=None, use_proxy=True, max_retry=1)
         # NOTE: the host_func may be called after refreshing the goal state, be careful about any goal state data
         # in the lambda.
         host_func = lambda: self._download_ext_handler_pkg_through_host(uri, destination)
@@ -654,7 +654,7 @@ class WireClient(object):
     def fetch_manifest_through_host(self, uri):
         host = self.get_host_plugin()
         uri, headers = host.get_artifact_request(uri)
-        response = self.fetch(uri, headers, use_proxy=False)
+        response = self.fetch(uri, headers, use_proxy=False, max_retry=1)
         return response
 
     def fetch_manifest(self, version_uris, timeout_in_minutes=5, timeout_in_ms=0):
@@ -677,7 +677,7 @@ class WireClient(object):
                 logger.verbose('The specified manifest URL is empty, ignored.')
                 continue
 
-            direct_func = lambda: self.fetch(version.uri)  # pylint: disable=W0640
+            direct_func = lambda: self.fetch(version.uri, max_retry=1)  # pylint: disable=W0640
             # NOTE: the host_func may be called after refreshing the goal state, be careful about any goal state data
             # in the lambda.
             host_func = lambda: self.fetch_manifest_through_host(version.uri)  # pylint: disable=W0640
@@ -695,11 +695,14 @@ class WireClient(object):
 
         raise ExtensionDownloadError("Failed to fetch manifest from all sources")
 
-    def stream(self, uri, destination, headers=None, use_proxy=None):
+    def stream(self, uri, destination, headers=None, use_proxy=None, max_retry=None):
+        """
+        max_retry indicates the maximum number of retries for the HTTP request; None indicates that the default value should be used
+        """
         success = False
         logger.verbose("Fetch [{0}] with headers [{1}] to file [{2}]", uri, headers, destination)
 
-        response = self._fetch_response(uri, headers, use_proxy)
+        response = self._fetch_response(uri, headers, use_proxy,  max_retry=max_retry)
         if response is not None and not restutil.request_failed(response):
             chunk_size = 1024 * 1024  # 1MB buffer
             try:
@@ -715,23 +718,30 @@ class WireClient(object):
 
         return success
 
-    def fetch(self, uri, headers=None, use_proxy=None, decode=True):
+    def fetch(self, uri, headers=None, use_proxy=None, decode=True, max_retry=None):
+        """
+        max_retry indicates the maximum number of retries for the HTTP request; None indicates that the default value should be used
+        """
         logger.verbose("Fetch [{0}] with headers [{1}]", uri, headers)
         content = None
-        response = self._fetch_response(uri, headers, use_proxy)
+        response = self._fetch_response(uri, headers, use_proxy, max_retry=max_retry)
         if response is not None and not restutil.request_failed(response):
             response_content = response.read()
             content = self.decode_config(response_content) if decode else response_content
         return content
 
-    def _fetch_response(self, uri, headers=None, use_proxy=None):
+    def _fetch_response(self, uri, headers=None, use_proxy=None, max_retry=None):
+        """
+        max_retry indicates the maximum number of retries for the HTTP request; None indicates that the default value should be used
+        """
         resp = None
         try:
             resp = self.call_storage_service(
                 restutil.http_get,
                 uri,
                 headers=headers,
-                use_proxy=use_proxy)
+                use_proxy=use_proxy,
+                max_retry=max_retry)
 
             host_plugin = self.get_host_plugin()
 

--- a/azurelinuxagent/common/utils/restutil.py
+++ b/azurelinuxagent/common/utils/restutil.py
@@ -351,11 +351,13 @@ def _http_request(method, host, rel_uri, port=None, data=None, secure=False,
 def http_request(method,
                  url, data, headers=None,
                  use_proxy=False,
-                 max_retry=DEFAULT_RETRIES,
+                 max_retry=None,
                  retry_codes=None,
                  retry_delay=DELAY_IN_SECONDS,
                  redact_data=False):
 
+    if max_retry is None:
+        max_retry = DEFAULT_RETRIES
     if retry_codes is None:
         retry_codes = RETRY_CODES
     global SECURE_WARNING_EMITTED  # pylint: disable=W0603
@@ -481,10 +483,12 @@ def http_request(method,
 def http_get(url,
              headers=None,
              use_proxy=False,
-             max_retry=DEFAULT_RETRIES,
+             max_retry=None,
              retry_codes=None,
              retry_delay=DELAY_IN_SECONDS):
 
+    if max_retry is None:
+        max_retry = DEFAULT_RETRIES
     if retry_codes is None:
         retry_codes = RETRY_CODES
     return http_request("GET",
@@ -498,10 +502,12 @@ def http_get(url,
 def http_head(url,
               headers=None,
               use_proxy=False,
-              max_retry=DEFAULT_RETRIES,
+              max_retry=None,
               retry_codes=None,
               retry_delay=DELAY_IN_SECONDS):
 
+    if max_retry is None:
+        max_retry = DEFAULT_RETRIES
     if retry_codes is None:
         retry_codes = RETRY_CODES
     return http_request("HEAD",
@@ -516,10 +522,12 @@ def http_post(url,
               data,
               headers=None,
               use_proxy=False,
-              max_retry=DEFAULT_RETRIES,
+              max_retry=None,
               retry_codes=None,
               retry_delay=DELAY_IN_SECONDS):
 
+    if max_retry is None:
+        max_retry = DEFAULT_RETRIES
     if retry_codes is None:
         retry_codes = RETRY_CODES
     return http_request("POST",
@@ -534,11 +542,13 @@ def http_put(url,
              data,
              headers=None,
              use_proxy=False,
-             max_retry=DEFAULT_RETRIES,
+             max_retry=None,
              retry_codes=None,
              retry_delay=DELAY_IN_SECONDS,
              redact_data=False):
 
+    if max_retry is None:
+        max_retry = DEFAULT_RETRIES
     if retry_codes is None:
         retry_codes = RETRY_CODES
     return http_request("PUT",
@@ -553,10 +563,12 @@ def http_put(url,
 def http_delete(url,
                 headers=None,
                 use_proxy=False,
-                max_retry=DEFAULT_RETRIES,
+                max_retry=None,
                 retry_codes=None,
                 retry_delay=DELAY_IN_SECONDS):
 
+    if max_retry is None:
+        max_retry = DEFAULT_RETRIES
     if retry_codes is None:
         retry_codes = RETRY_CODES
     return http_request("DELETE",

--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -65,7 +65,7 @@ HANDLER_COMPLETE_NAME_PATTERN = re.compile(_HANDLER_PATTERN + r'$', re.IGNORECAS
 HANDLER_PKG_EXT = ".zip"
 
 AGENT_STATUS_FILE = "waagent_status.json"
-NUMBER_OF_DOWNLOAD_RETRIES = 5
+NUMBER_OF_DOWNLOAD_RETRIES = 2
 
 # This is the default value for the env variables, whenever we call a command which is not an update scenario, we
 # set the env variable value to NOT_RUN to reduce ambiguity for the extension publishers

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -1029,7 +1029,7 @@ class GuestAgent(object):
         try:
             is_healthy = True
             error_response = ''
-            resp = restutil.http_get(uri, use_proxy=use_proxy, headers=headers)
+            resp = restutil.http_get(uri, use_proxy=use_proxy, headers=headers, max_retry=1)
             if restutil.request_succeeded(resp):
                 package = resp.read()
                 fileutil.write_file(self.get_agent_pkg_path(),


### PR DESCRIPTION
The http requests retry 6 times on errors; those retries are not needed when downloading manifests and zips, since they already have redundancy based on multiple URIs.