### PR TITLE
Add check for HostGAPlugin version

### DIFF
--- a/azurelinuxagent/common/protocol/extensions_goal_state.py
+++ b/azurelinuxagent/common/protocol/extensions_goal_state.py
@@ -21,6 +21,7 @@ import azurelinuxagent.common.logger as logger
 from azurelinuxagent.common.AgentGlobals import AgentGlobals
 from azurelinuxagent.common.exception import AgentError
 from azurelinuxagent.common.utils import textutil
+from azurelinuxagent.common.utils.flexible_version import FlexibleVersion
 from azurelinuxagent.common.protocol.restapi import ExtHandlerList, VMAgentManifestList
 
 
@@ -108,8 +109,10 @@ class ExtensionsGoalState(object):
         compare_attribute("activity_id")
         compare_attribute("correlation_id")
         compare_attribute("created_on_timestamp")
-        compare_attribute("status_upload_blob")
-        compare_attribute("status_upload_blob_type")
+        # The status blob was added after version 112
+        if from_vm_settings.host_ga_plugin_version > FlexibleVersion("1.0.8.112"):
+            compare_attribute("status_upload_blob")
+            compare_attribute("status_upload_blob_type")
         compare_attribute("required_features")
         compare_attribute("on_hold")
 

--- a/azurelinuxagent/common/protocol/extensions_goal_state_from_vm_settings.py
+++ b/azurelinuxagent/common/protocol/extensions_goal_state_from_vm_settings.py
@@ -21,6 +21,7 @@ import sys
 
 from azurelinuxagent.common.exception import VmSettingsError
 from azurelinuxagent.common.protocol.extensions_goal_state import ExtensionsGoalState
+from azurelinuxagent.common.utils.flexible_version import FlexibleVersion
 from azurelinuxagent.common.utils.textutil import format_exception
 
 
@@ -28,9 +29,9 @@ class ExtensionsGoalStateFromVmSettings(ExtensionsGoalState):
     def __init__(self, etag, json_text):
         super(ExtensionsGoalStateFromVmSettings, self).__init__()
         self._id = etag
-        self._host_ga_plugin_version = None
-        self._schema_version = None
         self._text = json_text
+        self._host_ga_plugin_version = FlexibleVersion()
+        self._schema_version = FlexibleVersion()
         self._activity_id = None
         self._correlation_id = None
         self._created_on_timestamp = None
@@ -48,6 +49,14 @@ class ExtensionsGoalStateFromVmSettings(ExtensionsGoalState):
     @property
     def id(self):
         return self._id
+
+    @property
+    def host_ga_plugin_version(self):
+        return self._host_ga_plugin_version
+
+    @property
+    def schema_version(self):
+        return self._schema_version
 
     @property
     def activity_id(self):
@@ -91,8 +100,12 @@ class ExtensionsGoalStateFromVmSettings(ExtensionsGoalState):
         # TODO: Parse all atttributes
 
     def _parse_simple_attributes(self, vm_settings):
-        self._host_ga_plugin_version = vm_settings.get("hostGAPluginVersion")
-        self._schema_version = vm_settings.get("vmSettingsSchemaVersion")
+        host_ga_plugin_version = vm_settings.get("hostGAPluginVersion")
+        if host_ga_plugin_version is not None:
+            self._host_ga_plugin_version = FlexibleVersion(host_ga_plugin_version)
+        schema_version = vm_settings.get("vmSettingsSchemaVersion")
+        if schema_version is not None:
+            self._schema_version = FlexibleVersion(schema_version)
         self._activity_id = self._string_to_id(vm_settings.get("activityId"))
         self._correlation_id = self._string_to_id(vm_settings.get("correlationId"))
         self._created_on_timestamp = self._ticks_to_utc_timestamp(vm_settings.get("extensionsLastModifiedTickCount"))

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -1337,7 +1337,7 @@ class WireClient(object):
                 etag, vm_settings = self._fetch_vm_settings(None)
                 extensions_goal_state = ExtensionsGoalStateFactory.create_from_vm_settings(etag, vm_settings)
                 message = "HostGAPlugin version: {0}".format(extensions_goal_state.host_ga_plugin_version)
-                logger.warn(message)
+                logger.info(message)
                 add_event(op=WALAEventOperation.HostPlugin, message=message, is_success=True)
             except Exception as exception:
                 message = "Failed to determine the HostGAPlugin version. Error: {0}".format(textutil.format_exception(exception))

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -1332,9 +1332,17 @@ class WireClient(object):
     def get_host_plugin(self):
         if self._host_plugin is None:
             goal_state = GoalState(self)
-            self._set_host_plugin(HostPluginProtocol(self.get_endpoint(),
-                                                     goal_state.container_id,
-                                                     goal_state.role_config_name))
+            self._set_host_plugin(HostPluginProtocol(self.get_endpoint(), goal_state.container_id, goal_state.role_config_name))
+            try:
+                etag, vm_settings = self._fetch_vm_settings(None)
+                extensions_goal_state = ExtensionsGoalStateFactory.create_from_vm_settings(etag, vm_settings)
+                message = "HostGAPlugin version: {0}".format(extensions_goal_state.host_ga_plugin_version)
+                logger.warn(message)
+                add_event(op=WALAEventOperation.HostPlugin, message=message, is_success=True)
+            except Exception as exception:
+                message = "Failed to determine the HostGAPlugin version. Error: {0}".format(textutil.format_exception(exception))
+                logger.warn(message)
+                add_event(op=WALAEventOperation.HostPlugin, message=message, is_success=False, log_event=False)
         return self._host_plugin
 
     def get_on_hold(self):

--- a/tests/data/hostgaplugin/vm_settings.json
+++ b/tests/data/hostgaplugin/vm_settings.json
@@ -1,4 +1,6 @@
 {
+    "hostGAPluginVersion":"1.0.8.115",
+    "vmSettingsSchemaVersion":"0.0",
     "activityId": "2e7f8b5d-f637-4721-b757-cb190d49b4e9",
     "correlationId": "1bef4c48-044e-4225-8f42-1d1eac1eb158",
     "extensionsLastModifiedTickCount": 637693267431616449,


### PR DESCRIPTION
Some of the older versions of the HostGAPlugin do not include the status blob; added check to skip it when comparing against ExtensionsConfig.

Also added telemetry for the HostGAPlugin  version.