### PR TITLE
Do not parse status blob

### DIFF
--- a/azurelinuxagent/common/protocol/extensions_goal_state.py
+++ b/azurelinuxagent/common/protocol/extensions_goal_state.py
@@ -105,10 +105,12 @@ class ExtensionsGoalState(object):
             )
             raise GoalStateMismatchError(message)
 
-        if from_extensions_config.get_status_upload_blob() != from_vm_settings.get_status_upload_blob():
-            raise_error("_status_upload_blob")
-        if from_extensions_config.get_status_upload_blob_type() != from_vm_settings.get_status_upload_blob_type():
-            raise_error("_status_upload_blob_type")
+        # TODO: HostGAPlugin 112 does not include the status blob; enable these checks once we can ensure a newer version is available. Also enable parsing
+        #       in the _ExtensionsGoalStateFromVmSettings.compare() method
+        # if from_extensions_config.get_status_upload_blob() != from_vm_settings.get_status_upload_blob():
+        #     raise_error("_status_upload_blob")
+        # if from_extensions_config.get_status_upload_blob_type() != from_vm_settings.get_status_upload_blob_type():
+        #     raise_error("_status_upload_blob_type")
         if from_extensions_config.get_required_features() != from_vm_settings.get_required_features():
             raise_error("_required_features")
 
@@ -546,7 +548,9 @@ class _ExtensionsGoalStateFromVmSettings(ExtensionsGoalState):
 
     def _parse_vm_settings(self, json_text):
         vm_settings = _CaseFoldedDict.from_dict(json.loads(json_text))
-        self._parse_status_upload_blob(vm_settings)
+        # TODO: HostGAPlugin 112 does not include the status blob; enable parsing once we can ensure a newer version is available. Also enable the check on
+        #       the ExtensionsGoalState.compare() method
+        # self._parse_status_upload_blob(vm_settings)
         self._parse_required_features(vm_settings)
         # TODO: Parse all atttributes
 

--- a/tests/protocol/test_extensions_goal_state.py
+++ b/tests/protocol/test_extensions_goal_state.py
@@ -43,8 +43,9 @@ class ExtensionsGoalStateTestCase(HttpRequestPredicates, AgentTestCase):
         vm_settings_text = fileutil.read_file(os.path.join(data_dir, "hostgaplugin/vm_settings.json"))
         vm_settings = ExtensionsGoalState.create_from_vm_settings("123", vm_settings_text)
 
-        self.assertEqual("https://dcrcqabsr1.blob.core.windows.net/$system/edpxmal5j1.058b176d-445b-4e75-bd97-4911511b7d96.status?sv=2018-03-28&sr=b&sk=system-1&sig=U4KaLxlyYfgQ%2fie8RCwgMBSXa3E4vlW0ozPYOEHikoc%3d&se=9999-01-01T00%3a00%3a00Z&sp=w", vm_settings.get_status_upload_blob(), 'statusUploadBlob.value was not parsed correctly')
-        self.assertEqual("BlockBlob", vm_settings.get_status_upload_blob_type(), 'statusBlobType was not parsed correctly')
+        # TODO: HostGAPlugin 112 does not include the status blob; see TODO in ExtensionsGoalState
+        # self.assertEqual("https://dcrcqabsr1.blob.core.windows.net/$system/edpxmal5j1.058b176d-445b-4e75-bd97-4911511b7d96.status?sv=2018-03-28&sr=b&sk=system-1&sig=U4KaLxlyYfgQ%2fie8RCwgMBSXa3E4vlW0ozPYOEHikoc%3d&se=9999-01-01T00%3a00%3a00Z&sp=w", vm_settings.get_status_upload_blob(), 'statusUploadBlob.value was not parsed correctly')
+        # self.assertEqual("BlockBlob", vm_settings.get_status_upload_blob_type(), 'statusBlobType was not parsed correctly')
         self.assertEqual(["MultipleExtensionsPerHandler"], vm_settings.get_required_features(), 'requiredFeatures was not parsed correctly')
 
 


### PR DESCRIPTION
HostGAPlugin 112 does not include the status blob. This will be enabled on a later release.