### PR TITLE
Retrieve full goal state explicitly

### DIFF
--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -301,7 +301,7 @@ class UpdateHandler(object):
             # call ensures the required info is initialized (e.g telemetry depends on the container ID.)
             #
             protocol = self.protocol_util.get_protocol()
-            protocol.client.update_goal_state()
+            protocol.client.update_goal_state(force_update=True)
 
             # Initialize the common parameters for telemetry events
             initialize_event_logger_vminfo_common_parameters(protocol)


### PR DESCRIPTION
UpdateHandler.run() always fetches a full goal state, since it makes the first call to update_goal_state in the extension handler process. I made the call to update_goal_state  to explicitly request a full goal state.

A couple of unit tests failed since the make multiple calls to run() using the same instance of UpdateHandler, so they were never retrieving the full goal state after the first call. Reusing the same instance of the UpdateHandler would never happen in the actual agent.