### PR TITLE
Refactoring of Agent's main loop

### DIFF
--- a/azurelinuxagent/common/event.py
+++ b/azurelinuxagent/common/event.py
@@ -105,7 +105,6 @@ class WALAEventOperation:
     PersistFirewallRules = "PersistFirewallRules"
     PluginSettingsVersionMismatch = "PluginSettingsVersionMismatch"
     InvalidExtensionConfig = "InvalidExtensionConfig"
-    ProcessGoalState = "ProcessGoalState"
     Provision = "Provision"
     ProvisionGuestAgent = "ProvisionGuestAgent"
     RemoteAccessHandling = "RemoteAccessHandling"

--- a/azurelinuxagent/common/exception.py
+++ b/azurelinuxagent/common/exception.py
@@ -22,6 +22,11 @@ Defines all exceptions
 """
 
 
+class ExitException(Exception):
+    """
+    Used to exit the agent's process
+    """
+
 class AgentError(Exception):
     """
     Base class of agent error.

--- a/azurelinuxagent/common/exception.py
+++ b/azurelinuxagent/common/exception.py
@@ -22,10 +22,14 @@ Defines all exceptions
 """
 
 
-class ExitException(Exception):
+class ExitException(BaseException):
     """
     Used to exit the agent's process
     """
+    def __init__(self, reason):
+        super(ExitException, self).__init__()
+        self.reason = reason
+
 
 class AgentError(Exception):
     """

--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -338,8 +338,11 @@ class ExtHandlersHandler(object):
             add_event(op=WALAEventOperation.ExtensionProcessing, is_success=False, message=msg, log_event=False)
             return
 
-        def goal_state_debug_info():
-            return "[Incarnation: {0}; Activity Id: {1}; Correlation Id: {2}; GS Creation Time: {3}]".format(etag, activity_id, correlation_id, gs_creation_time)
+        def goal_state_debug_info(duration=None):
+            if duration is None:
+                return "[Incarnation: {0}; Activity Id: {1}; Correlation Id: {2}; GS Creation Time: {3}]".format(etag, activity_id, correlation_id, gs_creation_time)
+            else:
+                return "[Incarnation: {0}; {1} ms; Activity Id: {2}; Correlation Id: {3}; GS Creation Time: {4}]".format(etag, duration, activity_id, correlation_id, gs_creation_time)
 
         utc_start = datetime.datetime.utcnow()
         error = None
@@ -354,10 +357,10 @@ class ExtHandlersHandler(object):
         finally:
             duration = elapsed_milliseconds(utc_start)
             if error is None:
-                message = 'ProcessExtensionsInGoalState completed {0}'.format(goal_state_debug_info())
+                message = 'ProcessExtensionsInGoalState completed {0}'.format(goal_state_debug_info(duration=duration))
                 logger.info(message)
             else:
-                message = 'ProcessExtensionsInGoalState failed {0}\nError:{1}'.format(goal_state_debug_info(), error)
+                message = 'ProcessExtensionsInGoalState failed {0}\nError:{1}'.format(goal_state_debug_info(duration=duration), error)
                 logger.warn(message)
             add_event(op=WALAEventOperation.ExtensionProcessing, is_success=(error is None), message=message, log_event=False, duration=duration)
 

--- a/azurelinuxagent/ga/remoteaccess.py
+++ b/azurelinuxagent/ga/remoteaccess.py
@@ -48,18 +48,14 @@ class RemoteAccessHandler(object):
         self._protocol = protocol
         self._cryptUtil = CryptUtil(conf.get_openssl_cmd())
         self._remote_access = None
-        self._incarnation = 0
         self._check_existing_jit_users = True
 
     def run(self):
         try:
             if self._os_util.jit_enabled:
-                current_incarnation = self._protocol.get_incarnation()
-                if self._incarnation != current_incarnation:
-                    # something changed. Handle remote access if any.
-                    self._incarnation = current_incarnation
-                    self._remote_access = self._protocol.client.get_remote_access()
-                    self._handle_remote_access()
+                # Handle remote access if any.
+                self._remote_access = self._protocol.client.get_remote_access()
+                self._handle_remote_access()
         except Exception as e:
             msg = u"Exception processing goal state for remote access users: {0} {1}".format(ustr(e), traceback.format_exc())
             add_event(AGENT_NAME,

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -43,8 +43,8 @@ from azurelinuxagent.common.persist_firewall_rules import PersistFirewallRulesHa
 from azurelinuxagent.common.cgroupconfigurator import CGroupConfigurator
 
 from azurelinuxagent.common.event import add_event, initialize_event_logger_vminfo_common_parameters, \
-    elapsed_milliseconds, WALAEventOperation, EVENTS_DIRECTORY
-from azurelinuxagent.common.exception import ResourceGoneError, UpdateError
+    WALAEventOperation, EVENTS_DIRECTORY
+from azurelinuxagent.common.exception import ResourceGoneError, UpdateError, ExitException
 from azurelinuxagent.common.future import ustr
 from azurelinuxagent.common.osutil import get_osutil, systemd
 from azurelinuxagent.common.protocol.util import get_protocol_util
@@ -100,7 +100,7 @@ class UpdateHandler(object):
         self.osutil = get_osutil()
         self.protocol_util = get_protocol_util()
 
-        self.running = True
+        self._is_running = True
         self.last_attempt_time = None
 
         self.agents = []
@@ -116,6 +116,8 @@ class UpdateHandler(object):
         self._heartbeat_id = str(uuid.uuid4()).upper()
         self._heartbeat_counter = 0
         self._heartbeat_update_goal_state_error_count = 0
+
+        self.last_incarnation = None
 
     def run_latest(self, child_args=None):
         """
@@ -225,7 +227,7 @@ class UpdateHandler(object):
 
         except Exception as e:
             # Ignore child errors during termination
-            if self.running:
+            if self.is_running:
                 msg = u"Agent {0} launched with command '{1}' failed with exception: {2}".format(
                     agent_name,
                     agent_cmd,
@@ -317,64 +319,15 @@ class UpdateHandler(object):
 
             goal_state_interval = conf.get_goal_state_period() if conf.get_extensions_enabled() else GOAL_STATE_INTERVAL_DISABLED
 
-            while self.running:
-                #
-                # Check that the parent process (the agent's daemon) is still running
-                #
-                if not debug and self._is_orphaned:
-                    logger.info("Agent {0} is an orphan -- exiting", CURRENT_AGENT)
-                    break
-
-                #
-                # Check that all the threads are still running
-                #
-                for thread_handler in all_thread_handlers:
-                    if not thread_handler.is_alive():
-                        logger.warn("{0} thread died, restarting".format(thread_handler.get_thread_name()))
-                        thread_handler.start()
-
-                #
-                # Process the goal state
-                #
-                if not protocol.try_update_goal_state():
-                    self._heartbeat_update_goal_state_error_count += 1
-                else:
-                    if self._upgrade_available(protocol):
-                        available_agent = self.get_latest_agent()
-                        if available_agent is None:
-                            logger.info(
-                                "Agent {0} is reverting to the installed agent -- exiting",
-                                CURRENT_AGENT)
-                        else:
-                            logger.info(
-                                u"Agent {0} discovered update {1} -- exiting",
-                                CURRENT_AGENT,
-                                available_agent.name)
-                        break
-
-                    utc_start = datetime.utcnow()
-
-                    last_etag = exthandlers_handler.last_etag
-                    exthandlers_handler.run()
-
-                    remote_access_handler.run()
-
-                    if last_etag != exthandlers_handler.last_etag:
-                        self._ensure_readonly_files()
-                        duration = elapsed_milliseconds(utc_start)
-                        activity_id, correlation_id, gs_creation_time = exthandlers_handler.get_goal_state_debug_metadata()
-                        msg = 'ProcessGoalState completed [Incarnation: {0}; {1} ms; Activity Id: {2}; Correlation Id: {3}; GS Creation Time: {4}]'.format(
-                            exthandlers_handler.last_etag, duration, activity_id, correlation_id, gs_creation_time)
-                        logger.info(msg)
-                        add_event(
-                            AGENT_NAME,
-                            op=WALAEventOperation.ProcessGoalState,
-                            duration=duration,
-                            message=msg)
-
+            while self.is_running:
+                self._check_daemon_running(debug)
+                self._check_threads_running(all_thread_handlers)
+                self._process_goal_state(protocol, exthandlers_handler, remote_access_handler)
                 self._send_heartbeat_telemetry(protocol)
                 time.sleep(goal_state_interval)
 
+        except ExitException:
+            pass  # exit the process
         except Exception as error:
             msg = u"Agent {0} failed with exception: {1}".format(CURRENT_AGENT, ustr(error))
             self._set_sentinel(msg=msg)
@@ -386,6 +339,45 @@ class UpdateHandler(object):
 
         self._shutdown()
         sys.exit(0)
+
+    def _check_daemon_running(self, debug):
+        # Check that the parent process (the agent's daemon) is still running
+        if not debug and self._is_orphaned:
+            logger.info("Agent {0} is an orphan -- exiting", CURRENT_AGENT)
+            raise ExitException()
+
+    def _check_threads_running(self, all_thread_handlers):
+        # Check that all the threads are still running
+        for thread_handler in all_thread_handlers:
+            if not thread_handler.is_alive():
+                logger.warn("{0} thread died, restarting".format(thread_handler.get_thread_name()))
+                thread_handler.start()
+
+    def _process_goal_state(self, protocol, exthandlers_handler, remote_access_handler):
+        if not protocol.try_update_goal_state():
+            self._heartbeat_update_goal_state_error_count += 1
+            return
+
+        if self._upgrade_available(protocol):
+            available_agent = self.get_latest_agent()
+            if available_agent is None:
+                logger.info("Agent {0} is reverting to the installed agent -- exiting", CURRENT_AGENT)
+            else:
+                logger.info(u"Agent {0} discovered update {1} -- exiting", CURRENT_AGENT, available_agent.name)
+            raise ExitException()
+
+        incarnation = protocol.get_incarnation()
+
+        try:
+            if incarnation != self.last_incarnation:
+                exthandlers_handler.run()
+
+            exthandlers_handler.report_ext_handlers_status(incarnation_changed=incarnation != self.last_incarnation)
+
+            if incarnation != self.last_incarnation:
+                remote_access_handler.run()
+        finally:
+            self.last_incarnation = incarnation
 
     def forward_signal(self, signum, frame):
         if signum == signal.SIGTERM:
@@ -587,6 +579,14 @@ class UpdateHandler(object):
         return pid_files
 
     @property
+    def is_running(self):
+        return self._is_running
+
+    @is_running.setter
+    def is_running(self, value):
+        self._is_running = value
+
+    @property
     def _is_clean_start(self):
         return not os.path.isfile(self._sentinel_file_path())
 
@@ -678,7 +678,7 @@ class UpdateHandler(object):
     def _shutdown(self):
         # Todo: Ensure all threads stopped when shutting down the main extension handler to ensure that the state of
         # all threads is clean.
-        self.running = False
+        self.is_running = False
 
         if not os.path.isfile(self._sentinel_file_path()):
             return

--- a/tests/ga/test_extension.py
+++ b/tests/ga/test_extension.py
@@ -1020,13 +1020,6 @@ class TestExtension(AgentTestCase):
 
                 _assert_event_reported_only_on_incarnation_change(expected_count=1)
 
-                # # Assert that on rerun it should not report errors unless incarnation changes
-                # for _ in range(5):
-                #     exthandlers_handler.run()
-                #     exthandlers_handler.report_ext_handlers_status()
-                #
-                #     _assert_event_reported_only_on_incarnation_change(expected_count=1)  # REMOVE TEST
-
                 test_data.set_incarnation(2)
                 protocol.update_goal_state()
 
@@ -1597,7 +1590,7 @@ class TestExtension(AgentTestCase):
         exthandlers_handler.report_ext_handlers_status()
 
         self._assert_handler_status(protocol.report_vm_status, "Ready", 1, "1.0.0")
-        self._assert_ext_status(protocol.report_vm_status, ValidHandlerStatus.error, 0)  # REMOVE TEST
+        self._assert_ext_status(protocol.report_vm_status, ValidHandlerStatus.error, 0)
 
     def test_wait_for_handler_completion_no_status(self, mock_http_get, mock_crypt_util, *args):
         """

--- a/tests/ga/test_multi_config_extension.py
+++ b/tests/ga/test_multi_config_extension.py
@@ -221,6 +221,7 @@ class TestMultiConfigExtensions(_MultiConfigBaseTestClass):
             return msg if with_message else None
 
         exthandlers_handler.run()
+        exthandlers_handler.report_ext_handlers_status()
         self.assertEqual(no_of_extensions,
                          len(protocol.aggregate_status['aggregateStatus']['handlerAggregateStatus']),
                          "incorrect extensions reported")
@@ -252,6 +253,7 @@ class TestMultiConfigExtensions(_MultiConfigBaseTestClass):
         protocol.mock_wire_data.set_incarnation(2)
         protocol.update_goal_state()
         exthandlers_handler.run()
+        exthandlers_handler.report_ext_handlers_status()
 
         mc_handlers = self._assert_and_get_handler_status(aggregate_status=protocol.aggregate_status,
                                                           handler_name="OSTCExtensions.ExampleHandlerLinux",
@@ -285,6 +287,7 @@ class TestMultiConfigExtensions(_MultiConfigBaseTestClass):
         with self._setup_test_env(mock_manifest=True) as (exthandlers_handler, protocol, no_of_extensions):
             with enable_invocations(first_ext, second_ext, third_ext, fourth_ext) as invocation_record:
                 exthandlers_handler.run()
+                exthandlers_handler.report_ext_handlers_status()
                 self.assertEqual(no_of_extensions,
                                  len(protocol.aggregate_status['aggregateStatus']['handlerAggregateStatus']),
                                  "incorrect extensions reported")
@@ -316,6 +319,7 @@ class TestMultiConfigExtensions(_MultiConfigBaseTestClass):
             protocol.mock_wire_data.set_extensions_config_state(ExtHandlerRequestedState.Uninstall)
             protocol.update_goal_state()
             exthandlers_handler.run()
+            exthandlers_handler.report_ext_handlers_status()
             self.assertEqual(0, len(protocol.aggregate_status['aggregateStatus']['handlerAggregateStatus']),
                              "No handler/extension status should be reported")
 
@@ -329,6 +333,7 @@ class TestMultiConfigExtensions(_MultiConfigBaseTestClass):
             protocol.mock_wire_data.set_incarnation(2)
             protocol.update_goal_state()
             exthandlers_handler.run()
+            exthandlers_handler.report_ext_handlers_status()
             self.assertEqual(no_of_extensions,
                              len(protocol.aggregate_status['aggregateStatus']['handlerAggregateStatus']),
                              "incorrect extensions reported")
@@ -370,6 +375,7 @@ class TestMultiConfigExtensions(_MultiConfigBaseTestClass):
             sc_ext = extension_emulator(name="Microsoft.Powershell.ExampleExtension", install_action=fail_action)
             with enable_invocations(first_ext, second_ext, third_ext, sc_ext) as invocation_record:
                 exthandlers_handler.run()
+                exthandlers_handler.report_ext_handlers_status()
                 self.assertEqual(no_of_extensions,
                                  len(protocol.aggregate_status['aggregateStatus']['handlerAggregateStatus']),
                                  "incorrect extensions reported")
@@ -415,6 +421,7 @@ class TestMultiConfigExtensions(_MultiConfigBaseTestClass):
             new_sc_ext = extension_emulator(name="Microsoft.Powershell.ExampleExtension", version=new_version)
             with enable_invocations(new_first_ext, new_second_ext, new_third_ext, new_sc_ext, *old_exts) as invocation_record:
                 exthandlers_handler.run()
+                exthandlers_handler.report_ext_handlers_status()
                 old_first, old_second, old_third, old_fourth = old_exts
                 invocation_record.compare(
                     # Disable all enabled commands for MC before updating the Handler
@@ -471,6 +478,7 @@ class TestMultiConfigExtensions(_MultiConfigBaseTestClass):
             with enable_invocations(new_first_ext, new_second_ext, new_third_ext, new_sc_ext,
                                     *old_exts) as invocation_record:
                 exthandlers_handler.run()
+                exthandlers_handler.report_ext_handlers_status()
                 old_first, old_second, old_third, old_fourth = old_exts
                 invocation_record.compare(
                     # Disable all enabled commands for MC before updating the Handler
@@ -537,6 +545,7 @@ class TestMultiConfigExtensions(_MultiConfigBaseTestClass):
             with enable_invocations(new_first_ext, new_second_ext, new_third_ext, new_fourth_ext,
                                     *old_exts) as invocation_record:
                 exthandlers_handler.run()
+                exthandlers_handler.report_ext_handlers_status()
                 old_first, _, _, old_fourth = old_exts
                 invocation_record.compare(
                     # Disable for firstExtension should fail 3 times, i.e., once per extension which tries to update the Handler
@@ -590,6 +599,7 @@ class TestMultiConfigExtensions(_MultiConfigBaseTestClass):
             fourth_ext = extension_emulator(name="Microsoft.Powershell.ExampleExtension", enable_action=fail_action)
             with enable_invocations(first_ext, second_ext, third_ext, fourth_ext) as invocation_record:
                 exthandlers_handler.run()
+                exthandlers_handler.report_ext_handlers_status()
                 self.assertEqual(no_of_extensions,
                                  len(protocol.aggregate_status['aggregateStatus']['handlerAggregateStatus']),
                                  "incorrect extensions reported")
@@ -646,6 +656,7 @@ class TestMultiConfigExtensions(_MultiConfigBaseTestClass):
             protocol.update_goal_state()
 
             ext_handler.run()
+            ext_handler.report_ext_handlers_status()
             mc_handlers = self._assert_and_get_handler_status(aggregate_status=protocol.aggregate_status,
                                                               handler_name="OSTCExtensions.ExampleHandlerLinux",
                                                               expected_count=2, status="Ready")
@@ -767,6 +778,7 @@ class TestMultiConfigExtensions(_MultiConfigBaseTestClass):
                 protocol.mock_wire_data.set_incarnation(2)
                 protocol.update_goal_state()
                 exthandlers_handler.run()
+                exthandlers_handler.report_ext_handlers_status()
 
                 mc_handlers = self._assert_and_get_handler_status(aggregate_status=protocol.aggregate_status,
                                                                   handler_name="OSTCExtensions.ExampleHandlerLinux",
@@ -978,6 +990,7 @@ class TestMultiConfigExtensions(_MultiConfigBaseTestClass):
         with self._setup_test_env() as (exthandlers_handler, protocol, no_of_extensions):
             with enable_invocations(first_ext, second_ext, third_ext, fourth_ext) as invocation_record:
                 exthandlers_handler.run()
+                exthandlers_handler.report_ext_handlers_status()
                 self.assertEqual(no_of_extensions,
                                  len(protocol.aggregate_status['aggregateStatus']['handlerAggregateStatus']),
                                  "incorrect extensions reported")
@@ -1017,6 +1030,7 @@ class TestMultiConfigExtensions(_MultiConfigBaseTestClass):
                 with enable_invocations(*old_exts) as invocation_record:
                     (_, _, _, fourth_ext) = old_exts
                     exthandlers_handler.run()
+                    exthandlers_handler.report_ext_handlers_status()
                     self.assertEqual(4, len(protocol.aggregate_status['aggregateStatus']['handlerAggregateStatus']),
                                      "incorrect extensions reported")
 
@@ -1069,6 +1083,7 @@ class TestMultiConfigExtensionSequencing(_MultiConfigBaseTestClass):
                 independent_sc_ext):
             with enable_invocations(first_ext, second_ext, third_ext, dependent_sc_ext, independent_sc_ext) as invocation_record:
                 exthandlers_handler.run()
+                exthandlers_handler.report_ext_handlers_status()
                 self.assertEqual(no_of_extensions,
                                  len(protocol.aggregate_status['aggregateStatus']['handlerAggregateStatus']),
                                  "incorrect extensions reported")
@@ -1144,6 +1159,7 @@ class TestMultiConfigExtensionSequencing(_MultiConfigBaseTestClass):
             with enable_invocations(first_ext, second_ext, third_ext, dependent_sc_ext,
                                     independent_sc_ext) as invocation_record:
                 exthandlers_handler.run()
+                exthandlers_handler.report_ext_handlers_status()
                 self.assertEqual(no_of_extensions,
                                  len(protocol.aggregate_status['aggregateStatus']['handlerAggregateStatus']),
                                  "incorrect extensions reported")
@@ -1197,6 +1213,7 @@ class TestMultiConfigExtensionSequencing(_MultiConfigBaseTestClass):
         with self._setup_test_env(mock_manifest=True) as (exthandlers_handler, protocol, no_of_extensions):
             with patch('azurelinuxagent.common.cgroupapi.subprocess.Popen', side_effect=mock_popen):
                 exthandlers_handler.run()
+                exthandlers_handler.report_ext_handlers_status()
 
                 self.assertEqual(no_of_extensions,
                                  len(protocol.aggregate_status['aggregateStatus']['handlerAggregateStatus']),

--- a/tests/ga/test_remoteaccess_handler.py
+++ b/tests/ga/test_remoteaccess_handler.py
@@ -469,7 +469,7 @@ class TestRemoteAccessHandler(AgentTestCase):
     def test_remote_access_handler_run_error(self, _):
         with patch("azurelinuxagent.ga.remoteaccess.get_osutil", return_value=MockOSUtil()):
             mock_protocol = WireProtocol("foo.bar")
-            mock_protocol.get_incarnation = MagicMock(side_effect=Exception("foobar!"))
+            mock_protocol.client.get_remote_access = MagicMock(side_effect=Exception("foobar!"))
 
             rah = RemoteAccessHandler(mock_protocol)
             rah.run()

--- a/tests/ga/test_update.py
+++ b/tests/ga/test_update.py
@@ -43,7 +43,7 @@ from azurelinuxagent.ga.update import GuestAgent, GuestAgentError, MAX_FAILURE, 
     CHILD_LAUNCH_RESTART_MAX, CHILD_HEALTH_INTERVAL, UpdateHandler
 from tests.protocol.mocks import mock_wire_protocol
 from tests.protocol.mockwiredata import DATA_FILE, DATA_FILE_MULTIPLE_EXT
-from tests.tools import AgentTestCase, call, data_dir, DEFAULT, patch, load_bin_data, load_data, Mock, MagicMock, \
+from tests.tools import AgentTestCase, data_dir, DEFAULT, patch, load_bin_data, load_data, Mock, MagicMock, \
     clear_singleton_instances, mock_sleep
 
 NO_ERROR = {
@@ -717,15 +717,16 @@ class TestUpdate(UpdateTestCase):
         UpdateTestCase.setUp(self)
         self.event_patch = patch('azurelinuxagent.common.event.add_event')
         self.update_handler = get_update_handler()
+        protocol = Mock()
+        protocol.get_ext_handlers = Mock(return_value=(Mock(), Mock()))
         self.update_handler.protocol_util = Mock()
+        self.update_handler.protocol_util.get_protocol = Mock(return_value=protocol)
 
         # Since ProtocolUtil is a singleton per thread, we need to clear it to ensure that the test cases do not reuse
         # a previous state
         clear_singleton_instances(ProtocolUtil)
 
     def test_creation(self):
-        self.assertTrue(self.update_handler.running)
-
         self.assertEqual(None, self.update_handler.last_attempt_time)
 
         self.assertEqual(0, len(self.update_handler.agents))
@@ -1246,7 +1247,7 @@ class TestUpdate(UpdateTestCase):
         self.assertEqual(0, latest_agent.error.failure_count)
 
         with patch('azurelinuxagent.ga.update.UpdateHandler.get_latest_agent', return_value=latest_agent):
-            self.update_handler.running = False
+            self.update_handler.is_running = False
             self._test_run_latest(mock_child=ChildMock(side_effect=Exception("Attempt blacklisting")))
 
         self.assertTrue(latest_agent.is_available)
@@ -1265,71 +1266,61 @@ class TestUpdate(UpdateTestCase):
         self._test_run_latest()
         self.assertEqual(0, mock_signal.call_count)
 
-    def _test_run(self, invocations=1, calls=None, enable_updates=False, sleep_interval=(6,)):
-        if calls is None:
-            calls = [call.run()]
+    def _test_run(self, invocations=1, calls=1, enable_updates=False, sleep_interval=(6,)):
         conf.get_autoupdate_enabled = Mock(return_value=enable_updates)
 
-        # Note:
-        # - Python only allows mutations of objects to which a function has
-        #   a reference. Incrementing an integer directly changes the
-        #   reference. Incrementing an item of a list changes an item to
-        #   which the code has a reference.
-        #   See http://stackoverflow.com/questions/26408941/python-nested-functions-and-variable-scope
-        iterations = [0]
-
-        def iterator(*args, **kwargs):  # pylint: disable=unused-argument
-            iterations[0] += 1
-            if iterations[0] >= invocations:
-                self.update_handler.running = False
-            return
+        def iterator(*_, **__):
+            iterator.count += 1
+            if iterator.count <= invocations:
+                return True
+            return False
+        iterator.count = 0
 
         fileutil.write_file(conf.get_agent_pid_file_path(), ustr(42))
 
         with patch('azurelinuxagent.ga.exthandlers.get_exthandlers_handler') as mock_handler:
-            with patch('azurelinuxagent.ga.remoteaccess.get_remote_access_handler') as mock_ra_handler:
-                with patch('azurelinuxagent.ga.update.get_monitor_handler') as mock_monitor:
-                    with patch('azurelinuxagent.ga.update.get_env_handler') as mock_env:
-                        with patch('azurelinuxagent.ga.update.get_collect_logs_handler') as mock_collect_logs:
-                            with patch('azurelinuxagent.ga.update.get_send_telemetry_events_handler') as mock_telemetry_send_events:
-                                with patch('azurelinuxagent.ga.update.get_collect_telemetry_events_handler') as mock_event_collector:
-                                    with patch('azurelinuxagent.ga.update.initialize_event_logger_vminfo_common_parameters'):
-                                        with patch('azurelinuxagent.ga.update.is_log_collection_allowed', return_value=True):
-                                            with patch('time.sleep', side_effect=iterator) as sleep_mock:
-                                                with patch('sys.exit') as mock_exit:
-                                                    if isinstance(os.getppid, MagicMock):
-                                                        self.update_handler.run()
-                                                    else:
-                                                        with patch('os.getppid', return_value=42):
+            mock_handler.run_ext_handlers = Mock()
+            with patch('azurelinuxagent.ga.update.get_monitor_handler') as mock_monitor:
+                with patch.object(UpdateHandler, 'is_running') as mock_is_running:
+                    mock_is_running.__get__ = Mock(side_effect=iterator)
+                    with patch('azurelinuxagent.ga.remoteaccess.get_remote_access_handler') as mock_ra_handler:
+                        with patch('azurelinuxagent.ga.update.get_env_handler') as mock_env:
+                            with patch('azurelinuxagent.ga.update.get_collect_logs_handler') as mock_collect_logs:
+                                with patch('azurelinuxagent.ga.update.get_send_telemetry_events_handler') as mock_telemetry_send_events:
+                                    with patch('azurelinuxagent.ga.update.get_collect_telemetry_events_handler') as mock_event_collector:
+                                        with patch('azurelinuxagent.ga.update.initialize_event_logger_vminfo_common_parameters'):
+                                            with patch('azurelinuxagent.ga.update.is_log_collection_allowed', return_value=True):
+                                                with patch('time.sleep') as sleep_mock:
+                                                    with patch('sys.exit') as mock_exit:
+                                                        if isinstance(os.getppid, MagicMock):
                                                             self.update_handler.run()
+                                                        else:
+                                                            with patch('os.getppid', return_value=42):
+                                                                self.update_handler.run()
 
-                                                self.assertEqual(1, mock_handler.call_count)
-                                                self.assertEqual(mock_handler.return_value.method_calls, calls)
-                                                self.assertEqual(1, mock_ra_handler.call_count)
-                                                self.assertEqual(mock_ra_handler.return_value.method_calls, calls)
-                                                self.assertEqual(invocations, sleep_mock.call_count)
-                                                if invocations > 0:
-                                                    self.assertEqual(sleep_interval, sleep_mock.call_args[0])
-                                                self.assertEqual(1, mock_monitor.call_count)
-                                                self.assertEqual(1, mock_env.call_count)
-                                                self.assertEqual(1, mock_collect_logs.call_count)
-                                                self.assertEqual(1, mock_telemetry_send_events.call_count)
-                                                self.assertEqual(1, mock_event_collector.call_count)
-                                                self.assertEqual(1, mock_exit.call_count)
+                                                    self.assertEqual(1, mock_handler.call_count)
+                                                    self.assertEqual(calls, len([c for c in [call[0] for call in mock_handler.return_value.method_calls] if c == 'run']))
+                                                    self.assertEqual(1, mock_ra_handler.call_count)
+                                                    self.assertEqual(calls, len(mock_ra_handler.return_value.method_calls))
+                                                    if calls > 0:
+                                                        self.assertEqual(sleep_interval, sleep_mock.call_args[0])
+                                                    self.assertEqual(1, mock_monitor.call_count)
+                                                    self.assertEqual(1, mock_env.call_count)
+                                                    self.assertEqual(1, mock_collect_logs.call_count)
+                                                    self.assertEqual(1, mock_telemetry_send_events.call_count)
+                                                    self.assertEqual(1, mock_event_collector.call_count)
+                                                    self.assertEqual(1, mock_exit.call_count)
 
     def test_run(self):
         self._test_run()
 
-    def test_run_keeps_running(self):
-        self._test_run(invocations=15, calls=[call.run()] * 15)
-
     def test_run_stops_if_update_available(self):
         self.update_handler._upgrade_available = Mock(return_value=True)
-        self._test_run(invocations=0, calls=[], enable_updates=True)
+        self._test_run(invocations=0, calls=0, enable_updates=True)
 
     def test_run_stops_if_orphaned(self):
         with patch('os.getppid', return_value=1):
-            self._test_run(invocations=0, calls=[], enable_updates=True)
+            self._test_run(invocations=0, calls=0, enable_updates=True)
 
     def test_run_clears_sentinel_on_successful_exit(self):
         self._test_run()
@@ -1337,7 +1328,7 @@ class TestUpdate(UpdateTestCase):
 
     def test_run_leaves_sentinel_on_unsuccessful_exit(self):
         self.update_handler._upgrade_available = Mock(side_effect=Exception)
-        self._test_run(invocations=0, calls=[], enable_updates=True)
+        self._test_run(invocations=1, calls=0, enable_updates=True)
         self.assertTrue(os.path.isfile(self.update_handler._sentinel_file_path()))
 
     def test_run_emits_restart_event(self):
@@ -1376,13 +1367,13 @@ class TestUpdate(UpdateTestCase):
     def test_shutdown(self):
         self.update_handler._set_sentinel()
         self.update_handler._shutdown()
-        self.assertFalse(self.update_handler.running)
+        self.assertFalse(self.update_handler.is_running)
         self.assertFalse(os.path.isfile(self.update_handler._sentinel_file_path()))
 
     def test_shutdown_ignores_missing_sentinel_file(self):
         self.assertFalse(os.path.isfile(self.update_handler._sentinel_file_path()))
         self.update_handler._shutdown()
-        self.assertFalse(self.update_handler.running)
+        self.assertFalse(self.update_handler.is_running)
         self.assertFalse(os.path.isfile(self.update_handler._sentinel_file_path()))
 
     def test_shutdown_ignores_exceptions(self):
@@ -1505,7 +1496,7 @@ class TestUpdate(UpdateTestCase):
         behavior never changes.
         """
         self.update_handler._upgrade_available = Mock(return_value=True)
-        self._test_run(invocations=0, calls=[], enable_updates=True, sleep_interval=(300,))
+        self._test_run(invocations=0, calls=0, enable_updates=True, sleep_interval=(300,))
 
     @patch('azurelinuxagent.common.conf.get_extensions_enabled', return_value=False)
     def test_interval_changes_when_extensions_disabled(self, _):
@@ -1513,7 +1504,7 @@ class TestUpdate(UpdateTestCase):
         When extension processing is disabled, the goal state interval should be larger.
         """
         self.update_handler._upgrade_available = Mock(return_value=False)
-        self._test_run(invocations=15, calls=[call.run()] * 15, sleep_interval=(300,))
+        self._test_run(invocations=1, calls=1, sleep_interval=(300,))
 
     @patch("azurelinuxagent.common.logger.info")
     @patch("azurelinuxagent.ga.update.add_event")
@@ -1561,7 +1552,7 @@ class TestUpdate(UpdateTestCase):
                     update_handler._cur_iteration = 0
                     update_handler._iterations = 0
                     update_handler.set_iterations = lambda i: _set_iterations(i)  # pylint: disable=unnecessary-lambda
-                    type(update_handler).running = PropertyMock(side_effect=check_running)
+                    type(update_handler).is_running = PropertyMock(side_effect=check_running)
                     with patch("time.sleep", side_effect=lambda _: mock_sleep(0.001)):
                         with patch('sys.exit'):
                             # Setup the initial number of iterations
@@ -1571,7 +1562,7 @@ class TestUpdate(UpdateTestCase):
                             finally:
                                 # Since PropertyMock requires us to mock the type(ClassName).property of the object,
                                 # reverting it back to keep the state of the test clean
-                                type(update_handler).running = True
+                                type(update_handler).is_running = True
 
     @staticmethod
     def _get_test_ext_handler_instance(protocol, name="OSTCExtensions.ExampleHandlerLinux", version="1.0.0"):
@@ -1701,34 +1692,36 @@ class MonitorThreadTest(AgentTestCase):
         AgentTestCase.setUp(self)
         self.event_patch = patch('azurelinuxagent.common.event.add_event')
         currentThread().setName("ExtHandler")
+        protocol = Mock()
+        protocol.get_ext_handlers = Mock(return_value=(Mock(), Mock()))
         self.update_handler = get_update_handler()
         self.update_handler.protocol_util = Mock()
+        self.update_handler.protocol_util.get_protocol = Mock(return_value=protocol)
         clear_singleton_instances(ProtocolUtil)
 
     def _test_run(self, invocations=1):
-        iterations = [0]
-
-        def iterator(*args, **kwargs):  # pylint: disable=unused-argument
-            iterations[0] += 1
-            if iterations[0] >= invocations:
-                self.update_handler.running = False
-            return
+        def iterator(*_, **__):
+            iterator.count += 1
+            if iterator.count <= invocations:
+                return True
+            return False
+        iterator.count = 0
 
         with patch('os.getpid', return_value=42):
             with patch.object(UpdateHandler, '_is_orphaned') as mock_is_orphaned:
                 mock_is_orphaned.__get__ = Mock(return_value=False)
-                with patch('azurelinuxagent.ga.exthandlers.get_exthandlers_handler'):
-                    with patch('azurelinuxagent.ga.remoteaccess.get_remote_access_handler'):
-                        with patch('azurelinuxagent.ga.update.initialize_event_logger_vminfo_common_parameters'):
-                            with patch('azurelinuxagent.common.cgroupapi.CGroupsApi.cgroups_supported', return_value=False):  # skip all cgroup stuff
-                                with patch('azurelinuxagent.ga.update.is_log_collection_allowed', return_value=True):
-                                    with patch('time.sleep', side_effect=iterator):
-                                        with patch('sys.exit'):
-                                            self.update_handler.run()
+                with patch.object(UpdateHandler, 'is_running') as mock_is_running:
+                    mock_is_running.__get__ = Mock(side_effect=iterator)
+                    with patch('azurelinuxagent.ga.exthandlers.get_exthandlers_handler'):
+                        with patch('azurelinuxagent.ga.remoteaccess.get_remote_access_handler'):
+                            with patch('azurelinuxagent.ga.update.initialize_event_logger_vminfo_common_parameters'):
+                                with patch('azurelinuxagent.common.cgroupapi.CGroupsApi.cgroups_supported', return_value=False):  # skip all cgroup stuff
+                                    with patch('azurelinuxagent.ga.update.is_log_collection_allowed', return_value=True):
+                                        with patch('time.sleep'):
+                                            with patch('sys.exit'):
+                                                self.update_handler.run()
 
     def _setup_mock_thread_and_start_test_run(self, mock_thread, is_alive=True, invocations=0):
-        self.assertTrue(self.update_handler.running)
-
         thread = MagicMock()
         thread.run = MagicMock()
         thread.is_alive = MagicMock(return_value=is_alive)
@@ -1739,8 +1732,6 @@ class MonitorThreadTest(AgentTestCase):
         return thread
 
     def test_start_threads(self, mock_env, mock_monitor, mock_collect_logs, mock_telemetry_send_events, mock_telemetry_collector):
-        self.assertTrue(self.update_handler.running)
-
         def _get_mock_thread():
             thread = MagicMock()
             thread.run = MagicMock()
@@ -1758,7 +1749,7 @@ class MonitorThreadTest(AgentTestCase):
             self.assertEqual(1, thread().run.call_count)
 
     def test_check_if_monitor_thread_is_alive(self, _, mock_monitor, *args):  # pylint: disable=unused-argument
-        mock_monitor_thread = self._setup_mock_thread_and_start_test_run(mock_monitor, is_alive=True, invocations=0)
+        mock_monitor_thread = self._setup_mock_thread_and_start_test_run(mock_monitor, is_alive=True, invocations=1)
         self.assertEqual(1, mock_monitor.call_count)
         self.assertEqual(1, mock_monitor_thread.run.call_count)
         self.assertEqual(1, mock_monitor_thread.is_alive.call_count)
@@ -1786,14 +1777,14 @@ class MonitorThreadTest(AgentTestCase):
         self.assertEqual(1, mock_env_thread.start.call_count)
 
     def test_restart_monitor_thread(self, _, mock_monitor, *args):  # pylint: disable=unused-argument
-        mock_monitor_thread = self._setup_mock_thread_and_start_test_run(mock_monitor, is_alive=False, invocations=0)
+        mock_monitor_thread = self._setup_mock_thread_and_start_test_run(mock_monitor, is_alive=False, invocations=1)
         self.assertEqual(True, mock_monitor.called)
         self.assertEqual(True, mock_monitor_thread.run.called)
         self.assertEqual(True, mock_monitor_thread.is_alive.called)
         self.assertEqual(True, mock_monitor_thread.start.called)
 
     def test_restart_env_thread(self, mock_env, *args):  # pylint: disable=unused-argument
-        mock_env_thread = self._setup_mock_thread_and_start_test_run(mock_env, is_alive=False, invocations=0)
+        mock_env_thread = self._setup_mock_thread_and_start_test_run(mock_env, is_alive=False, invocations=1)
         self.assertEqual(True, mock_env.called)
         self.assertEqual(True, mock_env_thread.run.called)
         self.assertEqual(True, mock_env_thread.is_alive.called)

--- a/tests/protocol/test_wire.py
+++ b/tests/protocol/test_wire.py
@@ -393,6 +393,8 @@ class TestWireProtocol(AgentTestCase):
 
             with patch("azurelinuxagent.common.agent_supported_feature._MultiConfigFeature.is_supported", True):
                 exthandlers_handler.run()
+                exthandlers_handler.report_ext_handlers_status()
+
                 self.assertIsNotNone(protocol.aggregate_status, "Aggregate status should not be None")
                 self.assertIn("supportedFeatures", protocol.aggregate_status, "supported features not reported")
                 multi_config_feature = get_supported_feature_by_name(SupportedFeatureNames.MultiConfig)
@@ -406,6 +408,8 @@ class TestWireProtocol(AgentTestCase):
             # Feature should not be reported if not present
             with patch("azurelinuxagent.common.agent_supported_feature._MultiConfigFeature.is_supported", False):
                 exthandlers_handler.run()
+                exthandlers_handler.report_ext_handlers_status()
+
                 self.assertIsNotNone(protocol.aggregate_status, "Aggregate status should not be None")
                 if "supportedFeatures" not in protocol.aggregate_status:
                     # In the case Multi-config was the only feature available, 'supportedFeatures' should not be


### PR DESCRIPTION
Some refactoring of the agent's main loop to facilitate the implementation of FastTrack.

* Split the code of the main loop across several helper functions
* Moved the check for new goal state (and some other helper logic) from ExtHandlersHandler.run to UpdateHandler.run (main loop)
* Separated the calls to ExtHandlersHandler.run and ExtHandlersHandler.report_ext_handlers_status

