### PR TITLE
Use Debug conf parameter for agent's CPU quota

### DIFF
--- a/azurelinuxagent/common/cgroupconfigurator.py
+++ b/azurelinuxagent/common/cgroupconfigurator.py
@@ -94,7 +94,6 @@ _AGENT_DROP_IN_FILE_CPU_QUOTA_CONTENTS_FORMAT = """
 [Service]
 CPUQuota={0}
 """
-_AGENT_CPU_QUOTA = 5
 _AGENT_THROTTLED_TIME_THRESHOLD = 120  # 2 minutes
 
 
@@ -424,7 +423,7 @@ class CGroupConfigurator(object):
             if not self.supported():
                 raise CGroupsException("Attempted to enable cgroups, but they are not supported on the current platform")
             self._cgroups_enabled = True
-            self.__set_cpu_quota(_AGENT_CPU_QUOTA)
+            self.__set_cpu_quota(conf.get_agent_cpu_quota())
 
         def disable(self, reason):
             self._cgroups_enabled = False

--- a/azurelinuxagent/common/conf.py
+++ b/azurelinuxagent/common/conf.py
@@ -182,6 +182,7 @@ __INTEGER_OPTIONS__ = {
     # versions of the Agent.
     #
     "Debug.CgroupCheckPeriod": 300,
+    "Debug.AgentCpuQuota": 100,
 }
 
 
@@ -531,6 +532,14 @@ def get_cgroup_disable_on_quota_check_failure(conf=__conf__):
     NOTE: This option is experimental and may be removed in later versions of the Agent.
     """
     return conf.get_switch("Debug.CgroupDisableOnQuotaCheckFailure", True)
+
+def get_agent_cpu_quota(conf=__conf__):
+    """
+    CPU quota for the agent as a percentage of 1 CPU (100% == 1 CPU)
+
+    NOTE: This option is experimental and may be removed in later versions of the Agent.
+    """
+    return conf.get_switch("Debug.AgentCpuQuota", 100)
 
 def get_enable_fast_track(conf=__conf__):
     """

--- a/azurelinuxagent/common/conf.py
+++ b/azurelinuxagent/common/conf.py
@@ -539,7 +539,7 @@ def get_agent_cpu_quota(conf=__conf__):
 
     NOTE: This option is experimental and may be removed in later versions of the Agent.
     """
-    return conf.get_switch("Debug.AgentCpuQuota", 100)
+    return conf.get_int("Debug.AgentCpuQuota", 100)
 
 def get_enable_fast_track(conf=__conf__):
     """

--- a/tests/common/test_cgroupconfigurator.py
+++ b/tests/common/test_cgroupconfigurator.py
@@ -28,8 +28,9 @@ import threading
 
 from nose.plugins.attrib import attr
 
+from azurelinuxagent.common import conf
 from azurelinuxagent.common.cgroup import AGENT_NAME_TELEMETRY, MetricsCounter, MetricValue, MetricsCategory
-from azurelinuxagent.common.cgroupconfigurator import CGroupConfigurator, _AGENT_THROTTLED_TIME_THRESHOLD, _AGENT_CPU_QUOTA
+from azurelinuxagent.common.cgroupconfigurator import CGroupConfigurator, _AGENT_THROTTLED_TIME_THRESHOLD
 from azurelinuxagent.common.cgroupstelemetry import CGroupsTelemetry
 from azurelinuxagent.common.event import WALAEventOperation
 from azurelinuxagent.common.exception import CGroupsException, ExtensionError, ExtensionErrorCodes
@@ -213,7 +214,7 @@ cgroup on /sys/fs/cgroup/blkio type cgroup (rw,nosuid,nodev,noexec,relatime,blki
 
             configurator.enable()
 
-            expected_quota = "CPUQuota={0}%".format(_AGENT_CPU_QUOTA)
+            expected_quota = "CPUQuota={0}%".format(conf.get_agent_cpu_quota())
             self.assertTrue(os.path.exists(agent_drop_in_file_cpu_quota), "{0} was not created".format(agent_drop_in_file_cpu_quota))
             self.assertTrue(
                 fileutil.findre_in_file(agent_drop_in_file_cpu_quota, expected_quota),

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -29,6 +29,7 @@ EXPECTED_CONFIGURATION = \
 AutoUpdate.GAFamily = Prod
 Autoupdate.Frequency = 3600
 DVD.MountPoint = /mnt/cdrom/secure
+Debug.AgentCpuQuota = 100
 Debug.CgroupCheckPeriod = 300
 Debug.CgroupDisableOnProcessCheckFailure = True
 Debug.CgroupDisableOnQuotaCheckFailure = True


### PR DESCRIPTION
Added Debug.AgentCpuQuota to waagent.conf to set up the value for the agent's CPU quota. Currently it is set to 100% (1 CPU, but automation will change it to 5%)