### PR TITLE
Fix bug with dependent extensions with no settings

### DIFF
--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -578,7 +578,7 @@ class ExtHandlersHandler(object):
 
         # If the handler had no settings, we should not wait at all for handler to report status.
         if extension is None:
-            logger.info("No settings found for {}, not waiting for it's status".format(extension_name))
+            logger.info("No settings found for {0}, not waiting for it's status".format(extension_name))
             return
 
         try:

--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -574,8 +574,12 @@ class ExtHandlersHandler(object):
         Check the status of the extension being handled. Wait until it has a terminal state or times out.
         :raises: Exception if it is not handled successfully.
         """
-
         extension_name = handler_i.get_extension_full_name(extension)
+
+        # If the handler had no settings, we should not wait at all for handler to report status.
+        if extension is None:
+            logger.info("No settings found for {}, not waiting for it's status".format(extension_name))
+            return
 
         try:
             ext_completed, status = False, None
@@ -1657,7 +1661,7 @@ class ExtHandlerInstance(object):
         self.logger.verbose("Collect extension status for {0}".format(self.get_extension_full_name(ext)))
         seq_no, ext_status_file = self.get_status_file_path(ext)
 
-        # We should never try to read any status from status file if the handler has no settings, returning None in that case
+        # We should never try to read any status file if the handler has no settings, returning None in that case
         if seq_no == -1 or ext is None:
             return None
 
@@ -1730,7 +1734,7 @@ class ExtHandlerInstance(object):
         seq_no, ext_status_file = self.get_status_file_path(ext)
 
         # This is legacy scenario for cases when no extension settings is available
-        if seq_no < 0 or ext_status_file is None or ext is None:
+        if seq_no < 0 or ext_status_file is None:
             return None
 
         # Missing status file is considered a non-terminal state here

--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -1656,7 +1656,9 @@ class ExtHandlerInstance(object):
     def collect_ext_status(self, ext):
         self.logger.verbose("Collect extension status for {0}".format(self.get_extension_full_name(ext)))
         seq_no, ext_status_file = self.get_status_file_path(ext)
-        if seq_no == -1:
+
+        # We should never try to read any status from status file if the handler has no settings, returning None in that case
+        if seq_no == -1 or ext is None:
             return None
 
         data = None
@@ -1728,7 +1730,7 @@ class ExtHandlerInstance(object):
         seq_no, ext_status_file = self.get_status_file_path(ext)
 
         # This is legacy scenario for cases when no extension settings is available
-        if seq_no < 0 or ext_status_file is None:
+        if seq_no < 0 or ext_status_file is None or ext is None:
             return None
 
         # Missing status file is considered a non-terminal state here

--- a/tests/data/wire/ext_conf_dependencies_with_empty_settings.xml
+++ b/tests/data/wire/ext_conf_dependencies_with_empty_settings.xml
@@ -1,0 +1,32 @@
+<Extensions version="1.0.0.0" goalStateIncarnation="9">
+    <GuestAgentExtension
+            xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+        <GAFamilies>
+            <GAFamily>
+                <Name>Prod</Name>
+                <Uris>
+                    <Uri>http://mock-goal-state/manifest_of_ga.xml</Uri>
+                </Uris>
+            </GAFamily>
+            <GAFamily>
+                <Name>Test</Name>
+                <Uris>
+                    <Uri>http://mock-goal-state/manifest_of_ga.xml</Uri>
+                </Uris>
+            </GAFamily>
+        </GAFamilies>
+    </GuestAgentExtension>
+    <Plugins>
+        <Plugin name="OSTCExtensions.ExampleHandlerLinux" version="1.0.0" location="http://mock-goal-state/rdfepirv2hknprdstr03.blob.core.windows.net/b01058962be54ceca550a390fa5ff064/Microsoft.OSTCExtensions_ExampleHandlerLinux_asiaeast_manifest.xml" config="" state="enabled" autoUpgrade="false" failoverlocation="http://mock-goal-state/rdfepirv2hknprdstr04.blob.core.windows.net/b01058962be54ceca550a390fa5ff064/Microsoft.OSTCExtensions_ExampleHandlerLinux_asiaeast_manifest.xml" runAsStartupTask="false" isJson="true" />
+        <Plugin name="OSTCExtensions.OtherExampleHandlerLinux" version="1.0.0" location="http://mock-goal-state/rdfepirv2hknprdstr03.blob.core.windows.net/b01058962be54ceca550a390fa5ff064/Microsoft.OSTCExtensions_OtherExampleHandlerLinux_asiaeast_manifest.xml" config="" state="enabled" autoUpgrade="false" failoverlocation="http://mock-goal-state/rdfepirv2hknprdstr04.blob.core.windows.net/b01058962be54ceca550a390fa5ff064/Microsoft.OSTCExtensions_OtherExampleHandlerLinux_asiaeast_manifest.xml" runAsStartupTask="false" isJson="true" />
+    </Plugins>
+    <PluginSettings>
+        <Plugin name="OSTCExtensions.ExampleHandlerLinux" version="1.0.0">
+            <DependsOn dependencyLevel="1">
+                <DependsOnExtension handler="OSTCExtensions.OtherExampleHandlerLinux" />
+            </DependsOn>
+            <RuntimeSettings seqNo="0">{"runtimeSettings":[{"handlerSettings":{"protectedSettingsCertThumbprint":"4037FBF5F1F3014F99B5D6C7799E9B20E6871CB3","protectedSettings":"MIICWgYJK","publicSettings":{"foo":"bar"}}}]}</RuntimeSettings>
+        </Plugin>
+    </PluginSettings>
+    <StatusUploadBlob statusBlobType="BlockBlob">https://test.blob.core.windows.net/vhds/test-cs12.test-cs12.test-cs12.status?sr=b&amp;sp=rw&amp;se=9999-01-01&amp;sk=key1&amp;sv=2014-02-14&amp;sig=hfRh7gzUE7sUtYwke78IOlZOrTRCYvkec4hGZ9zZzXo</StatusUploadBlob>
+</Extensions>

--- a/tests/ga/test_extension.py
+++ b/tests/ga/test_extension.py
@@ -992,6 +992,42 @@ class TestExtension(AgentTestCase):
                 (dep_ext_level_5, ExtensionCommandNames.UNINSTALL)
             )
 
+    def test_it_should_process_sequencing_properly_even_if_no_settings_for_dependent_extension(
+            self, mock_get, mock_crypt, *args):
+        test_data_file = DATA_FILE.copy()
+        test_data_file["ext_conf"] = "wire/ext_conf_multiple_depends_on_for_single_handler.xml"
+        test_data = mockwiredata.WireProtocolData(test_data_file)
+        exthandlers_handler, protocol = self._create_mock(test_data, mock_get, mock_crypt, *args)
+
+        ext_1 = extension_emulator(name="OSTCExtensions.ExampleHandlerLinux")
+        ext_2 = extension_emulator(name="OSTCExtensions.OtherExampleHandlerLinux")
+
+        with enable_invocations(ext_1, ext_2) as invocation_record:
+            exthandlers_handler.run()
+            exthandlers_handler.report_ext_handlers_status()
+
+            self._assert_handler_status(protocol.report_vm_status, "Ready", 1, "1.0.0",
+                                        expected_handler_name="OSTCExtensions.OtherExampleHandlerLinux")
+            self._assert_ext_status(protocol.report_vm_status, "success", 0,
+                                    expected_handler_name="OSTCExtensions.OtherExampleHandlerLinux")
+
+            # check handler list and dependency levels
+            self.assertTrue(exthandlers_handler.ext_handlers is not None)
+            self.assertTrue(exthandlers_handler.ext_handlers.extHandlers is not None)
+            self.assertEqual(len(exthandlers_handler.ext_handlers.extHandlers), 2)
+            self.assertEqual(1, next(handler for handler in exthandlers_handler.ext_handlers.extHandlers if
+                                     handler.name == ext_2.name).properties.extensions[0].dependencyLevel)
+            self.assertEqual(2, next(handler for handler in exthandlers_handler.ext_handlers.extHandlers if
+                                     handler.name == ext_1.name).properties.extensions[0].dependencyLevel)
+
+            # Ensure the invocation order follows the dependency levels
+            invocation_record.compare(
+                (ext_1, ExtensionCommandNames.INSTALL),
+                (ext_1, ExtensionCommandNames.ENABLE),
+                (ext_2, ExtensionCommandNames.INSTALL),
+                (ext_2, ExtensionCommandNames.ENABLE)
+            )
+
     def test_ext_handler_sequencing_should_fail_if_handler_failed(self, mock_get, mock_crypt, *args):
         test_data = mockwiredata.WireProtocolData(mockwiredata.DATA_FILE_EXT_SEQUENCING)
         exthandlers_handler, protocol = self._create_mock(test_data, mock_get, mock_crypt, *args)


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
There was a bug in the MultiConfig code where the agent was wrongfully trying to read status file of dependent extensions with no settings. Fixed that in this PR.

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).