### PR TITLE
Add support for Mariner 2.0 in DCRv2

### DIFF
--- a/dcr/azure-pipelines.yml
+++ b/dcr/azure-pipelines.yml
@@ -46,6 +46,12 @@ parameters:
         sku: "cbl-mariner-1"
         version: "latest"
         name: "mariner1"
+##
+      - publisher: "microsoftcblmariner"
+        offer: "cbl-mariner"
+        sku: "cbl-mariner-2"
+        version: "latest"
+        name: "mariner2"
 
 trigger:
   - develop

--- a/dcr/scenario_utils/check_waagent_log.py
+++ b/dcr/scenario_utils/check_waagent_log.py
@@ -96,6 +96,15 @@ def check_waagent_log_for_errors(waagent_log=AGENT_LOG_FILE, ignore=None):
             'message': r"The agent's process is not within a memory cgroup",
             'if': lambda log_line: re.match(r"((centos7\.8)|(centos7\.9)|(redhat7\.8)|(redhat8\.2))\D*", distro,
                                             flags=re.IGNORECASE)
+        },
+        # 2022-03-09T20:04:33.745721Z ERROR ExtHandler ExtHandler Event: name=Microsoft.Azure.Monitor.AzureMonitorLinuxAgent, op=Install, message=[ExtensionOperationError] \
+        #   Non-zero exit code: 51, /var/lib/waagent/Microsoft.Azure.Monitor.AzureMonitorLinuxAgent-1.15.3/./shim.sh -install
+        #
+        # This is a known issue where AMA does not support Mariner 2.0. Please remove when support is
+        # added in the next AMA release (1.16.x).
+        {
+            'message': r"Event: name=Microsoft.Azure.Monitor.AzureMonitorLinuxAgent, op=Install, message=\[ExtensionOperationError\] Non-zero exit code: 51",
+            'if': lambda log_line: "Mariner2.0" in distro and log_line.level == "ERROR" and log_line.who == "ExtHandler"
         }
     ]
 


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

This PR does two things: 
1. enables mariner 2.0 support in DCRv2 and 
2. (As a prerequisite for 1) suppresses AMA install failures in Mariner 2.0 agent logs.

AMA is currently incompatible with Mariner 2.0 but should have a fix out in its next release. In the meantime, since AMA is added to all our VMs automatically-- as opposed to intentionally as a part of our test setup-- we can suppress AMA install failures from `check_waagent_log` without impacting the integrity of our tests. once the fix is out (should be in AMA 1.16.x), this suppression can be reverted. 