### PR TITLE
Dont exit ext-handler if unable to fetch first GS

### DIFF
--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -43,8 +43,7 @@ from azurelinuxagent.common.cgroupconfigurator import CGroupConfigurator
 
 from azurelinuxagent.common.event import add_event, initialize_event_logger_vminfo_common_parameters, \
     WALAEventOperation, EVENTS_DIRECTORY
-from azurelinuxagent.common.exception import ResourceGoneError, UpdateError, ExitException, AgentUpgradeExitException, \
-    ProtocolError
+from azurelinuxagent.common.exception import ResourceGoneError, UpdateError, ExitException, AgentUpgradeExitException
 from azurelinuxagent.common.future import ustr
 from azurelinuxagent.common.osutil import get_osutil, systemd
 from azurelinuxagent.common.protocol.restapi import VMAgentUpdateStatus, VMAgentUpdateStatuses

--- a/tests/ga/test_update.py
+++ b/tests/ga/test_update.py
@@ -1743,30 +1743,26 @@ class TestUpdate(UpdateTestCase):
     def test_it_should_wait_to_fetch_first_goal_state(self):
         with _get_update_handler() as (update_handler, protocol):
             with patch("azurelinuxagent.common.logger.warn") as patch_warn:
-                with patch("azurelinuxagent.common.logger.info") as patch_info:
 
-                    # Fail GS fetching for the 1st 5 times the agent asks for it
-                    update_handler._fail_gs_count = 5
+                # Fail GS fetching for the 1st 5 times the agent asks for it
+                update_handler._fail_gs_count = 5
 
-                    def get_handler(url, **kwargs):
-                        if HttpRequestPredicates.is_goal_state_request(url) and update_handler._fail_gs_count > 0:
-                            update_handler._fail_gs_count -= 1
-                            return MockHttpResponse(status=500)
-                        return protocol.mock_wire_data.mock_http_get(url, **kwargs)
+                def get_handler(url, **kwargs):
+                    if HttpRequestPredicates.is_goal_state_request(url) and update_handler._fail_gs_count > 0:
+                        update_handler._fail_gs_count -= 1
+                        return MockHttpResponse(status=500)
+                    return protocol.mock_wire_data.mock_http_get(url, **kwargs)
 
-                    protocol.set_http_handlers(http_get_handler=get_handler)
-                    update_handler.run(debug=True)
+                protocol.set_http_handlers(http_get_handler=get_handler)
+                update_handler.run(debug=True)
 
         self.assertTrue(update_handler.exit_mock.called, "The process should have exited")
         exit_args, _ = update_handler.exit_mock.call_args
         self.assertEqual(exit_args[0], 0, "Exit code should be 0; List of all warnings logged by the agent: {0}".format(
             patch_warn.call_args_list))
         warn_msgs = [args[0] for (args, _) in patch_warn.call_args_list if
-                     "An error occurred while retrieving the goal state" in args[0]]
+                     "Unable to fetch GS" in args[0]]
         self.assertTrue(len(warn_msgs) > 0, "Error should've been reported when failed to retrieve GS")
-        info_msgs = [args[0] for (args, _) in patch_info.call_args_list if
-                     "Retrieving the goal state recovered from previous errors" in args[0]]
-        self.assertTrue(len(info_msgs) > 0, "Agent should've logged a message when recovered from GS errors")
 
 
 class TestAgentUpgrade(UpdateTestCase):

--- a/tests/ga/test_update.py
+++ b/tests/ga/test_update.py
@@ -1743,26 +1743,30 @@ class TestUpdate(UpdateTestCase):
     def test_it_should_wait_to_fetch_first_goal_state(self):
         with _get_update_handler() as (update_handler, protocol):
             with patch("azurelinuxagent.common.logger.warn") as patch_warn:
+                with patch("azurelinuxagent.common.logger.info") as patch_info:
 
-                # Fail GS fetching for the 1st 5 times the agent asks for it
-                update_handler._fail_gs_count = 5
+                    # Fail GS fetching for the 1st 5 times the agent asks for it
+                    update_handler._fail_gs_count = 5
 
-                def get_handler(url, **kwargs):
-                    if HttpRequestPredicates.is_goal_state_request(url) and update_handler._fail_gs_count > 0:
-                        update_handler._fail_gs_count -= 1
-                        return MockHttpResponse(status=500)
-                    return protocol.mock_wire_data.mock_http_get(url, **kwargs)
+                    def get_handler(url, **kwargs):
+                        if HttpRequestPredicates.is_goal_state_request(url) and update_handler._fail_gs_count > 0:
+                            update_handler._fail_gs_count -= 1
+                            return MockHttpResponse(status=500)
+                        return protocol.mock_wire_data.mock_http_get(url, **kwargs)
 
-                protocol.set_http_handlers(http_get_handler=get_handler)
-                update_handler.run(debug=True)
+                    protocol.set_http_handlers(http_get_handler=get_handler)
+                    update_handler.run(debug=True)
 
         self.assertTrue(update_handler.exit_mock.called, "The process should have exited")
         exit_args, _ = update_handler.exit_mock.call_args
         self.assertEqual(exit_args[0], 0, "Exit code should be 0; List of all warnings logged by the agent: {0}".format(
             patch_warn.call_args_list))
         warn_msgs = [args[0] for (args, _) in patch_warn.call_args_list if
-                     "Unable to fetch GS" in args[0]]
+                     "An error occurred while retrieving the goal state" in args[0]]
         self.assertTrue(len(warn_msgs) > 0, "Error should've been reported when failed to retrieve GS")
+        info_msgs = [args[0] for (args, _) in patch_info.call_args_list if
+                     "Retrieving the goal state recovered from previous errors" in args[0]]
+        self.assertTrue(len(info_msgs) > 0, "Agent should've logged a message when recovered from GS errors")
 
 
 class TestAgentUpgrade(UpdateTestCase):

--- a/tests/ga/test_update.py
+++ b/tests/ga/test_update.py
@@ -44,7 +44,7 @@ from azurelinuxagent.ga.update import GuestAgent, GuestAgentError, MAX_FAILURE, 
     get_update_handler, ORPHAN_POLL_INTERVAL, AGENT_PARTITION_FILE, AGENT_ERROR_FILE, ORPHAN_WAIT_INTERVAL, \
     CHILD_LAUNCH_RESTART_MAX, CHILD_HEALTH_INTERVAL, GOAL_STATE_PERIOD_EXTENSIONS_DISABLED, UpdateHandler, \
     READONLY_FILE_GLOBS, ExtensionsSummary, AgentUpgradeType
-from tests.protocol.mocks import mock_wire_protocol
+from tests.protocol.mocks import mock_wire_protocol, MockHttpResponse
 from tests.protocol.mockwiredata import DATA_FILE, DATA_FILE_MULTIPLE_EXT
 from tests.tools import AgentTestCase, data_dir, DEFAULT, patch, load_bin_data, Mock, MagicMock, \
     clear_singleton_instances, mock_sleep, skip_if_predicate_true
@@ -1739,6 +1739,34 @@ class TestUpdate(UpdateTestCase):
                 update_handler.run(debug=True)
                 for ext_dir in expected_events_dirs:
                     self.assertTrue(os.path.exists(ext_dir), "Extension directory {0} should exist!".format(ext_dir))
+
+    def test_it_should_wait_to_fetch_first_goal_state(self):
+        with _get_update_handler() as (update_handler, protocol):
+            with patch("azurelinuxagent.common.logger.warn") as patch_warn:
+                with patch("azurelinuxagent.common.logger.info") as patch_info:
+
+                    # Fail GS fetching for the 1st 5 times the agent asks for it
+                    update_handler._fail_gs_count = 5
+
+                    def get_handler(url, **kwargs):
+                        if HttpRequestPredicates.is_goal_state_request(url) and update_handler._fail_gs_count > 0:
+                            update_handler._fail_gs_count -= 1
+                            return MockHttpResponse(status=500)
+                        return protocol.mock_wire_data.mock_http_get(url, **kwargs)
+
+                    protocol.set_http_handlers(http_get_handler=get_handler)
+                    update_handler.run(debug=True)
+
+        self.assertTrue(update_handler.exit_mock.called, "The process should have exited")
+        exit_args, _ = update_handler.exit_mock.call_args
+        self.assertEqual(exit_args[0], 0, "Exit code should be 0; List of all warnings logged by the agent: {0}".format(
+            patch_warn.call_args_list))
+        warn_msgs = [args[0] for (args, _) in patch_warn.call_args_list if
+                     "An error occurred while retrieving the goal state" in args[0]]
+        self.assertTrue(len(warn_msgs) > 0, "Error should've been reported when failed to retrieve GS")
+        info_msgs = [args[0] for (args, _) in patch_info.call_args_list if
+                     "Retrieving the goal state recovered from previous errors" in args[0]]
+        self.assertTrue(len(info_msgs) > 0, "Agent should've logged a message when recovered from GS errors")
 
 
 class TestAgentUpgrade(UpdateTestCase):


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
During execution, if we fail to fetch the first GS, we exit the ext-handler which sometimes causes the agent to get blacklisted wrongfully. Modified that logic to make sure we always wait for the 1st GS before proceeding with anything.

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).