### PR TITLE
Add keep_alive property to collect_logs

### DIFF
--- a/azurelinuxagent/common/interfaces.py
+++ b/azurelinuxagent/common/interfaces.py
@@ -30,6 +30,15 @@ class ThreadHandlerInterface(object):
     def run(self):
         raise NotImplementedError("run() not implemented")
 
+    def keep_alive(self):
+        """
+        Returns true if the thread handler should be restarted when the thread dies
+        and false when it should remain dead.
+        
+        Defaults to True and can be overridden by sub-classes.
+        """
+        return True
+
     def is_alive(self):
         raise NotImplementedError("is_alive() not implemented")
 

--- a/azurelinuxagent/ga/collect_logs.py
+++ b/azurelinuxagent/ga/collect_logs.py
@@ -107,6 +107,9 @@ class CollectLogsHandler(ThreadHandlerInterface):
     def run(self):
         self.start()
 
+    def keep_alive(self):
+        return self.should_run
+
     def is_alive(self):
         return self.event_thread.is_alive()
 

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -421,7 +421,7 @@ class UpdateHandler(object):
     def _check_threads_running(self, all_thread_handlers):
         # Check that all the threads are still running
         for thread_handler in all_thread_handlers:
-            if not thread_handler.is_alive():
+            if thread_handler.keep_alive() and not thread_handler.is_alive():
                 logger.warn("{0} thread died, restarting".format(thread_handler.get_thread_name()))
                 thread_handler.start()
 


### PR DESCRIPTION
## Description

When `stop()`ed, the collect logs thread handler goes into  loop where the update handler tries to restart it every six seconds and it immediately exits because it is still marked as stopped. This behavior is shared by other sub-classes of `ThreadHandlerInterface` and might need to be fixed for them as well.

This PR adds a keep alive property to the thread handlers so that the update handler can know whether or not to restart them after they die. One priority in this hotfix was not to change the current behavior of other thread handlers so as to limit the scope of the changes.