### PR TITLE
Change format of debug info for test_run_latest

### DIFF
--- a/tests/ga/test_update.py
+++ b/tests/ga/test_update.py
@@ -1111,7 +1111,7 @@ class TestUpdate(UpdateTestCase):
             with patch('time.time', side_effect=mock_time.time):
                 with patch('time.sleep', side_effect=mock_time.sleep):
                     self.update_handler.run_latest(child_args=child_args)
-                    self.assertEqual(3, mock_popen.call_count, "Expected a single call to the latest agent; got: {0}".format(mock_popen.call_args_list))
+                    self.assertEqual(1, mock_popen.call_count, "Expected a single call to the latest agent; got: {0}".format(mock_popen.call_args_list))
 
                     return mock_popen.call_args
 

--- a/tests/ga/test_update.py
+++ b/tests/ga/test_update.py
@@ -1111,7 +1111,7 @@ class TestUpdate(UpdateTestCase):
             with patch('time.time', side_effect=mock_time.time):
                 with patch('time.sleep', side_effect=mock_time.sleep):
                     self.update_handler.run_latest(child_args=child_args)
-                    self.assertEqual(1, mock_popen.call_count, "Expected a single call to the latest agent; got: {0}".format([call.args for call in mock_popen.call_args_list]))
+                    self.assertEqual(3, mock_popen.call_count, "Expected a single call to the latest agent; got: {0}".format(mock_popen.call_args_list))
 
                     return mock_popen.call_args
 


### PR DESCRIPTION
The previous formatting does not work on python 2 (formats as "args"). The new format is harder to read, but formats OK on 2 & 3.