### PR TITLE
Ignore order when comparing manifest uris

### DIFF
--- a/azurelinuxagent/common/protocol/extensions_goal_state.py
+++ b/azurelinuxagent/common/protocol/extensions_goal_state.py
@@ -115,7 +115,6 @@ class ExtensionsGoalState(object):
 
         def compare_agent_manifests(first, second):
             compare_attributes(first, second, "family")
-            compare_attributes(first, second, "version")
             compare_attributes(first, second, "requested_version_string")
             compare_attributes(first, second, "uris", ignore_order=True)
 

--- a/azurelinuxagent/common/protocol/extensions_goal_state.py
+++ b/azurelinuxagent/common/protocol/extensions_goal_state.py
@@ -116,14 +116,14 @@ class ExtensionsGoalState(object):
         def compare_agent_manifests(first, second):
             compare_attributes(first, second, "family")
             compare_attributes(first, second, "version")
-            compare_attributes(first, second, "uris")
+            compare_attributes(first, second, "uris", ignore_order=True)
 
         def compare_extensions(first, second):
             compare_attributes(first, second, "name")
             compare_attributes(first, second, "version")
             compare_attributes(first, second, "state")
             compare_attributes(first, second, "supports_multi_config")
-            compare_attributes(first, second, "manifest_uris")
+            compare_attributes(first, second, "manifest_uris", ignore_order=True)
             compare_array(first.settings, second.settings, compare_settings, "settings")
 
         def compare_settings(first, second):
@@ -145,11 +145,16 @@ class ExtensionsGoalState(object):
                 finally:
                     context.pop()
 
-        def compare_attributes(first, second, attribute):
+        def compare_attributes(first, second, attribute, ignore_order=False):
             context.append(attribute)
             try:
                 first_value = getattr(first, attribute)
                 second_value = getattr(second, attribute)
+                if ignore_order:
+                    first_value = first_value[:]
+                    first_value.sort()
+                    second_value = second_value[:]
+                    second_value.sort()
 
                 if first_value != second_value:
                     raise Exception("[{0}] != [{1}] (Attribute: {2})".format(first_value, second_value, ".".join(context)))


### PR DESCRIPTION
Issue detected by automation: in some cases the order of the manifests is different in extensions config an vmsettings