### PR TITLE
Add support for Flatcar Container Linux

### DIFF
--- a/azurelinuxagent/common/osutil/factory.py
+++ b/azurelinuxagent/common/osutil/factory.py
@@ -81,7 +81,7 @@ def _get_osutil(distro_name, distro_code_name, distro_version, distro_full_name)
     if distro_name == "kali":
         return DebianOSBaseUtil()
 
-    if distro_name == "coreos" or distro_code_name == "coreos":
+    if distro_name in ("flatcar", "coreos") or distro_code_name in ("flatcar", "coreos"):
         return CoreOSUtil()
 
     if distro_name in ("suse", "sle_hpc", "sles", "opensuse"):

--- a/azurelinuxagent/pa/deprovision/factory.py
+++ b/azurelinuxagent/pa/deprovision/factory.py
@@ -35,7 +35,7 @@ def get_deprovision_handler(distro_name=DISTRO_NAME,
             return Ubuntu1804DeprovisionHandler()
         else:
             return UbuntuDeprovisionHandler()
-    if distro_name == "coreos":
+    if distro_name in ("flatcar", "coreos"):
         return CoreOSDeprovisionHandler()
     if "Clear Linux" in distro_full_name:
         return ClearLinuxDeprovisionHandler()  # pylint: disable=E1120

--- a/setup.py
+++ b/setup.py
@@ -123,7 +123,7 @@ def get_data_files(name, version, fullname):  # pylint: disable=R0912
         set_udev_files(data_files)
         set_systemd_files(data_files, dest=systemd_dir_path,
                           src=["init/arch/waagent.service"])
-    elif name == 'coreos':
+    elif name in ('coreos', 'flatcar'):
         set_bin_files(data_files, dest=agent_bin_path)
         set_conf_files(data_files, dest="/usr/share/oem",
                        src=["config/coreos/waagent.conf"])

--- a/tests/common/osutil/test_factory.py
+++ b/tests/common/osutil/test_factory.py
@@ -142,6 +142,12 @@ class TestOsUtilFactory(AgentTestCase):
                           distro_full_name="")
         self.assertTrue(isinstance(ret, CoreOSUtil))
         self.assertEqual(ret.get_service_name(), "waagent")
+        ret = _get_osutil(distro_name="flatcar",
+                          distro_code_name="",
+                          distro_version="",
+                          distro_full_name="")
+        self.assertTrue(isinstance(ret, CoreOSUtil))
+        self.assertEqual(ret.get_service_name(), "waagent")
 
     def test_get_osutil_it_should_return_suse(self):
         ret = _get_osutil(distro_name="suse",

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -452,6 +452,7 @@ supported_distro = [
     ["ubuntu", "15.10", "Snappy Ubuntu Core"],
 
     ["coreos", "", ""],
+    ["flatcar", "", ""],
 
     ["suse", "12", "SUSE Linux Enterprise Server"],
     ["suse", "13.2", "openSUSE"],


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

This adds support Flatcar Container Linux, which is a fork of CoreOS Container Linux, and is compatible with it. We currently [carry a patch in our wa-linux-agent package](https://github.com/flatcar-linux/coreos-overlay/blob/main/app-emulation/wa-linux-agent/files/0001-Support-flatcar.patch), and now I'm trying to upstream it.

I wasn't sure if I also need to update the code in `bin/waagent2.0`, which seems to be an older version of the project, so for now I left it alone. Please let me know if it needs updating too.

<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] If applicable, the PR references the bug/issue that it fixes in the description.
- [x] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [x] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).