### PR TITLE
Improvements in telemetry for vmSettings

### DIFF
--- a/azurelinuxagent/common/protocol/extensions_goal_state.py
+++ b/azurelinuxagent/common/protocol/extensions_goal_state.py
@@ -127,10 +127,11 @@ class ExtensionsGoalState(object):
             compare_array(first.settings, second.settings, compare_settings, "settings")
 
         def compare_settings(first, second):
+            # Note that we do not compare protectedSettings since the same settings can be re-encrypted, resulting
+            # on different encrypted text for the same plain text.
             compare_attributes(first, second, "name")
             compare_attributes(first, second, "sequenceNumber")
             compare_attributes(first, second, "publicSettings")
-            compare_attributes(first, second, "protectedSettings")
             compare_attributes(first, second, "certificateThumbprint")
             compare_attributes(first, second, "dependencyLevel")
             compare_attributes(first, second, "state")
@@ -157,7 +158,7 @@ class ExtensionsGoalState(object):
                     second_value.sort()
 
                 if first_value != second_value:
-                    if attribute.lower() in ('protectedsettings', 'publicsettings'):
+                    if attribute.lower() == 'publicsettings':
                         mistmatch = "[REDACTED] != [REDACTED] (Attribute: {0})".format(".".join(context))
                     else:
                         mistmatch = "[{0}] != [{1}] (Attribute: {2})".format(first_value, second_value, ".".join(context))

--- a/azurelinuxagent/common/protocol/extensions_goal_state_from_vm_settings.py
+++ b/azurelinuxagent/common/protocol/extensions_goal_state_from_vm_settings.py
@@ -53,7 +53,7 @@ class ExtensionsGoalStateFromVmSettings(ExtensionsGoalState):
             self._parse_vm_settings(json_text)
             self._do_common_validations()
         except Exception as e:
-            raise VmSettingsError("Error parsing vmSettings (etag: {0}): {1}\n{2}".format(etag, format_exception(e), self.get_redacted_text()))
+            raise VmSettingsError("Error parsing vmSettings (etag: {0} HGAP: {1}): {2}\n{3}".format(etag, self._host_ga_plugin_version, format_exception(e), self.get_redacted_text()))
 
     @property
     def id(self):
@@ -139,13 +139,15 @@ class ExtensionsGoalStateFromVmSettings(ExtensionsGoalState):
         #         "extensionGoalStatesSource": "Fabric",
         #         ...
         #     }
-        self._activity_id = self._string_to_id(vm_settings.get("activityId"))
-        self._correlation_id = self._string_to_id(vm_settings.get("correlationId"))
-        self._created_on_timestamp = self._ticks_to_utc_timestamp(vm_settings.get("extensionsLastModifiedTickCount"))
 
+        # The HGAP version is included in some messages, so parse it first
         host_ga_plugin_version = vm_settings.get("hostGAPluginVersion")
         if host_ga_plugin_version is not None:
             self._host_ga_plugin_version = FlexibleVersion(host_ga_plugin_version)
+
+        self._activity_id = self._string_to_id(vm_settings.get("activityId"))
+        self._correlation_id = self._string_to_id(vm_settings.get("correlationId"))
+        self._created_on_timestamp = self._ticks_to_utc_timestamp(vm_settings.get("extensionsLastModifiedTickCount"))
 
         schema_version = vm_settings.get("vmSettingsSchemaVersion")
         if schema_version is not None:

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -894,7 +894,7 @@ class WireClient(object):
         correlation_id = str(uuid.uuid4())
 
         def format_message(msg):
-            return "GET vmSettings [correlation ID: {0} eTag: {1}]: {2}".format(correlation_id, etag, msg)
+            return "GET vmSettings [correlation ID: {0} eTag: {1} HGAP: {2}]: {3}".format(correlation_id, etag, self._host_plugin_version, msg)
 
         try:
             def get_vm_settings():

--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -300,8 +300,9 @@ class ExtHandlersHandler(object):
         try:
             extensions_goal_state = self.protocol.get_extensions_goal_state()
 
-            # self.ext_handlers and etag need to be initialized first, since status reporting depends on them
-            self.ext_handlers = extensions_goal_state.extensions
+            # self.ext_handlers and etag need to be initialized first, since status reporting depends on them; also
+            # we make a deep copy of the extensions, since changes are made to self.ext_handlers while processing the extensions
+            self.ext_handlers = copy.deepcopy(extensions_goal_state.extensions)
             etag = self.protocol.client.get_goal_state().incarnation
 
             if not self._extension_processing_allowed():


### PR DESCRIPTION
* Do not compare protected settings
* Add version of Host GA Plugin to error messages
* Make deep copy of extensions to account for changes in the extension version