### PR TITLE
don't report CPU metrics if it's negative value

### DIFF
--- a/tests/common/test_cgroupstelemetry.py
+++ b/tests/common/test_cgroupstelemetry.py
@@ -374,12 +374,10 @@ class TestCGroupsTelemetry(AgentTestCase):
                 metrics = CGroupsTelemetry.poll_all_tracked()
                 self.assertEqual(0, len(metrics))
 
-    @patch("azurelinuxagent.common.cgroup.MemoryCgroup.get_max_memory_usage")
-    @patch("azurelinuxagent.common.cgroup.MemoryCgroup.get_memory_usage")
     @patch("azurelinuxagent.common.cgroup.CpuCgroup.get_cpu_usage")
     @patch("azurelinuxagent.common.cgroup.CpuCgroup.get_throttled_time")
     @patch("azurelinuxagent.common.cgroup.CGroup.is_active")
-    def test_cgroup_telemetry_should_not_report_cpu_negative_value(self, patch_is_active, path_get_throttled_time, patch_get_cpu_usage, patch_get_memory_usage, patch_get_memory_max_usage, *args):# pylint: disable=unused-argument
+    def test_cgroup_telemetry_should_not_report_cpu_negative_value(self, patch_is_active, path_get_throttled_time, patch_get_cpu_usage):
 
         num_polls = 5
         num_extensions = 1
@@ -389,28 +387,24 @@ class TestCGroupsTelemetry(AgentTestCase):
         cpu_percent_values.append(-1)
         cpu_throttled_values = [random.randint(0, 60 * 60) for _ in range(num_polls)]
 
-        memory_usage_values = [random.randint(0, 8 * 1024 ** 3) for _ in range(num_polls)]
-        max_memory_usage_values = [random.randint(0, 8 * 1024 ** 3) for _ in range(num_polls)]
-
-        self._track_new_extension_cgroups(num_extensions)
-        self.assertEqual(2 * num_extensions, len(CGroupsTelemetry._tracked))
+        dummy_cpu_cgroup = CpuCgroup("dummy_extension_name", "dummy_cpu_path")
+        CGroupsTelemetry.track_cgroup(dummy_cpu_cgroup)
+        self.assertEqual(1, len(CGroupsTelemetry._tracked))
 
         for i in range(num_polls):
             patch_is_active.return_value = True
             patch_get_cpu_usage.return_value = cpu_percent_values[i]
             path_get_throttled_time.return_value = cpu_throttled_values[i]
-            patch_get_memory_usage.return_value = memory_usage_values[i]  # example 200 MB
-            patch_get_memory_max_usage.return_value = max_memory_usage_values[i]  # example 450 MB
 
             CGroupsTelemetry._track_throttled_time = True
             metrics = CGroupsTelemetry.poll_all_tracked()
 
-            # 1 CPU metric + 1 CPU throttled + 1 Current Memory + 1 Max memory
+            # 1 CPU metric + 1 CPU throttled
             # ignore CPU metrics from telemetry if cpu cgroup reports negative value
             if i < num_polls-1:
-                self.assertEqual(len(metrics), 4 * num_extensions)
+                self.assertEqual(len(metrics), 2 * num_extensions)
             else:
-                self.assertEqual(len(metrics), 4 * num_extensions-2)
+                self.assertEqual(len(metrics), 0)
 
             for metric in metrics:
                 self.assertGreaterEqual(metric.value, 0, "telemetry should not report negative value")


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
The cpu usage can be negative value if we notice less current cpu ticks from last time and this could happen when service restart between two polls.

Fix is not to report telemetry if cpu usage is negative value.
 
Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).