### PR TITLE
Improve error message for vmSettings errors

### DIFF
--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -889,10 +889,10 @@ class WireClient(object):
             response_content = self.decode_config(response.read())
             return response_etag, response_content
 
-        except HttpError:
-            raise
         except ProtocolError:
             raise
+        except HttpError as http_error:
+            raise Exception("{0} [correlation ID: {1} eTag: {2}]".format(ustr(http_error), correlation_id, etag))
         except Exception as exception:
             error = textutil.format_exception(exception)  # since this is a generic error, we format the exception to include the traceback
             raise Exception("Error fetching vmSettings [correlation ID: {0} eTag: {1}]: {2}".format(correlation_id, etag, error))

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -889,6 +889,8 @@ class WireClient(object):
             response_content = self.decode_config(response.read())
             return response_etag, response_content
 
+        except HttpError:
+            raise
         except ProtocolError:
             raise
         except Exception as exception:
@@ -1508,11 +1510,12 @@ class _ErrorReporter(object):
         self._operation = operation
         self._error_count = 0
         self._next_period = datetime.now() + _ErrorReporter._Period
+        self._log_message_prefix = "[{0}] [Informational only, the Agent will continue normal operation]".format(self._operation)
 
     def report_error(self, error):
         self._error_count += 1
         if self._error_count <= _ErrorReporter._MaxErrors:
-            logger.info("[{0}] {1}", self._operation, error)
+            logger.info("{0} {1}", self._log_message_prefix, error)
             add_event(op=self._operation, message=error, is_success=False, log_event=False)
 
     def report_summary(self):
@@ -1520,6 +1523,6 @@ class _ErrorReporter(object):
             self._next_period = datetime.now() + _ErrorReporter._Period
             if self._error_count > 0:
                 message = "{0} errors in the last period".format(self._error_count)
-                logger.info("[{0}] {1}", self._operation, message)
+                logger.info("{0} {1}", self._log_message_prefix, message)
                 add_event(op=self._operation, message=message, is_success=False, log_event=False)
                 self._error_count = 0

--- a/tests/protocol/test_wire.py
+++ b/tests/protocol/test_wire.py
@@ -1274,7 +1274,7 @@ class UpdateGoalStateTestCase(HttpRequestPredicates, AgentTestCase):
                 with mock_wire_protocol(mockwiredata.DATA_FILE_VM_SETTINGS) as protocol:
                     protocol.do_not_mock = lambda method, url: method == "GET" and self.is_host_plugin_vm_settings_request(url)
 
-                    def http_get_vm_settings(_method, _host, _relative_url, **kwargs):
+                    def http_get_vm_settings(_method, _host, _relative_url, **_):
                         if isinstance(mock_response, Exception):
                             raise mock_response
                         return mock_response


### PR DESCRIPTION
Removed the traceback from 502 errors, and added a prefix on the local log to emphasize these are just informational errors.

