### PR TITLE
Use ExtensionsGoalState.id when checking for changes in extensions

### DIFF
--- a/azurelinuxagent/common/protocol/extensions_goal_state_from_extensions_config.py
+++ b/azurelinuxagent/common/protocol/extensions_goal_state_from_extensions_config.py
@@ -32,7 +32,7 @@ from azurelinuxagent.common.utils.textutil import parse_doc, parse_json, findall
 class ExtensionsGoalStateFromExtensionsConfig(ExtensionsGoalState):
     def __init__(self, incarnation, xml_text, wire_client):
         super(ExtensionsGoalStateFromExtensionsConfig, self).__init__()
-        self._id = incarnation
+        self._id = "incarnation_{0}".format(incarnation)
         self._incarnation = incarnation
         self._text = xml_text
         self._status_upload_blob = None

--- a/azurelinuxagent/common/protocol/extensions_goal_state_from_vm_settings.py
+++ b/azurelinuxagent/common/protocol/extensions_goal_state_from_vm_settings.py
@@ -33,7 +33,7 @@ class ExtensionsGoalStateFromVmSettings(ExtensionsGoalState):
 
     def __init__(self, etag, json_text):
         super(ExtensionsGoalStateFromVmSettings, self).__init__()
-        self._id = etag
+        self._id = "incarnation_{0}".format(etag)
         self._etag = etag
         self._text = json_text
         self._host_ga_plugin_version = FlexibleVersion('0.0.0.0')

--- a/azurelinuxagent/common/protocol/extensions_goal_state_from_vm_settings.py
+++ b/azurelinuxagent/common/protocol/extensions_goal_state_from_vm_settings.py
@@ -33,7 +33,7 @@ class ExtensionsGoalStateFromVmSettings(ExtensionsGoalState):
 
     def __init__(self, etag, json_text):
         super(ExtensionsGoalStateFromVmSettings, self).__init__()
-        self._id = "incarnation_{0}".format(etag)
+        self._id = "etag_{0}".format(etag)
         self._etag = etag
         self._text = json_text
         self._host_ga_plugin_version = FlexibleVersion('0.0.0.0')

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -108,9 +108,6 @@ class WireProtocol(DataContract):
         certificates = self.client.get_certs()
         return certificates.cert_list
 
-    def get_incarnation(self):
-        return self.client.get_goal_state().incarnation
-
     def get_vmagent_manifests(self):
         goal_state = self.client.get_goal_state()
         ext_conf = goal_state.extensions_goal_state

--- a/tests/ga/test_remoteaccess_handler.py
+++ b/tests/ga/test_remoteaccess_handler.py
@@ -343,9 +343,8 @@ class TestRemoteAccessHandler(AgentTestCase):
     @patch('azurelinuxagent.common.utils.cryptutil.CryptUtil.decrypt_secret', return_value="]aPPEv}uNg1FPnl?")
     @patch('azurelinuxagent.common.osutil.get_osutil', return_value=MockOSUtil())
     @patch('azurelinuxagent.common.protocol.util.ProtocolUtil.get_protocol', return_value=WireProtocol("12.34.56.78"))
-    @patch('azurelinuxagent.common.protocol.wire.WireProtocol.get_incarnation', return_value="1")
     @patch('azurelinuxagent.common.protocol.wire.WireClient.get_remote_access', return_value="asdf")
-    def test_remote_access_handler_run_bad_data(self, _1, _2, _3, _4, _5):
+    def test_remote_access_handler_run_bad_data(self, _1, _2, _3, _4):
         with patch("azurelinuxagent.ga.remoteaccess.get_osutil", return_value=MockOSUtil()):
             rah = RemoteAccessHandler(Mock())
             tstpassword = "]aPPEv}uNg1FPnl?"

--- a/tests/protocol/test_wire.py
+++ b/tests/protocol/test_wire.py
@@ -110,7 +110,7 @@ class TestWireProtocol(AgentTestCase, HttpRequestPredicates):
                 self.assertFalse(os.path.isfile(crt1))
                 self.assertFalse(os.path.isfile(crt2))
                 self.assertFalse(os.path.isfile(prv2))
-            self.assertEqual("1", protocol.get_incarnation())
+            self.assertEqual("1", protocol.get_goal_state().incarnation)
 
     @staticmethod
     def _get_telemetry_events_generator(event_list):


### PR DESCRIPTION
Once Fast Track is enabled we cannot use the incarnation to check for changes in the extensions goal state. Using 'id' instead (this abstracts the incarnation/etag used by WireServer/HostGAPlugin).