### PR TITLE
Set vmSettings as primary channel for extensions goal state

### DIFF
--- a/azurelinuxagent/common/protocol/extensions_goal_state.py
+++ b/azurelinuxagent/common/protocol/extensions_goal_state.py
@@ -19,14 +19,7 @@ import datetime
 
 import azurelinuxagent.common.logger as logger
 from azurelinuxagent.common.AgentGlobals import AgentGlobals
-from azurelinuxagent.common.exception import AgentError
 from azurelinuxagent.common.utils import textutil
-
-
-class GoalStateMismatchError(AgentError):
-    def __init__(self, message, attribute):
-        super(GoalStateMismatchError, self).__init__(message)
-        self.attribute = attribute
 
 
 class ExtensionsGoalState(object):
@@ -89,81 +82,6 @@ class ExtensionsGoalState(object):
         Returns the raw text (either the ExtensionsConfig or the vmSettings) with any confidential data removed, or an empty string for empty goal states.
         """
         raise NotImplementedError()
-
-    @staticmethod
-    def compare(from_extensions_config, from_vm_settings):
-        """
-        Compares the two instances given as argument and logs a GoalStateMismatch message if they are different.
-
-        NOTE: The order of the two instances is important for the debug info to be logged correctly (ExtensionsConfig first, vmSettings second)
-        """
-        context = []  # used to keep track of the attribute that is being compared
-
-        def compare_goal_states(first, second):
-            # A mismatch on the timestamp or the activity ID (and maybe also on the correlation ID) most likely indicate that we are comparing two
-            # different goal states so we check them first (we raise an exception as soon as a mismatch is detected). A mismatch on the other
-            # attributes likely indicates an actual issue on vmSettings or extensionsConfig).
-            compare_attributes(first, second, "created_on_timestamp")
-            compare_attributes(first, second, "activity_id")
-            compare_attributes(first, second, "correlation_id")
-            compare_attributes(first, second, "status_upload_blob")
-            compare_attributes(first, second, "status_upload_blob_type")
-            compare_attributes(first, second, "required_features")
-            compare_attributes(first, second, "on_hold")
-            compare_array(first.agent_manifests, second.agent_manifests, compare_agent_manifests, "agent_manifests")
-            compare_array(first.extensions, second.extensions, compare_extensions, "extensions")
-
-        def compare_agent_manifests(first, second):
-            compare_attributes(first, second, "family")
-            compare_attributes(first, second, "requested_version_string")
-            compare_attributes(first, second, "uris", ignore_order=True)
-
-        def compare_extensions(first, second):
-            compare_attributes(first, second, "name")
-            compare_attributes(first, second, "version")
-            compare_attributes(first, second, "state")
-            compare_attributes(first, second, "supports_multi_config")
-            compare_attributes(first, second, "manifest_uris", ignore_order=True)
-            compare_array(first.settings, second.settings, compare_settings, "settings")
-
-        def compare_settings(first, second):
-            compare_attributes(first, second, "name")
-            compare_attributes(first, second, "sequenceNumber")
-            compare_attributes(first, second, "publicSettings")
-            compare_attributes(first, second, "protectedSettings")
-            compare_attributes(first, second, "certificateThumbprint")
-            compare_attributes(first, second, "dependencyLevel")
-            compare_attributes(first, second, "state")
-
-        def compare_array(first, second, comparer, name):
-            if len(first) != len(second):
-                raise Exception("Number of items in {0} mismatch: {1} != {2}".format(name, len(first), len(second)))
-            for i in range(len(first)):
-                context.append("{0}[{1}]".format(name, i))
-                try:
-                    comparer(first[i], second[i])
-                finally:
-                    context.pop()
-
-        def compare_attributes(first, second, attribute, ignore_order=False):
-            context.append(attribute)
-            try:
-                first_value = getattr(first, attribute)
-                second_value = getattr(second, attribute)
-                if ignore_order:
-                    first_value = first_value[:]
-                    first_value.sort()
-                    second_value = second_value[:]
-                    second_value.sort()
-
-                if first_value != second_value:
-                    mistmatch = "[{0}] != [{1}] (Attribute: {2})".format(first_value, second_value, ".".join(context))
-                    message = "Mismatch in Goal States [Incarnation {0}] != [Etag: {1}]: {2}".format(from_extensions_config.id, from_vm_settings.id, mistmatch)
-                    raise GoalStateMismatchError(message, attribute)
-            finally:
-                context.pop()
-
-        compare_goal_states(from_extensions_config, from_vm_settings)
 
     def _do_common_validations(self):
         """

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -789,7 +789,9 @@ class WireClient(object):
             # (via the self._fetch_vm_settings_goal_state method).
             #
             # We always need at least 2 queries: one to the WireServer (to check for incarnation changes) and one to the HostGAPlugin
-            # (to check for extension updates).
+            # (to check for extension updates). Note that vmSettings are not a full goal state; they include only the extension information
+            # (minus certificates). The check on incarnation (which is also not included in the vmSettings) is needed to check for changes
+            # in, for example, the remote users for JIT access.
             #
             # We start by fetching the goal state from the WireServer. The response to this initial query will include the incarnation,
             # container ID, role config, and URLs to the rest of the goal state (certificates, remote users, extensions config, etc). We
@@ -827,7 +829,7 @@ class WireClient(object):
                 goal_state_updated = True
 
             #
-            # And, lastly, we fall back to extensionsConfig if Fast Track is disabled or not supported
+            # And, lastly, we use extensionsConfig if we don't have the vmSettings (Fast Track may be disabled or not supported).
             #
             if vm_settings_goal_state is not None:
                 self._extensions_goal_state = vm_settings_goal_state
@@ -850,7 +852,7 @@ class WireClient(object):
         Queries the vmSettings from the HostGAPlugin and returns an (ExtensionsGoalStateFromVmSettings, bool) tuple with the vmSettings and
         a boolean indicating if they are an updated (True) or a cached value (False).
 
-        Raises TypeError if the HostGAPlugin does not support the vmSettings API, or ProtocolError if the request fails for any other reason
+        Raises VmSettingsNotSupported if the HostGAPlugin does not support the vmSettings API, or ProtocolError if the request fails for any other reason
         (e.g. not supported, time out, server error).
         """
         def raise_not_supported(reset_state=False):

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -46,7 +46,7 @@ from azurelinuxagent.common.utils.archive import StateFlusher
 from azurelinuxagent.common.utils.cryptutil import CryptUtil
 from azurelinuxagent.common.utils.flexible_version import FlexibleVersion
 from azurelinuxagent.common.utils.textutil import parse_doc, findall, find, \
-    findtext, gettext, remove_bom, get_bytes_from_pem, parse_json, format_exception
+    findtext, gettext, remove_bom, get_bytes_from_pem, parse_json
 from azurelinuxagent.common.version import AGENT_NAME, CURRENT_VERSION
 
 VERSION_INFO_URI = "http://{0}/?comp=versions"

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -1537,7 +1537,6 @@ class _VmSettingsErrorReporter(object):
         self._error_count += 1
 
         if self._error_count <= _VmSettingsErrorReporter._MaxErrors:
-            logger.info("[VmSettings] [Informational only, the Agent will continue normal operation] {0}", error)
             add_event(op=WALAEventOperation.VmSettings, message=error, is_success=False, log_event=False)
 
         if category == _VmSettingsError.ServerError:

--- a/tests/protocol/mockwiredata.py
+++ b/tests/protocol/mockwiredata.py
@@ -197,7 +197,7 @@ class WireProtocolData(object):
             self.in_vm_artifacts_profile = load_data(in_vm_artifacts_profile_file)
 
     def mock_http_get(self, url, *_, **kwargs):
-        content = None
+        content = ''
         response_headers = []
 
         resp = MagicMock()

--- a/tests/protocol/test_extensions_goal_state.py
+++ b/tests/protocol/test_extensions_goal_state.py
@@ -16,7 +16,7 @@ if sys.version_info[0] < 3 or sys.version_info[0] == 3 and sys.version_info[1] <
 class ExtensionsGoalStateTestCase(AgentTestCase):
     def test_create_from_extensions_config_should_assume_block_when_blob_type_is_not_valid(self):
         data_file = mockwiredata.DATA_FILE.copy()
-        data_file["vm_settings"] = "hostgaplugin/ext_conf-invalid_blob_type.xml"
+        data_file["ext_conf"] = "hostgaplugin/ext_conf-invalid_blob_type.xml"
         with mock_wire_protocol(data_file) as protocol:
             extensions_goal_state = ExtensionsGoalStateFactory.create_from_extensions_config(123, load_data("hostgaplugin/ext_conf-invalid_blob_type.xml"), protocol)
             self.assertEqual("BlockBlob", extensions_goal_state.status_upload_blob_type, 'Expected BlockBob for an invalid statusBlobType')

--- a/tests/protocol/test_extensions_goal_state.py
+++ b/tests/protocol/test_extensions_goal_state.py
@@ -4,9 +4,7 @@ import copy
 import re
 import sys
 
-from azurelinuxagent.common.protocol.extensions_goal_state import ExtensionsGoalState, GoalStateMismatchError
 from azurelinuxagent.common.protocol.extensions_goal_state_factory import ExtensionsGoalStateFactory
-from azurelinuxagent.common.utils import textutil
 from tests.protocol.mocks import mockwiredata, mock_wire_protocol
 from tests.tools import AgentTestCase, load_data
 
@@ -16,53 +14,6 @@ if sys.version_info[0] < 3 or sys.version_info[0] == 3 and sys.version_info[1] <
 
 
 class ExtensionsGoalStateTestCase(AgentTestCase):
-    def test_compare_should_succeed_when_extensions_config_and_vm_settings_are_equal(self):
-        with mock_wire_protocol(mockwiredata.DATA_FILE_VM_SETTINGS) as protocol:
-            from_extensions_config = protocol.client.get_extensions_goal_state()
-            from_vm_settings = protocol.client._cached_vm_settings
-
-            try:
-                ExtensionsGoalState.compare(from_extensions_config, from_vm_settings)
-            except Exception as exception:
-                self.fail("Compare goal state failed: {0}".format(textutil.format_exception(exception)))
-
-    def test_compare_should_report_mismatches_between_extensions_config_and_vm_settings(self):
-        with mock_wire_protocol(mockwiredata.DATA_FILE_VM_SETTINGS) as protocol:
-            from_extensions_config = protocol.client.get_extensions_goal_state()
-            from_vm_settings = protocol.client._cached_vm_settings
-
-            def assert_compare_raises(setup_copy, failing_attribute):
-                from_vm_settings_copy = copy.deepcopy(from_vm_settings)
-                setup_copy(from_vm_settings_copy)
-
-                with self.assertRaisesRegexCM(GoalStateMismatchError, re.escape("(Attribute: {0})".format(failing_attribute)), re.DOTALL):
-                    ExtensionsGoalState.compare(from_extensions_config, from_vm_settings_copy)
-
-            assert_compare_raises(lambda c: setattr(c, "_activity_id",              'MOCK_ACTIVITY_ID'),        "activity_id")
-            assert_compare_raises(lambda c: setattr(c, "_correlation_id",           'MOCK_CORRELATION_ID'),     "correlation_id")
-            assert_compare_raises(lambda c: setattr(c, "_created_on_timestamp",     'MOCK_TIMESTAMP'),          "created_on_timestamp")
-            assert_compare_raises(lambda c: setattr(c, "_status_upload_blob",       'MOCK_UPLOAD_BLOB'),        "status_upload_blob")
-            assert_compare_raises(lambda c: setattr(c, "_status_upload_blob_type",  'MOCK_UPLOAD_BLOB_TYPE'),   "status_upload_blob_type")
-            assert_compare_raises(lambda c: setattr(c, "_required_features",        ['MOCK_REQUIRED_FEATURE']), "required_features")
-            assert_compare_raises(lambda c: setattr(c, "_on_hold",                  False),                     "on_hold")
-
-            assert_compare_raises(lambda c: setattr(c.agent_manifests[0], "family",  'MOCK_FAMILY'),  r"agent_manifests[0].family")
-            assert_compare_raises(lambda c: setattr(c.agent_manifests[0], "requested_version_string", 'MOCK_VERSION'), r"agent_manifests[0].requested_version_string")
-            assert_compare_raises(lambda c: setattr(c.agent_manifests[0], "uris",    ['MOCK_URI']),   r"agent_manifests[0].uris")
-
-            assert_compare_raises(lambda c: setattr(c.extensions[0], "version",  'MOCK_NAME'),         r"extensions[0].version")
-            assert_compare_raises(lambda c: setattr(c.extensions[0], "state",  'MOCK_STATE'),          r"extensions[0].state")
-            assert_compare_raises(lambda c: setattr(c.extensions[0], "manifest_uris",  ['MOCK_URI']),  r"extensions[0].manifest_uris")
-            assert_compare_raises(lambda c: setattr(c.extensions[0], "supports_multi_config",  True),  r"extensions[0].supports_multi_config")
-
-            assert_compare_raises(lambda c: setattr(c.extensions[0].settings[0], "name",                  'MOCK_NAME'),                 r"extensions[0].settings[0].name")
-            assert_compare_raises(lambda c: setattr(c.extensions[0].settings[0], "sequenceNumber",        98765),                       r"extensions[0].settings[0].sequenceNumber")
-            assert_compare_raises(lambda c: setattr(c.extensions[0].settings[0], "publicSettings",        {'MOCK_NAME': 'MOCK_VALUE'}), r"extensions[0].settings[0].publicSettings")
-            assert_compare_raises(lambda c: setattr(c.extensions[0].settings[0], "protectedSettings",     'MOCK_SETTINGS'),             r"extensions[0].settings[0].protectedSettings")
-            assert_compare_raises(lambda c: setattr(c.extensions[0].settings[0], "certificateThumbprint", 'MOCK_CERT'),                 r"extensions[0].settings[0].certificateThumbprint")
-            assert_compare_raises(lambda c: setattr(c.extensions[0].settings[0], "dependencyLevel",       56789),                       r"extensions[0].settings[0].dependencyLevel")
-            assert_compare_raises(lambda c: setattr(c.extensions[0].settings[0], "state",                 'MOCK_STATE'),                r"extensions[0].settings[0].state")
-
     def test_create_from_extensions_config_should_assume_block_when_blob_type_is_not_valid(self):
         data_file = mockwiredata.DATA_FILE.copy()
         data_file["vm_settings"] = "hostgaplugin/ext_conf-invalid_blob_type.xml"
@@ -88,7 +39,7 @@ class ExtensionsGoalStateTestCase(AgentTestCase):
         data_file["vm_settings"] = "hostgaplugin/vm_settings-requested_version.json"
         data_file["ext_conf"] = "hostgaplugin/ext_conf-requested_version.xml"
         with mock_wire_protocol(data_file) as protocol:
-            fabric_manifests, _ = protocol.get_vmagent_manifests()
+            fabric_manifests = protocol.client.get_goal_state().extensions_config.agent_manifests
             for manifest in fabric_manifests:
                 self.assertEqual(manifest.requested_version_string, "9.9.9.10", "Version should be 9.9.9.10")
 

--- a/tests/protocol/test_wire.py
+++ b/tests/protocol/test_wire.py
@@ -42,7 +42,7 @@ from azurelinuxagent.common.protocol.wire import WireProtocol, WireClient, \
     StatusBlob, VMStatus, EXT_CONF_FILE_NAME, _VmSettingsErrorReporter
 from azurelinuxagent.common.telemetryevent import GuestAgentExtensionEventsSchema, \
     TelemetryEventParam, TelemetryEvent
-from azurelinuxagent.common.utils import restutil, textutil
+from azurelinuxagent.common.utils import restutil
 from azurelinuxagent.common.version import CURRENT_VERSION, DISTRO_NAME, DISTRO_VERSION
 from azurelinuxagent.ga.exthandlers import get_exthandlers_handler
 from tests.ga.test_monitor import random_generator


### PR DESCRIPTION
Now  vmSettings is the primary channel for extensions goal state. There is not more fallback to extensionsConfig nor comparison of goal states.

ExtensionConfig is used only when Fast Track is not enable or is not supported.

All goal states are still going thru Fabric.