### PR TITLE
Allow systemd-run in the Agent's cgroup

### DIFF
--- a/azurelinuxagent/common/cgroupapi.py
+++ b/azurelinuxagent/common/cgroupapi.py
@@ -246,6 +246,8 @@ class SystemdCgroupsApi(CGroupsApi):
                 stderr=stderr,
                 env=env,
                 preexec_fn=os.setsid)
+
+            # We start systemd-run with shell == True so process.pid is the shell's pid, not the pid for systemd-run
             self._systemd_run_commands.append(process.pid)
 
         scope_name = scope + '.scope'

--- a/azurelinuxagent/common/cgroupconfigurator.py
+++ b/azurelinuxagent/common/cgroupconfigurator.py
@@ -504,7 +504,7 @@ class CGroupConfigurator(object):
                     if process in (daemon, extension_handler) or process in systemd_run_commands:
                         continue
                     # systemd_run_commands contains the shell that started systemd-run, so we also need to check for the parent
-                     if self._get_parent(process) in systemd_run_commands and self._get_command(process) == 'systemd-run':
+                    if self._get_parent(process) in systemd_run_commands and self._get_command(process) == 'systemd-run':
                          continue
                     # check if the process is a command started by the agent or a descendant of one of those commands
                     current = process

--- a/azurelinuxagent/common/cgroupconfigurator.py
+++ b/azurelinuxagent/common/cgroupconfigurator.py
@@ -523,7 +523,7 @@ class CGroupConfigurator(object):
         @staticmethod
         def _get_command(pid):
             try:
-                with open('/proc/{0}/cmdline'.format(pid), "r") as file_:
+                with open('/proc/{0}/comm'.format(pid), "r") as file_:
                     comm = file_.read()
                     if comm and comm[-1] == '\x00':  # if null-terminated, remove the null
                         comm = comm[:-1]

--- a/azurelinuxagent/common/cgroupconfigurator.py
+++ b/azurelinuxagent/common/cgroupconfigurator.py
@@ -505,7 +505,7 @@ class CGroupConfigurator(object):
                         continue
                     # systemd_run_commands contains the shell that started systemd-run, so we also need to check for the parent
                     if self._get_parent(process) in systemd_run_commands and self._get_command(process) == 'systemd-run':
-                         continue
+                        continue
                     # check if the process is a command started by the agent or a descendant of one of those commands
                     current = process
                     while current != 0 and current not in agent_commands:
@@ -529,7 +529,7 @@ class CGroupConfigurator(object):
                         comm = comm[:-1]
                     return comm
             except Exception:
-                return "UNKNOWN".format(pid)
+                return "UNKNOWN"
 
         @staticmethod
         def __format_processes(pid_list):


### PR DESCRIPTION
The Agent has been flagging systemd-run as not belonging to the Agent's cgroup. We use systemd-run to start extensions in their own scope and systemd-run itself does belong to the Agent's cgroup.

The Agent keeps track of the commands it uses, but in this case the call to popen is using shell=True so the agent is actually tracking the parent shell. not systemd-run. I added logic in _check_processes_in_agent_cgroup to account for this.