### PR TITLE
Add EnableFirewall and other required flags to mariner waagent conf

### DIFF
--- a/config/mariner/waagent.conf
+++ b/config/mariner/waagent.conf
@@ -1,6 +1,14 @@
 # Microsoft Azure Linux Agent Configuration
 #
 
+# Enable extension handling. Do not disable this unless you do not need password reset,
+# backup, monitoring, or any extension handling whatsoever.
+Extensions.Enabled=y
+
+# Which provisioning agent to use. Supported values are "auto" (default), "waagent",
+# "cloud-init", or "disabled".
+Provisioning.Agent=auto
+
 # Specified program is invoked with the argument "Ready" when we report ready status
 # to the endpoint server.
 Role.StateConsumer=None
@@ -14,9 +22,6 @@ Role.TopologyConsumer=None
 
 # Enable instance creation
 Provisioning.Enabled=n
-
-# Rely on cloud-init to provision
-Provisioning.UseCloudInit=y
 
 # Password authentication for root account will be unavailable.
 Provisioning.DeleteRootPassword=y
@@ -78,3 +83,6 @@ AutoUpdate.GAFamily=Prod
 # handling until inVMArtifactsProfile.OnHold is false.
 # Default is disabled
 # EnableOverProvisioning=n
+
+# Add firewall rules to protect access to Azure host node services
+OS.EnableFirewall=y


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
Add OS.EnableFirewall, Extensions.Enabled and Provisioning.Agent flags for Mariner distro waagent conf file.
Removing Provisioning.UseCloudInit flag.

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [x] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).