### PR TITLE
Improve reporting for Depends on errors for Single Config extensions

### DIFF
--- a/azurelinuxagent/common/protocol/restapi.py
+++ b/azurelinuxagent/common/protocol/restapi.py
@@ -280,6 +280,7 @@ class ExtHandlerStatus(DataContract):
         self.message = message
         self.supports_multi_config = False
         self.extension_status = None
+        self.dependency_failed = False
 
 
 class VMAgentStatus(DataContract):

--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -241,6 +241,7 @@ class ExtHandlerState(object):
     Installed = "Installed"
     Enabled = "Enabled"
     FailedUpgrade = "FailedUpgrade"
+    DidNotRun = "DidNotRun"
 
 
 class GoalStateStatus(object):
@@ -513,6 +514,11 @@ class ExtHandlersHandler(object):
                 # For SC extensions, overwrite the HandlerStatus with the relevant message
                 else:
                     handler_i.set_handler_status(message=depends_on_err_msg, code=-1)
+                    # We need to convey state to the extension status reporting logic. It will be looking for a status file
+                    # that should have been created by the extension itself, but it cannot be run in this case. Additionally,
+                    # the agent cannot create the status file itself as some extensions will not run when their status file
+                    # already exists, per a legacy bug in the agent.
+                    handler_i.set_handler_state(ExtHandlerState.DidNotRun)
 
                 continue
 
@@ -692,8 +698,8 @@ class ExtHandlersHandler(object):
         current_handler_state = ext_handler_i.get_handler_state()
         ext_handler_i.logger.info("[Enable] current handler state is: {0}", current_handler_state.lower())
         # We go through the entire process of downloading and initializing the extension if it's either a fresh
-        # extension or if it's a retry of a previously failed upgrade.
-        if current_handler_state == ExtHandlerState.NotInstalled or current_handler_state == ExtHandlerState.FailedUpgrade:
+        # extension, it's a retry of a previously failed upgrade, or if the extension did not run last goal state.
+        if current_handler_state in (ExtHandlerState.NotInstalled, ExtHandlerState.FailedUpgrade, ExtHandlerState.DidNotRun):
             self.__setup_new_handler(ext_handler_i, extension)
 
             if old_ext_handler_i is None:
@@ -1017,8 +1023,8 @@ class ExtHandlersHandler(object):
         if handler_state != ExtHandlerState.NotInstalled or ext_handler.supports_multi_config:
 
             # Since we require reading the Manifest for reading the heartbeat, this would fail if HandlerManifest not found.
-            # Only try to read heartbeat if HandlerState != NotInstalled.
-            if handler_state != ExtHandlerState.NotInstalled:
+            # Only try to read heartbeat if the handler was installed (!= ExtHandlerState.NotInstalled, ExtHandlerState.DidNotRun).
+            if not handler_state in (ExtHandlerState.NotInstalled, ExtHandlerState.DidNotRun):
                 # Heartbeat is a handler level thing only, so we dont need to modify this
                 try:
                     heartbeat = ext_handler_i.collect_heartbeat()
@@ -1678,6 +1684,11 @@ class ExtHandlerInstance(object):
         data_str = None
         # Extension.name contains the extension name in case of MC and Handler name in case of Single Config.
         ext_status = ExtensionStatus(name=ext.name, seq_no=seq_no)
+
+        if self.get_handler_state() == ExtHandlerState.DidNotRun:
+            handler_status = self.get_handler_status()
+            ext_status.message = handler_status.message
+            return ext_status
 
         try:
             data_str, data = self._read_status_file(ext_status_file)

--- a/tests/ga/test_extension.py
+++ b/tests/ga/test_extension.py
@@ -3451,10 +3451,12 @@ class TestExtension(TestExtensionBase, HttpRequestPredicates):
                     .format(extension.status_blobs))
 
                 extension_status_msg = get_keypath_or_throw(extension.status_blobs[0],
-                    "runtimeSettingsStatus/settingsStatus/status/formattedMessage/message")
+                    "runtimeSettingsStatus/settingsStatus/status/formattedMessage/message",
+                    msg="SC extension '{0}' did not report extension status when its dependency failed."\
+                        .format(extension.name))
+
                 expected_extension_status_msg = "Skipping processing of extensions since execution of dependent extension {0} failed"\
                     .format("OSTCExtensions.OtherExampleHandlerLinux")
-
                 self.assertEqual(extension_status_msg, expected_extension_status_msg, 
                     "Expected the extension status to match {0}, but got '{1}' instead."\
                         .format(expected_extension_status_msg, extension_status_msg))

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -120,6 +120,22 @@ def i_am_root():
 def is_python_version_26():
     return sys.version_info[0] == 2 and sys.version_info[1] == 6
 
+def get_keypath_or_throw(obj, keypath, msg=None):
+    keys = keypath.split('/')
+
+    cur_loc = obj
+    for key in keys:
+        if isinstance(cur_loc, dict) and (key in cur_loc):
+            cur_loc = cur_loc[key]
+            continue
+
+        if msg is None:
+            msg = "Expected Key path '{0}' in {1}"\
+                .format(keypath, obj)
+        raise AttributeError(msg)
+    
+    return cur_loc
+
 
 class AgentTestCase(unittest.TestCase):
     @classmethod


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

In the current code base, SC extensions report no extension status if any of their dependencies fail. This makes for unhelpful customer facing error messages. This PR  addresses this by explicitly reporting failed dependencies as a reason for not running.

<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).