### PR TITLE
Add an initial delay to the log collection background task

### DIFF
--- a/azurelinuxagent/ga/collect_logs.py
+++ b/azurelinuxagent/ga/collect_logs.py
@@ -36,6 +36,8 @@ from azurelinuxagent.common.utils import shellutil
 from azurelinuxagent.common.utils.shellutil import CommandError
 from azurelinuxagent.common.version import PY_VERSION_MAJOR, PY_VERSION_MINOR, AGENT_NAME, CURRENT_VERSION
 
+_INITIAL_LOG_COLLECTION_DELAY = 5 * 60 # Five minutes of delay
+
 def get_collect_logs_handler():
     return CollectLogsHandler()
 
@@ -133,6 +135,10 @@ class CollectLogsHandler(ThreadHandlerInterface):
         self.protocol = self.protocol_util.get_protocol()
 
     def daemon(self):
+        # Delay the first collector on start up to give short lived VMs (that might be dead before the second 
+        # collection has a chance to run) an opportunity to do produce meaningful logs to collect.
+        time.sleep(_INITIAL_LOG_COLLECTION_DELAY)
+
         try:
             CollectLogsHandler.enable_cgroups_validation()
             if self.protocol_util is None or self.protocol is None:


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

For especially short-lived VMs, the following scenario often happens:

* VM boots up and the log collection task runs
* VM does meaningful work that we would want logs for
* VM dies before the log collection task can run again

This change aims to delay the initial run of the log collection task so that it is between the "meaningful work" and the "VM dies" events.

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).