### PR TITLE
Fix operation name in InitializeHostPlugin event

### DIFF
--- a/azurelinuxagent/common/protocol/hostplugin.py
+++ b/azurelinuxagent/common/protocol/hostplugin.py
@@ -100,7 +100,7 @@ class HostPluginProtocol(object):
             self.api_versions = self.get_api_versions()
             self.is_available = API_VERSION in self.api_versions
             self.is_initialized = self.is_available
-            add_event(WALAEventOperation.InitializeHostPlugin,
+            add_event(op=WALAEventOperation.InitializeHostPlugin,
                       is_success=self.is_available)
         return self.is_available
 

--- a/tests/protocol/test_hostplugin.py
+++ b/tests/protocol/test_hostplugin.py
@@ -186,7 +186,7 @@ class TestHostPlugin(HttpRequestPredicates, AgentTestCase):
         self.assertEqual(should_initialize, host.is_initialized)
 
         self.assertEqual(1, patch_event.call_count)
-        self.assertEqual('InitializeHostPlugin', patch_event.call_args[0][0])
+        self.assertEqual('InitializeHostPlugin', patch_event.call_args[1]['op'])
 
         self.assertEqual(should_initialize, patch_event.call_args[1]['is_success'])
         self.assertEqual(1, patch_report_health.call_count)


### PR DESCRIPTION
The call to add_event was missing the parameter name ('op') so the OperationName was showing up as the Name