### PR TITLE
Represent empty publicSettings as None (vmSettings)

### DIFF
--- a/azurelinuxagent/common/protocol/extensions_goal_state_from_vm_settings.py
+++ b/azurelinuxagent/common/protocol/extensions_goal_state_from_vm_settings.py
@@ -348,8 +348,10 @@ class ExtensionsGoalStateFromVmSettings(ExtensionsGoalState):
                     for s in settings_list:
                         settings = ExtensionSettings()
                         public_settings = s.get('publicSettings')
-                        settings.publicSettings = {} if public_settings is None else json.loads(public_settings)
-                        # Note that protectedSettings and protectedSettingsCertThumbprint can be None (which would be serialized to the extension's settings file as null)
+                        # Note that publicSettings, protectedSettings and protectedSettingsCertThumbprint can be None; do not change this to, for example,
+                        # empty, since those values are serialized to the extension's status file and extensions may depend on the current implementation
+                        # (for example, no public settings would currently be serialized as '"publicSettings": null')
+                        settings.publicSettings = None if public_settings is None else json.loads(public_settings)
                         settings.protectedSettings = s.get('protectedSettings')
                         thumbprint = s.get('protectedSettingsCertThumbprint')
                         if thumbprint is None and settings.protectedSettings is not None:

--- a/tests/data/hostgaplugin/ext_conf.xml
+++ b/tests/data/hostgaplugin/ext_conf.xml
@@ -46,6 +46,11 @@
       <additionalLocation>https://umsawqtlsshtn5v2nfgh.blob.core.windows.net/f4086d41-69f9-3103-78e0-8a2c7e789d0f/f4086d41-69f9-3103-78e0-8a2c7e789d0f_manifest.xml</additionalLocation>
     </additionalLocations>
   </Plugin>
+  <Plugin name="Microsoft.OSTCExtensions.VMAccessForLinux" version="1.5.11" location="https://umsasc25p0kjg0c1dg4b.blob.core.windows.net/2bbece4f-0283-d415-b034-cc0adc6997a1/2bbece4f-0283-d415-b034-cc0adc6997a1_manifest.xml" state="enabled" autoUpgrade="false" failoverlocation="https://umsamfwlmfshvxx2lsjm.blob.core.windows.net/2bbece4f-0283-d415-b034-cc0adc6997a1/2bbece4f-0283-d415-b034-cc0adc6997a1_manifest.xml" runAsStartupTask="false" isJson="true" useExactVersion="true">
+    <additionalLocations>
+      <additionalLocation>https://umsah3cwjlctnmhsvzqv.blob.core.windows.net/2bbece4f-0283-d415-b034-cc0adc6997a1/2bbece4f-0283-d415-b034-cc0adc6997a1_manifest.xml</additionalLocation>
+    </additionalLocations>
+  </Plugin>
 </Plugins>
 <PluginSettings>
   <Plugin name="Microsoft.Azure.Monitor.AzureMonitorLinuxAgent" version="1.9.1">
@@ -116,6 +121,18 @@
     }
   ]
 }</ExtensionRuntimeSettings>
+  </Plugin>
+  <Plugin name="Microsoft.OSTCExtensions.VMAccessForLinux" version="1.5.11">
+    <RuntimeSettings seqNo="0">{
+  "runtimeSettings": [
+    {
+      "handlerSettings": {
+        "protectedSettingsCertThumbprint": "59A10F50FFE2A0408D3F03FE336C8FD5716CF25C",
+        "protectedSettings": "*** REDACTED ***"
+      }
+    }
+  ]
+}</RuntimeSettings>
   </Plugin>
 </PluginSettings>
 <InVMArtifactsProfileBlob>https://dcrcl3a0xs.blob.core.windows.net/$system/edp0plkw2b.86f4ae0a-61f8-48ae-9199-40f402d56864.vmSettings?sv=2018-03-28&amp;sr=b&amp;sk=system-1&amp;sig=PaiLic%3d&amp;se=9999-01-01T00%3a00%3a00Z&amp;sp=r</InVMArtifactsProfileBlob>

--- a/tests/data/hostgaplugin/vm_settings.json
+++ b/tests/data/hostgaplugin/vm_settings.json
@@ -147,6 +147,28 @@
                     "extensionState": "enabled"
                 }
             ]
+        },
+        {
+            "name": "Microsoft.OSTCExtensions.VMAccessForLinux",
+            "version": "1.5.11",
+            "location": "https://umsasc25p0kjg0c1dg4b.blob.core.windows.net/2bbece4f-0283-d415-b034-cc0adc6997a1/2bbece4f-0283-d415-b034-cc0adc6997a1_manifest.xml",
+            "failoverlocation": "https://umsamfwlmfshvxx2lsjm.blob.core.windows.net/2bbece4f-0283-d415-b034-cc0adc6997a1/2bbece4f-0283-d415-b034-cc0adc6997a1_manifest.xml",
+            "additionalLocations": [
+                "https://umsah3cwjlctnmhsvzqv.blob.core.windows.net/2bbece4f-0283-d415-b034-cc0adc6997a1/2bbece4f-0283-d415-b034-cc0adc6997a1_manifest.xml"
+            ],
+            "state": "enabled",
+            "autoUpgrade": false,
+            "runAsStartupTask": false,
+            "isJson": true,
+            "useExactVersion": true,
+            "settingsSeqNo": 0,
+            "isMultiConfig": false,
+            "settings": [
+                {
+                    "protectedSettingsCertThumbprint": "59A10F50FFE2A0408D3F03FE336C8FD5716CF25C",
+                    "protectedSettings": "*** REDACTED ***"
+                }
+            ]
         }
     ]
 }

--- a/tests/protocol/test_wire.py
+++ b/tests/protocol/test_wire.py
@@ -1201,14 +1201,14 @@ class UpdateGoalStateTestCase(HttpRequestPredicates, AgentTestCase):
 
         with open(extensions_config_file, "r") as file_:
             extensions_goal_state = ExtensionsGoalStateFactory.create_from_extensions_config(123, file_.read(), protocol)
-        self.assertEqual(4, len(extensions_goal_state.extensions), "Expected 4 extensions in the test ExtensionsConfig")
+        self.assertEqual(5, len(extensions_goal_state.extensions), "Expected 4 extensions in the test ExtensionsConfig")
         for e in extensions_goal_state.extensions:
             if e.name in ("Microsoft.Azure.Monitor.AzureMonitorLinuxAgent", "Microsoft.Azure.Security.Monitoring.AzureSecurityLinuxAgent"):
                 self.assertEqual(e.settings[0].protectedSettings, "*** REDACTED ***", "The protected settings for {0} were not redacted".format(e.name))
 
         with open(vm_settings_file, "r") as file_:
             extensions_goal_state = ExtensionsGoalStateFactory.create_from_vm_settings(None, file_.read())
-        self.assertEqual(4, len(extensions_goal_state.extensions), "Expected 4 extensions in the test vmSettings")
+        self.assertEqual(5, len(extensions_goal_state.extensions), "Expected 4 extensions in the test vmSettings")
         for e in extensions_goal_state.extensions:
             if e.name in ("Microsoft.Azure.Monitor.AzureMonitorLinuxAgent", "Microsoft.Azure.Security.Monitoring.AzureSecurityLinuxAgent"):
                 self.assertEqual(e.settings[0].protectedSettings, "*** REDACTED ***", "The protected settings for {0} were not redacted".format(e.name))

--- a/tests/protocol/test_wire.py
+++ b/tests/protocol/test_wire.py
@@ -1201,14 +1201,14 @@ class UpdateGoalStateTestCase(HttpRequestPredicates, AgentTestCase):
 
         with open(extensions_config_file, "r") as file_:
             extensions_goal_state = ExtensionsGoalStateFactory.create_from_extensions_config(123, file_.read(), protocol)
-        self.assertEqual(5, len(extensions_goal_state.extensions), "Expected 4 extensions in the test ExtensionsConfig")
+        self.assertEqual(5, len(extensions_goal_state.extensions), "Incorrect number of extensions in ExtensionsConfig")
         for e in extensions_goal_state.extensions:
             if e.name in ("Microsoft.Azure.Monitor.AzureMonitorLinuxAgent", "Microsoft.Azure.Security.Monitoring.AzureSecurityLinuxAgent"):
                 self.assertEqual(e.settings[0].protectedSettings, "*** REDACTED ***", "The protected settings for {0} were not redacted".format(e.name))
 
         with open(vm_settings_file, "r") as file_:
             extensions_goal_state = ExtensionsGoalStateFactory.create_from_vm_settings(None, file_.read())
-        self.assertEqual(5, len(extensions_goal_state.extensions), "Expected 4 extensions in the test vmSettings")
+        self.assertEqual(5, len(extensions_goal_state.extensions), "Incorrect number of extensions in vmSettings")
         for e in extensions_goal_state.extensions:
             if e.name in ("Microsoft.Azure.Monitor.AzureMonitorLinuxAgent", "Microsoft.Azure.Security.Monitoring.AzureSecurityLinuxAgent"):
                 self.assertEqual(e.settings[0].protectedSettings, "*** REDACTED ***", "The protected settings for {0} were not redacted".format(e.name))


### PR DESCRIPTION
Issue exposed by automation: empty public settings should be represented as None (was empty dict)