### PR TITLE
Move Github Actions VMs to Ubuntu 18

### DIFF
--- a/.github/workflows/ci_pr.yml
+++ b/.github/workflows/ci_pr.yml
@@ -11,7 +11,7 @@ jobs:
   test-legacy-python-versions:
     
     name: "Python 2.6 Unit Tests"
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
@@ -60,7 +60,7 @@ jobs:
             additional-nose-opts: "--with-coverage --cover-erase --cover-inclusive --cover-branches --cover-package=azurelinuxagent"
     
     name: "Python ${{ matrix.python-version }} Unit Tests"
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     env:
       PYLINTOPTS: ${{ matrix.PYLINTOPTS }}

--- a/.github/workflows/ci_pr.yml
+++ b/.github/workflows/ci_pr.yml
@@ -11,7 +11,7 @@ jobs:
   test-legacy-python-versions:
     
     name: "Python 2.6 Unit Tests"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       fail-fast: false
@@ -60,7 +60,7 @@ jobs:
             additional-nose-opts: "--with-coverage --cover-erase --cover-inclusive --cover-branches --cover-package=azurelinuxagent"
     
     name: "Python ${{ matrix.python-version }} Unit Tests"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     env:
       PYLINTOPTS: ${{ matrix.PYLINTOPTS }}


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

python2.6 previously required ubuntu 16 as later ubuntu versions did not support 2.6 in GHA. We have since moved to installing python2.6 from a frozen tar ball, and later ubuntus can be used. Unfortunately, python2.6 fails with a missing crypto module (_md5) on ubuntu-latest (currently ubuntu 20), and python3.4 fails on ubuntu-latest because it is not provided by `actions/setup-python@v2`.

ubuntu 16 is reaching EOL for GHA and must be replaced come September 2021. 

<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).