### PR TITLE
Fix failing cases in DCR v2

### DIFF
--- a/dcr/scenario_utils/test_orchestrator.py
+++ b/dcr/scenario_utils/test_orchestrator.py
@@ -72,7 +72,6 @@ class TestOrchestrator(LoggingHandler):
         The report is dropped in `/home/$(adminUsername)/` directory
         """
         assert file_name.startswith("test-result"), "File name is invalid, it should start with test-result*"
-        load_dotenv()
         admin_username = get_vm_data_from_env().admin_username
         self.__generate_report(os.path.join("/home", admin_username, file_name))
 
@@ -81,8 +80,6 @@ class TestOrchestrator(LoggingHandler):
         return (self.__test_suite.failures + self.__test_suite.errors) > 0
 
     def run_test_and_get_tc(self, test_name, test_func) -> TestCase:
-        stdout = ""
-
         tc = TestCase(test_name, classname=os.environ['SCENARIONAME'])
         start_time = time.time()
         self.log.info("Execute Test: {0}".format(test_name))

--- a/dcr/scenarios/ext-seq-multiple-dependencies/run.py
+++ b/dcr/scenarios/ext-seq-multiple-dependencies/run.py
@@ -1,3 +1,5 @@
+import socket
+
 from dcr.scenario_utils.check_waagent_log import check_waagent_log_for_errors
 from dcr.scenario_utils.test_orchestrator import TestFuncObj, TestOrchestrator
 
@@ -9,5 +11,5 @@ if __name__ == '__main__':
 
     test_orchestrator = TestOrchestrator("ExtSeqDependency-VM", tests=tests)
     test_orchestrator.run_tests()
-    test_orchestrator.generate_report_on_vm("test-result-ext-seq-vm.xml")
+    test_orchestrator.generate_report_on_vm(f"test-result-ext-seq-vm-{socket.gethostname()}.xml")
     assert not test_orchestrator.failed, f"Test Suite: {test_orchestrator.name} failed"

--- a/dcr/scripts/build_agent_zip.sh
+++ b/dcr/scripts/build_agent_zip.sh
@@ -9,7 +9,8 @@
 set -euxo pipefail
 
 version=$(grep '^AGENT_VERSION' "$BUILD_SOURCESDIRECTORY/azurelinuxagent/common/version.py" |  sed "s/.*'\([^']\+\)'.*/\1/")
-echo "##vso[task.setvariable variable=agentVersion]$version"
+# Azure Pipelines adds an extra quote at the end of the variable if we enable bash debugging as it prints an extra line - https://developercommunity.visualstudio.com/t/pipeline-variable-incorrectly-inserts-single-quote/375679
+set +x; echo "##vso[task.setvariable variable=agentVersion]$version"; set -x
 sudo ./makepkg.py
 sudo cp ./eggs/WALinuxAgent-$version.zip "$BUILD_SOURCESDIRECTORY/dcr"
 sudo cp -r ./eggs/WALinuxAgent-$version "$BUILD_SOURCESDIRECTORY/dcr"

--- a/dcr/scripts/get_pypy.sh
+++ b/dcr/scripts/get_pypy.sh
@@ -15,4 +15,7 @@ tar xf "$BUILD_SOURCESDIRECTORY/dcr/pypy.tar.bz2" -C "pypy"
 pypy_path=$(ls -d pypy/*/bin/pypy3)
 rm -rf "pypy.tar.bz2"
 popd
+
+# Azure Pipelines adds an extra quote at the end of the variable if we enable bash debugging as it prints an extra line - https://developercommunity.visualstudio.com/t/pipeline-variable-incorrectly-inserts-single-quote/375679
+set +x
 echo "##vso[task.setvariable variable=pypyPath]/home/$ADMINUSERNAME/dcr/$pypy_path"

--- a/dcr/templates/setup-vm-and-execute-tests.yml
+++ b/dcr/templates/setup-vm-and-execute-tests.yml
@@ -105,9 +105,6 @@ jobs:
 
       - script: |
           printenv > $(Build.SourcesDirectory)/dcr/.env
-
-          # This variable is needed in the Cleanup stage to determine whether to cleanup or not
-          echo '##vso[task.setvariable variable=armDeployed;isOutput=true]true'
         displayName: 'Get all environment variables'
         name: 'setOutputVars'
 


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
- We were not fetching all the reports in case of a VMSS, fixed that
- Some runs used to fail due to an extra quote (`'`) in the variable names. This is a known issue in bash scripts in Azure Pipelines. Fixed that too

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).