### PR TITLE
Refactor update_goal_state(); always query vmSettings; update vmSettings test data

### DIFF
--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -95,8 +95,8 @@ class WireProtocol(DataContract):
         logger.info('Initializing goal state during protocol detection')
         self.client.update_goal_state(force_update=True)
 
-    def update_goal_state(self):
-        self.client.update_goal_state()
+    def update_goal_state(self, force_update=False):
+        self.client.update_goal_state(force_update=force_update)
 
     def update_host_plugin_from_goal_state(self):
         self.client.update_host_plugin_from_goal_state()
@@ -790,7 +790,7 @@ class WireClient(object):
             if force_update:
                 logger.info("Forcing an update of the goal state..")
 
-            if self._goal_state is not None and self._goal_state.incarnation != goal_state.incarnation or force_update:
+            if force_update or self._goal_state is None or self._goal_state.incarnation != goal_state.incarnation:
                 goal_state.fetch_full_goal_state(self)
                 self._goal_state = goal_state
                 updated = True

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -95,8 +95,8 @@ class WireProtocol(DataContract):
         logger.info('Initializing goal state during protocol detection')
         self.client.update_goal_state(force_update=True)
 
-    def update_goal_state(self, force_update=False):
-        self.client.update_goal_state(force_update=force_update)
+    def update_goal_state(self):
+        self.client.update_goal_state()
 
     def update_host_plugin_from_goal_state(self):
         self.client.update_host_plugin_from_goal_state()

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -91,12 +91,9 @@ class WireProtocol(DataContract):
         cryptutil = CryptUtil(conf.get_openssl_cmd())
         cryptutil.gen_transport_cert(trans_prv_file, trans_cert_file)
 
-        # Set the initial goal state
+        # Initialize the goal state, including all the inner properties
         logger.info('Initializing goal state during protocol detection')
-        self.client.update_goal_state(forced=True)
-
-    def update_extensions_goal_state(self):
-        self.client.update_extensions_goal_state()
+        self.client.update_goal_state(force_update=True)
 
     def update_goal_state(self):
         self.client.update_goal_state()
@@ -774,36 +771,45 @@ class WireClient(object):
         """
         Fetches a new goal state and updates the Container ID and Role Config Name of the host plugin client
         """
-        goal_state = GoalState.fetch_goal_state(self)
+        goal_state = GoalState(self)
         self._update_host_plugin(goal_state.container_id, goal_state.role_config_name)
 
-    def update_goal_state(self, forced=False):
+    def update_goal_state(self, force_update=False):
         """
-        Updates the goal state if the incarnation changed or if 'forced' is True
+        Updates the goal state if the incarnation or etag changed or if 'force_update' is True
         """
         try:
-            if self._goal_state is None or forced:
-                new_goal_state = GoalState.fetch_full_goal_state(self)
-            else:
-                new_goal_state = GoalState.fetch_full_goal_state_if_incarnation_different_than(self, self._goal_state.incarnation)
+            updated = False
 
-            if new_goal_state is not None:
-                self._goal_state = new_goal_state
-                self._update_host_plugin(new_goal_state.container_id, new_goal_state.role_config_name)
-                if conf.get_enable_fast_track():
-                    self.update_extensions_goal_state()
+            goal_state = GoalState(self)
+
+            # Always update the hostgaplugin, since the agent may issue requests to it even if there are no other changes
+            # in the goal state (e.g. report status)
+            self._update_host_plugin(goal_state.container_id, goal_state.role_config_name)
+
+            if force_update:
+                logger.info("Forcing an update of the goal state..")
+
+            if self._goal_state is not None and self._goal_state.incarnation != goal_state.incarnation or force_update:
+                goal_state.fetch_full_goal_state(self)
+                self._goal_state = goal_state
+                updated = True
+
+            if conf.get_enable_fast_track():
+                if self._update_extensions_goal_state(force_update):
+                    updated = True
+
+            if updated:
                 self._save_goal_state()
 
         except Exception as exception:
             raise ProtocolError("Error fetching goal state: {0}".format(ustr(exception)))
 
-    def update_extensions_goal_state(self):
+    def _update_extensions_goal_state(self, force_update):
         correlation_id = str(uuid.uuid4())
-        etag = self.get_etag()
+        etag = None if force_update else self.get_etag()
 
         try:
-            # TODO: Remove this log statement when invoking this method on each iteration of the goal state loop (currently it is invoked only on a new goal state)
-            logger.info("Fetching vmSettings [correlation ID: {0} eTag: {1}]", correlation_id, etag)
             def get_vm_settings():
                 url, headers = self.get_host_plugin().get_vm_settings_request(correlation_id)
                 if etag is not None:
@@ -827,18 +833,17 @@ class WireClient(object):
                     response_etag = h[1]
                     break
 
-            if response_etag is not None:
-                logger.info("Fetched new vmSettings [correlation ID: {0} New eTag: {1}]", correlation_id, response_etag)
-                self._extensions_goal_state = ExtensionsGoalState(response_etag, vm_settings)
-            else:
-                # TODO: Remove this log statement (the entire else clause) when invoking this method on each iteration of the goal state loop (currently it is invoked only on a new goal state)
-                logger.error("Expected new vmSettings, but the response did not include an eTag [correlation ID: {0} eTag: {1}]", correlation_id, etag)
+            if response_etag is None:
+                return False
+
+            logger.info("Fetched new vmSettings [correlation ID: {0} New eTag: {1}]", correlation_id, response_etag)
+            self._extensions_goal_state = ExtensionsGoalState(response_etag, vm_settings)
+            return True
 
         except Exception as exception:
-            # TODO: raise ProtocolError instead of logging a warning
             message = "Error fetching vmSettings [correlation ID: {0} eTag: {1}]: {2}".format(correlation_id, etag, ustr(exception))
-            logger.warn(message)
             report_event(op=WALAEventOperation.GoalState, is_success=False, message=message, log_event=False)
+            logger.warn(message)
 
     def _update_host_plugin(self, container_id, role_config_name):
         if self._host_plugin is not None:
@@ -1087,7 +1092,7 @@ class WireClient(object):
 
         if ext_conf.status_upload_blob is None:
             # the status upload blob is in ExtensionsConfig so force a full goal state refresh
-            self.update_goal_state(forced=True)  # FT: This will come from the ExtensionsGoalState
+            self.update_goal_state(force_update=True)
             ext_conf = self.get_ext_conf()
 
         if ext_conf.status_upload_blob is None:
@@ -1291,7 +1296,7 @@ class WireClient(object):
 
     def get_host_plugin(self):
         if self._host_plugin is None:
-            goal_state = GoalState.fetch_goal_state(self)
+            goal_state = GoalState(self)
             self._set_host_plugin(HostPluginProtocol(self.get_endpoint(),
                                                      goal_state.container_id,
                                                      goal_state.role_config_name))

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -841,9 +841,7 @@ class WireClient(object):
             return True
 
         except Exception as exception:
-            message = "Error fetching vmSettings [correlation ID: {0} eTag: {1}]: {2}".format(correlation_id, etag, ustr(exception))
-            report_event(op=WALAEventOperation.GoalState, is_success=False, message=message, log_event=False)
-            logger.warn(message)
+            raise ProtocolError("Error fetching vmSettings [correlation ID: {0} eTag: {1}]: {2}".format(correlation_id, etag, ustr(exception)))
 
     def _update_host_plugin(self, container_id, role_config_name):
         if self._host_plugin is not None:

--- a/azurelinuxagent/daemon/main.py
+++ b/azurelinuxagent/daemon/main.py
@@ -160,7 +160,7 @@ class DaemonHandler(object):
                 #   current values.
                 protocol = self.protocol_util.get_protocol()
 
-                protocol.client.update_goal_state(forced=True)
+                protocol.client.update_goal_state(force_update=True)
 
                 setup_rdma_device(nd_version, protocol.client.get_shared_conf())
             except Exception as e:

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -297,11 +297,11 @@ class UpdateHandler(object):
             logger.info(u"Agent {0} is running as the goal state agent", CURRENT_AGENT)
 
             #
-            # Force initialization of the goal state; some components depend on information provided by the goal state and this
+            # Initialize the goal state; some components depend on information provided by the goal state and this
             # call ensures the required info is initialized (e.g telemetry depends on the container ID.)
             #
             protocol = self.protocol_util.get_protocol()
-            protocol.update_goal_state(force_update=True)
+            protocol.client.update_goal_state()
 
             # Initialize the common parameters for telemetry events
             initialize_event_logger_vminfo_common_parameters(protocol)

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -297,11 +297,11 @@ class UpdateHandler(object):
             logger.info(u"Agent {0} is running as the goal state agent", CURRENT_AGENT)
 
             #
-            # Fetch the goal state one time; some components depend on information provided by the goal state and this
+            # Force initialization of the goal state; some components depend on information provided by the goal state and this
             # call ensures the required info is initialized (e.g telemetry depends on the container ID.)
             #
             protocol = self.protocol_util.get_protocol()
-            protocol.update_goal_state()
+            protocol.update_goal_state(force_update=True)
 
             # Initialize the common parameters for telemetry events
             initialize_event_logger_vminfo_common_parameters(protocol)

--- a/tests/data/hostgaplugin/ext_conf-protected_settings.xml
+++ b/tests/data/hostgaplugin/ext_conf-protected_settings.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Extensions version="1.0.0.0" goalStateIncarnation="1"><GuestAgentExtension xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <GAFamilies>
+    <GAFamily>
+      <Name>Prod</Name>
+      <Uris>
+        <Uri>https://zrdfepirv2cbn09pr02a.blob.core.windows.net/7d89d439b79f4452950452399add2c90/Microsoft.OSTCLinuxAgent_Prod_useast2euap_manifest.xml</Uri>
+        <Uri>https://zrdfepirv2cbz06prdstr01a.blob.core.windows.net/7d89d439b79f4452950452399add2c90/Microsoft.OSTCLinuxAgent_Prod_useast2euap_manifest.xml</Uri>
+        <Uri>https://zrdfepirv2cbn04prdstr01a.blob.core.windows.net/7d89d439b79f4452950452399add2c90/Microsoft.OSTCLinuxAgent_Prod_useast2euap_manifest.xml</Uri>
+        <Uri>https://zrdfepirv2cbn06prdstr01a.blob.core.windows.net/7d89d439b79f4452950452399add2c90/Microsoft.OSTCLinuxAgent_Prod_useast2euap_manifest.xml</Uri>
+      </Uris>
+      <Version>2.4.0.1</Version>
+    </GAFamily>
+    <GAFamily>
+      <Name>Test</Name>
+      <Uris>
+        <Uri>https://zrdfepirv2cbn06prdstr01a.blob.core.windows.net/7d89d439b79f4452950452399add2c90/Microsoft.OSTCLinuxAgent_Test_useast2euap_manifest.xml</Uri>
+        <Uri>https://zrdfepirv2cbn09pr02a.blob.core.windows.net/7d89d439b79f4452950452399add2c90/Microsoft.OSTCLinuxAgent_Test_useast2euap_manifest.xml</Uri>
+        <Uri>https://zrdfepirv2cbn04prdstr01a.blob.core.windows.net/7d89d439b79f4452950452399add2c90/Microsoft.OSTCLinuxAgent_Test_useast2euap_manifest.xml</Uri>
+        <Uri>https://zrdfepirv2cbz06prdstr01a.blob.core.windows.net/7d89d439b79f4452950452399add2c90/Microsoft.OSTCLinuxAgent_Test_useast2euap_manifest.xml</Uri>
+      </Uris>
+      <Version>2.4.0.1</Version>
+    </GAFamily>
+  </GAFamilies>
+  <Location>EastUS2EUAP</Location>
+  <ServiceName>CRP</ServiceName>
+</GuestAgentExtension>
+<RequiredFeatures>
+  <RequiredFeature>
+    <Name>MultipleExtensionsPerHandler</Name>
+  </RequiredFeature>
+</RequiredFeatures>
+<StatusUploadBlob statusBlobType="PageBlob">https://md-jcv4sdpnxtrz.z47.blob.storage.azure.net/$system/nam-canary.fc9e847a-29fd-4ca8-a5ae-59e581425ca7.status?sv=2018-03-28&amp;sr=b&amp;sk=system-1&amp;sig=6n%2fhcx6RYxkk2tX1q1J4R9Ls1xJ8%2bQ3WjJn96x%2b%2fnEg%3d&amp;se=9999-01-01T00%3a00%3a00Z&amp;sp=rw</StatusUploadBlob>
+<Plugins>
+  <Plugin name="Microsoft.Azure.Extensions.customScript" version="2.1.3" location="https://zrdfepirv2cbn04prdstr01a.blob.core.windows.net/708cdbbfb9ad4802ac80a012992930b1/Microsoft.Azure.Extensions_CustomScript_useast2euap_manifest.xml" state="enabled" autoUpgrade="true" failoverlocation="https://zrdfepirv2cbn06prdstr01a.blob.core.windows.net/708cdbbfb9ad4802ac80a012992930b1/Microsoft.Azure.Extensions_CustomScript_useast2euap_manifest.xml" runAsStartupTask="false" isJson="true" useExactVersion="true">
+    <additionalLocations>
+      <additionalLocation>https://zrdfepirv2cbn09pr02a.blob.core.windows.net/708cdbbfb9ad4802ac80a012992930b1/Microsoft.Azure.Extensions_CustomScript_useast2euap_manifest.xml</additionalLocation>
+    </additionalLocations>
+  </Plugin>
+  <Plugin name="Microsoft.Azure.Monitor.AzureMonitorLinuxAgent" version="1.9.1" location="https://zrdfepirv2cbn04prdstr01a.blob.core.windows.net/a47f0806d764480a8d989d009c75007d/Microsoft.Azure.Monitor_AzureMonitorLinuxAgent_useast2euap_manifest.xml" state="enabled" autoUpgrade="true" failoverlocation="https://zrdfepirv2cbn06prdstr01a.blob.core.windows.net/a47f0806d764480a8d989d009c75007d/Microsoft.Azure.Monitor_AzureMonitorLinuxAgent_useast2euap_manifest.xml" runAsStartupTask="false" isJson="true" useExactVersion="true">
+    <additionalLocations>
+      <additionalLocation>https://zrdfepirv2cbn09pr02a.blob.core.windows.net/a47f0806d764480a8d989d009c75007d/Microsoft.Azure.Monitor_AzureMonitorLinuxAgent_useast2euap_manifest.xml</additionalLocation>
+    </additionalLocations>
+  </Plugin>
+  <Plugin name="Microsoft.Azure.Security.Monitoring.AzureSecurityLinuxAgent" version="2.15.112" location="https://zrdfepirv2cbn04prdstr01a.blob.core.windows.net/4ef06ad957494df49c807a5334f2b5d2/Microsoft.Azure.Security.Monitoring_AzureSecurityLinuxAgent_useast2euap_manifest.xml" state="enabled" autoUpgrade="true" failoverlocation="https://zrdfepirv2cbz06prdstr01a.blob.core.windows.net/4ef06ad957494df49c807a5334f2b5d2/Microsoft.Azure.Security.Monitoring_AzureSecurityLinuxAgent_useast2euap_manifest.xml" runAsStartupTask="false" isJson="true" useExactVersion="true">
+    <additionalLocations>
+      <additionalLocation>https://zrdfepirv2cbn06prdstr01a.blob.core.windows.net/4ef06ad957494df49c807a5334f2b5d2/Microsoft.Azure.Security.Monitoring_AzureSecurityLinuxAgent_useast2euap_manifest.xml</additionalLocation>
+    </additionalLocations>
+  </Plugin>
+  <Plugin name="Microsoft.CPlat.Core.RunCommandLinux" version="1.0.1" location="https://umsahsv3lrjswx2ggpxc.blob.core.windows.net/4beefb67-5a1e-aa37-7ede-3180ba34ba0d/4beefb67-5a1e-aa37-7ede-3180ba34ba0d_manifest.xml" state="enabled" autoUpgrade="true" failoverlocation="https://umsanjfkjbj4tsg50hbz.blob.core.windows.net/4beefb67-5a1e-aa37-7ede-3180ba34ba0d/4beefb67-5a1e-aa37-7ede-3180ba34ba0d_manifest.xml" runAsStartupTask="false" isJson="true" useExactVersion="true">
+    <additionalLocations>
+      <additionalLocation>https://umsaw3s1v4ftjvfg5qzl.blob.core.windows.net/4beefb67-5a1e-aa37-7ede-3180ba34ba0d/4beefb67-5a1e-aa37-7ede-3180ba34ba0d_manifest.xml</additionalLocation>
+    </additionalLocations>
+  </Plugin>
+</Plugins>
+<PluginSettings>
+  <Plugin name="Microsoft.Azure.Extensions.customScript" version="2.1.3">
+    <RuntimeSettings seqNo="1">{
+  "runtimeSettings": [
+    {
+      "handlerSettings": {
+        "protectedSettingsCertThumbprint": "4C4F304667711036E64AF4894B76EB208A863BD4",
+        "protectedSettings": "MIIBsAYJKoZIhvcNAQcDoIIBoTCCAZ0CAQAxggFpMIIBZQIBADBNMDkxNzA1BgoJkiaJk/IsZAEZFidXaW5kb3dzIEF6dXJlIENSUCBDZXJ0aWZpY2F0ZSBHZW5lcmF0b3ICEFpB/HKM/7evRk+DBz754wUwDQYJKoZIhvcNAQEBBQAEggEADPJwniDeIUXzxNrZCloitFdscQ59Bz1dj9DLBREAiM8jmxM0LLicTJDUv272Qm/4ZQgdqpFYBFjGab/9MX+Ih2x47FkVY1woBkckMaC/QOFv84gbboeQCmJYZC/rZJdh8rCMS+CEPq3uH1PVrvtSdZ9uxnaJ+E4exTPPviIiLIPtqWafNlzdbBt8HZjYaVw+SSe+CGzD2pAQeNttq3Rt/6NjCzrjG8ufKwvRoqnrInMs4x6nnN5/xvobKIBSv4/726usfk8Ug+9Q6Benvfpmre2+1M5PnGTfq78cO3o6mI3cPoBUjp5M0iJjAMGeMt81tyHkimZrEZm6pLa4NQMOEjArBgkqhkiG9w0BBwEwFAYIKoZIhvcNAwcECC5nVaiJaWt+gAhgeYvxUOYHXw=="
+      }
+    }
+  ]
+}</RuntimeSettings>
+  </Plugin>
+  <Plugin name="Microsoft.Azure.Monitor.AzureMonitorLinuxAgent" version="1.9.1">
+    <RuntimeSettings seqNo="0">{
+  "runtimeSettings": [
+    {
+      "handlerSettings": {
+        "protectedSettingsCertThumbprint": "4C4F304667711036E64AF4894B76EB208A863BD4",
+        "protectedSettings": "MIIBsAYJKoZIhvcNAQcDoIIBoTCCAZ0CAQAxggFpMIIBZQIBADBNMDkxNzA1BgoJkiaJk/IsZAEZFidXaW5kb3dzIEF6dXJlIENSUCBDZXJ0aWZpY2F0ZSBHZW5lcmF0b3ICEFpB/HKM/7evRk+DBz754wUwDQYJKoZIhvcNAQEBBQAEggEADPJwniDeIUXzxNrZCloitFdscQ59Bz1dj9DLBREAiM8jmxM0LLicTJDUv272Qm/4ZQgdqpFYBFjGab/9MX+Ih2x47FkVY1woBkckMaC/QOFv84gbboeQCmJYZC/rZJdh8rCMS+CEPq3uH1PVrvtSdZ9uxnaJ+E4exTPPviIiLIPtqWafNlzdbBt8HZjYaVw+SSe+CGzD2pAQeNttq3Rt/6NjCzrjG8ufKwvRoqnrInMs4x6nnN5/xvobKIBSv4/726usfk8Ug+9Q6Benvfpmre2+1M5PnGTfq78cO3o6mI3cPoBUjp5M0iJjAMGeMt81tyHkimZrEZm6pLa4NQMOEjArBgkqhkiG9w0BBwEwFAYIKoZIhvcNAwcECC5nVaiJaWt+gAhgeYvxUOYHXw==",
+        "publicSettings": {"GCS_AUTO_CONFIG":true}
+      }
+    }
+  ]
+}</RuntimeSettings>
+  </Plugin>
+  <Plugin name="Microsoft.Azure.Security.Monitoring.AzureSecurityLinuxAgent" version="2.15.112">
+    <RuntimeSettings seqNo="0">{
+  "runtimeSettings": [
+    {
+      "handlerSettings": {
+        "protectedSettingsCertThumbprint": "4C4F304667711036E64AF4894B76EB208A863BD4",
+        "protectedSettings": "MIIBsAYJKoZIhvcNAQcDoIIBoTCCAZ0CAQAxggFpMIIBZQIBADBNMDkxNzA1BgoJkiaJk/IsZAEZFidXaW5kb3dzIEF6dXJlIENSUCBDZXJ0aWZpY2F0ZSBHZW5lcmF0b3ICEFpB/HKM/7evRk+DBz754wUwDQYJKoZIhvcNAQEBBQAEggEADPJwniDeIUXzxNrZCloitFdscQ59Bz1dj9DLBREAiM8jmxM0LLicTJDUv272Qm/4ZQgdqpFYBFjGab/9MX+Ih2x47FkVY1woBkckMaC/QOFv84gbboeQCmJYZC/rZJdh8rCMS+CEPq3uH1PVrvtSdZ9uxnaJ+E4exTPPviIiLIPtqWafNlzdbBt8HZjYaVw+SSe+CGzD2pAQeNttq3Rt/6NjCzrjG8ufKwvRoqnrInMs4x6nnN5/xvobKIBSv4/726usfk8Ug+9Q6Benvfpmre2+1M5PnGTfq78cO3o6mI3cPoBUjp5M0iJjAMGeMt81tyHkimZrEZm6pLa4NQMOEjArBgkqhkiG9w0BBwEwFAYIKoZIhvcNAwcECC5nVaiJaWt+gAhgeYvxUOYHXw==",
+        "publicSettings": {"enableGenevaUpload":true}
+      }
+    }
+  ]
+}</RuntimeSettings>
+  </Plugin>
+  <Plugin name="Microsoft.CPlat.Core.RunCommandLinux" version="1.0.1">
+    <RuntimeSettings seqNo="2">{
+  "runtimeSettings": [
+    {
+      "handlerSettings": {
+        "protectedSettingsCertThumbprint": "4C4F304667711036E64AF4894B76EB208A863BD4",
+        "protectedSettings": "MIIBsAYJKoZIhvcNAQcDoIIBoTCCAZ0CAQAxggFpMIIBZQIBADBNMDkxNzA1BgoJkiaJk/IsZAEZFidXaW5kb3dzIEF6dXJlIENSUCBDZXJ0aWZpY2F0ZSBHZW5lcmF0b3ICEFpB/HKM/7evRk+DBz754wUwDQYJKoZIhvcNAQEBBQAEggEADPJwniDeIUXzxNrZCloitFdscQ59Bz1dj9DLBREAiM8jmxM0LLicTJDUv272Qm/4ZQgdqpFYBFjGab/9MX+Ih2x47FkVY1woBkckMaC/QOFv84gbboeQCmJYZC/rZJdh8rCMS+CEPq3uH1PVrvtSdZ9uxnaJ+E4exTPPviIiLIPtqWafNlzdbBt8HZjYaVw+SSe+CGzD2pAQeNttq3Rt/6NjCzrjG8ufKwvRoqnrInMs4x6nnN5/xvobKIBSv4/726usfk8Ug+9Q6Benvfpmre2+1M5PnGTfq78cO3o6mI3cPoBUjp5M0iJjAMGeMt81tyHkimZrEZm6pLa4NQMOEjArBgkqhkiG9w0BBwEwFAYIKoZIhvcNAwcECC5nVaiJaWt+gAhgeYvxUOYHXw==",
+        "publicSettings": {}
+      }
+    }
+  ]
+}</RuntimeSettings>
+  </Plugin>
+</PluginSettings>
+<SecureIdentity>
+  <IdentityClientId p2:nil="true" xmlns:p2="http://www.w3.org/2001/XMLSchema-instance" />
+  <IdentityClientTenantId p2:nil="true" xmlns:p2="http://www.w3.org/2001/XMLSchema-instance" />
+  <IdentityObjectId p2:nil="true" xmlns:p2="http://www.w3.org/2001/XMLSchema-instance" />
+  <IdentitySecretUrl>https://control-eastus2euap.identity.azure.net/subscriptions/a53f7094-a16c-47af-abe4-b05c05d0d79a/resourcegroups/narrieta-rg/providers/Microsoft.Compute/virtualMachines/nam-canary/credentials/v2/systemassigned?arpid=2ebf1440-8fc3-413b-abea-249d5af1488b</IdentitySecretUrl>
+  <IdentityInternalId>2ebf1440-8fc3-413b-abea-249d5af1488b</IdentityInternalId>
+  <IdentityTag>f1b49e76-b675-459b-a493-29de3a6fe978</IdentityTag>
+  <UserAssignedIdentities>
+    <UserAssignedIdentity>
+      <IdentityClientId>f40a031a-27f4-4d98-9850-49d58028f3ae</IdentityClientId>
+      <IdentityClientTenantId>72f988bf-86f1-41af-91ab-2d7cd011db47</IdentityClientTenantId>
+      <IdentityObjectId>20152205-d986-4a5e-a1f7-e38876f27dea</IdentityObjectId>
+      <IdentitySecretUrl>https://control-eastus2euap.identity.azure.net/subscriptions/a53f7094-a16c-47af-abe4-b05c05d0d79a/resourcegroups/narrieta-rg/providers/Microsoft.Compute/virtualMachines/nam-canary/credentials/v2/userassigned?arpid=2ebf1440-8fc3-413b-abea-249d5af1488b&amp;uaid=f40a031a-27f4-4d98-9850-49d58028f3ae&amp;tid=72f988bf-86f1-41af-91ab-2d7cd011db47</IdentitySecretUrl>
+      <IdentityResourceId>/subscriptions/a53f7094-a16c-47af-abe4-b05c05d0d79a/resourceGroups/AzSecPackAutoConfigRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/AzSecPackAutoConfigUA-eastus2euap</IdentityResourceId>
+    </UserAssignedIdentity>
+  </UserAssignedIdentities>
+</SecureIdentity>
+<VaultSecrets>
+  <VaultCertificates />
+</VaultSecrets>
+<InVMArtifactsProfileBlob>https://md-jcv4sdpnxtrz.z47.blob.storage.azure.net/$system/nam-canary.fc9e847a-29fd-4ca8-a5ae-59e581425ca7.vmSettings?sv=2018-03-28&amp;sr=b&amp;sk=system-1&amp;sig=TMVEkKTY3%2bDpMJIjnO90uGaayI1t%2fd3yPYoxAFAjCcQ%3d&amp;se=9999-01-01T00%3a00%3a00Z&amp;sp=r</InVMArtifactsProfileBlob>
+<InVMGoalStateMetaData inSvdSeqNo="20" createdOnTicks="637629365237217593" activityId="b3f493e2-cab8-487d-820a-5718504f2f3f" correlationId="4f4939fb-35e6-411f-98f1-aeaf8796ed30" /></Extensions>

--- a/tests/data/hostgaplugin/ext_conf.xml
+++ b/tests/data/hostgaplugin/ext_conf.xml
@@ -1,28 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Extensions version="1.0.0.0" goalStateIncarnation="1"><GuestAgentExtension xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+<Extensions version="1.0.0.0" goalStateIncarnation="10"><GuestAgentExtension xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
   <GAFamilies>
     <GAFamily>
       <Name>Prod</Name>
       <Uris>
-        <Uri>https://zrdfepirv2cbn09pr02a.blob.core.windows.net/7d89d439b79f4452950452399add2c90/Microsoft.OSTCLinuxAgent_Prod_useast2euap_manifest.xml</Uri>
-        <Uri>https://zrdfepirv2cbz06prdstr01a.blob.core.windows.net/7d89d439b79f4452950452399add2c90/Microsoft.OSTCLinuxAgent_Prod_useast2euap_manifest.xml</Uri>
-        <Uri>https://zrdfepirv2cbn04prdstr01a.blob.core.windows.net/7d89d439b79f4452950452399add2c90/Microsoft.OSTCLinuxAgent_Prod_useast2euap_manifest.xml</Uri>
-        <Uri>https://zrdfepirv2cbn06prdstr01a.blob.core.windows.net/7d89d439b79f4452950452399add2c90/Microsoft.OSTCLinuxAgent_Prod_useast2euap_manifest.xml</Uri>
+        <Uri>https://ardfepirv2cdm03prdstr01a.blob.core.windows.net/7d89d439b79f4452950452399add2c90/Microsoft.OSTCLinuxAgent_Prod_uscentraleuap_manifest.xml</Uri>
+        <Uri>https://zrdfepirv2cdm03prdstr01a.blob.core.windows.net/7d89d439b79f4452950452399add2c90/Microsoft.OSTCLinuxAgent_Prod_uscentraleuap_manifest.xml</Uri>
       </Uris>
       <Version>2.4.0.1</Version>
     </GAFamily>
     <GAFamily>
       <Name>Test</Name>
       <Uris>
-        <Uri>https://zrdfepirv2cbn06prdstr01a.blob.core.windows.net/7d89d439b79f4452950452399add2c90/Microsoft.OSTCLinuxAgent_Test_useast2euap_manifest.xml</Uri>
-        <Uri>https://zrdfepirv2cbn09pr02a.blob.core.windows.net/7d89d439b79f4452950452399add2c90/Microsoft.OSTCLinuxAgent_Test_useast2euap_manifest.xml</Uri>
-        <Uri>https://zrdfepirv2cbn04prdstr01a.blob.core.windows.net/7d89d439b79f4452950452399add2c90/Microsoft.OSTCLinuxAgent_Test_useast2euap_manifest.xml</Uri>
-        <Uri>https://zrdfepirv2cbz06prdstr01a.blob.core.windows.net/7d89d439b79f4452950452399add2c90/Microsoft.OSTCLinuxAgent_Test_useast2euap_manifest.xml</Uri>
+        <Uri>https://zrdfepirv2cdm03prdstr01a.blob.core.windows.net/7d89d439b79f4452950452399add2c90/Microsoft.OSTCLinuxAgent_Test_uscentraleuap_manifest.xml</Uri>
+        <Uri>https://ardfepirv2cdm03prdstr01a.blob.core.windows.net/7d89d439b79f4452950452399add2c90/Microsoft.OSTCLinuxAgent_Test_uscentraleuap_manifest.xml</Uri>
       </Uris>
       <Version>2.4.0.1</Version>
     </GAFamily>
   </GAFamilies>
-  <Location>EastUS2EUAP</Location>
+  <Location>CentralUSEUAP</Location>
   <ServiceName>CRP</ServiceName>
 </GuestAgentExtension>
 <RequiredFeatures>
@@ -30,101 +26,56 @@
     <Name>MultipleExtensionsPerHandler</Name>
   </RequiredFeature>
 </RequiredFeatures>
-<StatusUploadBlob statusBlobType="PageBlob">https://md-jcv4sdpnxtrz.z47.blob.storage.azure.net/$system/nam-canary.fc9e847a-29fd-4ca8-a5ae-59e581425ca7.status?sv=2018-03-28&amp;sr=b&amp;sk=system-1&amp;sig=6n%2fhcx6RYxkk2tX1q1J4R9Ls1xJ8%2bQ3WjJn96x%2b%2fnEg%3d&amp;se=9999-01-01T00%3a00%3a00Z&amp;sp=rw</StatusUploadBlob>
+<StatusUploadBlob statusBlobType="BlockBlob">https://dcrcf5h3g6.blob.core.windows.net/$system/edpymvazsh.ba323e38-2145-4cb9-8cbf-778c7824bc9e.status?sv=2018-03-28&amp;sr=b&amp;sk=system-1&amp;sig=xYQPQ6IHQh%2b57h2OA6u4CUr85wzaxQH7WF2qHi3Hu98%3d&amp;se=9999-01-01T00%3a00%3a00Z&amp;sp=w</StatusUploadBlob>
 <Plugins>
-  <Plugin name="Microsoft.Azure.Extensions.customScript" version="2.1.3" location="https://zrdfepirv2cbn04prdstr01a.blob.core.windows.net/708cdbbfb9ad4802ac80a012992930b1/Microsoft.Azure.Extensions_CustomScript_useast2euap_manifest.xml" state="enabled" autoUpgrade="true" failoverlocation="https://zrdfepirv2cbn06prdstr01a.blob.core.windows.net/708cdbbfb9ad4802ac80a012992930b1/Microsoft.Azure.Extensions_CustomScript_useast2euap_manifest.xml" runAsStartupTask="false" isJson="true" useExactVersion="true">
+  <Plugin name="Microsoft.Azure.Extensions.CustomScript" version="2.1.3" location="https://zrdfepirv2cdm03prdstr01a.blob.core.windows.net/708cdbbfb9ad4802ac80a012992930b1/Microsoft.Azure.Extensions_CustomScript_uscentraleuap_manifest.xml" state="enabled" autoUpgrade="true" failoverlocation="https://ardfepirv2cdm03prdstr01a.blob.core.windows.net/708cdbbfb9ad4802ac80a012992930b1/Microsoft.Azure.Extensions_CustomScript_uscentraleuap_manifest.xml" runAsStartupTask="false" isJson="true" useExactVersion="true" />
+  <Plugin name="Microsoft.CPlat.Core.RunCommandHandlerLinux" version="1.2.0" location="https://umsavbvncrpzbnxmxzmr.blob.core.windows.net/f4086d41-69f9-3103-78e0-8a2c7e789d0f/f4086d41-69f9-3103-78e0-8a2c7e789d0f_manifest.xml" state="enabled" autoUpgrade="true" failoverlocation="https://umsawqtlsshtn5v2nfgh.blob.core.windows.net/f4086d41-69f9-3103-78e0-8a2c7e789d0f/f4086d41-69f9-3103-78e0-8a2c7e789d0f_manifest.xml" runAsStartupTask="false" isJson="true" useExactVersion="true">
     <additionalLocations>
-      <additionalLocation>https://zrdfepirv2cbn09pr02a.blob.core.windows.net/708cdbbfb9ad4802ac80a012992930b1/Microsoft.Azure.Extensions_CustomScript_useast2euap_manifest.xml</additionalLocation>
-    </additionalLocations>
-  </Plugin>
-  <Plugin name="Microsoft.Azure.Monitor.AzureMonitorLinuxAgent" version="1.9.1" location="https://zrdfepirv2cbn04prdstr01a.blob.core.windows.net/a47f0806d764480a8d989d009c75007d/Microsoft.Azure.Monitor_AzureMonitorLinuxAgent_useast2euap_manifest.xml" state="enabled" autoUpgrade="true" failoverlocation="https://zrdfepirv2cbn06prdstr01a.blob.core.windows.net/a47f0806d764480a8d989d009c75007d/Microsoft.Azure.Monitor_AzureMonitorLinuxAgent_useast2euap_manifest.xml" runAsStartupTask="false" isJson="true" useExactVersion="true">
-    <additionalLocations>
-      <additionalLocation>https://zrdfepirv2cbn09pr02a.blob.core.windows.net/a47f0806d764480a8d989d009c75007d/Microsoft.Azure.Monitor_AzureMonitorLinuxAgent_useast2euap_manifest.xml</additionalLocation>
-    </additionalLocations>
-  </Plugin>
-  <Plugin name="Microsoft.Azure.Security.Monitoring.AzureSecurityLinuxAgent" version="2.15.112" location="https://zrdfepirv2cbn04prdstr01a.blob.core.windows.net/4ef06ad957494df49c807a5334f2b5d2/Microsoft.Azure.Security.Monitoring_AzureSecurityLinuxAgent_useast2euap_manifest.xml" state="enabled" autoUpgrade="true" failoverlocation="https://zrdfepirv2cbz06prdstr01a.blob.core.windows.net/4ef06ad957494df49c807a5334f2b5d2/Microsoft.Azure.Security.Monitoring_AzureSecurityLinuxAgent_useast2euap_manifest.xml" runAsStartupTask="false" isJson="true" useExactVersion="true">
-    <additionalLocations>
-      <additionalLocation>https://zrdfepirv2cbn06prdstr01a.blob.core.windows.net/4ef06ad957494df49c807a5334f2b5d2/Microsoft.Azure.Security.Monitoring_AzureSecurityLinuxAgent_useast2euap_manifest.xml</additionalLocation>
-    </additionalLocations>
-  </Plugin>
-  <Plugin name="Microsoft.CPlat.Core.RunCommandLinux" version="1.0.1" location="https://umsahsv3lrjswx2ggpxc.blob.core.windows.net/4beefb67-5a1e-aa37-7ede-3180ba34ba0d/4beefb67-5a1e-aa37-7ede-3180ba34ba0d_manifest.xml" state="enabled" autoUpgrade="true" failoverlocation="https://umsanjfkjbj4tsg50hbz.blob.core.windows.net/4beefb67-5a1e-aa37-7ede-3180ba34ba0d/4beefb67-5a1e-aa37-7ede-3180ba34ba0d_manifest.xml" runAsStartupTask="false" isJson="true" useExactVersion="true">
-    <additionalLocations>
-      <additionalLocation>https://umsaw3s1v4ftjvfg5qzl.blob.core.windows.net/4beefb67-5a1e-aa37-7ede-3180ba34ba0d/4beefb67-5a1e-aa37-7ede-3180ba34ba0d_manifest.xml</additionalLocation>
+      <additionalLocation>https://umsajbjtqrb3zqjvgb2z.blob.core.windows.net/f4086d41-69f9-3103-78e0-8a2c7e789d0f/f4086d41-69f9-3103-78e0-8a2c7e789d0f_manifest.xml</additionalLocation>
     </additionalLocations>
   </Plugin>
 </Plugins>
 <PluginSettings>
-  <Plugin name="Microsoft.Azure.Extensions.customScript" version="2.1.3">
-    <RuntimeSettings seqNo="1">{
-  "runtimeSettings": [
-    {
-      "handlerSettings": {
-        "protectedSettingsCertThumbprint": "4C4F304667711036E64AF4894B76EB208A863BD4",
-        "protectedSettings": "MIIBsAYJKoZIhvcNAQcDoIIBoTCCAZ0CAQAxggFpMIIBZQIBADBNMDkxNzA1BgoJkiaJk/IsZAEZFidXaW5kb3dzIEF6dXJlIENSUCBDZXJ0aWZpY2F0ZSBHZW5lcmF0b3ICEFpB/HKM/7evRk+DBz754wUwDQYJKoZIhvcNAQEBBQAEggEADPJwniDeIUXzxNrZCloitFdscQ59Bz1dj9DLBREAiM8jmxM0LLicTJDUv272Qm/4ZQgdqpFYBFjGab/9MX+Ih2x47FkVY1woBkckMaC/QOFv84gbboeQCmJYZC/rZJdh8rCMS+CEPq3uH1PVrvtSdZ9uxnaJ+E4exTPPviIiLIPtqWafNlzdbBt8HZjYaVw+SSe+CGzD2pAQeNttq3Rt/6NjCzrjG8ufKwvRoqnrInMs4x6nnN5/xvobKIBSv4/726usfk8Ug+9Q6Benvfpmre2+1M5PnGTfq78cO3o6mI3cPoBUjp5M0iJjAMGeMt81tyHkimZrEZm6pLa4NQMOEjArBgkqhkiG9w0BBwEwFAYIKoZIhvcNAwcECC5nVaiJaWt+gAhgeYvxUOYHXw=="
-      }
-    }
-  ]
-}</RuntimeSettings>
-  </Plugin>
-  <Plugin name="Microsoft.Azure.Monitor.AzureMonitorLinuxAgent" version="1.9.1">
+  <Plugin name="Microsoft.Azure.Extensions.CustomScript" version="2.1.3">
     <RuntimeSettings seqNo="0">{
   "runtimeSettings": [
     {
       "handlerSettings": {
-        "protectedSettingsCertThumbprint": "4C4F304667711036E64AF4894B76EB208A863BD4",
-        "protectedSettings": "MIIBsAYJKoZIhvcNAQcDoIIBoTCCAZ0CAQAxggFpMIIBZQIBADBNMDkxNzA1BgoJkiaJk/IsZAEZFidXaW5kb3dzIEF6dXJlIENSUCBDZXJ0aWZpY2F0ZSBHZW5lcmF0b3ICEFpB/HKM/7evRk+DBz754wUwDQYJKoZIhvcNAQEBBQAEggEADPJwniDeIUXzxNrZCloitFdscQ59Bz1dj9DLBREAiM8jmxM0LLicTJDUv272Qm/4ZQgdqpFYBFjGab/9MX+Ih2x47FkVY1woBkckMaC/QOFv84gbboeQCmJYZC/rZJdh8rCMS+CEPq3uH1PVrvtSdZ9uxnaJ+E4exTPPviIiLIPtqWafNlzdbBt8HZjYaVw+SSe+CGzD2pAQeNttq3Rt/6NjCzrjG8ufKwvRoqnrInMs4x6nnN5/xvobKIBSv4/726usfk8Ug+9Q6Benvfpmre2+1M5PnGTfq78cO3o6mI3cPoBUjp5M0iJjAMGeMt81tyHkimZrEZm6pLa4NQMOEjArBgkqhkiG9w0BBwEwFAYIKoZIhvcNAwcECC5nVaiJaWt+gAhgeYvxUOYHXw==",
-        "publicSettings": {"GCS_AUTO_CONFIG":true}
+        "publicSettings": {"commandToExecute":"echo '26c8d804-6d2e-4da1-ab5b-629ad733b3bb'"}
       }
     }
   ]
 }</RuntimeSettings>
   </Plugin>
-  <Plugin name="Microsoft.Azure.Security.Monitoring.AzureSecurityLinuxAgent" version="2.15.112">
-    <RuntimeSettings seqNo="0">{
+  <Plugin name="Microsoft.CPlat.Core.RunCommandHandlerLinux" version="1.2.0">
+    <ExtensionRuntimeSettings seqNo="0" name="MCExt1" state="enabled">{
   "runtimeSettings": [
     {
       "handlerSettings": {
-        "protectedSettingsCertThumbprint": "4C4F304667711036E64AF4894B76EB208A863BD4",
-        "protectedSettings": "MIIBsAYJKoZIhvcNAQcDoIIBoTCCAZ0CAQAxggFpMIIBZQIBADBNMDkxNzA1BgoJkiaJk/IsZAEZFidXaW5kb3dzIEF6dXJlIENSUCBDZXJ0aWZpY2F0ZSBHZW5lcmF0b3ICEFpB/HKM/7evRk+DBz754wUwDQYJKoZIhvcNAQEBBQAEggEADPJwniDeIUXzxNrZCloitFdscQ59Bz1dj9DLBREAiM8jmxM0LLicTJDUv272Qm/4ZQgdqpFYBFjGab/9MX+Ih2x47FkVY1woBkckMaC/QOFv84gbboeQCmJYZC/rZJdh8rCMS+CEPq3uH1PVrvtSdZ9uxnaJ+E4exTPPviIiLIPtqWafNlzdbBt8HZjYaVw+SSe+CGzD2pAQeNttq3Rt/6NjCzrjG8ufKwvRoqnrInMs4x6nnN5/xvobKIBSv4/726usfk8Ug+9Q6Benvfpmre2+1M5PnGTfq78cO3o6mI3cPoBUjp5M0iJjAMGeMt81tyHkimZrEZm6pLa4NQMOEjArBgkqhkiG9w0BBwEwFAYIKoZIhvcNAwcECC5nVaiJaWt+gAhgeYvxUOYHXw==",
-        "publicSettings": {"enableGenevaUpload":true}
+        "publicSettings": {"source":{"script":"echo '571bbcda-2992-4417-a65c-eaad1832c1f9'"}}
       }
     }
   ]
-}</RuntimeSettings>
-  </Plugin>
-  <Plugin name="Microsoft.CPlat.Core.RunCommandLinux" version="1.0.1">
-    <RuntimeSettings seqNo="2">{
+}</ExtensionRuntimeSettings>
+    <ExtensionRuntimeSettings seqNo="0" name="MCExt2" state="enabled">{
   "runtimeSettings": [
     {
       "handlerSettings": {
-        "protectedSettingsCertThumbprint": "4C4F304667711036E64AF4894B76EB208A863BD4",
-        "protectedSettings": "MIIBsAYJKoZIhvcNAQcDoIIBoTCCAZ0CAQAxggFpMIIBZQIBADBNMDkxNzA1BgoJkiaJk/IsZAEZFidXaW5kb3dzIEF6dXJlIENSUCBDZXJ0aWZpY2F0ZSBHZW5lcmF0b3ICEFpB/HKM/7evRk+DBz754wUwDQYJKoZIhvcNAQEBBQAEggEADPJwniDeIUXzxNrZCloitFdscQ59Bz1dj9DLBREAiM8jmxM0LLicTJDUv272Qm/4ZQgdqpFYBFjGab/9MX+Ih2x47FkVY1woBkckMaC/QOFv84gbboeQCmJYZC/rZJdh8rCMS+CEPq3uH1PVrvtSdZ9uxnaJ+E4exTPPviIiLIPtqWafNlzdbBt8HZjYaVw+SSe+CGzD2pAQeNttq3Rt/6NjCzrjG8ufKwvRoqnrInMs4x6nnN5/xvobKIBSv4/726usfk8Ug+9Q6Benvfpmre2+1M5PnGTfq78cO3o6mI3cPoBUjp5M0iJjAMGeMt81tyHkimZrEZm6pLa4NQMOEjArBgkqhkiG9w0BBwEwFAYIKoZIhvcNAwcECC5nVaiJaWt+gAhgeYvxUOYHXw==",
-        "publicSettings": {}
+        "publicSettings": {"source":{"script":"echo '58d6ac9d-9ef3-400a-99d7-1c3b5451eef6'"}}
       }
     }
   ]
-}</RuntimeSettings>
+}</ExtensionRuntimeSettings>
+    <ExtensionRuntimeSettings seqNo="0" name="MCExt3" state="enabled">{
+  "runtimeSettings": [
+    {
+      "handlerSettings": {
+        "publicSettings": {"source":{"script":"echo '834cad38-9eec-483e-946d-f713cafc3da8'"}}
+      }
+    }
+  ]
+}</ExtensionRuntimeSettings>
   </Plugin>
 </PluginSettings>
-<SecureIdentity>
-  <IdentityClientId p2:nil="true" xmlns:p2="http://www.w3.org/2001/XMLSchema-instance" />
-  <IdentityClientTenantId p2:nil="true" xmlns:p2="http://www.w3.org/2001/XMLSchema-instance" />
-  <IdentityObjectId p2:nil="true" xmlns:p2="http://www.w3.org/2001/XMLSchema-instance" />
-  <IdentitySecretUrl>https://control-eastus2euap.identity.azure.net/subscriptions/a53f7094-a16c-47af-abe4-b05c05d0d79a/resourcegroups/narrieta-rg/providers/Microsoft.Compute/virtualMachines/nam-canary/credentials/v2/systemassigned?arpid=2ebf1440-8fc3-413b-abea-249d5af1488b</IdentitySecretUrl>
-  <IdentityInternalId>2ebf1440-8fc3-413b-abea-249d5af1488b</IdentityInternalId>
-  <IdentityTag>f1b49e76-b675-459b-a493-29de3a6fe978</IdentityTag>
-  <UserAssignedIdentities>
-    <UserAssignedIdentity>
-      <IdentityClientId>f40a031a-27f4-4d98-9850-49d58028f3ae</IdentityClientId>
-      <IdentityClientTenantId>72f988bf-86f1-41af-91ab-2d7cd011db47</IdentityClientTenantId>
-      <IdentityObjectId>20152205-d986-4a5e-a1f7-e38876f27dea</IdentityObjectId>
-      <IdentitySecretUrl>https://control-eastus2euap.identity.azure.net/subscriptions/a53f7094-a16c-47af-abe4-b05c05d0d79a/resourcegroups/narrieta-rg/providers/Microsoft.Compute/virtualMachines/nam-canary/credentials/v2/userassigned?arpid=2ebf1440-8fc3-413b-abea-249d5af1488b&amp;uaid=f40a031a-27f4-4d98-9850-49d58028f3ae&amp;tid=72f988bf-86f1-41af-91ab-2d7cd011db47</IdentitySecretUrl>
-      <IdentityResourceId>/subscriptions/a53f7094-a16c-47af-abe4-b05c05d0d79a/resourceGroups/AzSecPackAutoConfigRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/AzSecPackAutoConfigUA-eastus2euap</IdentityResourceId>
-    </UserAssignedIdentity>
-  </UserAssignedIdentities>
-</SecureIdentity>
-<VaultSecrets>
-  <VaultCertificates />
-</VaultSecrets>
-<InVMArtifactsProfileBlob>https://md-jcv4sdpnxtrz.z47.blob.storage.azure.net/$system/nam-canary.fc9e847a-29fd-4ca8-a5ae-59e581425ca7.vmSettings?sv=2018-03-28&amp;sr=b&amp;sk=system-1&amp;sig=TMVEkKTY3%2bDpMJIjnO90uGaayI1t%2fd3yPYoxAFAjCcQ%3d&amp;se=9999-01-01T00%3a00%3a00Z&amp;sp=r</InVMArtifactsProfileBlob>
-<InVMGoalStateMetaData inSvdSeqNo="20" createdOnTicks="637629365237217593" activityId="b3f493e2-cab8-487d-820a-5718504f2f3f" correlationId="4f4939fb-35e6-411f-98f1-aeaf8796ed30" /></Extensions>
+<InVMArtifactsProfileBlob>https://dcrcf5h3g6.blob.core.windows.net/$system/edpymvazsh.ba323e38-2145-4cb9-8cbf-778c7824bc9e.vmSettings?sv=2018-03-28&amp;sr=b&amp;sk=system-1&amp;sig=y40xBuoKCIheR%2fzq2P7ocWSRmsWNB9TizIojGwm0A2A%3d&amp;se=9999-01-01T00%3a00%3a00Z&amp;sp=r</InVMArtifactsProfileBlob>
+<InVMGoalStateMetaData inSvdSeqNo="10" createdOnTicks="637632862319659103" activityId="c86d8064-6f11-4145-8178-e0587e0584de" correlationId="6609dcb1-fccc-474a-9a59-8bd71ba06983" /></Extensions>

--- a/tests/data/hostgaplugin/vm_settings-protected_settings.json
+++ b/tests/data/hostgaplugin/vm_settings-protected_settings.json
@@ -1,0 +1,108 @@
+{
+    "activityId": "b3f493e2-cab8-487d-820a-5718504f2f3f",
+    "correlationId": "4f4939fb-35e6-411f-98f1-aeaf8796ed30",
+    "extensionsLastModifiedTickCount": 637629365237217593,
+    "inVMMetadata": {
+        "subscriptionId": "a53f7094-a16c-47af-abe4-b05c05d0d79a",
+        "resourceGroupName": "narrieta-rg",
+        "vmName": "nam-canary",
+        "location": "EastUS2EUAP",
+        "vmId": "fc9e847a-29fd-4ca8-a5ae-59e581425ca7",
+        "vmSize": "Standard_DS1_v2",
+        "osType": "Linux",
+        "vmImage": {
+            "publisher": "Canonical",
+            "offer": "UbuntuServer",
+            "sku": "18.04-LTS",
+            "version": "18.04.202104150"
+        }
+    },
+    "requiredFeatures": [
+        {
+            "name": "MultipleExtensionsPerHandler"
+        }
+    ],
+    "gaFamilies": [
+        {
+            "name": "Prod",
+            "version": "2.4.0.1"
+        },
+        {
+            "name": "Test",
+            "version": "2.4.0.1"
+        }
+    ],
+    "extensionGoalStates": [
+        {
+            "name": "Microsoft.Azure.Extensions.customScript",
+            "version": "2.1.3",
+            "location": "https://zrdfepirv2cbn04prdstr01a.blob.core.windows.net/708cdbbfb9ad4802ac80a012992930b1/Microsoft.Azure.Extensions_CustomScript_useast2euap_manifest.xml",
+            "state": "enabled",
+            "autoUpgrade": true,
+            "runAsStartupTask": false,
+            "isJson": true,
+            "useExactVersion": true,
+            "settingsSeqNo": 1,
+            "settings": [
+                {
+                    "protectedSettingsCertThumbprint": "4C4F304667711036E64AF4894B76EB208A863BD4",
+                    "protectedSettings": "MIIBsAYJKoZIhvcNAQcDoIIBoTCCAZ0CAQAxggFpMIIBZQIBADBNMDkxNzA1BgoJkiaJk/IsZAEZFidXaW5kb3dzIEF6dXJlIENSUCBDZXJ0aWZpY2F0ZSBHZW5lcmF0b3ICEFpB/HKM/7evRk+DBz754wUwDQYJKoZIhvcNAQEBBQAEggEADPJwniDeIUXzxNrZCloitFdscQ59Bz1dj9DLBREAiM8jmxM0LLicTJDUv272Qm/4ZQgdqpFYBFjGab/9MX+Ih2x47FkVY1woBkckMaC/QOFv84gbboeQCmJYZC/rZJdh8rCMS+CEPq3uH1PVrvtSdZ9uxnaJ+E4exTPPviIiLIPtqWafNlzdbBt8HZjYaVw+SSe+CGzD2pAQeNttq3Rt/6NjCzrjG8ufKwvRoqnrInMs4x6nnN5/xvobKIBSv4/726usfk8Ug+9Q6Benvfpmre2+1M5PnGTfq78cO3o6mI3cPoBUjp5M0iJjAMGeMt81tyHkimZrEZm6pLa4NQMOEjArBgkqhkiG9w0BBwEwFAYIKoZIhvcNAwcECC5nVaiJaWt+gAhgeYvxUOYHXw=="
+                }
+            ]
+        },
+        {
+            "name": "Microsoft.Azure.Monitor.AzureMonitorLinuxAgent",
+            "version": "1.9.1",
+            "location": "https://zrdfepirv2cbn04prdstr01a.blob.core.windows.net/a47f0806d764480a8d989d009c75007d/Microsoft.Azure.Monitor_AzureMonitorLinuxAgent_useast2euap_manifest.xml",
+            "state": "enabled",
+            "autoUpgrade": true,
+            "runAsStartupTask": false,
+            "isJson": true,
+            "useExactVersion": true,
+            "settingsSeqNo": 0,
+            "settings": [
+                {
+                    "protectedSettingsCertThumbprint": "4C4F304667711036E64AF4894B76EB208A863BD4",
+                    "protectedSettings": "MIIBsAYJKoZIhvcNAQcDoIIBoTCCAZ0CAQAxggFpMIIBZQIBADBNMDkxNzA1BgoJkiaJk/IsZAEZFidXaW5kb3dzIEF6dXJlIENSUCBDZXJ0aWZpY2F0ZSBHZW5lcmF0b3ICEFpB/HKM/7evRk+DBz754wUwDQYJKoZIhvcNAQEBBQAEggEADPJwniDeIUXzxNrZCloitFdscQ59Bz1dj9DLBREAiM8jmxM0LLicTJDUv272Qm/4ZQgdqpFYBFjGab/9MX+Ih2x47FkVY1woBkckMaC/QOFv84gbboeQCmJYZC/rZJdh8rCMS+CEPq3uH1PVrvtSdZ9uxnaJ+E4exTPPviIiLIPtqWafNlzdbBt8HZjYaVw+SSe+CGzD2pAQeNttq3Rt/6NjCzrjG8ufKwvRoqnrInMs4x6nnN5/xvobKIBSv4/726usfk8Ug+9Q6Benvfpmre2+1M5PnGTfq78cO3o6mI3cPoBUjp5M0iJjAMGeMt81tyHkimZrEZm6pLa4NQMOEjArBgkqhkiG9w0BBwEwFAYIKoZIhvcNAwcECC5nVaiJaWt+gAhgeYvxUOYHXw==",
+                    "publicSettings": "{\"GCS_AUTO_CONFIG\":true}"
+                }
+            ]
+        },
+        {
+            "name": "Microsoft.Azure.Security.Monitoring.AzureSecurityLinuxAgent",
+            "version": "2.15.112",
+            "location": "https://zrdfepirv2cbn04prdstr01a.blob.core.windows.net/4ef06ad957494df49c807a5334f2b5d2/Microsoft.Azure.Security.Monitoring_AzureSecurityLinuxAgent_useast2euap_manifest.xml",
+            "state": "enabled",
+            "autoUpgrade": true,
+            "runAsStartupTask": false,
+            "isJson": true,
+            "useExactVersion": true,
+            "settingsSeqNo": 0,
+            "settings": [
+                {
+                    "protectedSettingsCertThumbprint": "4C4F304667711036E64AF4894B76EB208A863BD4",
+                    "protectedSettings": "MIIBsAYJKoZIhvcNAQcDoIIBoTCCAZ0CAQAxggFpMIIBZQIBADBNMDkxNzA1BgoJkiaJk/IsZAEZFidXaW5kb3dzIEF6dXJlIENSUCBDZXJ0aWZpY2F0ZSBHZW5lcmF0b3ICEFpB/HKM/7evRk+DBz754wUwDQYJKoZIhvcNAQEBBQAEggEADPJwniDeIUXzxNrZCloitFdscQ59Bz1dj9DLBREAiM8jmxM0LLicTJDUv272Qm/4ZQgdqpFYBFjGab/9MX+Ih2x47FkVY1woBkckMaC/QOFv84gbboeQCmJYZC/rZJdh8rCMS+CEPq3uH1PVrvtSdZ9uxnaJ+E4exTPPviIiLIPtqWafNlzdbBt8HZjYaVw+SSe+CGzD2pAQeNttq3Rt/6NjCzrjG8ufKwvRoqnrInMs4x6nnN5/xvobKIBSv4/726usfk8Ug+9Q6Benvfpmre2+1M5PnGTfq78cO3o6mI3cPoBUjp5M0iJjAMGeMt81tyHkimZrEZm6pLa4NQMOEjArBgkqhkiG9w0BBwEwFAYIKoZIhvcNAwcECC5nVaiJaWt+gAhgeYvxUOYHXw==",
+                    "publicSettings": "{\"enableGenevaUpload\":true}"
+                }
+            ]
+        },
+        {
+            "name": "Microsoft.CPlat.Core.RunCommandLinux",
+            "version": "1.0.1",
+            "location": "https://umsahsv3lrjswx2ggpxc.blob.core.windows.net/4beefb67-5a1e-aa37-7ede-3180ba34ba0d/4beefb67-5a1e-aa37-7ede-3180ba34ba0d_manifest.xml",
+            "state": "enabled",
+            "autoUpgrade": true,
+            "runAsStartupTask": false,
+            "isJson": true,
+            "useExactVersion": true,
+            "settingsSeqNo": 2,
+            "settings": [
+                {
+                    "protectedSettingsCertThumbprint": "4C4F304667711036E64AF4894B76EB208A863BD4",
+                    "protectedSettings": "MIIBsAYJKoZIhvcNAQcDoIIBoTCCAZ0CAQAxggFpMIIBZQIBADBNMDkxNzA1BgoJkiaJk/IsZAEZFidXaW5kb3dzIEF6dXJlIENSUCBDZXJ0aWZpY2F0ZSBHZW5lcmF0b3ICEFpB/HKM/7evRk+DBz754wUwDQYJKoZIhvcNAQEBBQAEggEADPJwniDeIUXzxNrZCloitFdscQ59Bz1dj9DLBREAiM8jmxM0LLicTJDUv272Qm/4ZQgdqpFYBFjGab/9MX+Ih2x47FkVY1woBkckMaC/QOFv84gbboeQCmJYZC/rZJdh8rCMS+CEPq3uH1PVrvtSdZ9uxnaJ+E4exTPPviIiLIPtqWafNlzdbBt8HZjYaVw+SSe+CGzD2pAQeNttq3Rt/6NjCzrjG8ufKwvRoqnrInMs4x6nnN5/xvobKIBSv4/726usfk8Ug+9Q6Benvfpmre2+1M5PnGTfq78cO3o6mI3cPoBUjp5M0iJjAMGeMt81tyHkimZrEZm6pLa4NQMOEjArBgkqhkiG9w0BBwEwFAYIKoZIhvcNAwcECC5nVaiJaWt+gAhgeYvxUOYHXw==",
+                    "publicSettings": "{}"
+                }
+            ]
+        }
+    ]
+}

--- a/tests/data/hostgaplugin/vm_settings.json
+++ b/tests/data/hostgaplugin/vm_settings.json
@@ -1,21 +1,15 @@
 {
-    "activityId": "b3f493e2-cab8-487d-820a-5718504f2f3f",
-    "correlationId": "4f4939fb-35e6-411f-98f1-aeaf8796ed30",
-    "extensionsLastModifiedTickCount": 637629365237217593,
+    "activityId": "c86d8064-6f11-4145-8178-e0587e0584de",
+    "correlationId": "6609dcb1-fccc-474a-9a59-8bd71ba06983",
+    "extensionsLastModifiedTickCount": 637632862319659103,
     "inVMMetadata": {
-        "subscriptionId": "a53f7094-a16c-47af-abe4-b05c05d0d79a",
-        "resourceGroupName": "narrieta-rg",
-        "vmName": "nam-canary",
-        "location": "EastUS2EUAP",
-        "vmId": "fc9e847a-29fd-4ca8-a5ae-59e581425ca7",
-        "vmSize": "Standard_DS1_v2",
-        "osType": "Linux",
-        "vmImage": {
-            "publisher": "Canonical",
-            "offer": "UbuntuServer",
-            "sku": "18.04-LTS",
-            "version": "18.04.202104150"
-        }
+        "subscriptionId": "8e037ad4-618f-4466-8bc8-5099d41ac15b",
+        "resourceGroupName": "rg-dc-ht3rnxw",
+        "vmName": "edpymvazsh",
+        "location": "CentralUSEUAP",
+        "vmId": "ba323e38-2145-4cb9-8cbf-778c7824bc9e",
+        "vmSize": "Standard_D2s_v3",
+        "osType": "Linux"
     },
     "requiredFeatures": [
         {
@@ -34,26 +28,9 @@
     ],
     "extensionGoalStates": [
         {
-            "name": "Microsoft.Azure.Extensions.customScript",
+            "name": "Microsoft.Azure.Extensions.CustomScript",
             "version": "2.1.3",
-            "location": "https://zrdfepirv2cbn04prdstr01a.blob.core.windows.net/708cdbbfb9ad4802ac80a012992930b1/Microsoft.Azure.Extensions_CustomScript_useast2euap_manifest.xml",
-            "state": "enabled",
-            "autoUpgrade": true,
-            "runAsStartupTask": false,
-            "isJson": true,
-            "useExactVersion": true,
-            "settingsSeqNo": 1,
-            "settings": [
-                {
-                    "protectedSettingsCertThumbprint": "4C4F304667711036E64AF4894B76EB208A863BD4",
-                    "protectedSettings": "MIIBsAYJKoZIhvcNAQcDoIIBoTCCAZ0CAQAxggFpMIIBZQIBADBNMDkxNzA1BgoJkiaJk/IsZAEZFidXaW5kb3dzIEF6dXJlIENSUCBDZXJ0aWZpY2F0ZSBHZW5lcmF0b3ICEFpB/HKM/7evRk+DBz754wUwDQYJKoZIhvcNAQEBBQAEggEADPJwniDeIUXzxNrZCloitFdscQ59Bz1dj9DLBREAiM8jmxM0LLicTJDUv272Qm/4ZQgdqpFYBFjGab/9MX+Ih2x47FkVY1woBkckMaC/QOFv84gbboeQCmJYZC/rZJdh8rCMS+CEPq3uH1PVrvtSdZ9uxnaJ+E4exTPPviIiLIPtqWafNlzdbBt8HZjYaVw+SSe+CGzD2pAQeNttq3Rt/6NjCzrjG8ufKwvRoqnrInMs4x6nnN5/xvobKIBSv4/726usfk8Ug+9Q6Benvfpmre2+1M5PnGTfq78cO3o6mI3cPoBUjp5M0iJjAMGeMt81tyHkimZrEZm6pLa4NQMOEjArBgkqhkiG9w0BBwEwFAYIKoZIhvcNAwcECC5nVaiJaWt+gAhgeYvxUOYHXw=="
-                }
-            ]
-        },
-        {
-            "name": "Microsoft.Azure.Monitor.AzureMonitorLinuxAgent",
-            "version": "1.9.1",
-            "location": "https://zrdfepirv2cbn04prdstr01a.blob.core.windows.net/a47f0806d764480a8d989d009c75007d/Microsoft.Azure.Monitor_AzureMonitorLinuxAgent_useast2euap_manifest.xml",
+            "location": "https://zrdfepirv2cdm03prdstr01a.blob.core.windows.net/708cdbbfb9ad4802ac80a012992930b1/Microsoft.Azure.Extensions_CustomScript_uscentraleuap_manifest.xml",
             "state": "enabled",
             "autoUpgrade": true,
             "runAsStartupTask": false,
@@ -62,45 +39,37 @@
             "settingsSeqNo": 0,
             "settings": [
                 {
-                    "protectedSettingsCertThumbprint": "4C4F304667711036E64AF4894B76EB208A863BD4",
-                    "protectedSettings": "MIIBsAYJKoZIhvcNAQcDoIIBoTCCAZ0CAQAxggFpMIIBZQIBADBNMDkxNzA1BgoJkiaJk/IsZAEZFidXaW5kb3dzIEF6dXJlIENSUCBDZXJ0aWZpY2F0ZSBHZW5lcmF0b3ICEFpB/HKM/7evRk+DBz754wUwDQYJKoZIhvcNAQEBBQAEggEADPJwniDeIUXzxNrZCloitFdscQ59Bz1dj9DLBREAiM8jmxM0LLicTJDUv272Qm/4ZQgdqpFYBFjGab/9MX+Ih2x47FkVY1woBkckMaC/QOFv84gbboeQCmJYZC/rZJdh8rCMS+CEPq3uH1PVrvtSdZ9uxnaJ+E4exTPPviIiLIPtqWafNlzdbBt8HZjYaVw+SSe+CGzD2pAQeNttq3Rt/6NjCzrjG8ufKwvRoqnrInMs4x6nnN5/xvobKIBSv4/726usfk8Ug+9Q6Benvfpmre2+1M5PnGTfq78cO3o6mI3cPoBUjp5M0iJjAMGeMt81tyHkimZrEZm6pLa4NQMOEjArBgkqhkiG9w0BBwEwFAYIKoZIhvcNAwcECC5nVaiJaWt+gAhgeYvxUOYHXw==",
-                    "publicSettings": "{\"GCS_AUTO_CONFIG\":true}"
+                    "publicSettings": "{\"commandToExecute\":\"echo '26c8d804-6d2e-4da1-ab5b-629ad733b3bb'\"}"
                 }
             ]
         },
         {
-            "name": "Microsoft.Azure.Security.Monitoring.AzureSecurityLinuxAgent",
-            "version": "2.15.112",
-            "location": "https://zrdfepirv2cbn04prdstr01a.blob.core.windows.net/4ef06ad957494df49c807a5334f2b5d2/Microsoft.Azure.Security.Monitoring_AzureSecurityLinuxAgent_useast2euap_manifest.xml",
+            "name": "Microsoft.CPlat.Core.RunCommandHandlerLinux",
+            "version": "1.2.0",
+            "location": "https://umsavbvncrpzbnxmxzmr.blob.core.windows.net/f4086d41-69f9-3103-78e0-8a2c7e789d0f/f4086d41-69f9-3103-78e0-8a2c7e789d0f_manifest.xml",
             "state": "enabled",
             "autoUpgrade": true,
             "runAsStartupTask": false,
             "isJson": true,
             "useExactVersion": true,
-            "settingsSeqNo": 0,
             "settings": [
                 {
-                    "protectedSettingsCertThumbprint": "4C4F304667711036E64AF4894B76EB208A863BD4",
-                    "protectedSettings": "MIIBsAYJKoZIhvcNAQcDoIIBoTCCAZ0CAQAxggFpMIIBZQIBADBNMDkxNzA1BgoJkiaJk/IsZAEZFidXaW5kb3dzIEF6dXJlIENSUCBDZXJ0aWZpY2F0ZSBHZW5lcmF0b3ICEFpB/HKM/7evRk+DBz754wUwDQYJKoZIhvcNAQEBBQAEggEADPJwniDeIUXzxNrZCloitFdscQ59Bz1dj9DLBREAiM8jmxM0LLicTJDUv272Qm/4ZQgdqpFYBFjGab/9MX+Ih2x47FkVY1woBkckMaC/QOFv84gbboeQCmJYZC/rZJdh8rCMS+CEPq3uH1PVrvtSdZ9uxnaJ+E4exTPPviIiLIPtqWafNlzdbBt8HZjYaVw+SSe+CGzD2pAQeNttq3Rt/6NjCzrjG8ufKwvRoqnrInMs4x6nnN5/xvobKIBSv4/726usfk8Ug+9Q6Benvfpmre2+1M5PnGTfq78cO3o6mI3cPoBUjp5M0iJjAMGeMt81tyHkimZrEZm6pLa4NQMOEjArBgkqhkiG9w0BBwEwFAYIKoZIhvcNAwcECC5nVaiJaWt+gAhgeYvxUOYHXw==",
-                    "publicSettings": "{\"enableGenevaUpload\":true}"
-                }
-            ]
-        },
-        {
-            "name": "Microsoft.CPlat.Core.RunCommandLinux",
-            "version": "1.0.1",
-            "location": "https://umsahsv3lrjswx2ggpxc.blob.core.windows.net/4beefb67-5a1e-aa37-7ede-3180ba34ba0d/4beefb67-5a1e-aa37-7ede-3180ba34ba0d_manifest.xml",
-            "state": "enabled",
-            "autoUpgrade": true,
-            "runAsStartupTask": false,
-            "isJson": true,
-            "useExactVersion": true,
-            "settingsSeqNo": 2,
-            "settings": [
+                    "publicSettings": "{\"source\":{\"script\":\"echo '571bbcda-2992-4417-a65c-eaad1832c1f9'\"}}",
+                    "seqNo": 0,
+                    "extensionName": "MCExt1",
+                    "extensionState": "enabled"
+                },
                 {
-                    "protectedSettingsCertThumbprint": "4C4F304667711036E64AF4894B76EB208A863BD4",
-                    "protectedSettings": "MIIBsAYJKoZIhvcNAQcDoIIBoTCCAZ0CAQAxggFpMIIBZQIBADBNMDkxNzA1BgoJkiaJk/IsZAEZFidXaW5kb3dzIEF6dXJlIENSUCBDZXJ0aWZpY2F0ZSBHZW5lcmF0b3ICEFpB/HKM/7evRk+DBz754wUwDQYJKoZIhvcNAQEBBQAEggEADPJwniDeIUXzxNrZCloitFdscQ59Bz1dj9DLBREAiM8jmxM0LLicTJDUv272Qm/4ZQgdqpFYBFjGab/9MX+Ih2x47FkVY1woBkckMaC/QOFv84gbboeQCmJYZC/rZJdh8rCMS+CEPq3uH1PVrvtSdZ9uxnaJ+E4exTPPviIiLIPtqWafNlzdbBt8HZjYaVw+SSe+CGzD2pAQeNttq3Rt/6NjCzrjG8ufKwvRoqnrInMs4x6nnN5/xvobKIBSv4/726usfk8Ug+9Q6Benvfpmre2+1M5PnGTfq78cO3o6mI3cPoBUjp5M0iJjAMGeMt81tyHkimZrEZm6pLa4NQMOEjArBgkqhkiG9w0BBwEwFAYIKoZIhvcNAwcECC5nVaiJaWt+gAhgeYvxUOYHXw==",
-                    "publicSettings": "{}"
+                    "publicSettings": "{\"source\":{\"script\":\"echo '58d6ac9d-9ef3-400a-99d7-1c3b5451eef6'\"}}",
+                    "seqNo": 0,
+                    "extensionName": "MCExt2",
+                    "extensionState": "enabled"
+                },
+                {
+                    "publicSettings": "{\"source\":{\"script\":\"echo '834cad38-9eec-483e-946d-f713cafc3da8'\"}}",
+                    "seqNo": 0,
+                    "extensionName": "MCExt3",
+                    "extensionState": "enabled"
                 }
             ]
         }

--- a/tests/ga/test_update.py
+++ b/tests/ga/test_update.py
@@ -47,7 +47,7 @@ from azurelinuxagent.ga.update import GuestAgent, GuestAgentError, MAX_FAILURE, 
 from tests.protocol.mocks import mock_wire_protocol
 from tests.protocol.mockwiredata import DATA_FILE, DATA_FILE_MULTIPLE_EXT
 from tests.tools import AgentTestCase, data_dir, DEFAULT, patch, load_bin_data, load_data, Mock, MagicMock, \
-    clear_singleton_instances, mock_sleep, skip_if_predicate_true
+    clear_singleton_instances, mock_sleep
 from tests.protocol import mockwiredata
 from tests.protocol.mocks import HttpRequestPredicates
 
@@ -1907,29 +1907,23 @@ class TryUpdateGoalStateTestCase(HttpRequestPredicates, AgentTestCase):
             update_handler = get_update_handler()
             self.assertFalse(update_handler._try_update_goal_state(protocol), "try_update_goal_state should have failed")
 
-    @skip_if_predicate_true(lambda: True, "TODO: Enable this test once we start retrieving the ExtensionsGoalState (vmSettings)")
     def test_it_should_update_the_goal_state(self):
         update_handler = get_update_handler()
         with mock_wire_protocol(mockwiredata.DATA_FILE) as protocol:
             protocol.mock_wire_data.set_incarnation(12345)
-            protocol.mock_wire_data.set_etag('54321')
 
             # the first goal state should produce an update
             update_handler._try_update_goal_state(protocol)
             self.assertEqual(protocol.get_incarnation(), '12345', "The goal state was not updated (received unexpected incarnation)")
-            self.assertEqual(protocol.get_etag(), '54321', "The extensions goal state was not updated (received unexpected ETag)")
 
             # no changes in the goal state should not produce an update
             update_handler._try_update_goal_state(protocol)
             self.assertEqual(protocol.get_incarnation(), '12345', "The goal state should not be updated (received unexpected incarnation)")
-            self.assertEqual(protocol.get_etag(), '54321', "The extensions goal state should not be updated (received unexpected ETag)")
 
             # a new  goal state should produce an update
             protocol.mock_wire_data.set_incarnation(6789)
-            protocol.mock_wire_data.set_etag('9876')
             update_handler._try_update_goal_state(protocol)
             self.assertEqual(protocol.get_incarnation(), '6789', "The goal state was not updated (received unexpected incarnation)")
-            self.assertEqual(protocol.get_etag(), '9876', "The extensions goal state was not updated (received unexpected ETag)")
 
     def test_it_should_log_errors_only_when_the_error_state_changes(self):
         with mock_wire_protocol(mockwiredata.DATA_FILE) as protocol:

--- a/tests/protocol/mockwiredata.py
+++ b/tests/protocol/mockwiredata.py
@@ -112,7 +112,12 @@ DATA_FILE_REQUIRED_FEATURES = DATA_FILE.copy()
 DATA_FILE_REQUIRED_FEATURES["ext_conf"] = "wire/ext_conf_required_features.xml"
 
 DATA_FILE_VM_SETTINGS = DATA_FILE.copy()
+DATA_FILE_VM_SETTINGS["vm_settings"] = "hostgaplugin/vm_settings.json"
 DATA_FILE_VM_SETTINGS["ext_conf"] = "hostgaplugin/ext_conf.xml"
+
+DATA_FILE_VM_SETTINGS_PROTECTED_SETTINGS = DATA_FILE.copy()
+DATA_FILE_VM_SETTINGS_PROTECTED_SETTINGS["vm_settings"] = "hostgaplugin/vm_settings-protected_settings.json"
+DATA_FILE_VM_SETTINGS_PROTECTED_SETTINGS["ext_conf"] = "hostgaplugin/ext_conf-protected_settings.xml"
 
 class WireProtocolData(object):
     def __init__(self, data_files=None):

--- a/tests/protocol/test_wire.py
+++ b/tests/protocol/test_wire.py
@@ -1075,7 +1075,7 @@ class UpdateGoalStateTestCase(AgentTestCase):
                 '''
 
                 if forced:
-                    protocol.client.update_goal_state(forced=True)
+                    protocol.client.update_goal_state(force_update=True)
                 else:
                     protocol.client.update_goal_state()
 
@@ -1090,7 +1090,7 @@ class UpdateGoalStateTestCase(AgentTestCase):
                 self.assertEqual(protocol.client.get_host_plugin().container_id, new_container_id)
                 self.assertEqual(protocol.client.get_host_plugin().role_config_name, new_role_config_name)
 
-    def test_non_forced_update_should_not_update_the_goal_state_nor_the_host_plugin_when_the_incarnation_does_not_change(self):
+    def test_non_forced_update_should_not_update_the_goal_state_but_should_update_the_host_plugin_when_the_incarnation_does_not_change(self):
         with mock_wire_protocol(mockwiredata.DATA_FILE) as protocol:
             protocol.client.get_host_plugin()
 
@@ -1098,11 +1098,11 @@ class UpdateGoalStateTestCase(AgentTestCase):
             # goal state and then change those fields.
             goal_state = protocol.client.get_goal_state().xml_text
             shared_conf = protocol.client.get_shared_conf().xml_text
-            container_id = protocol.client.get_host_plugin().container_id
-            role_config_name = protocol.client.get_host_plugin().role_config_name
 
-            protocol.mock_wire_data.set_container_id(str(uuid.uuid4()))
-            protocol.mock_wire_data.set_role_config_name(str(uuid.uuid4()))
+            new_container_id = str(uuid.uuid4())
+            new_role_config_name = str(uuid.uuid4())
+            protocol.mock_wire_data.set_container_id(new_container_id)
+            protocol.mock_wire_data.set_role_config_name(new_role_config_name)
             protocol.mock_wire_data.shared_config = WireProtocolData.replace_xml_attribute_value(
                 protocol.mock_wire_data.shared_config, "Deployment", "name", str(uuid.uuid4()))
 
@@ -1111,8 +1111,8 @@ class UpdateGoalStateTestCase(AgentTestCase):
             self.assertEqual(protocol.client.get_goal_state().xml_text, goal_state)
             self.assertEqual(protocol.client.get_shared_conf().xml_text, shared_conf)
 
-            self.assertEqual(protocol.client.get_host_plugin().container_id, container_id)
-            self.assertEqual(protocol.client.get_host_plugin().role_config_name, role_config_name)
+            self.assertEqual(protocol.client.get_host_plugin().container_id, new_container_id)
+            self.assertEqual(protocol.client.get_host_plugin().role_config_name, new_role_config_name)
 
     def test_forced_update_should_update_the_goal_state_and_the_host_plugin_when_the_incarnation_does_not_change(self):
         with mock_wire_protocol(mockwiredata.DATA_FILE) as protocol:
@@ -1129,7 +1129,7 @@ class UpdateGoalStateTestCase(AgentTestCase):
             protocol.mock_wire_data.set_role_config_name(new_role_config_name)
             protocol.mock_wire_data.shared_config = new_shared_conf
 
-            protocol.client.update_goal_state(forced=True)
+            protocol.client.update_goal_state(force_update=True)
 
             self.assertEqual(protocol.client.get_goal_state().incarnation, incarnation)
             self.assertEqual(protocol.client.get_shared_conf().xml_text, new_shared_conf)


### PR DESCRIPTION
I did some refactoring on the logic to update the goal state. Before fast track it was a simple check on incarnation. Fast track requires additional logic; I'll complete that logic on a separate PR, for now I am moving the current logic from GoalState to WireClient.

In addition, with this PR now we query the vmSettings on each iteration of the main loop.

Lastly, I updated the test data files for vmSettings to include data for Multi-Config Extensions.