### PR TITLE
Improve logic of unexpected processes check started by agent

### DIFF
--- a/azurelinuxagent/common/cgroupconfigurator.py
+++ b/azurelinuxagent/common/cgroupconfigurator.py
@@ -654,8 +654,7 @@ class CGroupConfigurator(object):
                         environ = env_file.read()
                         if environ and environ[-1] == '\x00':
                             environ = environ[:-1]
-                        match = re.search(shellutil.PARENT_PROCESS_NAME + "=" + shellutil.AZURE_GUEST_AGENT, environ)
-                        return match is not None
+                        return "{0}={1}".format(shellutil.PARENT_PROCESS_NAME, shellutil.AZURE_GUEST_AGENT) in environ
             except Exception:
                 pass
             return False

--- a/azurelinuxagent/common/cgroupconfigurator.py
+++ b/azurelinuxagent/common/cgroupconfigurator.py
@@ -606,7 +606,7 @@ class CGroupConfigurator(object):
                     while current != 0 and current not in agent_commands:
                         current = self._get_parent(current)
                     # Process started by agent will have a marker and check if that marker found in process environment.
-                    if current == 0 and not self.__is_process_env_flag_found(process):
+                    if current == 0 and not self.__is_process_descendant_of_the_agent(process):
                         unexpected.append(self.__format_process(process))
                         if len(unexpected) >= 5:  # collect just a small sample
                             break
@@ -642,9 +642,10 @@ class CGroupConfigurator(object):
             return "[PID: {0}] UNKNOWN".format(pid)
 
         @staticmethod
-        def __is_process_env_flag_found(pid):
+        def __is_process_descendant_of_the_agent(pid):
             """
-            Returns True if the process env flag(PARENT_NAME) found otherwise False
+            Returns True if the process is descendant of the agent by looking at the env flag(AZURE_GUEST_AGENT_PARENT_PROCESS_NAME)
+            that we set when the process starts otherwise False.
             """
             try:
                 env = '/proc/{0}/environ'.format(pid)

--- a/azurelinuxagent/common/utils/shellutil.py
+++ b/azurelinuxagent/common/utils/shellutil.py
@@ -345,7 +345,7 @@ def quote(word_list):
 #
 _running_commands = []
 _running_commands_lock = threading.RLock()
-PARENT_PROCESS_NAME = "PARENT_PROCESS_NAME"
+PARENT_PROCESS_NAME = "AZURE_GUEST_AGENT_PARENT_PROCESS_NAME"
 AZURE_GUEST_AGENT = "AZURE_GUEST_AGENT"
 
 

--- a/azurelinuxagent/common/utils/shellutil.py
+++ b/azurelinuxagent/common/utils/shellutil.py
@@ -16,7 +16,7 @@
 #
 # Requires Python 2.6+ and Openssl 1.0+
 #
-
+import os
 import subprocess
 import tempfile
 import threading
@@ -345,10 +345,23 @@ def quote(word_list):
 #
 _running_commands = []
 _running_commands_lock = threading.RLock()
+PARENT_PROCESS_NAME = "PARENT_PROCESS_NAME"
+AZURE_GUEST_AGENT = "AZURE_GUEST_AGENT"
 
 
 def _popen(*args, **kwargs):
     with _running_commands_lock:
+        # Add the environment variables
+        env = {}
+        if 'env' in kwargs:
+            env.update(kwargs['env'])
+        else:
+            env.update(os.environ)
+
+        # Set the marker before process start
+        env[PARENT_PROCESS_NAME] = AZURE_GUEST_AGENT
+        kwargs['env'] = env
+
         process = subprocess.Popen(*args, **kwargs)
         _running_commands.append(process.pid)
         return process

--- a/tests/ga/test_multi_config_extension.py
+++ b/tests/ga/test_multi_config_extension.py
@@ -738,6 +738,10 @@ class TestMultiConfigExtensions(_MultiConfigBaseTestClass):
                     self.assertFalse(any(env_var in commands['data'] for env_var in not_expected), "Unwanted env variable found")
 
         def mock_popen(cmd, *_, **kwargs):
+            # This cgroupsapi Popen mocking all other popen calls. The extension emulator being called
+            # with assumption that extension commands run with custom environment but now I introduced env
+            # flag for other non extension commands which breaking the extension emulator logic.
+            # So, I added ExtensionVersion check to call extension emulator on extension operations.
             if 'env' in kwargs and ExtCommandEnvVariable.ExtensionVersion in kwargs['env']:
                 handler_name, __, command = extract_extension_info_from_command(cmd)
                 name = handler_name

--- a/tests/ga/test_multi_config_extension.py
+++ b/tests/ga/test_multi_config_extension.py
@@ -738,10 +738,9 @@ class TestMultiConfigExtensions(_MultiConfigBaseTestClass):
                     self.assertFalse(any(env_var in commands['data'] for env_var in not_expected), "Unwanted env variable found")
 
         def mock_popen(cmd, *_, **kwargs):
-            # This cgroupsapi Popen mocking all other popen calls. The extension emulator being called
-            # with assumption that extension commands run with custom environment but now I introduced env
-            # flag for other non extension commands which breaking the extension emulator logic.
-            # So, I added ExtensionVersion check to call extension emulator on extension operations.
+            # This cgroupsapi Popen mocking all other popen calls which breaking the extension emulator logic.
+            # The emulator should be used only on extension commands and not on other commands even env flag set.
+            # So, added ExtensionVersion check to avoid using extension emulator on non extension operations.
             if 'env' in kwargs and ExtCommandEnvVariable.ExtensionVersion in kwargs['env']:
                 handler_name, __, command = extract_extension_info_from_command(cmd)
                 name = handler_name

--- a/tests/ga/test_multi_config_extension.py
+++ b/tests/ga/test_multi_config_extension.py
@@ -738,7 +738,7 @@ class TestMultiConfigExtensions(_MultiConfigBaseTestClass):
                     self.assertFalse(any(env_var in commands['data'] for env_var in not_expected), "Unwanted env variable found")
 
         def mock_popen(cmd, *_, **kwargs):
-            if 'env' in kwargs:
+            if 'env' in kwargs and ExtCommandEnvVariable.ExtensionVersion in kwargs['env']:
                 handler_name, __, command = extract_extension_info_from_command(cmd)
                 name = handler_name
                 if ExtCommandEnvVariable.ExtensionName in kwargs['env']:

--- a/tests/utils/test_shell_util.py
+++ b/tests/utils/test_shell_util.py
@@ -166,8 +166,9 @@ exit({0})
             self.assertEqual(popen_patch.call_count, 1)
 
             args, kwargs = popen_patch.call_args
-            self.assertTrue("A TEST STRING" in args)
-            self.assertEqual(kwargs[shellutil.PARENT_PROCESS_NAME], shellutil.AZURE_GUEST_AGENT)
+            self.assertTrue(any(arg for arg in args[0] if "A TEST STRING" in arg), "command not being used")
+            self.assertEqual(kwargs['env'].get(shellutil.PARENT_PROCESS_NAME), shellutil.AZURE_GUEST_AGENT,
+                             "Env flag not being used")
 
     def test_run_pipe_should_execute_a_pipe_with_two_commands(self):
         # Output the same string 3 times and then remove duplicates

--- a/tests/utils/test_shell_util.py
+++ b/tests/utils/test_shell_util.py
@@ -17,6 +17,7 @@
 #
 import os
 import signal
+import subprocess
 import tempfile
 import threading
 import unittest
@@ -155,6 +156,18 @@ exit({0})
         command = ["echo", "-n", "A TEST STRING"]
         ret = shellutil.run_command(command)
         self.assertEqual(ret, "A TEST STRING")
+
+    def test_run_command_should_use_popen_arg_list(self):
+        with patch("azurelinuxagent.common.utils.shellutil.subprocess.Popen", wraps=subprocess.Popen) as popen_patch:
+            command = ["echo", "-n", "A TEST STRING"]
+            ret = shellutil.run_command(command)
+
+            self.assertEqual(ret, "A TEST STRING")
+            self.assertEqual(popen_patch.call_count, 1)
+
+            args, kwargs = popen_patch.call_args
+            self.assertTrue("A TEST STRING" in args)
+            self.assertEqual(kwargs[shellutil.PARENT_PROCESS_NAME], shellutil.AZURE_GUEST_AGENT)
 
     def test_run_pipe_should_execute_a_pipe_with_two_commands(self):
         # Output the same string 3 times and then remove duplicates


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

 The current logic of finding parent and if parent is agent, then we don't consider it as unexpected process and don't disable cgroups. That is broken if the process gets orphaned on certain scenarios after it's started by agent.
 
Design:
we should explicitly add an env variable to the processes we create and change the cgroupconfigurator to look for that var.


<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).