### PR TITLE
Temporarily disable get vmsize while UTs are hanging

### DIFF
--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -1215,7 +1215,9 @@ class UpdateHandler(object):
             auto_update_enabled = 1 if conf.get_autoupdate_enabled() else 0
             # Include VMSize in the heartbeat message because the kusto table does not have 
             # a separate column for it (or architecture).
-            vmsize = self._get_vm_size(protocol)
+            # Temporarily disable vmsize because it is breaking UTs. TODO: Re-enable when this is fixed.
+            # vmsize = self._get_vm_size(protocol)
+            vmsize = "unknown"
 
             telemetry_msg = "{0};{1};{2};{3};{4};{5}".format(self._heartbeat_counter, self._heartbeat_id, dropped_packets,
                                                          self._heartbeat_update_goal_state_error_count,

--- a/tests/ga/test_update.py
+++ b/tests/ga/test_update.py
@@ -1567,6 +1567,8 @@ class TestUpdate(UpdateTestCase):
         self.assertTrue(any(call_args[0] == "[HEARTBEAT] Agent {0} is running as the goal state agent {1}"
                             for call_args in patch_info.call_args), "The heartbeat was not written to the agent's log")
 
+
+    @skip_if_predicate_true(lambda: True, "Enable this test when VMSize bug hanging Uts is fixed.")
     @patch("azurelinuxagent.ga.update.add_event")
     @patch("azurelinuxagent.common.protocol.imds.ImdsClient")
     def test_telemetry_heartbeat_retries_failed_vm_size_fetch(self, mock_imds_factory, patch_add_event, *_):


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

The VMSize heartbeat reporting added in #2462 is hanging UTs ran on non-Azure VM systems. This PR is meant to temporarily disable this reporting until #2513 can be merged and fix the bug.

<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).