### PR TITLE
Parse dependency level in vmSettings

### DIFF
--- a/azurelinuxagent/common/protocol/extensions_goal_state_from_vm_settings.py
+++ b/azurelinuxagent/common/protocol/extensions_goal_state_from_vm_settings.py
@@ -260,15 +260,8 @@ class ExtensionsGoalStateFromVmSettings(ExtensionsGoalState):
         #                 }
         #             ],
         #             "dependsOn": [
-        #                 {
-        #                     "DependsOnExtension": [
-        #                         {
-        #                             "handler": "Microsoft.Azure.Security.Monitoring.AzureSecurityLinuxAgent"
-        #                         }
-        #                     ],
-        #                     "dependencyLevel": 1
-        #                 }
-        #            ]
+        #                 ...
+        #             ]
         #         },
         #         {
         #             "name": "Microsoft.CPlat.Core.RunCommandHandlerLinux",
@@ -304,7 +297,10 @@ class ExtensionsGoalStateFromVmSettings(ExtensionsGoalState):
         #                     "extensionName": "MCExt3",
         #                     "extensionState": "enabled"
         #                 }
-        #             ]
+        #             ],
+        #             "dependsOn": [
+        #                 ...
+        #            ]
         #         }
         #         ...
         #     ]
@@ -372,17 +368,100 @@ class ExtensionsGoalStateFromVmSettings(ExtensionsGoalState):
                 #
                 depends_on = extension_gs.get("dependsOn")
                 if depends_on is not None:
-                    if not isinstance(depends_on, list):
-                        raise Exception('dependsOn should be an array')
-                    if extension.supports_multi_config:
-                        # TODO: Parse dependencies for multi-config extensions
-                        pass
-                    else:
-                        if len(depends_on) != 1:
-                            raise Exception('dependsOn should be an array with exactly one item for single-config extensions')
-                        extension.settings[0].dependencyLevel = depends_on[0]['dependencyLevel']
+                    self._parse_dependency_level(depends_on, extension)
 
                 self._extensions.append(extension)
+
+
+    @staticmethod
+    def _parse_dependency_level(depends_on, extension):
+        # Sample (NOTE: The first sample is single-config, the second multi-config):
+        # {
+        #     ...
+        #     "extensionGoalStates": [
+        #         {
+        #             "name": "Microsoft.Azure.Monitor.AzureMonitorLinuxAgent",
+        #             ...
+        #             "settings": [
+        #                 ...
+        #             ],
+        #             "dependsOn": [
+        #                 {
+        #                     "DependsOnExtension": [
+        #                         {
+        #                             "handler": "Microsoft.Azure.Security.Monitoring.AzureSecurityLinuxAgent"
+        #                         }
+        #                     ],
+        #                     "dependencyLevel": 1
+        #                 }
+        #             ]
+        #         },
+        #         {
+        #             "name": "Microsoft.CPlat.Core.RunCommandHandlerLinux",
+        #             ...
+        #             "isMultiConfig": true,
+        #             "settings": [
+        #                 {
+        #                     ...
+        #                     "extensionName": "MCExt1",
+        #                 },
+        #                 {
+        #                     ...
+        #                     "extensionName": "MCExt2",
+        #                 },
+        #                 {
+        #                     ...
+        #                     "extensionName": "MCExt3",
+        #                 }
+        #             ],
+        #             "dependsOn": [
+        #                 {
+        #                     "dependsOnExtension": [
+        #                         {
+        #                             "extension": "...",
+        #                             "handler": "..."
+        #                         },
+        #                         {
+        #                             "extension": "...",
+        #                             "handler": "..."
+        #                         }
+        #                     ],
+        #                     "dependencyLevel": 2,
+        #                     "name": "MCExt1"
+        #                 },
+        #                 {
+        #                     "dependsOnExtension": [
+        #                         {
+        #                             "extension": "...",
+        #                             "handler": "..."
+        #                         }
+        #                     ],
+        #                     "dependencyLevel": 1,
+        #                     "name": "MCExt2"
+        #                 }
+        #                 ...
+        #             ]
+        #     ...
+        # }
+        if not isinstance(depends_on, list):
+            raise Exception('dependsOn should be an array')
+
+        if not extension.supports_multi_config:
+            # single-config
+            if len(depends_on) != 1:
+                raise Exception('dependsOn should be an array with exactly one item for single-config extensions')
+            extension.settings[0].dependencyLevel = depends_on[0]['dependencyLevel']
+        else:
+            # multi-config
+            settings_by_name = {}
+            for settings in extension.settings:
+                settings_by_name[settings.name] = settings
+
+            for dependency in depends_on:
+                settings = settings_by_name.get(dependency["name"])
+                if settings is None:
+                    raise Exception("Dependency '{0}' does not correspond to any of the settings in the extension (settings: {1})".format(dependency["name"], settings_by_name.keys()))
+                settings.dependencyLevel = dependency["dependencyLevel"]
 
 
 #

--- a/tests/data/hostgaplugin/ext_conf.xml
+++ b/tests/data/hostgaplugin/ext_conf.xml
@@ -89,6 +89,13 @@
 }</RuntimeSettings>
   </Plugin>
   <Plugin name="Microsoft.CPlat.Core.RunCommandHandlerLinux" version="1.2.0">
+    <DependsOn dependencyLevel="2" name="MCExt1">
+      <DependsOnExtension extension="..." handler="..." />
+      <DependsOnExtension extension="..." handler="..." />
+    </DependsOn>
+    <DependsOn dependencyLevel="1" name="MCExt2">
+      <DependsOnExtension extension="..." handler="..." />
+    </DependsOn>
     <ExtensionRuntimeSettings seqNo="0" name="MCExt1" state="enabled">{
   "runtimeSettings": [
     {

--- a/tests/data/hostgaplugin/vm_settings.json
+++ b/tests/data/hostgaplugin/vm_settings.json
@@ -146,6 +146,32 @@
                     "extensionName": "MCExt3",
                     "extensionState": "enabled"
                 }
+            ],
+            "dependsOn": [
+                {
+                    "dependsOnExtension": [
+                        {
+                            "extension": "...",
+                            "handler": "..."
+                        },
+                        {
+                            "extension": "...",
+                            "handler": "..."
+                        }
+                    ],
+                    "dependencyLevel": 2,
+                    "name": "MCExt1"
+                },
+                {
+                    "dependsOnExtension": [
+                        {
+                            "extension": "...",
+                            "handler": "..."
+                        }
+                    ],
+                    "dependencyLevel": 1,
+                    "name": "MCExt2"
+                }
             ]
         }
     ]

--- a/tests/protocol/test_extensions_goal_state_from_vm_settings.py
+++ b/tests/protocol/test_extensions_goal_state_from_vm_settings.py
@@ -36,7 +36,7 @@ class ExtensionsGoalStateFromVmSettingsTestCase(AgentTestCase):
         self.assertEqual("https://zrdfepirv2cdm03prdstr01a.blob.core.windows.net/7d89d439b79f4452950452399add2c90/Microsoft.OSTCLinuxAgent_Prod_uscentraleuap_manifest.xml", vm_settings.agent_manifests[0].uris[0], "Incorrect number of uris.")
 
         # extensions
-        self.assertEqual(4, len(vm_settings.extensions), "Incorrect number of extensions. Got: {0}".format(vm_settings.extensions))
+        self.assertEqual(5, len(vm_settings.extensions), "Incorrect number of extensions. Got: {0}".format(vm_settings.extensions))
         self.assertEqual('Microsoft.Azure.Monitor.AzureMonitorLinuxAgent', vm_settings.extensions[0].name, "Incorrect extension name")
         self.assertEqual(1, len(vm_settings.extensions[0].settings[0].publicSettings), "Incorrect number of public settings")
         self.assertEqual(True, vm_settings.extensions[0].settings[0].publicSettings["GCS_AUTO_CONFIG"], "Incorrect public settings")

--- a/tests/protocol/test_extensions_goal_state_from_vm_settings.py
+++ b/tests/protocol/test_extensions_goal_state_from_vm_settings.py
@@ -25,12 +25,27 @@ class ExtensionsGoalStateFromVmSettingsTestCase(AgentTestCase):
         assert_property("required_features", ["MultipleExtensionsPerHandler"])
         assert_property("on_hold", True)
 
-        # we check only 1 item in each list (but check the length of each list)
+        #
+        # for the rest of the attributes, we check only 1 item in each container (but check the length of the container)
+        #
+
+        # agent manifests
         self.assertEqual(2, len(vm_settings.agent_manifests), "Incorrect number of agent manifests. Got: {0}".format(vm_settings.agent_manifests))
         self.assertEqual("Prod", vm_settings.agent_manifests[0].family, "Incorrect agent family.")
         self.assertEqual(2, len(vm_settings.agent_manifests[0].uris), "Incorrect number of uris. Got: {0}".format(vm_settings.agent_manifests[0].uris))
         self.assertEqual("https://zrdfepirv2cdm03prdstr01a.blob.core.windows.net/7d89d439b79f4452950452399add2c90/Microsoft.OSTCLinuxAgent_Prod_uscentraleuap_manifest.xml", vm_settings.agent_manifests[0].uris[0], "Incorrect number of uris.")
 
+        # extensions
+        self.assertEqual(4, len(vm_settings.extensions), "Incorrect number of extensions. Got: {0}".format(vm_settings.extensions))
+        self.assertEqual('Microsoft.Azure.Monitor.AzureMonitorLinuxAgent', vm_settings.extensions[0].name, "Incorrect extension name")
+        self.assertEqual(1, len(vm_settings.extensions[0].settings[0].publicSettings), "Incorrect number of public settings")
+        self.assertEqual(True, vm_settings.extensions[0].settings[0].publicSettings["GCS_AUTO_CONFIG"], "Incorrect public settings")
+
+        # dependency level (single-config)
+        self.assertEqual(1, vm_settings.extensions[2].settings[0].dependencyLevel, "Incorrect dependency level (single-config)")
+
+        # dependency level (multi-config)
+        self.assertEqual(1, vm_settings.extensions[3].settings[1].dependencyLevel, "Incorrect dependency level (multi-config)")
 
 class CaseFoldedDictionaryTestCase(AgentTestCase):
     def test_it_should_retrieve_items_ignoring_case(self):


### PR DESCRIPTION
I crafted the test data by hand, so some of the values are left unspecified (value "..."). Those values are not relevant to the code that was added, but I will update them once we have end-to-end automation for this feature.