### PR TITLE
Fix test_get_latest_agent_should_return_latest_agent_even_on_bad_error_json

### DIFF
--- a/tests/ga/test_update.py
+++ b/tests/ga/test_update.py
@@ -1345,7 +1345,7 @@ class TestUpdate(UpdateTestCase):
         self.assertEqual(0, mock_signal.call_count)
 
     def test_get_latest_agent_should_return_latest_agent_even_on_bad_error_json(self):
-        self.prepare_agents()
+        dst_ver = self.prepare_agents()
         # Add a malformed error.json file in all existing agents
         for agent_dir in self.agent_dirs():
             error_file_path = os.path.join(agent_dir, AGENT_ERROR_FILE)
@@ -1353,7 +1353,7 @@ class TestUpdate(UpdateTestCase):
                 f.write("")
 
         latest_agent = self.update_handler.get_latest_agent()
-        self.assertEqual(latest_agent.name, 'WALinuxAgent-9.9.9.28', "Latest agent is invalid")
+        self.assertEqual(latest_agent.version, dst_ver, "Latest agent version is invalid")
 
     def _test_run(self, invocations=1, calls=1, enable_updates=False, sleep_interval=(6,)):
         conf.get_autoupdate_enabled = Mock(return_value=enable_updates)


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

The test `test_get_latest_agent_should_return_latest_agent_even_on_bad_error_json` was dependent on the `9.9.*` version which was breaking on `release-*` branches. Removed that dependency

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).