### PR TITLE
Modify deny-listing logic of the Agent

### DIFF
--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -480,11 +480,11 @@ class UpdateHandler(object):
                     # (unless the CURRENT_VERSION == daemon version, but since we don't support downgrading
                     # below daemon version, we will never reach this code path if that's the scenario)
                     current_agent = next(agent for agent in self.agents if agent.version == CURRENT_VERSION)
-                    logger.info(
-                        "Blacklisting the agent {0} since a downgrade was requested in the GoalState, "
-                        "suggesting that we really don't want to execute any extensions using this version".format(
-                            CURRENT_VERSION))
-                    current_agent.mark_failure(is_fatal=True)
+                    msg = "Blacklisting the agent {0} since a downgrade was requested in the GoalState, " \
+                          "suggesting that we really don't want to execute any extensions using this version".format(
+                           CURRENT_VERSION)
+                    logger.info(msg)
+                    current_agent.mark_failure(is_fatal=True, reason=msg)
                 except StopIteration:
                     logger.warn(
                         "Could not find a matching agent with current version {0} to blacklist, skipping it".format(

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -1254,7 +1254,7 @@ class UpdateHandler(object):
         # (this flag signifies that this agent was blacklisted by the newer agents).
         try:
             legacy_blacklisted_agents = [agent for agent in self._load_agents() if
-                                         agent.is_blacklisted and agent.error.reason is None]
+                                         agent.is_blacklisted and agent.error.reason == '']
             for agent in legacy_blacklisted_agents:
                 agent.clear_error()
         except Exception as err:
@@ -1354,7 +1354,7 @@ class GuestAgent(object):
         return self.is_blacklisted or \
                os.path.isfile(self.get_agent_manifest_path())
 
-    def mark_failure(self, is_fatal=False, reason=None):
+    def mark_failure(self, is_fatal=False, reason=''):
         try:
             if not os.path.isdir(self.get_agent_dir()):
                 os.makedirs(self.get_agent_dir())
@@ -1552,12 +1552,12 @@ class GuestAgentError(object):
             raise UpdateError(u"GuestAgentError requires a path")
         self.path = path
         self.failure_count = 0
-        self.reason = None
+        self.reason = ''
 
         self.clear()
         return
 
-    def mark_failure(self, is_fatal=False, reason=None):
+    def mark_failure(self, is_fatal=False, reason=''):
         self.last_failure = time.time()
         self.failure_count += 1
         self.was_fatal = is_fatal
@@ -1568,7 +1568,7 @@ class GuestAgentError(object):
         self.last_failure = 0.0
         self.failure_count = 0
         self.was_fatal = False
-        self.reason = None
+        self.reason = ''
         return
 
     @property
@@ -1603,8 +1603,8 @@ class GuestAgentError(object):
         self.last_failure = max(self.last_failure, data.get(u"last_failure", 0.0))
         self.failure_count = max(self.failure_count, data.get(u"failure_count", 0))
         self.was_fatal = self.was_fatal or data.get(u"was_fatal", False)
-        reason = data.get(u"reason", None)
-        self.reason = reason if reason is not None else self.reason
+        reason = data.get(u"reason", '')
+        self.reason = reason if reason != '' else self.reason
         return
 
     def to_json(self):

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -1300,7 +1300,13 @@ class GuestAgent(object):
 
             # If we're unable to download/unpack the agent, delete the Agent directory and the zip file (if exists) to
             # ensure we try downloading again in the next round.
-            fileutil.clean_ioerror(e, paths=[self.get_agent_dir(), self.get_agent_pkg_path()])
+            try:
+                if os.path.isdir(self.get_agent_dir()):
+                    shutil.rmtree(self.get_agent_dir(), ignore_errors=True)
+                if os.path.isfile(self.get_agent_pkg_path()):
+                    os.remove(self.get_agent_pkg_path())
+            except Exception as err:
+                logger.warn("Unable to delete Agent files: {0}".format(err))
 
             msg = u"Agent {0} install failed with exception:".format(
                 self.name)

--- a/tests/ga/test_update.py
+++ b/tests/ga/test_update.py
@@ -1273,7 +1273,7 @@ class TestUpdate(UpdateTestCase):
         with patch('azurelinuxagent.ga.update.UpdateHandler.get_latest_agent_greater_than_daemon', return_value=latest_agent):
             self._test_run_latest(mock_child=ChildMock(return_value=1))
 
-        self.assertFalse(latest_agent.is_blacklisted, "Agent should not be black-listeed")
+        self.assertFalse(latest_agent.is_blacklisted, "Agent should not be blacklisted")
 
     def test_run_latest_exception_blacklists(self):
         self.prepare_agents()

--- a/tests/ga/test_update.py
+++ b/tests/ga/test_update.py
@@ -2321,8 +2321,11 @@ class TestAgentUpgrade(UpdateTestCase):
             self.__assert_exit_code_successful(update_handler.exit_mock)
             self.__assert_upgrade_telemetry_emitted_for_requested_version(mock_telemetry, upgrade=False,
                                                                           version=downgraded_version)
-            self.assertTrue(next(agent for agent in self.agents() if agent.version == CURRENT_VERSION).is_blacklisted,
-                            "The current agent should be blacklisted")
+            current_agent = next(agent for agent in self.agents() if agent.version == CURRENT_VERSION)
+            self.assertTrue(current_agent.is_blacklisted, "The current agent should be blacklisted")
+            self.assertEqual(current_agent.error.reason, "Blacklisting the agent {0} since a downgrade was requested in the GoalState, "
+                                                         "suggesting that we really don't want to execute any extensions using this version".format(CURRENT_VERSION),
+                             "Invalid reason specified for blacklisting agent")
 
     def test_it_should_not_downgrade_below_daemon_version(self):
         data_file = mockwiredata.DATA_FILE.copy()

--- a/tests/ga/test_update.py
+++ b/tests/ga/test_update.py
@@ -1262,8 +1262,7 @@ class TestUpdate(UpdateTestCase):
         finally:
             shutil.rmtree(tempdir, True)
 
-    def test_run_latest_nonzero_code_marks_failures(self):
-        # logger.add_logger_appender(logger.AppenderType.STDOUT)
+    def test_run_latest_nonzero_code_does_not_mark_failure(self):
         self.prepare_agents()
 
         latest_agent = self.update_handler.get_latest_agent_greater_than_daemon()
@@ -1274,10 +1273,7 @@ class TestUpdate(UpdateTestCase):
         with patch('azurelinuxagent.ga.update.UpdateHandler.get_latest_agent_greater_than_daemon', return_value=latest_agent):
             self._test_run_latest(mock_child=ChildMock(return_value=1))
 
-        self.assertTrue(latest_agent.is_blacklisted)
-        self.assertFalse(latest_agent.is_available)
-        self.assertNotEqual(0.0, latest_agent.error.last_failure)
-        self.assertEqual(1, latest_agent.error.failure_count)
+        self.assertFalse(latest_agent.is_blacklisted, "Agent should not be black-listeed")
 
     def test_run_latest_exception_blacklists(self):
         self.prepare_agents()


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

This PR tackles the following - 
- Currently the agent blacklists the agent in 3 scenarios. This PR reduces it to a single place
- Add a new flag (`reason`) in the `error.json` file to differentiate between new blacklisting logic and old
- Un-blacklist the agents that were blacklisted by the legacy agents in order to clean the state

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).