### PR TITLE
Set agent version to 8.8.8.8 on Fast Track branch

### DIFF
--- a/azurelinuxagent/common/version.py
+++ b/azurelinuxagent/common/version.py
@@ -209,7 +209,7 @@ AGENT_LONG_NAME = "Azure Linux Agent"
 #
 #            When doing a release, be sure to use the actual agent version. Current agent version: 2.4.0.0
 #
-AGENT_VERSION = '9.9.9.9'
+AGENT_VERSION = '8.8.8.8'
 AGENT_LONG_VERSION = "{0}-{1}".format(AGENT_NAME, AGENT_VERSION)
 AGENT_DESCRIPTION = """
 The Azure Linux Agent supports the provisioning and running of Linux


### PR DESCRIPTION
This will make easier to track telemetry from the Fast Track branch. This change will not be merged to develop.