### PR TITLE
Add support for python 2.6 to the log collection code

### DIFF
--- a/azurelinuxagent/common/logcollector.py
+++ b/azurelinuxagent/common/logcollector.py
@@ -366,7 +366,8 @@ class LogCollector(object):
 
                 compressed_archive.write(OUTPUT_RESULTS_FILE_PATH.encode("utf-8"), arcname="results.txt")
             finally:
-                compressed_archive.close()
+                if compressed_archive is not None:
+                    compressed_archive.close()
 
             return COMPRESSED_ARCHIVE_PATH
         except Exception as e:

--- a/azurelinuxagent/common/logcollector.py
+++ b/azurelinuxagent/common/logcollector.py
@@ -350,7 +350,6 @@ class LogCollector(object):
 
             try:
                 compressed_archive = zipfile.ZipFile(COMPRESSED_ARCHIVE_PATH, "w", compression=zipfile.ZIP_DEFLATED)
-                compressed_archive.__enter__()
 
                 for file_to_collect in files_to_collect:
                     archive_file_name = LogCollector._convert_file_name_to_archive_name(file_to_collect)
@@ -367,7 +366,7 @@ class LogCollector(object):
 
                 compressed_archive.write(OUTPUT_RESULTS_FILE_PATH.encode("utf-8"), arcname="results.txt")
             finally:
-                compressed_archive.__exit__()
+                compressed_archive.close()
 
             # with zipfile.ZipFile(COMPRESSED_ARCHIVE_PATH, "w", compression=zipfile.ZIP_DEFLATED) as compressed_archive:
             #     for file_to_collect in files_to_collect:

--- a/azurelinuxagent/common/logcollector.py
+++ b/azurelinuxagent/common/logcollector.py
@@ -348,7 +348,10 @@ class LogCollector(object):
             files_to_collect = self._create_list_of_files_to_collect()
             _LOGGER.info("### Creating compressed archive ###")
 
-            with zipfile.ZipFile(COMPRESSED_ARCHIVE_PATH, "w", compression=zipfile.ZIP_DEFLATED) as compressed_archive:
+            try:
+                compressed_archive = zipfile.ZipFile(COMPRESSED_ARCHIVE_PATH, "w", compression=zipfile.ZIP_DEFLATED)
+                compressed_archive.__enter__()
+
                 for file_to_collect in files_to_collect:
                     archive_file_name = LogCollector._convert_file_name_to_archive_name(file_to_collect)
                     compressed_archive.write(file_to_collect.encode("utf-8"), arcname=archive_file_name)
@@ -363,6 +366,24 @@ class LogCollector(object):
                 _LOGGER.info("Elapsed time: %s ms", elapsed_ms)
 
                 compressed_archive.write(OUTPUT_RESULTS_FILE_PATH.encode("utf-8"), arcname="results.txt")
+            finally:
+                compressed_archive.__exit__()
+
+            # with zipfile.ZipFile(COMPRESSED_ARCHIVE_PATH, "w", compression=zipfile.ZIP_DEFLATED) as compressed_archive:
+            #     for file_to_collect in files_to_collect:
+            #         archive_file_name = LogCollector._convert_file_name_to_archive_name(file_to_collect)
+            #         compressed_archive.write(file_to_collect.encode("utf-8"), arcname=archive_file_name)
+
+            #     compressed_archive_size = os.path.getsize(COMPRESSED_ARCHIVE_PATH)
+            #     _LOGGER.info("Successfully compressed files. Compressed archive size is %s b", compressed_archive_size)
+
+            #     end_time = datetime.utcnow()
+            #     duration = end_time - start_time
+            #     elapsed_ms = int(((duration.days * 24 * 60 * 60 + duration.seconds) * 1000) + (duration.microseconds / 1000.0))
+            #     _LOGGER.info("Finishing log collection at %s", end_time.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"))
+            #     _LOGGER.info("Elapsed time: %s ms", elapsed_ms)
+
+            #     compressed_archive.write(OUTPUT_RESULTS_FILE_PATH.encode("utf-8"), arcname="results.txt")
 
             return COMPRESSED_ARCHIVE_PATH
         except Exception as e:

--- a/azurelinuxagent/common/logcollector.py
+++ b/azurelinuxagent/common/logcollector.py
@@ -368,22 +368,6 @@ class LogCollector(object):
             finally:
                 compressed_archive.close()
 
-            # with zipfile.ZipFile(COMPRESSED_ARCHIVE_PATH, "w", compression=zipfile.ZIP_DEFLATED) as compressed_archive:
-            #     for file_to_collect in files_to_collect:
-            #         archive_file_name = LogCollector._convert_file_name_to_archive_name(file_to_collect)
-            #         compressed_archive.write(file_to_collect.encode("utf-8"), arcname=archive_file_name)
-
-            #     compressed_archive_size = os.path.getsize(COMPRESSED_ARCHIVE_PATH)
-            #     _LOGGER.info("Successfully compressed files. Compressed archive size is %s b", compressed_archive_size)
-
-            #     end_time = datetime.utcnow()
-            #     duration = end_time - start_time
-            #     elapsed_ms = int(((duration.days * 24 * 60 * 60 + duration.seconds) * 1000) + (duration.microseconds / 1000.0))
-            #     _LOGGER.info("Finishing log collection at %s", end_time.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"))
-            #     _LOGGER.info("Elapsed time: %s ms", elapsed_ms)
-
-            #     compressed_archive.write(OUTPUT_RESULTS_FILE_PATH.encode("utf-8"), arcname="results.txt")
-
             return COMPRESSED_ARCHIVE_PATH
         except Exception as e:
             msg = "Failed to collect logs: {0}".format(ustr(e))

--- a/azurelinuxagent/common/logcollector.py
+++ b/azurelinuxagent/common/logcollector.py
@@ -348,6 +348,8 @@ class LogCollector(object):
             files_to_collect = self._create_list_of_files_to_collect()
             _LOGGER.info("### Creating compressed archive ###")
 
+            compressed_archive = None
+
             try:
                 compressed_archive = zipfile.ZipFile(COMPRESSED_ARCHIVE_PATH, "w", compression=zipfile.ZIP_DEFLATED)
 

--- a/azurelinuxagent/ga/collect_logs.py
+++ b/azurelinuxagent/ga/collect_logs.py
@@ -47,7 +47,7 @@ def is_log_collection_allowed():
     # 3) The python version must be greater than 2.6 in order to support the ZipFile library used when collecting.
     conf_enabled = conf.get_collect_logs()
     cgroups_enabled = CGroupConfigurator.get_instance().enabled()
-    supported_python = PY_VERSION_MINOR >= 7 if PY_VERSION_MAJOR == 2 else PY_VERSION_MAJOR == 3
+    supported_python = PY_VERSION_MINOR >= 6 if PY_VERSION_MAJOR == 2 else PY_VERSION_MAJOR == 3
     is_allowed = conf_enabled and cgroups_enabled and supported_python
 
     msg = "Checking if log collection is allowed at this time [{0}]. All three conditions must be met: " \


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Relaxes the requirements for the log collection background task to allow for python2.6 to run it. Right now, there aren't any distros that are on python2.6 and also have cgroups enabled (another requirement of that code running), but if/when cgroups are enabled for those distros, the log collection background task will also be enabled for those distros.

Also makes the log collection code python2.6 compatible, which right now allows `waagent -collect-logs` to be ran on distros with python2.6.

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).