### PR TITLE
Parse onHold in vmSettings

### DIFF
--- a/azurelinuxagent/common/protocol/extensions_goal_state_from_vm_settings.py
+++ b/azurelinuxagent/common/protocol/extensions_goal_state_from_vm_settings.py
@@ -30,8 +30,8 @@ class ExtensionsGoalStateFromVmSettings(ExtensionsGoalState):
         super(ExtensionsGoalStateFromVmSettings, self).__init__()
         self._id = etag
         self._text = json_text
-        self._host_ga_plugin_version = FlexibleVersion()
-        self._schema_version = FlexibleVersion()
+        self._host_ga_plugin_version = FlexibleVersion('0.0.0.0')
+        self._schema_version = FlexibleVersion('0.0.0.0')
         self._activity_id = None
         self._correlation_id = None
         self._created_on_timestamp = None
@@ -100,15 +100,21 @@ class ExtensionsGoalStateFromVmSettings(ExtensionsGoalState):
         # TODO: Parse all atttributes
 
     def _parse_simple_attributes(self, vm_settings):
-        host_ga_plugin_version = vm_settings.get("hostGAPluginVersion")
-        if host_ga_plugin_version is not None:
-            self._host_ga_plugin_version = FlexibleVersion(host_ga_plugin_version)
-        schema_version = vm_settings.get("vmSettingsSchemaVersion")
-        if schema_version is not None:
-            self._schema_version = FlexibleVersion(schema_version)
         self._activity_id = self._string_to_id(vm_settings.get("activityId"))
         self._correlation_id = self._string_to_id(vm_settings.get("correlationId"))
         self._created_on_timestamp = self._ticks_to_utc_timestamp(vm_settings.get("extensionsLastModifiedTickCount"))
+
+        host_ga_plugin_version = vm_settings.get("hostGAPluginVersion")
+        if host_ga_plugin_version is not None:
+            self._host_ga_plugin_version = FlexibleVersion(host_ga_plugin_version)
+
+        schema_version = vm_settings.get("vmSettingsSchemaVersion")
+        if schema_version is not None:
+            self._schema_version = FlexibleVersion(schema_version)
+
+        on_hold = vm_settings.get("onHold")
+        if on_hold is not None:
+            self._on_hold = on_hold
 
     def _parse_status_upload_blob(self, vm_settings):
         status_upload_blob = vm_settings.get("statusUploadBlob")

--- a/tests/data/hostgaplugin/in_vm_artifacts_profile.json
+++ b/tests/data/hostgaplugin/in_vm_artifacts_profile.json
@@ -1,0 +1,1 @@
+{ "onHold": true }

--- a/tests/data/hostgaplugin/vm_settings.json
+++ b/tests/data/hostgaplugin/vm_settings.json
@@ -5,6 +5,7 @@
     "correlationId": "1bef4c48-044e-4225-8f42-1d1eac1eb158",
     "extensionsLastModifiedTickCount": 637693267431616449,
     "extensionGoalStatesSource": "Fabric",
+    "onHold": true,
     "StatusUploadBlob": {
         "statusBlobType": "BlockBlob",
         "value": "https://dcrcqabsr1.blob.core.windows.net/$system/edpxmal5j1.058b176d-445b-4e75-bd97-4911511b7d96.status?sv=2018-03-28&sr=b&sk=system-1&sig=U4KaLxlyYfgQ%2fie8RCwgMBSXa3E4vlW0ozPYOEHikoc%3d&se=9999-01-01T00%3a00%3a00Z&sp=w"

--- a/tests/protocol/mockwiredata.py
+++ b/tests/protocol/mockwiredata.py
@@ -114,6 +114,7 @@ DATA_FILE_REQUIRED_FEATURES["ext_conf"] = "wire/ext_conf_required_features.xml"
 DATA_FILE_VM_SETTINGS = DATA_FILE.copy()
 DATA_FILE_VM_SETTINGS["vm_settings"] = "hostgaplugin/vm_settings.json"
 DATA_FILE_VM_SETTINGS["ext_conf"] = "hostgaplugin/ext_conf.xml"
+DATA_FILE_VM_SETTINGS["in_vm_artifacts_profile"] = "hostgaplugin/in_vm_artifacts_profile.json"
 
 DATA_FILE_VM_SETTINGS_PROTECTED_SETTINGS = DATA_FILE.copy()
 DATA_FILE_VM_SETTINGS_PROTECTED_SETTINGS["vm_settings"] = "hostgaplugin/vm_settings-protected_settings.json"
@@ -275,7 +276,7 @@ class WireProtocolData(object):
                 content = self.in_vm_artifacts_profile
                 self.call_counts["in_vm_artifacts_profile"] += 1
             else:
-                raise Exception("Bad url {0}".format(url))
+                raise NotImplementedError(url)
 
         resp.read = Mock(return_value=content.encode("utf-8"))
         resp.getheaders = Mock(return_value=response_headers)
@@ -291,7 +292,7 @@ class WireProtocolData(object):
             self.call_counts['/HealthService'] += 1
             content = ''
         else:
-            raise Exception("Bad url {0}".format(url))
+            raise NotImplementedError(url)
 
         resp.read = Mock(return_value=content.encode("utf-8"))
         return resp
@@ -308,7 +309,7 @@ class WireProtocolData(object):
             self.call_counts['/StatusBlob'] += 1
             self.status_blobs.append(data)
         else:
-            raise Exception("Bad url {0}".format(url))
+            raise NotImplementedError(url)
 
         resp.read = Mock(return_value=content.encode("utf-8"))
         return resp

--- a/tests/protocol/test_extensions_goal_state.py
+++ b/tests/protocol/test_extensions_goal_state.py
@@ -27,7 +27,7 @@ class ExtensionsGoalStateTestCase(AgentTestCase):
             test_property("status_upload_blob",      'MOCK_UPLOAD_BLOB')
             test_property("status_upload_blob_type", 'MOCK_UPLOAD_BLOB_TYPE')
             test_property("required_features",       ['MOCK_REQUIRED_FEATURE'])
-            test_property("on_hold",                 True)
+            test_property("on_hold",                 False)
 
     def test_compare_should_check_the_status_upload_blob_only_when_the_host_ga_plugin_version_is_greater_then_112(self):
         with mock_wire_protocol(mockwiredata.DATA_FILE_VM_SETTINGS) as protocol:

--- a/tests/protocol/test_extensions_goal_state_from_vm_settings.py
+++ b/tests/protocol/test_extensions_goal_state_from_vm_settings.py
@@ -23,7 +23,7 @@ class ExtensionsGoalStateFromVmSettingsTestCase(AgentTestCase):
         assert_property("status_upload_blob", "https://dcrcqabsr1.blob.core.windows.net/$system/edpxmal5j1.058b176d-445b-4e75-bd97-4911511b7d96.status?sv=2018-03-28&sr=b&sk=system-1&sig=U4KaLxlyYfgQ%2fie8RCwgMBSXa3E4vlW0ozPYOEHikoc%3d&se=9999-01-01T00%3a00%3a00Z&sp=w")
         assert_property("status_upload_blob_type", "BlockBlob")
         assert_property("required_features", ["MultipleExtensionsPerHandler"])
-        assert_property("on_hold", False)
+        assert_property("on_hold", True)
 
 
 class CaseFoldedDictionaryTestCase(AgentTestCase):

--- a/tests/protocol/test_hostplugin.py
+++ b/tests/protocol/test_hostplugin.py
@@ -244,6 +244,8 @@ class TestHostPlugin(HttpRequestPredicates, AgentTestCase):
         as part of status upload.
         """
         with self.create_mock_protocol() as wire_protocol:
+            wire.HostPluginProtocol.is_default_channel = False
+
             wire_protocol.update_goal_state()
 
             # act
@@ -276,6 +278,8 @@ class TestHostPlugin(HttpRequestPredicates, AgentTestCase):
         When host plugin returns a 503, we should fall back to the direct channel
         """
         with self.create_mock_protocol() as wire_protocol:
+            wire.HostPluginProtocol.is_default_channel = False
+
             wire_protocol.update_goal_state()
 
             # act
@@ -309,6 +313,8 @@ class TestHostPlugin(HttpRequestPredicates, AgentTestCase):
         When host plugin returns a 410, we should force the goal state update and return
         """
         with self.create_mock_protocol() as wire_protocol:
+            wire.HostPluginProtocol.is_default_channel = False
+
             wire_protocol.update_goal_state()
 
             # act
@@ -342,6 +348,8 @@ class TestHostPlugin(HttpRequestPredicates, AgentTestCase):
         When host plugin returns a 500, and direct fails, we should raise a ProtocolError
         """
         with self.create_mock_protocol() as wire_protocol:
+            wire.HostPluginProtocol.is_default_channel = False
+
             wire_protocol.update_goal_state()
 
             # act


### PR DESCRIPTION
While doing this I also initialized the FlexibleVersions explicitly. Although the default FlexibleVersion is equivalent to version 0.0.0.0, it displays kinda funny. Explicit initialization displays slightly better.
```

>>> f = FlexibleVersion()
>>> f0 = FlexibleVersion('0.0.0.0')
>>> f1 = FlexibleVersion('1.0.0.0')
>>> f.major, f.minor
(0, 0)
>>> f > f1
False
>>> f == f0
True
>>> f
FlexibleVersion ('', '.', ('alpha', 'beta', 'rc'))
>>> f0
FlexibleVersion ('0.0.0.0', '.', ('alpha', 'beta', 'rc'))
```