### PR TITLE
Use vmSettings for extension processing

### DIFF
--- a/azurelinuxagent/common/protocol/extensions_goal_state.py
+++ b/azurelinuxagent/common/protocol/extensions_goal_state.py
@@ -22,7 +22,6 @@ from azurelinuxagent.common.future import ustr
 from azurelinuxagent.common.AgentGlobals import AgentGlobals
 from azurelinuxagent.common.exception import AgentError
 from azurelinuxagent.common.utils import textutil
-from azurelinuxagent.common.utils.flexible_version import FlexibleVersion
 
 
 class GoalStateMismatchError(AgentError):
@@ -104,10 +103,8 @@ class ExtensionsGoalState(object):
             compare_attributes(first, second, "activity_id")
             compare_attributes(first, second, "correlation_id")
             compare_attributes(first, second, "created_on_timestamp")
-            # The status blob was added after version 112
-            if from_vm_settings.host_ga_plugin_version > FlexibleVersion("1.0.8.112"):
-                compare_attributes(first, second, "status_upload_blob")
-                compare_attributes(first, second, "status_upload_blob_type")
+            compare_attributes(first, second, "status_upload_blob")
+            compare_attributes(first, second, "status_upload_blob_type")
             compare_attributes(first, second, "required_features")
             compare_attributes(first, second, "on_hold")
             compare_array(first.agent_manifests, second.agent_manifests, compare_agent_manifests, "agent_manifests")

--- a/azurelinuxagent/common/protocol/extensions_goal_state_from_extensions_config.py
+++ b/azurelinuxagent/common/protocol/extensions_goal_state_from_extensions_config.py
@@ -33,6 +33,7 @@ class ExtensionsGoalStateFromExtensionsConfig(ExtensionsGoalState):
     def __init__(self, incarnation, xml_text, wire_client):
         super(ExtensionsGoalStateFromExtensionsConfig, self).__init__()
         self._id = incarnation
+        self._incarnation = incarnation
         self._text = xml_text
         self._status_upload_blob = None
         self._status_upload_blob_type = None
@@ -130,6 +131,10 @@ class ExtensionsGoalStateFromExtensionsConfig(ExtensionsGoalState):
     @property
     def id(self):
         return self._id
+
+    @property
+    def incarnation(self):
+        return self._incarnation
 
     @property
     def activity_id(self):

--- a/azurelinuxagent/common/protocol/extensions_goal_state_from_vm_settings.py
+++ b/azurelinuxagent/common/protocol/extensions_goal_state_from_vm_settings.py
@@ -34,6 +34,7 @@ class ExtensionsGoalStateFromVmSettings(ExtensionsGoalState):
     def __init__(self, etag, json_text):
         super(ExtensionsGoalStateFromVmSettings, self).__init__()
         self._id = etag
+        self._etag = etag
         self._text = json_text
         self._host_ga_plugin_version = FlexibleVersion('0.0.0.0')
         self._schema_version = FlexibleVersion('0.0.0.0')
@@ -57,6 +58,10 @@ class ExtensionsGoalStateFromVmSettings(ExtensionsGoalState):
     @property
     def id(self):
         return self._id
+
+    @property
+    def etag(self):
+        return self._etag
 
     @property
     def host_ga_plugin_version(self):

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -969,14 +969,9 @@ class WireClient(object):
 
     def get_extensions_goal_state(self):
         if self._extensions_goal_state is None:
-            raise ProtocolError("Trying to fetch ExtensioalState before initialization!")
+            raise ProtocolError("Trying to fetch ExtensionsGoalState before initialization!")
 
-        try:
-            ExtensionsGoalState.compare(self._goal_state.extensions_config,  self._extensions_goal_state)
-        except Exception as e:
-            logger.info("{0}", textutil.format_exception(e))
-
-        return self._extensions_goal_state  # self._goal_state.extensions_config  # self._extensions_goal_state
+        return self._extensions_goal_state
 
     def get_ext_manifest(self, ext_handler):
         if self._goal_state is None:

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -45,6 +45,7 @@ from azurelinuxagent.common.telemetryevent import GuestAgentExtensionEventsSchem
 from azurelinuxagent.common.utils import fileutil, restutil
 from azurelinuxagent.common.utils.archive import StateFlusher
 from azurelinuxagent.common.utils.cryptutil import CryptUtil
+from azurelinuxagent.common.utils.flexible_version import FlexibleVersion
 from azurelinuxagent.common.utils.textutil import parse_doc, findall, find, \
     findtext, gettext, remove_bom, get_bytes_from_pem, parse_json
 from azurelinuxagent.common.version import AGENT_NAME, CURRENT_VERSION
@@ -575,8 +576,8 @@ class WireClient(object):
         logger.info("Wire server endpoint:{0}", endpoint)
         self._endpoint = endpoint
         self._goal_state = None
-        self._extensions_goal_state = None  # goal state from ExtensionsConfig
-        self._extensions_goal_state_from_vm_settings = None  # goal state from vmSettings
+        self._extensions_goal_state = None  # The goal state to use for extensions; can be an ExtensionsGoalStateFromVmSettings or ExtensionsGoalStateFromExtensionsConfig
+        self._vm_settings_goal_state = None  # Cached value of the most recent ExtensionsGoalStateFromVmSettings
         self._host_plugin = None
         self.status_blob = StatusBlob(self)
         self.goal_state_flusher = StateFlusher(conf.get_lib_dir())
@@ -781,14 +782,13 @@ class WireClient(object):
         Updates the goal state if the incarnation or etag changed or if 'force_update' is True
         """
         try:
-            updated = False
-
             goal_state = GoalState(self)
 
             # Always update the hostgaplugin, since the agent may issue requests to it even if there are no other changes
             # in the goal state (e.g. report status)
             self._update_host_plugin(goal_state.container_id, goal_state.role_config_name)
 
+            # Fetch the full goal state if needed
             if force_update:
                 logger.info("Forcing an update of the goal state..")
 
@@ -796,61 +796,50 @@ class WireClient(object):
                 self._goal_state is None or self._extensions_goal_state is None or \
                 self._goal_state.incarnation != goal_state.incarnation
 
-            #
-            # TODO: Today we always update self._extensions_goal_state using the ExtensionsConfig. After that, (unless
-            #       FastTrack is disabled in waagent.conf) we query the vmSettings only to compare them against the
-            #       ExtensionsConfig.
-            #       When FastTrack is fully implemented, we will need instead to update self._extensions_goal_state
-            #       from the vmSettings and fallback to the ExtensionsConfig only if FastTrack is disabled or if it is
-            #       not supported by the HostGAPlugin.
-            #       Extensions processing is always based on self._extensions_goal_state, while self._extensions_goal_state_from_vm_settings
-            #       is currently held only for debugging purposes.
-            #
-            if fetch_full_goal_state:
+            if not fetch_full_goal_state:
+                goal_state_updated = False
+            else:
                 goal_state.fetch_full_goal_state(self)
                 self._goal_state = goal_state
-                if self._goal_state.extensions_config_uri is None:
-                    self._extensions_goal_state = ExtensionsGoalStateFactory.create_empty()
-                else:
-                    xml_text = self.fetch_config(self._goal_state.extensions_config_uri, self.get_header())
-                    self._extensions_goal_state = ExtensionsGoalStateFactory.create_from_extensions_config(goal_state.incarnation, xml_text, self)
-                updated = True
+                goal_state_updated = True
 
+            vm_settings_goal_state_updated = False
             if conf.get_enable_fast_track():
-                # Since currently we query vmSettings only to exercise the HostGAPlugin, errors in this section of the code should not
-                # prevent the agent from processing the goal state; we simply report a summary of those errors.
                 try:
-                    request_etag = None if force_update or self._extensions_goal_state_from_vm_settings is None else self._extensions_goal_state_from_vm_settings.id
-                    response_etag, vm_settings = self._fetch_vm_settings(request_etag)
-                    if vm_settings is not None:  # vmSettings is None when there has not been a new goal state, or the HostGAPlugin does not support FastTrack
-                        is_first_vm_settings = self._extensions_goal_state_from_vm_settings is None
-                        self._extensions_goal_state_from_vm_settings = ExtensionsGoalStateFactory.create_from_vm_settings(response_etag, vm_settings)
-                        if is_first_vm_settings:
-                            message = "HostGAPlugin version: {0}".format(self._extensions_goal_state_from_vm_settings.host_ga_plugin_version)
-                            logger.info(message)
-                            add_event(op=WALAEventOperation.HostPlugin, message=message, is_success=True)
-                        updated = True
-                    # If either goal state was updated, compare them
-                    if updated and self._extensions_goal_state_from_vm_settings is not None:
-                        ExtensionsGoalState.compare(self._extensions_goal_state, self._extensions_goal_state_from_vm_settings)
+                    vm_settings_goal_state = self._fetch_vm_settings_goal_state(force_update=force_update)
+                    if vm_settings_goal_state is None:  # if vmSettings are None, Fast Track is not supported; use extensionsConfig
+                        self._extensions_goal_state = self._goal_state.extensions_config
+                    else:
+                        if self._vm_settings_goal_state is None or self._vm_settings_goal_state.etag != vm_settings_goal_state.etag:
+                            self._vm_settings_goal_state = vm_settings_goal_state
+                            self._extensions_goal_state = vm_settings_goal_state
+                            vm_settings_goal_state_updated = True
+
+                    if goal_state_updated or vm_settings_goal_state_updated:
+                        # compare() raises a GoalStateMismatchError if the goal states don't match
+                        ExtensionsGoalState.compare(self._goal_state.extensions_config, self._vm_settings_goal_state)
                 except Exception as error:
+                    # if there is any error on vmSettings then use extensionsConfig
+                    self._extensions_goal_state = self._goal_state.extensions_config
                     # TODO: Once FastTrack is stable, these exceptions should be rare. Add a traceback to the error message at that point.
                     self._vm_settings_error_reporter.report_error(ustr(error))
                 self._vm_settings_error_reporter.report_summary()
 
-            # If either goal state was updated, save them
-            if updated:
+            # If either goal state changed (goal_state or vm_settings_goal_state) save them
+            if goal_state_updated or vm_settings_goal_state_updated:
                 self._save_goal_state()
 
+        except ProtocolError:
+            raise
         except Exception as exception:
             raise ProtocolError("Error fetching goal state: {0}".format(ustr(exception)))
 
-    def _fetch_vm_settings(self, etag):
+    def _fetch_vm_settings_goal_state(self, force_update):
         """
-        Queries the vmSettings from the HostGAPlugin using the given etag, returns a tuple of the response's etag and content.
-        If the vmSettings have not been updated for the given etag, or if the HostGAPlugin does not support FastTrack,
-        returns (None, None).
+        Queries the vmSettings from the HostGAPlugin and returns an instance of ExtensionsGoalStateFromVmSettings.
+        Returns None if the HostGAPlugin does not support FastTrack.
         """
+        etag = None if force_update or self._vm_settings_goal_state is None else self._vm_settings_goal_state.etag
         correlation_id = str(uuid.uuid4())
 
         try:
@@ -866,16 +855,11 @@ class WireClient(object):
                 self.update_host_plugin_from_goal_state()
                 response = get_vm_settings()
 
-            if response.status == httpclient.NOT_MODIFIED:
-                return None, None
-
-            # TODO: Currently we use the vmSettings just to compare against ExtensionsConfig and we handle
-            #       Not Supported just as if there was no update in the vmSettings. Once FastTrack is
-            #       fully enabled, if the HostGAPlugin does not support FastTrack we actually need to
-            #       fallback to using the ExtensionsConfig
             if response.status == httpclient.NOT_FOUND:  # the HostGAPlugin does not support FastTrack
-                return None, None
-            # END TODO
+                return None
+
+            if response.status == httpclient.NOT_MODIFIED:  # The goal state hasn't changed, return the current instance
+                return self._vm_settings_goal_state
 
             if response.status != httpclient.OK:
                 error_description = restutil.read_response_error(response)
@@ -895,7 +879,20 @@ class WireClient(object):
 
             logger.info("Fetched new vmSettings [correlation ID: {0} New eTag: {1}]", correlation_id, response_etag)
             response_content = self.decode_config(response.read())
-            return response_etag, response_content
+            vm_settings = ExtensionsGoalStateFactory.create_from_vm_settings(response_etag, response_content)
+
+            # log the HostGAPlugin version when we fetch the vmSettings for the first time
+            is_first_vm_settings = self._vm_settings_goal_state is None
+            if is_first_vm_settings:
+                message = "HostGAPlugin version: {0}".format(vm_settings.host_ga_plugin_version)
+                logger.info(message)
+                add_event(op=WALAEventOperation.HostPlugin, message=message, is_success=True)
+
+            # Don't support HostGAPlugin versions older than 115
+            if vm_settings.host_ga_plugin_version < FlexibleVersion("1.0.8.115"):
+                return None
+
+            return vm_settings
 
         except ProtocolError:
             raise
@@ -927,15 +924,15 @@ class WireClient(object):
             save_if_not_none(self._goal_state.hosting_env, HOSTING_ENV_FILE_NAME)
             save_if_not_none(self._goal_state.shared_conf, SHARED_CONF_FILE_NAME)
             save_if_not_none(self._goal_state.remote_access, REMOTE_ACCESS_FILE_NAME.format(self._goal_state.incarnation))
-            if self._extensions_goal_state is not None:
-                text = self._extensions_goal_state.get_redacted_text()
+            if self._goal_state.extensions_config is not None:
+                text = self._goal_state.extensions_config.get_redacted_text()
                 if text != '':
-                    self._save_cache(text, EXT_CONF_FILE_NAME.format(self._extensions_goal_state.id))
-            # TODO: When Fast Track is fully enabled self._extensions_goal_state_from_vm_settings will go away and this can be deleted
-            if self._extensions_goal_state_from_vm_settings is not None:
-                text = self._extensions_goal_state_from_vm_settings.get_redacted_text()
+                    self._save_cache(text, EXT_CONF_FILE_NAME.format(self._goal_state.extensions_config.incarnation))
+            # TODO: When Fast Track is fully enabled self._vm_settings_goal_state will go away and this can be deleted
+            if self._vm_settings_goal_state is not None:
+                text = self._vm_settings_goal_state.get_redacted_text()
                 if text != '':
-                    self._save_cache(text, VM_SETTINGS_FILE_NAME.format(self._extensions_goal_state_from_vm_settings.id))
+                    self._save_cache(text, VM_SETTINGS_FILE_NAME.format(self._vm_settings_goal_state.id))
             # END TODO
 
         except Exception as e:

--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -300,13 +300,13 @@ class ExtHandlersHandler(object):
         try:
             extensions_goal_state = self.protocol.get_extensions_goal_state()
 
-            # self.ext_handlers needs to be initialized first, since status reporting depends on it
+            # self.ext_handlers and etag need to be initialized first, since status reporting depends on them
             self.ext_handlers = extensions_goal_state.extensions
+            etag = self.protocol.client.get_goal_state().incarnation
 
             if not self._extension_processing_allowed():
                 return
 
-            etag = extensions_goal_state.id
             gs_creation_time = extensions_goal_state.created_on_timestamp
             activity_id = extensions_goal_state.activity_id
             correlation_id = extensions_goal_state.correlation_id

--- a/tests/data/hostgaplugin/vm_settings-difference_in_required_features.json
+++ b/tests/data/hostgaplugin/vm_settings-difference_in_required_features.json
@@ -1,0 +1,200 @@
+{
+    "hostGAPluginVersion": "1.0.8.115",
+    "vmSettingsSchemaVersion": "0.0",
+    "activityId": "a33f6f53-43d6-4625-b322-1a39651a00c9",
+    "correlationId": "9a47a2a2-e740-4bfc-b11b-4f2f7cfe7d2e",
+    "extensionsLastModifiedTickCount": 637726657706205217,
+    "extensionGoalStatesSource": "Fabric",
+    "onHold": true,
+    "statusUploadBlob": {
+        "statusBlobType": "BlockBlob",
+        "value": "https://dcrcl3a0xs.blob.core.windows.net/$system/edp0plkw2b.86f4ae0a-61f8-48ae-9199-40f402d56864.status?sv=2018-03-28&sr=b&sk=system-1&sig=KNWgC2%3d&se=9999-01-01T00%3a00%3a00Z&sp=w"
+    },
+    "inVMMetadata": {
+        "subscriptionId": "8e037ad4-618f-4466-8bc8-5099d41ac15b",
+        "resourceGroupName": "rg-dc-86fjzhp",
+        "vmName": "edp0plkw2b",
+        "location": "CentralUSEUAP",
+        "vmId": "86f4ae0a-61f8-48ae-9199-40f402d56864",
+        "vmSize": "Standard_B2s",
+        "osType": "Linux"
+    },
+    "requiredFeatures": [
+        {
+            "name": "A_NON_EXISTING_FEATURE_USED_TO_PRODUCE_AN_ERROR"
+        }
+    ],
+    "gaFamilies": [
+        {
+            "name": "Prod",
+            "uris": [
+                "https://zrdfepirv2cdm03prdstr01a.blob.core.windows.net/7d89d439b79f4452950452399add2c90/Microsoft.OSTCLinuxAgent_Prod_uscentraleuap_manifest.xml",
+                "https://ardfepirv2cdm03prdstr01a.blob.core.windows.net/7d89d439b79f4452950452399add2c90/Microsoft.OSTCLinuxAgent_Prod_uscentraleuap_manifest.xml"
+            ]
+        },
+        {
+            "name": "Test",
+            "uris": [
+                "https://zrdfepirv2cdm03prdstr01a.blob.core.windows.net/7d89d439b79f4452950452399add2c90/Microsoft.OSTCLinuxAgent_Test_uscentraleuap_manifest.xml",
+                "https://ardfepirv2cdm03prdstr01a.blob.core.windows.net/7d89d439b79f4452950452399add2c90/Microsoft.OSTCLinuxAgent_Test_uscentraleuap_manifest.xml"
+            ]
+        }
+    ],
+    "extensionGoalStates": [
+        {
+            "name": "Microsoft.Azure.Monitor.AzureMonitorLinuxAgent",
+            "version": "1.9.1",
+            "location": "https://zrdfepirv2cbn04prdstr01a.blob.core.windows.net/a47f0806d764480a8d989d009c75007d/Microsoft.Azure.Monitor_AzureMonitorLinuxAgent_useast2euap_manifest.xml",
+            "failoverlocation": "https://zrdfepirv2cbn06prdstr01a.blob.core.windows.net/a47f0806d764480a8d989d009c75007d/Microsoft.Azure.Monitor_AzureMonitorLinuxAgent_useast2euap_manifest.xml",
+            "additionalLocations": ["https://zrdfepirv2cbn09pr02a.blob.core.windows.net/a47f0806d764480a8d989d009c75007d/Microsoft.Azure.Monitor_AzureMonitorLinuxAgent_useast2euap_manifest.xml"],
+            "state": "enabled",
+            "autoUpgrade": true,
+            "runAsStartupTask": false,
+            "isJson": true,
+            "useExactVersion": true,
+            "settingsSeqNo": 0,
+            "settings": [
+                {
+                    "protectedSettingsCertThumbprint": "4C4F304667711036E64AF4894B76EB208A863BD4",
+                    "protectedSettings": "MIIBsAYJKoZIhvcNAQcDoIIBoTCCAZ0CAQAxggFpMIIBZQIBADBNMDkxNzA1BgoJkiaJk/IsZAEZFidXaW5kb3dzIEF6dXJlIENSUCBDZXJ0aWZpY2F0ZSBHZW5lcmF0b3ICEFpB/HKM/7evRk+DBz754wUwDQYJKoZIhvcNAQEBBQAEggEADPJwniDeIUXzxNrZCloitFdscQ59Bz1dj9DLBREAiM8jmxM0LLicTJDUv272Qm/4ZQgdqpFYBFjGab/9MX+Ih2x47FkVY1woBkckMaC/QOFv84gbboeQCmJYZC/rZJdh8rCMS+CEPq3uH1PVrvtSdZ9uxnaJ+E4exTPPviIiLIPtqWafNlzdbBt8HZjYaVw+SSe+CGzD2pAQeNttq3Rt/6NjCzrjG8ufKwvRoqnrInMs4x6nnN5/xvobKIBSv4/726usfk8Ug+9Q6Benvfpmre2+1M5PnGTfq78cO3o6mI3cPoBUjp5M0iJjAMGeMt81tyHkimZrEZm6pLa4NQMOEjArBgkqhkiG9w0BBwEwFAYIKoZIhvcNAwcECC5nVaiJaWt+gAhgeYvxUOYHXw==",
+                    "publicSettings": "{\"GCS_AUTO_CONFIG\":true}"
+                }
+            ]
+        },
+        {
+            "name": "Microsoft.Azure.Security.Monitoring.AzureSecurityLinuxAgent",
+            "version": "2.15.112",
+            "location": "https://zrdfepirv2cbn04prdstr01a.blob.core.windows.net/4ef06ad957494df49c807a5334f2b5d2/Microsoft.Azure.Security.Monitoring_AzureSecurityLinuxAgent_useast2euap_manifest.xml",
+            "failoverlocation": "https://zrdfepirv2cbz06prdstr01a.blob.core.windows.net/4ef06ad957494df49c807a5334f2b5d2/Microsoft.Azure.Security.Monitoring_AzureSecurityLinuxAgent_useast2euap_manifest.xml",
+            "additionalLocations": ["https://zrdfepirv2cbn06prdstr01a.blob.core.windows.net/4ef06ad957494df49c807a5334f2b5d2/Microsoft.Azure.Security.Monitoring_AzureSecurityLinuxAgent_useast2euap_manifest.xml"],
+            "state": "enabled",
+            "autoUpgrade": true,
+            "runAsStartupTask": false,
+            "isJson": true,
+            "useExactVersion": true,
+            "settingsSeqNo": 0,
+            "settings": [
+                {
+                    "protectedSettingsCertThumbprint": "4C4F304667711036E64AF4894B76EB208A863BD4",
+                    "protectedSettings": "MIIBsAYJKoZIhvcNAQcDoIIBoTCCAZ0CAQAxggFpMIIBZQIBADBNMDkxNzA1BgoJkiaJk/IsZAEZFidXaW5kb3dzIEF6dXJlIENSUCBDZXJ0aWZpY2F0ZSBHZW5lcmF0b3ICEFpB/HKM/7evRk+DBz754wUwDQYJKoZIhvcNAQEBBQAEggEADPJwniDeIUXzxNrZCloitFdscQ59Bz1dj9DLBREAiM8jmxM0LLicTJDUv272Qm/4ZQgdqpFYBFjGab/9MX+Ih2x47FkVY1woBkckMaC/QOFv84gbboeQCmJYZC/rZJdh8rCMS+CEPq3uH1PVrvtSdZ9uxnaJ+E4exTPPviIiLIPtqWafNlzdbBt8HZjYaVw+SSe+CGzD2pAQeNttq3Rt/6NjCzrjG8ufKwvRoqnrInMs4x6nnN5/xvobKIBSv4/726usfk8Ug+9Q6Benvfpmre2+1M5PnGTfq78cO3o6mI3cPoBUjp5M0iJjAMGeMt81tyHkimZrEZm6pLa4NQMOEjArBgkqhkiG9w0BBwEwFAYIKoZIhvcNAwcECC5nVaiJaWt+gAhgeYvxUOYHXw==",
+                    "publicSettings": "{\"enableGenevaUpload\":true}"
+                }
+            ]
+        },
+        {
+            "name": "Microsoft.Azure.Extensions.CustomScript",
+            "version": "2.1.6",
+            "location": "https://umsavwggj2v40kvqhc0w.blob.core.windows.net/5237dd14-0aad-f051-0fad-1e33e1b63091/5237dd14-0aad-f051-0fad-1e33e1b63091_manifest.xml",
+            "failoverlocation": "https://umsafwzhkbm1rfrhl0ws.blob.core.windows.net/5237dd14-0aad-f051-0fad-1e33e1b63091/5237dd14-0aad-f051-0fad-1e33e1b63091_manifest.xml",
+            "additionalLocations": [
+                "https://umsanh4b5rfz0q0p4pwm.blob.core.windows.net/5237dd14-0aad-f051-0fad-1e33e1b63091/5237dd14-0aad-f051-0fad-1e33e1b63091_manifest.xml"
+            ],
+            "state": "enabled",
+            "autoUpgrade": true,
+            "runAsStartupTask": false,
+            "isJson": true,
+            "useExactVersion": true,
+            "settingsSeqNo": 0,
+            "isMultiConfig": false,
+            "settings": [
+                {
+                    "publicSettings": "{\"commandToExecute\":\"echo 'cee174d4-4daa-4b07-9958-53b9649445c2'\"}"
+                }
+            ],
+            "dependsOn": [
+                {
+                    "DependsOnExtension": [
+                        {
+                            "handler": "Microsoft.Azure.Security.Monitoring.AzureSecurityLinuxAgent"
+                        }
+                    ],
+                    "dependencyLevel": 1
+                }
+            ]
+        },
+        {
+            "name": "Microsoft.CPlat.Core.RunCommandHandlerLinux",
+            "version": "1.2.0",
+            "location": "https://umsavbvncrpzbnxmxzmr.blob.core.windows.net/f4086d41-69f9-3103-78e0-8a2c7e789d0f/f4086d41-69f9-3103-78e0-8a2c7e789d0f_manifest.xml",
+            "failoverlocation": "https://umsajbjtqrb3zqjvgb2z.blob.core.windows.net/f4086d41-69f9-3103-78e0-8a2c7e789d0f/f4086d41-69f9-3103-78e0-8a2c7e789d0f_manifest.xml",
+            "additionalLocations": [
+                "https://umsawqtlsshtn5v2nfgh.blob.core.windows.net/f4086d41-69f9-3103-78e0-8a2c7e789d0f/f4086d41-69f9-3103-78e0-8a2c7e789d0f_manifest.xml"
+            ],
+            "state": "enabled",
+            "autoUpgrade": true,
+            "runAsStartupTask": false,
+            "isJson": true,
+            "useExactVersion": true,
+            "settingsSeqNo": 0,
+            "isMultiConfig": true,
+            "settings": [
+                {
+                    "publicSettings": "{\"source\":{\"script\":\"echo '4abb1e88-f349-41f8-8442-247d9fdfcac5'\"}}",
+                    "seqNo": 0,
+                    "extensionName": "MCExt1",
+                    "extensionState": "enabled"
+                },
+                {
+                    "publicSettings": "{\"source\":{\"script\":\"echo 'e865c9bc-a7b3-42c6-9a79-cfa98a1ee8b3'\"}}",
+                    "seqNo": 0,
+                    "extensionName": "MCExt2",
+                    "extensionState": "enabled"
+                },
+                {
+                    "publicSettings": "{\"source\":{\"script\":\"echo 'f923e416-0340-485c-9243-8b84fb9930c6'\"}}",
+                    "seqNo": 0,
+                    "extensionName": "MCExt3",
+                    "extensionState": "enabled"
+                }
+            ],
+            "dependsOn": [
+                {
+                    "dependsOnExtension": [
+                        {
+                            "extension": "...",
+                            "handler": "..."
+                        },
+                        {
+                            "extension": "...",
+                            "handler": "..."
+                        }
+                    ],
+                    "dependencyLevel": 2,
+                    "name": "MCExt1"
+                },
+                {
+                    "dependsOnExtension": [
+                        {
+                            "extension": "...",
+                            "handler": "..."
+                        }
+                    ],
+                    "dependencyLevel": 1,
+                    "name": "MCExt2"
+                }
+            ]
+        },
+        {
+            "name": "Microsoft.OSTCExtensions.VMAccessForLinux",
+            "version": "1.5.11",
+            "location": "https://umsasc25p0kjg0c1dg4b.blob.core.windows.net/2bbece4f-0283-d415-b034-cc0adc6997a1/2bbece4f-0283-d415-b034-cc0adc6997a1_manifest.xml",
+            "failoverlocation": "https://umsamfwlmfshvxx2lsjm.blob.core.windows.net/2bbece4f-0283-d415-b034-cc0adc6997a1/2bbece4f-0283-d415-b034-cc0adc6997a1_manifest.xml",
+            "additionalLocations": [
+                "https://umsah3cwjlctnmhsvzqv.blob.core.windows.net/2bbece4f-0283-d415-b034-cc0adc6997a1/2bbece4f-0283-d415-b034-cc0adc6997a1_manifest.xml"
+            ],
+            "state": "enabled",
+            "autoUpgrade": false,
+            "runAsStartupTask": false,
+            "isJson": true,
+            "useExactVersion": true,
+            "settingsSeqNo": 0,
+            "isMultiConfig": false,
+            "settings": [
+                {
+                    "protectedSettingsCertThumbprint": "59A10F50FFE2A0408D3F03FE336C8FD5716CF25C",
+                    "protectedSettings": "*** REDACTED ***"
+                }
+            ]
+        }
+    ]
+}

--- a/tests/data/hostgaplugin/vm_settings-invalid_blob_type.json
+++ b/tests/data/hostgaplugin/vm_settings-invalid_blob_type.json
@@ -1,4 +1,6 @@
 {
+    "hostGAPluginVersion": "1.0.8.115",
+    "vmSettingsSchemaVersion": "0.0",
     "activityId": "2e7f8b5d-f637-4721-b757-cb190d49b4e9",
     "correlationId": "1bef4c48-044e-4225-8f42-1d1eac1eb158",
     "extensionsLastModifiedTickCount": 637693267431616449,

--- a/tests/data/hostgaplugin/vm_settings-parse_error.json
+++ b/tests/data/hostgaplugin/vm_settings-parse_error.json
@@ -1,0 +1,71 @@
+{
+    "hostGAPluginVersion": "1.0.8.115",
+    "vmSettingsSchemaVersion": THIS_IS_A_SYNTAX_ERROR,
+    "activityId": "a33f6f53-43d6-4625-b322-1a39651a00c9",
+    "correlationId": "9a47a2a2-e740-4bfc-b11b-4f2f7cfe7d2e",
+    "extensionsLastModifiedTickCount": 637726657706205217,
+    "extensionGoalStatesSource": "Fabric",
+    "onHold": true,
+    "statusUploadBlob": {
+        "statusBlobType": "BlockBlob",
+        "value": "https://dcrcl3a0xs.blob.core.windows.net/$system/edp0plkw2b.86f4ae0a-61f8-48ae-9199-40f402d56864.status?sv=2018-03-28&sr=b&sk=system-1&sig=KNWgC2%3d&se=9999-01-01T00%3a00%3a00Z&sp=w"
+    },
+    "inVMMetadata": {
+        "subscriptionId": "8e037ad4-618f-4466-8bc8-5099d41ac15b",
+        "resourceGroupName": "rg-dc-86fjzhp",
+        "vmName": "edp0plkw2b",
+        "location": "CentralUSEUAP",
+        "vmId": "86f4ae0a-61f8-48ae-9199-40f402d56864",
+        "vmSize": "Standard_B2s",
+        "osType": "Linux"
+    },
+    "gaFamilies": [
+        {
+            "name": "Prod",
+            "uris": [
+                "https://zrdfepirv2cdm03prdstr01a.blob.core.windows.net/7d89d439b79f4452950452399add2c90/Microsoft.OSTCLinuxAgent_Prod_uscentraleuap_manifest.xml",
+                "https://ardfepirv2cdm03prdstr01a.blob.core.windows.net/7d89d439b79f4452950452399add2c90/Microsoft.OSTCLinuxAgent_Prod_uscentraleuap_manifest.xml"
+            ]
+        },
+        {
+            "name": "Test",
+            "uris": [
+                "https://zrdfepirv2cdm03prdstr01a.blob.core.windows.net/7d89d439b79f4452950452399add2c90/Microsoft.OSTCLinuxAgent_Test_uscentraleuap_manifest.xml",
+                "https://ardfepirv2cdm03prdstr01a.blob.core.windows.net/7d89d439b79f4452950452399add2c90/Microsoft.OSTCLinuxAgent_Test_uscentraleuap_manifest.xml"
+            ]
+        }
+    ],
+    "extensionGoalStates": [
+        {
+            "name": "Microsoft.Azure.Extensions.CustomScript",
+            "version": "2.1.6",
+            "location": "https://umsavwggj2v40kvqhc0w.blob.core.windows.net/5237dd14-0aad-f051-0fad-1e33e1b63091/5237dd14-0aad-f051-0fad-1e33e1b63091_manifest.xml",
+            "failoverlocation": "https://umsafwzhkbm1rfrhl0ws.blob.core.windows.net/5237dd14-0aad-f051-0fad-1e33e1b63091/5237dd14-0aad-f051-0fad-1e33e1b63091_manifest.xml",
+            "additionalLocations": [
+                "https://umsanh4b5rfz0q0p4pwm.blob.core.windows.net/5237dd14-0aad-f051-0fad-1e33e1b63091/5237dd14-0aad-f051-0fad-1e33e1b63091_manifest.xml"
+            ],
+            "state": "enabled",
+            "autoUpgrade": true,
+            "runAsStartupTask": false,
+            "isJson": true,
+            "useExactVersion": true,
+            "settingsSeqNo": 0,
+            "isMultiConfig": false,
+            "settings": [
+                {
+                    "publicSettings": "{\"commandToExecute\":\"echo 'cee174d4-4daa-4b07-9958-53b9649445c2'\"}"
+                }
+            ],
+            "dependsOn": [
+                {
+                    "DependsOnExtension": [
+                        {
+                            "handler": "Microsoft.Azure.Security.Monitoring.AzureSecurityLinuxAgent"
+                        }
+                    ],
+                    "dependencyLevel": 1
+                }
+            ]
+        }
+    ]
+}

--- a/tests/data/hostgaplugin/vm_settings-unsupported_version.json
+++ b/tests/data/hostgaplugin/vm_settings-unsupported_version.json
@@ -1,0 +1,71 @@
+{
+    "hostGAPluginVersion": "1.0.8.114",
+    "vmSettingsSchemaVersion": "0.0",
+    "activityId": "a33f6f53-43d6-4625-b322-1a39651a00c9",
+    "correlationId": "9a47a2a2-e740-4bfc-b11b-4f2f7cfe7d2e",
+    "extensionsLastModifiedTickCount": 637726657706205217,
+    "extensionGoalStatesSource": "Fabric",
+    "onHold": true,
+    "statusUploadBlob": {
+        "statusBlobType": "BlockBlob",
+        "value": "https://dcrcl3a0xs.blob.core.windows.net/$system/edp0plkw2b.86f4ae0a-61f8-48ae-9199-40f402d56864.status?sv=2018-03-28&sr=b&sk=system-1&sig=KNWgC2%3d&se=9999-01-01T00%3a00%3a00Z&sp=w"
+    },
+    "inVMMetadata": {
+        "subscriptionId": "8e037ad4-618f-4466-8bc8-5099d41ac15b",
+        "resourceGroupName": "rg-dc-86fjzhp",
+        "vmName": "edp0plkw2b",
+        "location": "CentralUSEUAP",
+        "vmId": "86f4ae0a-61f8-48ae-9199-40f402d56864",
+        "vmSize": "Standard_B2s",
+        "osType": "Linux"
+    },
+    "gaFamilies": [
+        {
+            "name": "Prod",
+            "uris": [
+                "https://zrdfepirv2cdm03prdstr01a.blob.core.windows.net/7d89d439b79f4452950452399add2c90/Microsoft.OSTCLinuxAgent_Prod_uscentraleuap_manifest.xml",
+                "https://ardfepirv2cdm03prdstr01a.blob.core.windows.net/7d89d439b79f4452950452399add2c90/Microsoft.OSTCLinuxAgent_Prod_uscentraleuap_manifest.xml"
+            ]
+        },
+        {
+            "name": "Test",
+            "uris": [
+                "https://zrdfepirv2cdm03prdstr01a.blob.core.windows.net/7d89d439b79f4452950452399add2c90/Microsoft.OSTCLinuxAgent_Test_uscentraleuap_manifest.xml",
+                "https://ardfepirv2cdm03prdstr01a.blob.core.windows.net/7d89d439b79f4452950452399add2c90/Microsoft.OSTCLinuxAgent_Test_uscentraleuap_manifest.xml"
+            ]
+        }
+    ],
+    "extensionGoalStates": [
+        {
+            "name": "Microsoft.Azure.Extensions.CustomScript",
+            "version": "2.1.6",
+            "location": "https://umsavwggj2v40kvqhc0w.blob.core.windows.net/5237dd14-0aad-f051-0fad-1e33e1b63091/5237dd14-0aad-f051-0fad-1e33e1b63091_manifest.xml",
+            "failoverlocation": "https://umsafwzhkbm1rfrhl0ws.blob.core.windows.net/5237dd14-0aad-f051-0fad-1e33e1b63091/5237dd14-0aad-f051-0fad-1e33e1b63091_manifest.xml",
+            "additionalLocations": [
+                "https://umsanh4b5rfz0q0p4pwm.blob.core.windows.net/5237dd14-0aad-f051-0fad-1e33e1b63091/5237dd14-0aad-f051-0fad-1e33e1b63091_manifest.xml"
+            ],
+            "state": "enabled",
+            "autoUpgrade": true,
+            "runAsStartupTask": false,
+            "isJson": true,
+            "useExactVersion": true,
+            "settingsSeqNo": 0,
+            "isMultiConfig": false,
+            "settings": [
+                {
+                    "publicSettings": "{\"commandToExecute\":\"echo 'cee174d4-4daa-4b07-9958-53b9649445c2'\"}"
+                }
+            ],
+            "dependsOn": [
+                {
+                    "DependsOnExtension": [
+                        {
+                            "handler": "Microsoft.Azure.Security.Monitoring.AzureSecurityLinuxAgent"
+                        }
+                    ],
+                    "dependencyLevel": 1
+                }
+            ]
+        }
+    ]
+}

--- a/tests/protocol/test_extensions_goal_state.py
+++ b/tests/protocol/test_extensions_goal_state.py
@@ -5,10 +5,10 @@ import re
 import sys
 
 from azurelinuxagent.common.protocol.extensions_goal_state import ExtensionsGoalState, GoalStateMismatchError
-from azurelinuxagent.common.utils.flexible_version import FlexibleVersion
+from azurelinuxagent.common.protocol.extensions_goal_state_factory import ExtensionsGoalStateFactory
 from azurelinuxagent.common.utils import textutil
 from tests.protocol.mocks import mockwiredata, mock_wire_protocol
-from tests.tools import AgentTestCase
+from tests.tools import AgentTestCase, load_data
 
 # Python < 3.7 can't copy regular expressions, this is the recommended patch
 if sys.version_info[0] < 3 or sys.version_info[0] == 3 and sys.version_info[1] < 7:
@@ -19,7 +19,7 @@ class ExtensionsGoalStateTestCase(AgentTestCase):
     def test_compare_should_succeed_when_extensions_config_and_vm_settings_are_equal(self):
         with mock_wire_protocol(mockwiredata.DATA_FILE_VM_SETTINGS) as protocol:
             from_extensions_config = protocol.client.get_extensions_goal_state()
-            from_vm_settings = protocol.client._extensions_goal_state_from_vm_settings
+            from_vm_settings = protocol.client._vm_settings_goal_state
 
             try:
                 ExtensionsGoalState.compare(from_extensions_config, from_vm_settings)
@@ -29,7 +29,7 @@ class ExtensionsGoalStateTestCase(AgentTestCase):
     def test_compare_should_report_mismatches_between_extensions_config_and_vm_settings(self):
         with mock_wire_protocol(mockwiredata.DATA_FILE_VM_SETTINGS) as protocol:
             from_extensions_config = protocol.client.get_extensions_goal_state()
-            from_vm_settings = protocol.client._extensions_goal_state_from_vm_settings
+            from_vm_settings = protocol.client._vm_settings_goal_state
 
             def assert_compare_raises(setup_copy, failing_attribute):
                 from_vm_settings_copy = copy.deepcopy(from_vm_settings)
@@ -63,45 +63,16 @@ class ExtensionsGoalStateTestCase(AgentTestCase):
             assert_compare_raises(lambda c: setattr(c.extensions[0].settings[0], "dependencyLevel",       56789),                       r"extensions[0].settings[0].dependencyLevel")
             assert_compare_raises(lambda c: setattr(c.extensions[0].settings[0], "state",                 'MOCK_STATE'),                r"extensions[0].settings[0].state")
 
-    def test_compare_should_check_the_status_upload_blob_only_when_the_host_ga_plugin_version_is_greater_then_112(self):
-        with mock_wire_protocol(mockwiredata.DATA_FILE_VM_SETTINGS) as protocol:
-            from_extensions_config = protocol.client.get_extensions_goal_state()
-            from_vm_settings = protocol.client._extensions_goal_state_from_vm_settings
-
-            # we set the status upload value to a dummy value to verify whether the compare() method is checking it or not
-            from_vm_settings._status_upload_blob = "A DUMMY VALUE FOR THE STATUS UPLOAD BLOB"
-
-            #
-            # 112 and below should not check the status blob
-            #
-            from_vm_settings._host_ga_plugin_version = FlexibleVersion("1.0.8.112")
-
-            try:
-                ExtensionsGoalState.compare(from_extensions_config, from_vm_settings)
-            except GoalStateMismatchError as error:
-                self.fail("The status upload blob should not have been checked when the Host GA Plugin version is 112 or below (Got error: {0})".format(error))
-
-            #
-            # 113 and above should check the status blob
-            #
-            from_vm_settings._host_ga_plugin_version = FlexibleVersion("1.0.8.113")
-
-            with self.assertRaisesRegexCM(GoalStateMismatchError, r"\(Attribute: status_upload_blob\)"):
-                ExtensionsGoalState.compare(from_extensions_config, from_vm_settings)
-
     def test_create_from_extensions_config_should_assume_block_when_blob_type_is_not_valid(self):
         data_file = mockwiredata.DATA_FILE.copy()
-        data_file["ext_conf"] = "hostgaplugin/ext_conf-invalid_blob_type.xml"
+        data_file["vm_settings"] = "hostgaplugin/ext_conf-invalid_blob_type.xml"
         with mock_wire_protocol(data_file) as protocol:
-            actual = protocol.client.get_extensions_goal_state().status_upload_blob_type
-            self.assertEqual("BlockBlob", actual, 'Expected BlockBob for an invalid statusBlobType')
+            extensions_goal_state = ExtensionsGoalStateFactory.create_from_extensions_config(123, load_data("hostgaplugin/ext_conf-invalid_blob_type.xml"), protocol)
+            self.assertEqual("BlockBlob", extensions_goal_state.status_upload_blob_type, 'Expected BlockBob for an invalid statusBlobType')
 
     def test_create_from_vm_settings_should_assume_block_when_blob_type_is_not_valid(self):
-        data_file = mockwiredata.DATA_FILE.copy()
-        data_file["vm_settings"] = "hostgaplugin/vm_settings-invalid_blob_type.json"
-        with mock_wire_protocol(data_file) as protocol:
-            actual = protocol.client._extensions_goal_state_from_vm_settings.status_upload_blob_type
-            self.assertEqual("BlockBlob", actual, 'Expected BlockBob for an invalid statusBlobType')
+        extensions_goal_state = ExtensionsGoalStateFactory.create_from_vm_settings(1234567890, load_data("hostgaplugin/vm_settings-invalid_blob_type.json"))
+        self.assertEqual("BlockBlob", extensions_goal_state.status_upload_blob_type, 'Expected BlockBob for an invalid statusBlobType')
 
     def test_extension_goal_state_should_parse_requested_version_properly(self):
         with mock_wire_protocol(mockwiredata.DATA_FILE) as protocol:
@@ -109,7 +80,7 @@ class ExtensionsGoalStateTestCase(AgentTestCase):
             for manifest in fabric_manifests:
                 self.assertEqual(manifest.requested_version_string, "0.0.0.0", "Version should be None")
 
-            vm_settings_ga_manifests = protocol.client._extensions_goal_state_from_vm_settings.agent_manifests
+            vm_settings_ga_manifests = protocol.client._vm_settings_goal_state.agent_manifests
             for manifest in vm_settings_ga_manifests:
                 self.assertEqual(manifest.requested_version_string, "0.0.0.0", "Version should be None")
 
@@ -121,6 +92,6 @@ class ExtensionsGoalStateTestCase(AgentTestCase):
             for manifest in fabric_manifests:
                 self.assertEqual(manifest.requested_version_string, "9.9.9.10", "Version should be 9.9.9.10")
 
-            vm_settings_ga_manifests = protocol.client._extensions_goal_state_from_vm_settings.agent_manifests
+            vm_settings_ga_manifests = protocol.client._vm_settings_goal_state.agent_manifests
             for manifest in vm_settings_ga_manifests:
                 self.assertEqual(manifest.requested_version_string, "9.9.9.9", "Version should be 9.9.9.9")

--- a/tests/protocol/test_wire.py
+++ b/tests/protocol/test_wire.py
@@ -37,6 +37,7 @@ from azurelinuxagent.common.protocol import hostplugin
 from azurelinuxagent.common.protocol.extensions_goal_state import GoalStateMismatchError
 from azurelinuxagent.common.protocol.extensions_goal_state_factory import ExtensionsGoalStateFactory
 from azurelinuxagent.common.protocol.extensions_goal_state_from_extensions_config import ExtensionsGoalStateFromExtensionsConfig
+from azurelinuxagent.common.protocol.extensions_goal_state_from_vm_settings import ExtensionsGoalStateFromVmSettings
 from azurelinuxagent.common.protocol.hostplugin import HostPluginProtocol
 from azurelinuxagent.common.protocol.wire import WireProtocol, WireClient, \
     StatusBlob, VMStatus, EXT_CONF_FILE_NAME, _ErrorReporter
@@ -1313,10 +1314,89 @@ class UpdateGoalStateTestCase(HttpRequestPredicates, AgentTestCase):
 
                 self.assertEqual(3, len(messages), "Expected additional errors to be reported in the next period (got: {0})".format(messages))
 
+    def test_it_should_use_vm_settings_by_default(self):
+        with mock_wire_protocol(mockwiredata.DATA_FILE_VM_SETTINGS) as protocol:
+            extensions_goal_state = protocol.get_extensions_goal_state()
+            self.assertTrue(
+                isinstance(extensions_goal_state, ExtensionsGoalStateFromVmSettings),
+                'The extensions goal state should have been created from the vmSettings (got: {0})'.format(type(extensions_goal_state)))
+
+    def _assert_is_extensions_goal_state_from_extesions_config(self, extensions_goal_state):
+        self.assertTrue(
+            isinstance(extensions_goal_state, ExtensionsGoalStateFromExtensionsConfig),
+            'The extensions goal state should have been created from the extensionsConfig (got: {0})'.format(type(extensions_goal_state)))
+
+    def test_it_should_use_extensions_config_when_fast_track_is_disabled(self):
+        with patch("azurelinuxagent.common.conf.get_enable_fast_track", return_value=False):
+            with mock_wire_protocol(mockwiredata.DATA_FILE_VM_SETTINGS) as protocol:
+                self._assert_is_extensions_goal_state_from_extesions_config(protocol.get_extensions_goal_state())
+
+    def test_it_should_use_extensions_config_when_fast_track_is_not_supported(self):
+        def http_get_handler(url, *_, **__):
+            if self.is_host_plugin_vm_settings_request(url):
+                return MockHttpResponse(httpclient.NOT_FOUND)
+            return None
+
+        with mock_wire_protocol(mockwiredata.DATA_FILE_VM_SETTINGS, http_get_handler=http_get_handler) as protocol:
+            self._assert_is_extensions_goal_state_from_extesions_config(protocol.get_extensions_goal_state())
+
+    def test_it_should_use_extensions_config_when_the_vm_settings_request_fails(self):
+        def http_get_handler(url, *_, **__):
+            if self.is_host_plugin_vm_settings_request(url):
+                return MockHttpResponse(httpclient.INTERNAL_SERVER_ERROR)
+            return None
+
+        with mock_wire_protocol(mockwiredata.DATA_FILE_VM_SETTINGS, http_get_handler=http_get_handler) as protocol:
+            self._assert_is_extensions_goal_state_from_extesions_config(protocol.get_extensions_goal_state())
+
+    def test_it_should_use_extensions_config_when_the_host_ga_plugin_version_is_not_supported(self):
+        data_file = mockwiredata.DATA_FILE_VM_SETTINGS.copy()
+        data_file["vm_settings"] = "hostgaplugin/vm_settings-unsupported_version.json"
+
+        with mock_wire_protocol(data_file) as protocol:
+            self._assert_is_extensions_goal_state_from_extesions_config(protocol.get_extensions_goal_state())
+
+    def test_it_should_use_extensions_config_when_vm_settings_can_not_be_parsed(self):
+        data_file = mockwiredata.DATA_FILE_VM_SETTINGS.copy()
+        data_file["vm_settings"] = "hostgaplugin/vm_settings-parse_error.json"
+
+        with mock_wire_protocol(data_file) as protocol:
+            self._assert_is_extensions_goal_state_from_extesions_config(protocol.get_extensions_goal_state())
+
+    def test_it_should_use_extensions_config_when_vm_settings_do_not_match_extensions_config(self):
+        data_file = mockwiredata.DATA_FILE_VM_SETTINGS.copy()
+        data_file["vm_settings"] = "hostgaplugin/vm_settings-difference_in_required_features.json"
+
+        with patch('azurelinuxagent.common.event.EventLogger.add_event') as add_event_patcher:
+            with mock_wire_protocol(data_file) as protocol:
+                self._assert_is_extensions_goal_state_from_extesions_config(protocol.get_extensions_goal_state())
+
+                reported = [call for call in add_event_patcher.call_args_list if call.kwargs['op'] == "VmSettings" and "GoalStateMismatchError" in call.kwargs['message']]
+                self.assertEqual(1, len(reported), "The goal state mismatch should have been reported exactly once; got: {0}".format([call.kwargs['message'] for call in add_event_patcher.call_args_list]))
+
+    def test_it_should_compare_goal_states_when_vm_settings_change(self):
+        with mock_wire_protocol(mockwiredata.DATA_FILE_VM_SETTINGS) as protocol:
+            protocol.mock_wire_data.set_etag("aNewEtag")
+
+            with patch('azurelinuxagent.common.protocol.extensions_goal_state.ExtensionsGoalState.compare') as compare_patcher:
+                protocol.update_goal_state()
+
+            self.assertEqual(1, compare_patcher.call_count, "ExtensionsGoalState.compare() should have been called exactly once")
+
+    def test_it_should_compare_goal_states_when_extensions_config_change(self):
+        with mock_wire_protocol(mockwiredata.DATA_FILE_VM_SETTINGS) as protocol:
+            protocol.mock_wire_data.set_incarnation(468753)
+
+            with patch('azurelinuxagent.common.protocol.extensions_goal_state.ExtensionsGoalState.compare') as compare_patcher:
+                protocol.update_goal_state()
+
+            self.assertEqual(1, compare_patcher.call_count, "ExtensionsGoalState.compare() should have been called exactly once")
+
 
 class UpdateHostPluginFromGoalStateTestCase(AgentTestCase):
     """
     Tests for WireClient.update_host_plugin_from_goal_state()
+
     """
 
     def test_it_should_update_the_host_plugin_with_or_without_incarnation_changes(self):

--- a/tests/protocol/test_wire.py
+++ b/tests/protocol/test_wire.py
@@ -1321,7 +1321,7 @@ class UpdateGoalStateTestCase(HttpRequestPredicates, AgentTestCase):
                 isinstance(extensions_goal_state, ExtensionsGoalStateFromVmSettings),
                 'The extensions goal state should have been created from the vmSettings (got: {0})'.format(type(extensions_goal_state)))
 
-    def _assert_is_extensions_goal_state_from_extesions_config(self, extensions_goal_state):
+    def _assert_is_extensions_goal_state_from_extensions_config(self, extensions_goal_state):
         self.assertTrue(
             isinstance(extensions_goal_state, ExtensionsGoalStateFromExtensionsConfig),
             'The extensions goal state should have been created from the extensionsConfig (got: {0})'.format(type(extensions_goal_state)))
@@ -1329,7 +1329,7 @@ class UpdateGoalStateTestCase(HttpRequestPredicates, AgentTestCase):
     def test_it_should_use_extensions_config_when_fast_track_is_disabled(self):
         with patch("azurelinuxagent.common.conf.get_enable_fast_track", return_value=False):
             with mock_wire_protocol(mockwiredata.DATA_FILE_VM_SETTINGS) as protocol:
-                self._assert_is_extensions_goal_state_from_extesions_config(protocol.get_extensions_goal_state())
+                self._assert_is_extensions_goal_state_from_extensions_config(protocol.get_extensions_goal_state())
 
     def test_it_should_use_extensions_config_when_fast_track_is_not_supported(self):
         def http_get_handler(url, *_, **__):
@@ -1338,7 +1338,7 @@ class UpdateGoalStateTestCase(HttpRequestPredicates, AgentTestCase):
             return None
 
         with mock_wire_protocol(mockwiredata.DATA_FILE_VM_SETTINGS, http_get_handler=http_get_handler) as protocol:
-            self._assert_is_extensions_goal_state_from_extesions_config(protocol.get_extensions_goal_state())
+            self._assert_is_extensions_goal_state_from_extensions_config(protocol.get_extensions_goal_state())
 
     def test_it_should_use_extensions_config_when_the_vm_settings_request_fails(self):
         def http_get_handler(url, *_, **__):
@@ -1347,21 +1347,21 @@ class UpdateGoalStateTestCase(HttpRequestPredicates, AgentTestCase):
             return None
 
         with mock_wire_protocol(mockwiredata.DATA_FILE_VM_SETTINGS, http_get_handler=http_get_handler) as protocol:
-            self._assert_is_extensions_goal_state_from_extesions_config(protocol.get_extensions_goal_state())
+            self._assert_is_extensions_goal_state_from_extensions_config(protocol.get_extensions_goal_state())
 
     def test_it_should_use_extensions_config_when_the_host_ga_plugin_version_is_not_supported(self):
         data_file = mockwiredata.DATA_FILE_VM_SETTINGS.copy()
         data_file["vm_settings"] = "hostgaplugin/vm_settings-unsupported_version.json"
 
         with mock_wire_protocol(data_file) as protocol:
-            self._assert_is_extensions_goal_state_from_extesions_config(protocol.get_extensions_goal_state())
+            self._assert_is_extensions_goal_state_from_extensions_config(protocol.get_extensions_goal_state())
 
     def test_it_should_use_extensions_config_when_vm_settings_can_not_be_parsed(self):
         data_file = mockwiredata.DATA_FILE_VM_SETTINGS.copy()
         data_file["vm_settings"] = "hostgaplugin/vm_settings-parse_error.json"
 
         with mock_wire_protocol(data_file) as protocol:
-            self._assert_is_extensions_goal_state_from_extesions_config(protocol.get_extensions_goal_state())
+            self._assert_is_extensions_goal_state_from_extensions_config(protocol.get_extensions_goal_state())
 
     def test_it_should_use_extensions_config_when_vm_settings_do_not_match_extensions_config(self):
         data_file = mockwiredata.DATA_FILE_VM_SETTINGS.copy()
@@ -1369,7 +1369,7 @@ class UpdateGoalStateTestCase(HttpRequestPredicates, AgentTestCase):
 
         with patch('azurelinuxagent.common.event.EventLogger.add_event') as add_event_patcher:
             with mock_wire_protocol(data_file) as protocol:
-                self._assert_is_extensions_goal_state_from_extesions_config(protocol.get_extensions_goal_state())
+                self._assert_is_extensions_goal_state_from_extensions_config(protocol.get_extensions_goal_state())
 
                 reported = [kwargs for _, kwargs in add_event_patcher.call_args_list if kwargs['op'] == "VmSettings" and "GoalStateMismatchError" in kwargs['message']]
                 self.assertEqual(1, len(reported), "The goal state mismatch should have been reported exactly once; got: {0}".format([kwargs['message'] for _, kwargs in add_event_patcher.call_args_list]))

--- a/tests/protocol/test_wire.py
+++ b/tests/protocol/test_wire.py
@@ -1371,8 +1371,8 @@ class UpdateGoalStateTestCase(HttpRequestPredicates, AgentTestCase):
             with mock_wire_protocol(data_file) as protocol:
                 self._assert_is_extensions_goal_state_from_extesions_config(protocol.get_extensions_goal_state())
 
-                reported = [call for call in add_event_patcher.call_args_list if call.kwargs['op'] == "VmSettings" and "GoalStateMismatchError" in call.kwargs['message']]
-                self.assertEqual(1, len(reported), "The goal state mismatch should have been reported exactly once; got: {0}".format([call.kwargs['message'] for call in add_event_patcher.call_args_list]))
+                reported = [kwargs for _, kwargs in add_event_patcher.call_args_list if kwargs['op'] == "VmSettings" and "GoalStateMismatchError" in kwargs['message']]
+                self.assertEqual(1, len(reported), "The goal state mismatch should have been reported exactly once; got: {0}".format([kwargs['message'] for _, kwargs in add_event_patcher.call_args_list]))
 
     def test_it_should_compare_goal_states_when_vm_settings_change(self):
         with mock_wire_protocol(mockwiredata.DATA_FILE_VM_SETTINGS) as protocol:


### PR DESCRIPTION
Now we use vmSettings for extension processing. We still fallback to extensionsConfig if the HostGAPlugin does not support Fast Track, if there are errors fetching the vmSettings, or if they are different to extensionsConfig.