### PR TITLE
Fast Track: Ignore Fabric goal states from HostGAPlugin; process most recent goal state from WireServer/HostGAPlugin

### DIFF
--- a/azurelinuxagent/common/exception.py
+++ b/azurelinuxagent/common/exception.py
@@ -121,16 +121,6 @@ class ExtensionsConfigError(ExtensionsGoalStateError):
     """
 
 
-class VmSettingsError(ExtensionsGoalStateError):
-    """
-    Error raised when the VmSettings are malformed
-    """
-    def __init__(self, message, etag, vm_settings_text, inner=None):
-        super(VmSettingsError, self).__init__(message, inner)
-        self.etag = etag
-        self.vm_settings_text = vm_settings_text
-
-
 class MultiConfigExtensionEnableError(ExtensionError):
     """
     Error raised when enable for a Multi-Config extension is failing.

--- a/azurelinuxagent/common/protocol/extensions_goal_state.py
+++ b/azurelinuxagent/common/protocol/extensions_goal_state.py
@@ -19,6 +19,7 @@ import datetime
 
 import azurelinuxagent.common.logger as logger
 from azurelinuxagent.common.AgentGlobals import AgentGlobals
+from azurelinuxagent.common.exception import AgentError
 from azurelinuxagent.common.utils import textutil
 
 
@@ -32,6 +33,16 @@ class GoalStateSource(object):
     Fabric = "Fabric"
     FastTrack = "FastTrack"
     Empty = "Empty"
+
+
+class VmSettingsParseError(AgentError):
+    """
+    Error raised when the VmSettings are malformed
+    """
+    def __init__(self, message, etag, vm_settings_text, inner=None):
+        super(VmSettingsParseError, self).__init__(message, inner)
+        self.etag = etag
+        self.vm_settings_text = vm_settings_text
 
 
 class ExtensionsGoalState(object):

--- a/azurelinuxagent/common/protocol/goal_state.py
+++ b/azurelinuxagent/common/protocol/goal_state.py
@@ -141,7 +141,8 @@ class GoalState(object):
             logger.info("Fetched new vmSettings [HostGAPlugin correlation ID: {0} eTag: {1} source: {2}]", vm_settings.hostga_plugin_correlation_id, vm_settings.etag, vm_settings.source)
         # Ignore the vmSettings if their source is Fabric (processing a Fabric goal state may require the tenant certificate and the vmSettings don't include it.)
         if vm_settings is not None and vm_settings.source == GoalStateSource.Fabric:
-            logger.info("The vmSettings originated via Fabric; will ignore them.")
+            if vm_settings_updated:
+                logger.info("The vmSettings originated via Fabric; will ignore them.")
             vm_settings, vm_settings_updated = None, False
 
         # If neither goal state has changed we are done with the update

--- a/azurelinuxagent/common/protocol/goal_state.py
+++ b/azurelinuxagent/common/protocol/goal_state.py
@@ -233,8 +233,9 @@ class GoalState(object):
             except VmSettingsNotSupported:
                 pass
             except VmSettingsParseError as exception:
-                # ensure we save the vmSettings if there were parsing errors; use a special
-                GoalStateHistory(timeutil.create_null_timestamp(), "0").save(exception.vm_settings_text, "VmSettings.{0}.json".format(exception.etag))
+                # ensure we save the vmSettings if there were parsing errors, but save them only once per ETag
+                if not GoalStateHistory.tag_exists(exception.etag):
+                    GoalStateHistory(timeutil.create_timestamp(), exception.etag).save_vm_settings(exception.vm_settings_text)
                 raise
 
         return vm_settings, vm_settings_updated

--- a/azurelinuxagent/common/utils/archive.py
+++ b/azurelinuxagent/common/utils/archive.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the Apache License.
 import errno
+import glob
 import os
 import re
 import shutil
@@ -206,6 +207,13 @@ class GoalStateHistory(object):
     def __init__(self, timestamp, tag):
         self._errors = False
         self._root = os.path.join(conf.get_lib_dir(), ARCHIVE_DIRECTORY_NAME, "{0}_{1}".format(timestamp, tag) if tag is not None else timestamp)
+
+    @staticmethod
+    def tag_exists(tag):
+        """
+        Returns True when an item with the given 'tag' already exists in the history directory
+        """
+        return len(glob.glob(os.path.join(conf.get_lib_dir(), ARCHIVE_DIRECTORY_NAME, "*_{0}".format(tag)))) > 0
 
     def save(self, data, file_name):
         try:

--- a/azurelinuxagent/common/utils/archive.py
+++ b/azurelinuxagent/common/utils/archive.py
@@ -53,18 +53,19 @@ _CACHE_PATTERNS = [
 
 #
 # Legacy names
+#   2018-04-06T08:21:37.142697
+#   2018-04-06T08:21:37.142697.zip
 #   2018-04-06T08:21:37.142697_incarnation_N
 #   2018-04-06T08:21:37.142697_incarnation_N.zip
 #
 # Current names
 #
-#   2018-04-06T08:21:37.142697
-#   2018-04-06T08:21:37.142697.zip
-#   2018-04-06T08:21:37.142697_N
-#   2018-04-06T08:21:37.142697_N.zip
+#   2018-04-06T08:21:37.142697_N-M
+#   2018-04-06T08:21:37.142697_N-M.zip
 #
-_ARCHIVE_PATTERNS_DIRECTORY = re.compile(r"^\d{4}\-\d{2}\-\d{2}T\d{2}:\d{2}:\d{2}\.\d+((_incarnation)?_(\d+|status))?$")
-_ARCHIVE_PATTERNS_ZIP = re.compile(r"^\d{4}\-\d{2}\-\d{2}T\d{2}:\d{2}:\d{2}\.\d+((_incarnation)?_(\d+|status))?\.zip$")
+_ARCHIVE_BASE_PATTERN = r"\d{4}\-\d{2}\-\d{2}T\d{2}:\d{2}:\d{2}\.\d+((_incarnation)?_(\d+|status)(-\d+)?)?"
+_ARCHIVE_PATTERNS_DIRECTORY = re.compile(r'^{0}$'.format(_ARCHIVE_BASE_PATTERN))
+_ARCHIVE_PATTERNS_ZIP = re.compile(r'^{0}\.zip$'.format(_ARCHIVE_BASE_PATTERN))
 
 _GOAL_STATE_FILE_NAME = "GoalState.xml"
 _VM_SETTINGS_FILE_NAME = "VmSettings.json"

--- a/azurelinuxagent/common/utils/archive.py
+++ b/azurelinuxagent/common/utils/archive.py
@@ -203,7 +203,7 @@ class StateArchiver(object):
 
 
 class GoalStateHistory(object):
-    def __init__(self, timestamp, tag=None):
+    def __init__(self, timestamp, tag):
         self._errors = False
         self._root = os.path.join(conf.get_lib_dir(), ARCHIVE_DIRECTORY_NAME, "{0}_{1}".format(timestamp, tag) if tag is not None else timestamp)
 

--- a/azurelinuxagent/common/utils/timeutil.py
+++ b/azurelinuxagent/common/utils/timeutil.py
@@ -10,10 +10,6 @@ def create_timestamp():
     return datetime.datetime.utcnow().isoformat()
 
 
-def create_null_timestamp():
-    return "0000-00-00T00:00:00.000000"
-
-
 def datetime_to_ticks(dt):
     """
     Converts 'dt', a datetime, to the number of ticks (1 tick == 1/10000000 sec) since datetime.min (0001-01-01 00:00:00).

--- a/azurelinuxagent/common/utils/timeutil.py
+++ b/azurelinuxagent/common/utils/timeutil.py
@@ -19,4 +19,12 @@ def datetime_to_ticks(dt):
 
     Note that the resolution of a datetime goes only to microseconds.
     """
-    return 10 ** 7 * (dt - datetime.datetime.min).total_seconds()
+    return 10 ** 7 * total_seconds(dt - datetime.datetime.min)
+
+
+def total_seconds(dt):
+    """
+    Compute the total_seconds for timedelta 'td'. Used instead timedelta.total_seconds() because 2.6 does not implement total_seconds.
+    """
+    return ((24 * dt.days * 60 * 60 + dt.seconds) * 10.0 ** 6 + dt.microseconds) / 10.0 ** 6
+

--- a/azurelinuxagent/common/utils/timeutil.py
+++ b/azurelinuxagent/common/utils/timeutil.py
@@ -19,12 +19,12 @@ def datetime_to_ticks(dt):
 
     Note that the resolution of a datetime goes only to microseconds.
     """
-    return 10 ** 7 * total_seconds(dt - datetime.datetime.min)
+    return int(10 ** 7 * total_seconds(dt - datetime.datetime.min))
 
 
 def total_seconds(dt):
     """
     Compute the total_seconds for timedelta 'td'. Used instead timedelta.total_seconds() because 2.6 does not implement total_seconds.
     """
-    return ((24 * dt.days * 60 * 60 + dt.seconds) * 10.0 ** 6 + dt.microseconds) / 10.0 ** 6
+    return ((24.0 * 60 * 60 * dt.days + dt.seconds) * 10 ** 6 + dt.microseconds) / 10 ** 6
 

--- a/azurelinuxagent/common/utils/timeutil.py
+++ b/azurelinuxagent/common/utils/timeutil.py
@@ -3,11 +3,14 @@
 import datetime
 
 
-def create_timestamp():
+def create_timestamp(dt=None):
     """
-    Returns a string with current UTC time in iso format
+    Returns a string with the given datetime iso format. If no datetime is given as parameter, it
+    uses datetime.utcnow().
     """
-    return datetime.datetime.utcnow().isoformat()
+    if dt is None:
+        dt = datetime.datetime.utcnow()
+    return dt.isoformat()
 
 
 def datetime_to_ticks(dt):

--- a/azurelinuxagent/common/utils/timeutil.py
+++ b/azurelinuxagent/common/utils/timeutil.py
@@ -8,3 +8,7 @@ def create_timestamp():
     Returns a string with current UTC time in iso format
     """
     return datetime.datetime.utcnow().isoformat()
+
+
+def create_null_timestamp():
+    return "0000-00-00T00:00:00.000000"

--- a/azurelinuxagent/common/utils/timeutil.py
+++ b/azurelinuxagent/common/utils/timeutil.py
@@ -12,3 +12,12 @@ def create_timestamp():
 
 def create_null_timestamp():
     return "0000-00-00T00:00:00.000000"
+
+
+def datetime_to_ticks(dt):
+    """
+    Converts 'dt', a datetime, to the number of ticks (1 tick == 1/10000000 sec) since datetime.min (0001-01-01 00:00:00).
+
+    Note that the resolution of a datetime goes only to microseconds.
+    """
+    return 10 ** 7 * (dt - datetime.datetime.min).total_seconds()

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -45,7 +45,6 @@ from azurelinuxagent.common.exception import ResourceGoneError, UpdateError, Exi
 from azurelinuxagent.common.future import ustr
 from azurelinuxagent.common.osutil import get_osutil, systemd
 from azurelinuxagent.common.persist_firewall_rules import PersistFirewallRulesHandler
-from azurelinuxagent.common.protocol.extensions_goal_state import GoalStateChannel
 from azurelinuxagent.common.protocol.hostplugin import HostPluginProtocol
 from azurelinuxagent.common.protocol.restapi import VMAgentUpdateStatus, VMAgentUpdateStatuses, ExtHandlerPackageList, \
     VERSION_0

--- a/tests/data/hostgaplugin/vm_settings-difference_in_required_features.json
+++ b/tests/data/hostgaplugin/vm_settings-difference_in_required_features.json
@@ -5,7 +5,7 @@
     "correlationId": "9a47a2a2-e740-4bfc-b11b-4f2f7cfe7d2e",
     "inSvdSeqNo": 1,
     "extensionsLastModifiedTickCount": 637726657706205217,
-    "extensionGoalStatesSource": "Fabric",
+    "extensionGoalStatesSource": "FastTrack",
     "onHold": true,
     "statusUploadBlob": {
         "statusBlobType": "BlockBlob",

--- a/tests/data/hostgaplugin/vm_settings-empty_depends_on.json
+++ b/tests/data/hostgaplugin/vm_settings-empty_depends_on.json
@@ -5,7 +5,7 @@
     "correlationId": "1bef4c48-044e-4225-8f42-1d1eac1eb158",
     "inSvdSeqNo": 1,
     "extensionsLastModifiedTickCount": 637693267431616449,
-    "extensionGoalStatesSource": "Fabric",
+    "extensionGoalStatesSource": "FastTrack",
     "StatusUploadBlob": {
         "statusBlobType": "BlockBlob",
         "value": "https://dcrcqabsr1.blob.core.windows.net/$system/edpxmal5j1.058b176d-445b-4e75-bd97-4911511b7d96.status?sv=2018-03-28&sr=b&sk=system-1&sig=U4KaLxlyYfgQ%2fie8RCwgMBSXa3E4vlW0ozPYOEHikoc%3d&se=9999-01-01T00%3a00%3a00Z&sp=w"

--- a/tests/data/hostgaplugin/vm_settings-invalid_blob_type.json
+++ b/tests/data/hostgaplugin/vm_settings-invalid_blob_type.json
@@ -5,7 +5,7 @@
     "correlationId": "1bef4c48-044e-4225-8f42-1d1eac1eb158",
     "inSvdSeqNo": 1,
     "extensionsLastModifiedTickCount": 637693267431616449,
-    "extensionGoalStatesSource": "Fabric",
+    "extensionGoalStatesSource": "FastTrack",
     "StatusUploadBlob": {
         "statusBlobType": "INVALID_BLOB_TYPE",
         "value": "https://dcrcqabsr1.blob.core.windows.net/$system/edpxmal5j1.058b176d-445b-4e75-bd97-4911511b7d96.status?sv=2018-03-28&sr=b&sk=system-1&sig=U4KaLxlyYfgQ%2fie8RCwgMBSXa3E4vlW0ozPYOEHikoc%3d&se=9999-01-01T00%3a00%3a00Z&sp=w"

--- a/tests/data/hostgaplugin/vm_settings-no_extension_manifests.json
+++ b/tests/data/hostgaplugin/vm_settings-no_extension_manifests.json
@@ -5,7 +5,7 @@
     "correlationId": "c143f8f0-a66b-4881-8c06-1efd278b0b02",
     "inSvdSeqNo": 978,
     "extensionsLastModifiedTickCount": 637829610574739741,
-    "extensionGoalStatesSource": "Fabric",
+    "extensionGoalStatesSource": "FastTrack",
     "statusUploadBlob": {
         "statusBlobType": "PageBlob",
         "value": "https://md-ssd-xpdjf15s.blob.core.windows.net/$system/u-sqlwatcher.f338f67e.status?sv=2018-03-28&sr=b&sk=system-1&sig=88Y3NM%2b1aU%3d&se=9999-01-01T00%3a00%3a00Z&sp=rw"

--- a/tests/data/hostgaplugin/vm_settings-no_status_upload_blob.json
+++ b/tests/data/hostgaplugin/vm_settings-no_status_upload_blob.json
@@ -5,7 +5,7 @@
     "correlationId": "9a47a2a2-e740-4bfc-b11b-4f2f7cfe7d2e",
     "inSvdSeqNo": 1,
     "extensionsLastModifiedTickCount": 637726657706205217,
-    "extensionGoalStatesSource": "Fabric",
+    "extensionGoalStatesSource": "FastTrack",
     "onHold": true,
     "inVMMetadata": {
         "subscriptionId": "8e037ad4-618f-4466-8bc8-5099d41ac15b",

--- a/tests/data/hostgaplugin/vm_settings-no_status_upload_blob.json
+++ b/tests/data/hostgaplugin/vm_settings-no_status_upload_blob.json
@@ -4,7 +4,7 @@
     "activityId": "a33f6f53-43d6-4625-b322-1a39651a00c9",
     "correlationId": "9a47a2a2-e740-4bfc-b11b-4f2f7cfe7d2e",
     "inSvdSeqNo": 1,
-    "extensionsLastModifiedTickCount": 637726657706205217,
+    "extensionsLastModifiedTickCount": 637726657706209999,
     "extensionGoalStatesSource": "FastTrack",
     "onHold": true,
     "inVMMetadata": {

--- a/tests/data/hostgaplugin/vm_settings-out-of-sync.json
+++ b/tests/data/hostgaplugin/vm_settings-out-of-sync.json
@@ -5,7 +5,7 @@
     "correlationId": "EEEEEEEE-DDDD-CCCC-BBBB-AAAAAAAAAAAA",
     "inSvdSeqNo": 1,
     "extensionsLastModifiedTickCount": 637726657000000000,
-    "extensionGoalStatesSource": "Fabric",
+    "extensionGoalStatesSource": "FastTrack",
     "onHold": true,
     "statusUploadBlob": {
         "statusBlobType": "BlockBlob",

--- a/tests/data/hostgaplugin/vm_settings-parse_error.json
+++ b/tests/data/hostgaplugin/vm_settings-parse_error.json
@@ -5,7 +5,7 @@
     "correlationId": "9a47a2a2-e740-4bfc-b11b-4f2f7cfe7d2e",
     "inSvdSeqNo": 1,
     "extensionsLastModifiedTickCount": 637726657706205217,
-    "extensionGoalStatesSource": "Fabric",
+    "extensionGoalStatesSource": "FastTrack",
     "onHold": true,
     "statusUploadBlob": {
         "statusBlobType": "BlockBlob",

--- a/tests/data/hostgaplugin/vm_settings-requested_version.json
+++ b/tests/data/hostgaplugin/vm_settings-requested_version.json
@@ -5,7 +5,7 @@
     "correlationId": "9a47a2a2-e740-4bfc-b11b-4f2f7cfe7d2e",
     "inSvdSeqNo": 1,
     "extensionsLastModifiedTickCount": 637726657706205217,
-    "extensionGoalStatesSource": "Fabric",
+    "extensionGoalStatesSource": "FastTrack",
     "onHold": true,
     "statusUploadBlob": {
         "statusBlobType": "BlockBlob",

--- a/tests/data/hostgaplugin/vm_settings-requested_version.json
+++ b/tests/data/hostgaplugin/vm_settings-requested_version.json
@@ -4,7 +4,7 @@
     "activityId": "a33f6f53-43d6-4625-b322-1a39651a00c9",
     "correlationId": "9a47a2a2-e740-4bfc-b11b-4f2f7cfe7d2e",
     "inSvdSeqNo": 1,
-    "extensionsLastModifiedTickCount": 637726657706205217,
+    "extensionsLastModifiedTickCount": 637726699999999999,
     "extensionGoalStatesSource": "FastTrack",
     "onHold": true,
     "statusUploadBlob": {

--- a/tests/data/hostgaplugin/vm_settings-unsupported_version.json
+++ b/tests/data/hostgaplugin/vm_settings-unsupported_version.json
@@ -5,7 +5,7 @@
     "correlationId": "9a47a2a2-e740-4bfc-b11b-4f2f7cfe7d2e",
     "inSvdSeqNo": 1,
     "extensionsLastModifiedTickCount": 637726657706205217,
-    "extensionGoalStatesSource": "Fabric",
+    "extensionGoalStatesSource": "FastTrack",
     "onHold": true,
     "statusUploadBlob": {
         "statusBlobType": "BlockBlob",

--- a/tests/data/hostgaplugin/vm_settings.json
+++ b/tests/data/hostgaplugin/vm_settings.json
@@ -5,7 +5,7 @@
     "correlationId": "9a47a2a2-e740-4bfc-b11b-4f2f7cfe7d2e",
     "inSvdSeqNo": 1,
     "extensionsLastModifiedTickCount": 637726657706205217,
-    "extensionGoalStatesSource": "Fabric",
+    "extensionGoalStatesSource": "FastTrack",
     "onHold": true,
     "statusUploadBlob": {
         "statusBlobType": "BlockBlob",

--- a/tests/data/hostgaplugin/vm_settings.json
+++ b/tests/data/hostgaplugin/vm_settings.json
@@ -4,7 +4,7 @@
     "activityId": "a33f6f53-43d6-4625-b322-1a39651a00c9",
     "correlationId": "9a47a2a2-e740-4bfc-b11b-4f2f7cfe7d2e",
     "inSvdSeqNo": 1,
-    "extensionsLastModifiedTickCount": 637726657706205217,
+    "extensionsLastModifiedTickCount": 637726657706205299,
     "extensionGoalStatesSource": "FastTrack",
     "onHold": true,
     "statusUploadBlob": {

--- a/tests/data/wire/ext_conf-no_gs_metadata.xml
+++ b/tests/data/wire/ext_conf-no_gs_metadata.xml
@@ -2,14 +2,12 @@
   <GAFamilies>
     <GAFamily>
       <Name>Prod</Name>
-      <Version>9.9.9.10</Version>
       <Uris>
           <Uri>http://mock-goal-state/manifest_of_ga.xml</Uri>
       </Uris>
     </GAFamily>
     <GAFamily>
       <Name>Test</Name>
-      <Version>9.9.9.10</Version>
       <Uris>
           <Uri>http://mock-goal-state/manifest_of_ga.xml</Uri>
         </Uris>
@@ -24,6 +22,6 @@
     <RuntimeSettings seqNo="0">{"runtimeSettings":[{"handlerSettings":{"protectedSettingsCertThumbprint":"4037FBF5F1F3014F99B5D6C7799E9B20E6871CB3","protectedSettings":"MIICWgYJK","publicSettings":{"foo":"bar"}}}]}</RuntimeSettings>
   </Plugin>
 </PluginSettings>
-  <InVMGoalStateMetaData inSvdSeqNo="10" createdOnTicks="637726657706205217" activityId="a33f6f53-43d6-4625-b322-1a39651a00c9" correlationId="9a47a2a2-e740-4bfc-b11b-4f2f7cfe7d2e" />
-<StatusUploadBlob statusBlobType="BlockBlob">https://test.blob.core.windows.net/vhds/test-cs12.test-cs12.test-cs12.status?sr=b&amp;sp=rw&amp;se=9999-01-01&amp;sk=key1&amp;sv=2014-02-14&amp;sig=hfRh7gzUE7sUtYwke78IOlZOrTRCYvkec4hGZ9zZzXo</StatusUploadBlob></Extensions>
+<StatusUploadBlob statusBlobType="BlockBlob">https://test.blob.core.windows.net/vhds/test-cs12.test-cs12.test-cs12.status?sr=b&amp;sp=rw&amp;se=9999-01-01&amp;sk=key1&amp;sv=2014-02-14&amp;sig=hfRh7gzUE7sUtYwke78IOlZOrTRCYvkec4hGZ9zZzXo</StatusUploadBlob>
+</Extensions>
 

--- a/tests/data/wire/ext_conf.xml
+++ b/tests/data/wire/ext_conf.xml
@@ -22,5 +22,7 @@
     <RuntimeSettings seqNo="0">{"runtimeSettings":[{"handlerSettings":{"protectedSettingsCertThumbprint":"4037FBF5F1F3014F99B5D6C7799E9B20E6871CB3","protectedSettings":"MIICWgYJK","publicSettings":{"foo":"bar"}}}]}</RuntimeSettings>
   </Plugin>
 </PluginSettings>
-<StatusUploadBlob statusBlobType="BlockBlob">https://test.blob.core.windows.net/vhds/test-cs12.test-cs12.test-cs12.status?sr=b&amp;sp=rw&amp;se=9999-01-01&amp;sk=key1&amp;sv=2014-02-14&amp;sig=hfRh7gzUE7sUtYwke78IOlZOrTRCYvkec4hGZ9zZzXo</StatusUploadBlob></Extensions>
+<StatusUploadBlob statusBlobType="BlockBlob">https://test.blob.core.windows.net/vhds/test-cs12.test-cs12.test-cs12.status?sr=b&amp;sp=rw&amp;se=9999-01-01&amp;sk=key1&amp;sv=2014-02-14&amp;sig=hfRh7gzUE7sUtYwke78IOlZOrTRCYvkec4hGZ9zZzXo</StatusUploadBlob>
+<InVMGoalStateMetaData inSvdSeqNo="10" createdOnTicks="637726657706205217" activityId="a33f6f53-43d6-4625-b322-1a39651a00c9" correlationId="9a47a2a2-e740-4bfc-b11b-4f2f7cfe7d2e" />
+</Extensions>
 

--- a/tests/data/wire/ext_conf_additional_locations.xml
+++ b/tests/data/wire/ext_conf_additional_locations.xml
@@ -27,5 +27,8 @@
     <RuntimeSettings seqNo="0">{"runtimeSettings":[{"handlerSettings":{"protectedSettingsCertThumbprint":"4037FBF5F1F3014F99B5D6C7799E9B20E6871CB3","protectedSettings":"MIICWgYJK","publicSettings":{"foo":"bar"}}}]}</RuntimeSettings>
   </Plugin>
 </PluginSettings>
-<StatusUploadBlob statusBlobType="BlockBlob">https://test.blob.core.windows.net/vhds/test-cs12.test-cs12.test-cs12.status?sr=b&amp;sp=rw&amp;se=9999-01-01&amp;sk=key1&amp;sv=2014-02-14&amp;sig=hfRh7gzUE7sUtYwke78IOlZOrTRCYvkec4hGZ9zZzXo</StatusUploadBlob></Extensions>
+<StatusUploadBlob statusBlobType="BlockBlob">https://test.blob.core.windows.net/vhds/test-cs12.test-cs12.test-cs12.status?sr=b&amp;sp=rw&amp;se=9999-01-01&amp;sk=key1&amp;sv=2014-02-14&amp;sig=hfRh7gzUE7sUtYwke78IOlZOrTRCYvkec4hGZ9zZzXo</StatusUploadBlob>
+<InVMGoalStateMetaData inSvdSeqNo="10" createdOnTicks="637726657706205217" activityId="a33f6f53-43d6-4625-b322-1a39651a00c9" correlationId="9a47a2a2-e740-4bfc-b11b-4f2f7cfe7d2e" />
+</Extensions>
+
 

--- a/tests/data/wire/ext_conf_aks_extension.xml
+++ b/tests/data/wire/ext_conf_aks_extension.xml
@@ -65,5 +65,6 @@
     <StatusUploadBlob statusBlobType="BlockBlob">
         https://test.blob.core.windows.net/vhds/test-cs12.test-cs12.test-cs12.status?sr=b&amp;sp=rw&amp;se=9999-01-01&amp;sk=key1&amp;sv=2014-02-14&amp;sig=hfRh7gzUE7sUtYwke78IOlZOrTRCYvkec4hGZ9zZzXo
     </StatusUploadBlob>
+<InVMGoalStateMetaData inSvdSeqNo="10" createdOnTicks="637726657706205217" activityId="a33f6f53-43d6-4625-b322-1a39651a00c9" correlationId="9a47a2a2-e740-4bfc-b11b-4f2f7cfe7d2e" />
 </Extensions>
 

--- a/tests/data/wire/ext_conf_autoupgrade.xml
+++ b/tests/data/wire/ext_conf_autoupgrade.xml
@@ -24,5 +24,7 @@
     <RuntimeSettings seqNo="0">{"runtimeSettings":[{"handlerSettings":{"protectedSettingsCertThumbprint":"4037FBF5F1F3014F99B5D6C7799E9B20E6871CB3","protectedSettings":"MIICWgYJK","publicSettings":{"foo":"bar"}}}]}</RuntimeSettings>
   </Plugin>
 </PluginSettings>
-<StatusUploadBlob>https://test.blob.core.windows.net/vhds/test-cs12.test-cs12.test-cs12.status?sr=b&amp;sp=rw&amp;se=9999-01-01&amp;sk=key1&amp;sv=2014-02-14&amp;sig=hfRh7gzUE7sUtYwke78IOlZOrTRCYvkec4hGZ9zZzXo</StatusUploadBlob></Extensions>
+<StatusUploadBlob>https://test.blob.core.windows.net/vhds/test-cs12.test-cs12.test-cs12.status?sr=b&amp;sp=rw&amp;se=9999-01-01&amp;sk=key1&amp;sv=2014-02-14&amp;sig=hfRh7gzUE7sUtYwke78IOlZOrTRCYvkec4hGZ9zZzXo</StatusUploadBlob>
+<InVMGoalStateMetaData inSvdSeqNo="10" createdOnTicks="637726657706205217" activityId="a33f6f53-43d6-4625-b322-1a39651a00c9" correlationId="9a47a2a2-e740-4bfc-b11b-4f2f7cfe7d2e" />
+</Extensions>
 

--- a/tests/data/wire/ext_conf_autoupgrade_internalversion.xml
+++ b/tests/data/wire/ext_conf_autoupgrade_internalversion.xml
@@ -24,5 +24,7 @@
     <RuntimeSettings seqNo="0">{"runtimeSettings":[{"handlerSettings":{"protectedSettingsCertThumbprint":"4037FBF5F1F3014F99B5D6C7799E9B20E6871CB3","protectedSettings":"MIICWgYJK","publicSettings":{"foo":"bar"}}}]}</RuntimeSettings>
   </Plugin>
 </PluginSettings>
-<StatusUploadBlob>https://test.blob.core.windows.net/vhds/test-cs12.test-cs12.test-cs12.status?sr=b&amp;sp=rw&amp;se=9999-01-01&amp;sk=key1&amp;sv=2014-02-14&amp;sig=hfRh7gzUE7sUtYwke78IOlZOrTRCYvkec4hGZ9zZzXo</StatusUploadBlob></Extensions>
+<StatusUploadBlob>https://test.blob.core.windows.net/vhds/test-cs12.test-cs12.test-cs12.status?sr=b&amp;sp=rw&amp;se=9999-01-01&amp;sk=key1&amp;sv=2014-02-14&amp;sig=hfRh7gzUE7sUtYwke78IOlZOrTRCYvkec4hGZ9zZzXo</StatusUploadBlob>
+<InVMGoalStateMetaData inSvdSeqNo="10" createdOnTicks="637726657706205217" activityId="a33f6f53-43d6-4625-b322-1a39651a00c9" correlationId="9a47a2a2-e740-4bfc-b11b-4f2f7cfe7d2e" />
+</Extensions>
 

--- a/tests/data/wire/ext_conf_dependencies_with_empty_settings.xml
+++ b/tests/data/wire/ext_conf_dependencies_with_empty_settings.xml
@@ -29,4 +29,5 @@
         </Plugin>
     </PluginSettings>
     <StatusUploadBlob statusBlobType="BlockBlob">https://test.blob.core.windows.net/vhds/test-cs12.test-cs12.test-cs12.status?sr=b&amp;sp=rw&amp;se=9999-01-01&amp;sk=key1&amp;sv=2014-02-14&amp;sig=hfRh7gzUE7sUtYwke78IOlZOrTRCYvkec4hGZ9zZzXo</StatusUploadBlob>
+<InVMGoalStateMetaData inSvdSeqNo="10" createdOnTicks="637726657706205217" activityId="a33f6f53-43d6-4625-b322-1a39651a00c9" correlationId="9a47a2a2-e740-4bfc-b11b-4f2f7cfe7d2e" />
 </Extensions>

--- a/tests/data/wire/ext_conf_in_vm_artifacts_profile.xml
+++ b/tests/data/wire/ext_conf_in_vm_artifacts_profile.xml
@@ -25,4 +25,5 @@
   </PluginSettings>
   <StatusUploadBlob statusBlobType="BlockBlob">https://test.blob.core.windows.net/vhds/test-cs12.test-cs12.test-cs12.status?sr=b&amp;sp=rw&amp;se=9999-01-01&amp;sk=key1&amp;sv=2014-02-14&amp;sig=hfRh7gzUE7sUtYwke78IOlZOrTRCYvkec4hGZ9zZzXo</StatusUploadBlob>
   <InVMArtifactsProfileBlob statusBlobType="BlockBlob">https://mock-goal-state/test.blob.core.windows.net/$system/test-cs12.test-cs12.test-cs12.vmSettings?sv=2016-05-31&amp;sr=b&amp;sk=system-1&amp;sig=saskey;se=9999-01-01T00%3a00%3a00Z&amp;sp=r</InVMArtifactsProfileBlob>
+<InVMGoalStateMetaData inSvdSeqNo="10" createdOnTicks="637726657706205217" activityId="a33f6f53-43d6-4625-b322-1a39651a00c9" correlationId="9a47a2a2-e740-4bfc-b11b-4f2f7cfe7d2e" />
 </Extensions>

--- a/tests/data/wire/ext_conf_in_vm_empty_artifacts_profile.xml
+++ b/tests/data/wire/ext_conf_in_vm_empty_artifacts_profile.xml
@@ -25,4 +25,5 @@
   </PluginSettings>
   <StatusUploadBlob statusBlobType="BlockBlob">https://test.blob.core.windows.net/vhds/test-cs12.test-cs12.test-cs12.status?sr=b&amp;sp=rw&amp;se=9999-01-01&amp;sk=key1&amp;sv=2014-02-14&amp;sig=hfRh7gzUE7sUtYwke78IOlZOrTRCYvkec4hGZ9zZzXo</StatusUploadBlob>
   <InVMArtifactsProfileBlob statusBlobType="BlockBlob">   </InVMArtifactsProfileBlob>
+<InVMGoalStateMetaData inSvdSeqNo="10" createdOnTicks="637726657706205217" activityId="a33f6f53-43d6-4625-b322-1a39651a00c9" correlationId="9a47a2a2-e740-4bfc-b11b-4f2f7cfe7d2e" />
 </Extensions>

--- a/tests/data/wire/ext_conf_internalversion.xml
+++ b/tests/data/wire/ext_conf_internalversion.xml
@@ -24,5 +24,7 @@
     <RuntimeSettings seqNo="0">{"runtimeSettings":[{"handlerSettings":{"protectedSettingsCertThumbprint":"4037FBF5F1F3014F99B5D6C7799E9B20E6871CB3","protectedSettings":"MIICWgYJK","publicSettings":{"foo":"bar"}}}]}</RuntimeSettings>
   </Plugin>
 </PluginSettings>
-<StatusUploadBlob>https://test.blob.core.windows.net/vhds/test-cs12.test-cs12.test-cs12.status?sr=b&amp;sp=rw&amp;se=9999-01-01&amp;sk=key1&amp;sv=2014-02-14&amp;sig=hfRh7gzUE7sUtYwke78IOlZOrTRCYvkec4hGZ9zZzXo</StatusUploadBlob></Extensions>
+<StatusUploadBlob>https://test.blob.core.windows.net/vhds/test-cs12.test-cs12.test-cs12.status?sr=b&amp;sp=rw&amp;se=9999-01-01&amp;sk=key1&amp;sv=2014-02-14&amp;sig=hfRh7gzUE7sUtYwke78IOlZOrTRCYvkec4hGZ9zZzXo</StatusUploadBlob>
+<InVMGoalStateMetaData inSvdSeqNo="10" createdOnTicks="637726657706205217" activityId="a33f6f53-43d6-4625-b322-1a39651a00c9" correlationId="9a47a2a2-e740-4bfc-b11b-4f2f7cfe7d2e" />
+</Extensions>
 

--- a/tests/data/wire/ext_conf_invalid_and_valid_handlers.xml
+++ b/tests/data/wire/ext_conf_invalid_and_valid_handlers.xml
@@ -30,5 +30,6 @@
 		</Plugin>
 	</PluginSettings>
 	<StatusUploadBlob statusBlobType="BlockBlob">https://test.blob.core.windows.net/vhds/test-cs12.test-cs12.test-cs12.status?sr=b&amp;sp=rw&amp;se=9999-01-01&amp;sk=key1&amp;sv=2014-02-14&amp;sig=hfRh7gzUE7sUtYwke78IOlZOrTRCYvkec4hGZ9zZzXo</StatusUploadBlob>
+	<InVMGoalStateMetaData inSvdSeqNo="10" createdOnTicks="637726657706205217" activityId="a33f6f53-43d6-4625-b322-1a39651a00c9" correlationId="9a47a2a2-e740-4bfc-b11b-4f2f7cfe7d2e" />
 </Extensions>
 

--- a/tests/data/wire/ext_conf_missing_family.xml
+++ b/tests/data/wire/ext_conf_missing_family.xml
@@ -30,4 +30,5 @@
         <Location>eastus</Location>
     </GuestAgentExtension>
     <StatusUploadBlob statusBlobType="BlockBlob">https://walaautoasmeastus.blob.core.windows.net/vhds/walaautos73small.walaautos73small.walaautos73small.status?sr=b&amp;sp=rw&amp;se=9999-01-01&amp;sk=key1&amp;sv=2014-02-14&amp;sig=u%2BCA2Cxb7ticiEBRIW8HWgNW7gl2NPuOGQl0u95ApQE%3D</StatusUploadBlob>
+<InVMGoalStateMetaData inSvdSeqNo="10" createdOnTicks="637726657706205217" activityId="a33f6f53-43d6-4625-b322-1a39651a00c9" correlationId="9a47a2a2-e740-4bfc-b11b-4f2f7cfe7d2e" />
 </Extensions>

--- a/tests/data/wire/ext_conf_missing_requested_version.xml
+++ b/tests/data/wire/ext_conf_missing_requested_version.xml
@@ -34,5 +34,6 @@
     <StatusUploadBlob statusBlobType="BlockBlob">
         https://test.blob.core.windows.net/vhds/test-cs12.test-cs12.test-cs12.status?sr=b&amp;sp=rw&amp;se=9999-01-01&amp;sk=key1&amp;sv=2014-02-14&amp;sig=hfRh7gzUE7sUtYwke78IOlZOrTRCYvkec4hGZ9zZzXo
     </StatusUploadBlob>
+    <InVMGoalStateMetaData inSvdSeqNo="10" createdOnTicks="637726657706205217" activityId="a33f6f53-43d6-4625-b322-1a39651a00c9" correlationId="9a47a2a2-e740-4bfc-b11b-4f2f7cfe7d2e" />
 </Extensions>
 

--- a/tests/data/wire/ext_conf_multiple_extensions.xml
+++ b/tests/data/wire/ext_conf_multiple_extensions.xml
@@ -52,5 +52,6 @@
     <StatusUploadBlob statusBlobType="BlockBlob">
         https://test.blob.core.windows.net/vhds/test-cs12.test-cs12.test-cs12.status?sr=b&amp;sp=rw&amp;se=9999-01-01&amp;sk=key1&amp;sv=2014-02-14&amp;sig=hfRh7gzUE7sUtYwke78IOlZOrTRCYvkec4hGZ9zZzXo
     </StatusUploadBlob>
+    <InVMGoalStateMetaData inSvdSeqNo="10" createdOnTicks="637726657706205217" activityId="a33f6f53-43d6-4625-b322-1a39651a00c9" correlationId="9a47a2a2-e740-4bfc-b11b-4f2f7cfe7d2e" />
 </Extensions>
 

--- a/tests/data/wire/ext_conf_no_extensions-block_blob.xml
+++ b/tests/data/wire/ext_conf_no_extensions-block_blob.xml
@@ -8,5 +8,6 @@
   <PluginSettings>
   </PluginSettings>
   <StatusUploadBlob statusBlobType="BlockBlob">http://foo</StatusUploadBlob>
+  <InVMGoalStateMetaData inSvdSeqNo="10" createdOnTicks="637726657706205217" activityId="a33f6f53-43d6-4625-b322-1a39651a00c9" correlationId="9a47a2a2-e740-4bfc-b11b-4f2f7cfe7d2e" />
 </Extensions>
 

--- a/tests/data/wire/ext_conf_no_extensions-no_status_blob.xml
+++ b/tests/data/wire/ext_conf_no_extensions-no_status_blob.xml
@@ -7,5 +7,6 @@
   </Plugins>
   <PluginSettings>
   </PluginSettings>
+  <InVMGoalStateMetaData inSvdSeqNo="10" createdOnTicks="637726657706205217" activityId="a33f6f53-43d6-4625-b322-1a39651a00c9" correlationId="9a47a2a2-e740-4bfc-b11b-4f2f7cfe7d2e" />
 </Extensions>
 

--- a/tests/data/wire/ext_conf_no_extensions-page_blob.xml
+++ b/tests/data/wire/ext_conf_no_extensions-page_blob.xml
@@ -20,5 +20,6 @@
   <PluginSettings>
   </PluginSettings>
   <StatusUploadBlob statusBlobType="PageBlob">http://sas_url</StatusUploadBlob>
+  <InVMGoalStateMetaData inSvdSeqNo="10" createdOnTicks="637726657706205217" activityId="a33f6f53-43d6-4625-b322-1a39651a00c9" correlationId="9a47a2a2-e740-4bfc-b11b-4f2f7cfe7d2e" />
 </Extensions>
 

--- a/tests/data/wire/ext_conf_no_public.xml
+++ b/tests/data/wire/ext_conf_no_public.xml
@@ -42,5 +42,6 @@
     <RuntimeSettings seqNo="0">{"runtimeSettings":[{"handlerSettings":{"protectedSettingsCertThumbprint":"4037FBF5F1F3014F99B5D6C7799E9B20E6871CB3","protectedSettings":"MIICWgYJK"}}]}</RuntimeSettings>
   </Plugin>
 </PluginSettings>
+  <InVMGoalStateMetaData inSvdSeqNo="10" createdOnTicks="637726657706205217" activityId="a33f6f53-43d6-4625-b322-1a39651a00c9" correlationId="9a47a2a2-e740-4bfc-b11b-4f2f7cfe7d2e" />
 <StatusUploadBlob>https://test.blob.core.windows.net/vhds/test-cs12.test-cs12.test-cs12.status?sr=b&amp;sp=rw&amp;se=9999-01-01&amp;sk=key1&amp;sv=2014-02-14&amp;sig=hfRh7gzUE7sUtYwke78IOlZOrTRCYvkec4hGZ9zZzXo</StatusUploadBlob></Extensions>
 

--- a/tests/data/wire/ext_conf_no_settings.xml
+++ b/tests/data/wire/ext_conf_no_settings.xml
@@ -37,5 +37,6 @@
 <Plugins>
   <Plugin name="OSTCExtensions.ExampleHandlerLinux" version="1.0" location="http://mock-goal-state/rdfepirv2hknprdstr03.blob.core.windows.net/b01058962be54ceca550a390fa5ff064/Microsoft.OSTCExtensions_ExampleHandlerLinux_asiaeast_manifest.xml" config="" state="enabled" autoUpgrade="false" failoverlocation="http://mock-goal-state/rdfepirv2hknprdstr04.blob.core.windows.net/b01058962be54ceca550a390fa5ff064/Microsoft.OSTCExtensions_ExampleHandlerLinux_asiaeast_manifest.xml" runAsStartupTask="false" isJson="true" />
 </Plugins>
+  <InVMGoalStateMetaData inSvdSeqNo="10" createdOnTicks="637726657706205217" activityId="a33f6f53-43d6-4625-b322-1a39651a00c9" correlationId="9a47a2a2-e740-4bfc-b11b-4f2f7cfe7d2e" />
 <StatusUploadBlob>https://test.blob.core.windows.net/vhds/test-cs12.test-cs12.test-cs12.status?sr=b&amp;sp=rw&amp;se=9999-01-01&amp;sk=key1&amp;sv=2014-02-14&amp;sig=hfRh7gzUE7sUtYwke78IOlZOrTRCYvkec4hGZ9zZzXo</StatusUploadBlob></Extensions>
 

--- a/tests/data/wire/ext_conf_required_features.xml
+++ b/tests/data/wire/ext_conf_required_features.xml
@@ -36,5 +36,6 @@
 		</Plugin>
 	</PluginSettings>
 	<StatusUploadBlob statusBlobType="BlockBlob">https://test.blob.core.windows.net/vhds/test-cs12.test-cs12.test-cs12.status?sr=b&amp;sp=rw&amp;se=9999-01-01&amp;sk=key1&amp;sv=2014-02-14&amp;sig=hfRh7gzUE7sUtYwke78IOlZOrTRCYvkec4hGZ9zZzXo</StatusUploadBlob>
+	<InVMGoalStateMetaData inSvdSeqNo="10" createdOnTicks="637726657706205217" activityId="a33f6f53-43d6-4625-b322-1a39651a00c9" correlationId="9a47a2a2-e740-4bfc-b11b-4f2f7cfe7d2e" />
 </Extensions>
 

--- a/tests/data/wire/ext_conf_sequencing.xml
+++ b/tests/data/wire/ext_conf_sequencing.xml
@@ -31,4 +31,6 @@
     <RuntimeSettings seqNo="0">{"runtimeSettings":[{"handlerSettings":{"protectedSettingsCertThumbprint":"4037FBF5F1F3014F99B5D6C7799E9B20E6871CB3","protectedSettings":"MIICWgYJK","publicSettings":{"foo":"bar"}}}]}</RuntimeSettings>
   </Plugin>
 </PluginSettings>
-<StatusUploadBlob statusBlobType="BlockBlob">https://test.blob.core.windows.net/vhds/test-cs12.test-cs12.test-cs12.status?sr=b&amp;sp=rw&amp;se=9999-01-01&amp;sk=key1&amp;sv=2014-02-14&amp;sig=hfRh7gzUE7sUtYwke78IOlZOrTRCYvkec4hGZ9zZzXo</StatusUploadBlob></Extensions>
+<StatusUploadBlob statusBlobType="BlockBlob">https://test.blob.core.windows.net/vhds/test-cs12.test-cs12.test-cs12.status?sr=b&amp;sp=rw&amp;se=9999-01-01&amp;sk=key1&amp;sv=2014-02-14&amp;sig=hfRh7gzUE7sUtYwke78IOlZOrTRCYvkec4hGZ9zZzXo</StatusUploadBlob>
+  <InVMGoalStateMetaData inSvdSeqNo="10" createdOnTicks="637726657706205217" activityId="a33f6f53-43d6-4625-b322-1a39651a00c9" correlationId="9a47a2a2-e740-4bfc-b11b-4f2f7cfe7d2e" />
+</Extensions>

--- a/tests/data/wire/ext_conf_settings_case_mismatch.xml
+++ b/tests/data/wire/ext_conf_settings_case_mismatch.xml
@@ -52,5 +52,6 @@
     <StatusUploadBlob statusBlobType="BlockBlob">
         https://test.blob.core.windows.net/vhds/test-cs12.test-cs12.test-cs12.status?sr=b&amp;sp=rw&amp;se=9999-01-01&amp;sk=key1&amp;sv=2014-02-14&amp;sig=hfRh7gzUE7sUtYwke78IOlZOrTRCYvkec4hGZ9zZzXo
     </StatusUploadBlob>
+  <InVMGoalStateMetaData inSvdSeqNo="10" createdOnTicks="637726657706205217" activityId="a33f6f53-43d6-4625-b322-1a39651a00c9" correlationId="9a47a2a2-e740-4bfc-b11b-4f2f7cfe7d2e" />
 </Extensions>
 

--- a/tests/data/wire/ext_conf_upgradeguid.xml
+++ b/tests/data/wire/ext_conf_upgradeguid.xml
@@ -22,5 +22,7 @@
     <RuntimeSettings seqNo="0">{"runtimeSettings":[{"handlerSettings":{"protectedSettingsCertThumbprint":"4037FBF5F1F3014F99B5D6C7799E9B20E6871CB3","protectedSettings":"MIICWgYJK","publicSettings":{"foo":"bar"}}}]}</RuntimeSettings>
   </Plugin>
 </PluginSettings>
-<StatusUploadBlob statusBlobType="BlockBlob">https://test.blob.core.windows.net/vhds/test-cs12.test-cs12.test-cs12.status?sr=b&amp;sp=rw&amp;se=9999-01-01&amp;sk=key1&amp;sv=2014-02-14&amp;sig=hfRh7gzUE7sUtYwke78IOlZOrTRCYvkec4hGZ9zZzXo</StatusUploadBlob></Extensions>
+<StatusUploadBlob statusBlobType="BlockBlob">https://test.blob.core.windows.net/vhds/test-cs12.test-cs12.test-cs12.status?sr=b&amp;sp=rw&amp;se=9999-01-01&amp;sk=key1&amp;sv=2014-02-14&amp;sig=hfRh7gzUE7sUtYwke78IOlZOrTRCYvkec4hGZ9zZzXo</StatusUploadBlob>
+  <InVMGoalStateMetaData inSvdSeqNo="10" createdOnTicks="637726657706205217" activityId="a33f6f53-43d6-4625-b322-1a39651a00c9" correlationId="9a47a2a2-e740-4bfc-b11b-4f2f7cfe7d2e" />
+</Extensions>
 

--- a/tests/data/wire/invalid_config/ext_conf_multiple_depends_on_for_single_handler.xml
+++ b/tests/data/wire/invalid_config/ext_conf_multiple_depends_on_for_single_handler.xml
@@ -41,4 +41,5 @@
 		</Plugin>
 	</PluginSettings>
 	<StatusUploadBlob statusBlobType="BlockBlob">https://test.blob.core.windows.net/vhds/test-cs12.test-cs12.test-cs12.status?sr=b&amp;sp=rw&amp;se=9999-01-01&amp;sk=key1&amp;sv=2014-02-14&amp;sig=hfRh7gzUE7sUtYwke78IOlZOrTRCYvkec4hGZ9zZzXo</StatusUploadBlob>
+<InVMGoalStateMetaData inSvdSeqNo="10" createdOnTicks="637726657706205217" activityId="a33f6f53-43d6-4625-b322-1a39651a00c9" correlationId="9a47a2a2-e740-4bfc-b11b-4f2f7cfe7d2e" />
 </Extensions>

--- a/tests/data/wire/invalid_config/ext_conf_multiple_runtime_settings_same_plugin.xml
+++ b/tests/data/wire/invalid_config/ext_conf_multiple_runtime_settings_same_plugin.xml
@@ -26,5 +26,6 @@
 		</Plugin>
 	</PluginSettings>
 	<StatusUploadBlob statusBlobType="BlockBlob">https://test.blob.core.windows.net/vhds/test-cs12.test-cs12.test-cs12.status?sr=b&amp;sp=rw&amp;se=9999-01-01&amp;sk=key1&amp;sv=2014-02-14&amp;sig=hfRh7gzUE7sUtYwke78IOlZOrTRCYvkec4hGZ9zZzXo</StatusUploadBlob>
+<InVMGoalStateMetaData inSvdSeqNo="10" createdOnTicks="637726657706205217" activityId="a33f6f53-43d6-4625-b322-1a39651a00c9" correlationId="9a47a2a2-e740-4bfc-b11b-4f2f7cfe7d2e" />
 </Extensions>
 

--- a/tests/data/wire/invalid_config/ext_conf_multiple_settings_for_same_handler.xml
+++ b/tests/data/wire/invalid_config/ext_conf_multiple_settings_for_same_handler.xml
@@ -28,5 +28,6 @@
 		</Plugin>
 	</PluginSettings>
 	<StatusUploadBlob statusBlobType="BlockBlob">https://test.blob.core.windows.net/vhds/test-cs12.test-cs12.test-cs12.status?sr=b&amp;sp=rw&amp;se=9999-01-01&amp;sk=key1&amp;sv=2014-02-14&amp;sig=hfRh7gzUE7sUtYwke78IOlZOrTRCYvkec4hGZ9zZzXo</StatusUploadBlob>
+<InVMGoalStateMetaData inSvdSeqNo="10" createdOnTicks="637726657706205217" activityId="a33f6f53-43d6-4625-b322-1a39651a00c9" correlationId="9a47a2a2-e740-4bfc-b11b-4f2f7cfe7d2e" />
 </Extensions>
 

--- a/tests/data/wire/invalid_config/ext_conf_plugin_settings_version_mismatch.xml
+++ b/tests/data/wire/invalid_config/ext_conf_plugin_settings_version_mismatch.xml
@@ -25,5 +25,7 @@
     <RuntimeSettings seqNo="0">{"runtimeSettings":[{"handlerSettings":{"protectedSettingsCertThumbprint":"4037FBF5F1F3014F99B5D6C7799E9B20E6871CB3","protectedSettings":"MIICWgYJK","publicSettings":{"foo":"bar"}}}]}</RuntimeSettings>
   </Plugin>
 </PluginSettings>
-<StatusUploadBlob statusBlobType="BlockBlob">https://test.blob.core.windows.net/vhds/test-cs12.test-cs12.test-cs12.status?sr=b&amp;sp=rw&amp;se=9999-01-01&amp;sk=key1&amp;sv=2014-02-14&amp;sig=hfRh7gzUE7sUtYwke78IOlZOrTRCYvkec4hGZ9zZzXo</StatusUploadBlob></Extensions>
+<StatusUploadBlob statusBlobType="BlockBlob">https://test.blob.core.windows.net/vhds/test-cs12.test-cs12.test-cs12.status?sr=b&amp;sp=rw&amp;se=9999-01-01&amp;sk=key1&amp;sv=2014-02-14&amp;sig=hfRh7gzUE7sUtYwke78IOlZOrTRCYvkec4hGZ9zZzXo</StatusUploadBlob>
+<InVMGoalStateMetaData inSvdSeqNo="10" createdOnTicks="637726657706205217" activityId="a33f6f53-43d6-4625-b322-1a39651a00c9" correlationId="9a47a2a2-e740-4bfc-b11b-4f2f7cfe7d2e" />
+</Extensions>
 

--- a/tests/data/wire/invalid_config/ext_conf_single_and_multi_config_settings_same_plugin.xml
+++ b/tests/data/wire/invalid_config/ext_conf_single_and_multi_config_settings_same_plugin.xml
@@ -26,5 +26,6 @@
 		</Plugin>
 	</PluginSettings>
 	<StatusUploadBlob statusBlobType="BlockBlob">https://test.blob.core.windows.net/vhds/test-cs12.test-cs12.test-cs12.status?sr=b&amp;sp=rw&amp;se=9999-01-01&amp;sk=key1&amp;sv=2014-02-14&amp;sig=hfRh7gzUE7sUtYwke78IOlZOrTRCYvkec4hGZ9zZzXo</StatusUploadBlob>
+<InVMGoalStateMetaData inSvdSeqNo="10" createdOnTicks="637726657706205217" activityId="a33f6f53-43d6-4625-b322-1a39651a00c9" correlationId="9a47a2a2-e740-4bfc-b11b-4f2f7cfe7d2e" />
 </Extensions>
 

--- a/tests/ga/test_extension.py
+++ b/tests/ga/test_extension.py
@@ -3533,7 +3533,7 @@ class TestExtension(TestExtensionBase, HttpRequestPredicates):
                     exthandlers_handler.report_ext_handlers_status()
 
                     self._assert_handler_status(protocol.report_vm_status, "Ready", 1, "1.0.0")
-                    self.assertEqual("1", protocol.report_vm_status.call_args[0][0].vmAgent.vm_artifacts_aggregate_status.goal_state_aggregate_status.in_svd_seq_no, "Incarnation mismatch")
+                    self.assertEqual("1", protocol.report_vm_status.call_args[0][0].vmAgent.vm_artifacts_aggregate_status.goal_state_aggregate_status.in_svd_seq_no, "SVD sequence number mismatch")
 
 
 if __name__ == '__main__':

--- a/tests/ga/test_multi_config_extension.py
+++ b/tests/ga/test_multi_config_extension.py
@@ -1,5 +1,4 @@
 import contextlib
-import datetime
 import json
 import os.path
 import re

--- a/tests/ga/test_multi_config_extension.py
+++ b/tests/ga/test_multi_config_extension.py
@@ -1,4 +1,5 @@
 import contextlib
+import datetime
 import json
 import os.path
 import re

--- a/tests/ga/test_report_status.py
+++ b/tests/ga/test_report_status.py
@@ -139,12 +139,11 @@ class ReportStatusTestCase(AgentTestCase):
             self._test_supported_features_includes_fast_track(protocol, False)
 
     def _test_supported_features_includes_fast_track(self, protocol, expected):
-        with patch("azurelinuxagent.common.conf.get_enable_fast_track", return_value=True):
-            with ReportStatusTestCase._mock_update_handler(protocol) as update_handler:
-                update_handler.run(debug=True)
+        with ReportStatusTestCase._mock_update_handler(protocol) as update_handler:
+            update_handler.run(debug=True)
 
-                status = json.loads(protocol.mock_wire_data.status_blobs[0])
-                supported_features = status['supportedFeatures']
-                includes_fast_track = any(f['Key'] == 'FastTrack' for f in supported_features)
-                self.assertEqual(expected, includes_fast_track, "supportedFeatures should {0}include FastTrack. Got: {1}".format("" if expected else "not ", supported_features))
+            status = json.loads(protocol.mock_wire_data.status_blobs[0])
+            supported_features = status['supportedFeatures']
+            includes_fast_track = any(f['Key'] == 'FastTrack' for f in supported_features)
+            self.assertEqual(expected, includes_fast_track, "supportedFeatures should {0}include FastTrack. Got: {1}".format("" if expected else "not ", supported_features))
 

--- a/tests/protocol/mockwiredata.py
+++ b/tests/protocol/mockwiredata.py
@@ -394,6 +394,14 @@ class WireProtocolData(object):
         except ValueError:  # some test data include syntax errors; ignore those
             pass
 
+    def set_vm_settings_source(self, source):
+        """
+        Sets the "extensionGoalStatesSource" for the mock vm_settings data
+        """
+        vm_settings = json.loads(self.vm_settings)
+        vm_settings["extensionGoalStatesSource"] = source
+        self.vm_settings = json.dumps(vm_settings)
+
     def set_incarnation(self, incarnation, timestamp=None):
         """
         Sets the incarnation in the goal state, but not on its subcomponents (e.g. hosting env, shared config).

--- a/tests/protocol/mockwiredata.py
+++ b/tests/protocol/mockwiredata.py
@@ -367,17 +367,17 @@ class WireProtocolData(object):
     #
     @staticmethod
     def replace_xml_element_value(xml_document, element_name, element_value):
-        new_xml_document = re.sub(r'(?<=<{0}>).+(?=</{0}>)'.format(element_name), element_value, xml_document)
-        if new_xml_document == xml_document:
-            raise Exception("Could not match element '{0}'", element_name)  # pylint: disable=raising-format-tuple
-        return new_xml_document
+        element_regex = r'(?<=<{0}>).+(?=</{0}>)'.format(element_name)
+        if not re.search(element_regex, xml_document):
+            raise Exception("Can't find XML element '{0}' in {1}".format(element_name, xml_document))
+        return re.sub(element_regex, element_value, xml_document)
 
     @staticmethod
     def replace_xml_attribute_value(xml_document, element_name, attribute_name, attribute_value):
-        new_xml_document = re.sub(r'(?<=<{0} )(.*{1}=")[^"]+(?="[^>]*>)'.format(element_name, attribute_name), r'\g<1>{0}'.format(attribute_value), xml_document)
-        if new_xml_document == xml_document:
-            raise Exception("Could not match attribute '{0}' of element '{1}'".format(attribute_name, element_name))
-        return new_xml_document
+        attribute_regex = r'(?<=<{0} )(.*{1}=")[^"]+(?="[^>]*>)'.format(element_name, attribute_name)
+        if not re.search(attribute_regex, xml_document):
+            raise Exception("Can't find attribute {0} in XML element '{1}'. Document: {2}".format(attribute_name, element_name, xml_document))
+        return re.sub(attribute_regex, r'\g<1>{0}'.format(attribute_value), xml_document)
 
     def set_etag(self, etag, timestamp=None):
         """

--- a/tests/protocol/test_extensions_goal_state_from_extensions_config.py
+++ b/tests/protocol/test_extensions_goal_state_from_extensions_config.py
@@ -15,7 +15,9 @@ class ExtensionsGoalStateFromExtensionsConfigTestCase(AgentTestCase):
             self.assertEqual('2020-11-09T17:48:50.412125Z', extensions_goal_state.created_on_timestamp, "Incorrect GS Creation time")
 
     def test_it_should_use_default_values_when_in_vm_metadata_is_missing(self):
-        with mock_wire_protocol(mockwiredata.DATA_FILE) as protocol:
+        data_file = mockwiredata.DATA_FILE.copy()
+        data_file["ext_conf"] = "wire/ext_conf-no_gs_metadata.xml"
+        with mock_wire_protocol(data_file) as protocol:
             extensions_goal_state = protocol.get_goal_state().extensions_goal_state
             self.assertEqual(AgentGlobals.GUID_ZERO, extensions_goal_state.activity_id, "Incorrect activity Id")
             self.assertEqual(AgentGlobals.GUID_ZERO, extensions_goal_state.correlation_id, "Incorrect correlation Id")

--- a/tests/protocol/test_extensions_goal_state_from_vm_settings.py
+++ b/tests/protocol/test_extensions_goal_state_from_vm_settings.py
@@ -5,7 +5,7 @@ import json
 from azurelinuxagent.common.protocol.extensions_goal_state import GoalStateChannel
 from azurelinuxagent.common.protocol.extensions_goal_state_from_vm_settings import _CaseFoldedDict
 from tests.protocol.mocks import mockwiredata, mock_wire_protocol
-from tests.tools import AgentTestCase, patch
+from tests.tools import AgentTestCase
 
 
 class ExtensionsGoalStateFromVmSettingsTestCase(AgentTestCase):

--- a/tests/protocol/test_extensions_goal_state_from_vm_settings.py
+++ b/tests/protocol/test_extensions_goal_state_from_vm_settings.py
@@ -19,7 +19,7 @@ class ExtensionsGoalStateFromVmSettingsTestCase(AgentTestCase):
 
             assert_property("activity_id", "a33f6f53-43d6-4625-b322-1a39651a00c9")
             assert_property("correlation_id", "9a47a2a2-e740-4bfc-b11b-4f2f7cfe7d2e")
-            assert_property("created_on_timestamp", "2021-11-16T13:22:50.620522Z")
+            assert_property("created_on_timestamp", "2021-11-16T13:22:50.620529Z")
             assert_property("status_upload_blob", "https://dcrcl3a0xs.blob.core.windows.net/$system/edp0plkw2b.86f4ae0a-61f8-48ae-9199-40f402d56864.status?sv=2018-03-28&sr=b&sk=system-1&sig=KNWgC2%3d&se=9999-01-01T00%3a00%3a00Z&sp=w")
             assert_property("status_upload_blob_type", "BlockBlob")
             assert_property("required_features", ["MultipleExtensionsPerHandler"])

--- a/tests/protocol/test_extensions_goal_state_from_vm_settings.py
+++ b/tests/protocol/test_extensions_goal_state_from_vm_settings.py
@@ -8,9 +8,8 @@ from tests.protocol.mocks import mockwiredata, mock_wire_protocol
 from tests.tools import AgentTestCase, patch
 
 
-@patch("azurelinuxagent.common.conf.get_enable_fast_track", return_value=True)
 class ExtensionsGoalStateFromVmSettingsTestCase(AgentTestCase):
-    def test_it_should_parse_vm_settings(self, _):
+    def test_it_should_parse_vm_settings(self):
         with mock_wire_protocol(mockwiredata.DATA_FILE_VM_SETTINGS) as protocol:
             extensions_goal_state = protocol.get_goal_state().extensions_goal_state
 
@@ -48,7 +47,7 @@ class ExtensionsGoalStateFromVmSettingsTestCase(AgentTestCase):
             # dependency level (multi-config)
             self.assertEqual(1, extensions_goal_state.extensions[3].settings[1].dependencyLevel, "Incorrect dependency level (multi-config)")
 
-    def test_it_should_parse_requested_version_properly(self, _):
+    def test_it_should_parse_requested_version_properly(self):
         with mock_wire_protocol(mockwiredata.DATA_FILE_VM_SETTINGS) as protocol:
             manifests, _ = protocol.get_vmagent_manifests()
             for manifest in manifests:
@@ -61,7 +60,7 @@ class ExtensionsGoalStateFromVmSettingsTestCase(AgentTestCase):
             for manifest in manifests:
                 self.assertEqual(manifest.requested_version_string, "9.9.9.9", "Version should be 9.9.9.9")
 
-    def test_it_should_parse_missing_status_upload_blob_as_none(self, _):
+    def test_it_should_parse_missing_status_upload_blob_as_none(self):
         data_file = mockwiredata.DATA_FILE_VM_SETTINGS.copy()
         data_file["vm_settings"] = "hostgaplugin/vm_settings-no_status_upload_blob.json"
         with mock_wire_protocol(data_file) as protocol:
@@ -70,7 +69,7 @@ class ExtensionsGoalStateFromVmSettingsTestCase(AgentTestCase):
             self.assertIsNone(extensions_goal_state.status_upload_blob, "Expected status upload blob to be None")
             self.assertEqual("BlockBlob", extensions_goal_state.status_upload_blob_type, "Expected status upload blob to be Block")
 
-    def test_it_should_parse_missing_extension_manifests_as_empty(self, _):
+    def test_it_should_parse_missing_extension_manifests_as_empty(self):
         data_file = mockwiredata.DATA_FILE_VM_SETTINGS.copy()
         data_file["vm_settings"] = "hostgaplugin/vm_settings-no_extension_manifests.json"
         with mock_wire_protocol(data_file) as protocol:
@@ -86,7 +85,7 @@ class ExtensionsGoalStateFromVmSettingsTestCase(AgentTestCase):
                 ],
                 extensions_goal_state.extensions[2].manifest_uris, "Incorrect list of manifests for {0}".format(extensions_goal_state.extensions[2]))
 
-    def test_it_should_default_to_block_blob_when_the_status_blob_type_is_not_valid(self, _):
+    def test_it_should_default_to_block_blob_when_the_status_blob_type_is_not_valid(self):
         data_file = mockwiredata.DATA_FILE_VM_SETTINGS.copy()
         data_file["vm_settings"] = "hostgaplugin/vm_settings-invalid_blob_type.json"
         with mock_wire_protocol(data_file) as protocol:
@@ -94,7 +93,7 @@ class ExtensionsGoalStateFromVmSettingsTestCase(AgentTestCase):
 
             self.assertEqual("BlockBlob", extensions_goal_state.status_upload_blob_type, 'Expected BlockBlob for an invalid statusBlobType')
 
-    def test_its_source_channel_should_be_host_ga_plugin(self, _):
+    def test_its_source_channel_should_be_host_ga_plugin(self):
         with mock_wire_protocol(mockwiredata.DATA_FILE_VM_SETTINGS) as protocol:
             extensions_goal_state = protocol.get_goal_state().extensions_goal_state
 

--- a/tests/protocol/test_goal_state.py
+++ b/tests/protocol/test_goal_state.py
@@ -131,7 +131,7 @@ class GoalStateTestCase(AgentTestCase):
 
             # Do an extra call to update the goal state; this should save the vmsettings to the history directory
             # only once (self._find_history_subdirectory asserts 1 single match)
-            time.sleep(0.5)  # add a short delay to ensure that a new timestamp would be saved in the history folder
+            time.sleep(0.1)  # add a short delay to ensure that a new timestamp would be saved in the history folder
             with self.assertRaises(ProtocolError):
                 _ = GoalState(protocol.client)
 

--- a/tests/protocol/test_goal_state.py
+++ b/tests/protocol/test_goal_state.py
@@ -1,12 +1,15 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the Apache License.
 
+import contextlib
+import datetime
 import glob
 import os
 import re
 import time
 
 from azurelinuxagent.common.future import httpclient
+from azurelinuxagent.common.protocol.extensions_goal_state import GoalStateSource, GoalStateChannel
 from azurelinuxagent.common.protocol.goal_state import GoalState, _GET_GOAL_STATE_MAX_ATTEMPTS
 from azurelinuxagent.common.exception import ProtocolError
 from azurelinuxagent.common.utils import fileutil
@@ -29,8 +32,7 @@ class GoalStateTestCase(AgentTestCase):
                     GoalState(protocol.client)
                 self.assertEqual(_GET_GOAL_STATE_MAX_ATTEMPTS, mock_sleep.call_count, "Unexpected number of retries")
 
-    @patch("azurelinuxagent.common.conf.get_enable_fast_track", return_value=True)
-    def test_instantiating_goal_state_should_save_the_goal_state_to_the_history_directory(self, _):
+    def test_instantiating_goal_state_should_save_the_goal_state_to_the_history_directory(self):
         with mock_wire_protocol(mockwiredata.DATA_FILE_VM_SETTINGS) as protocol:
             protocol.mock_wire_data.set_incarnation(999)
             protocol.mock_wire_data.set_etag(888)
@@ -54,8 +56,7 @@ class GoalStateTestCase(AgentTestCase):
 
         self.assertEqual(expected_files, actual_files, "The expected files were not saved to {0}".format(directory))
 
-    @patch("azurelinuxagent.common.conf.get_enable_fast_track", return_value=True)
-    def test_update_should_create_new_history_subdirectories(self, _):
+    def test_update_should_create_new_history_subdirectories(self):
         with mock_wire_protocol(mockwiredata.DATA_FILE_VM_SETTINGS) as protocol:
             protocol.mock_wire_data.set_incarnation(123)
             protocol.mock_wire_data.set_etag(654)
@@ -83,8 +84,7 @@ class GoalStateTestCase(AgentTestCase):
             self._assert_directory_contents(
                 self._find_history_subdirectory("234-987"), ["VmSettings.json"])
 
-    @patch("azurelinuxagent.common.conf.get_enable_fast_track", return_value=True)
-    def test_it_should_redact_the_protected_settings_when_saving_to_the_history_directory(self, _):
+    def test_it_should_redact_the_protected_settings_when_saving_to_the_history_directory(self):
         with mock_wire_protocol(mockwiredata.DATA_FILE_VM_SETTINGS) as protocol:
             protocol.mock_wire_data.set_incarnation(888)
 
@@ -118,8 +118,7 @@ class GoalStateTestCase(AgentTestCase):
                         len(protected_settings),
                         "Could not find the expected number of redacted settings in {0}.\nExpected {1}.\n{2}".format(file_name, len(protected_settings), file_contents))
 
-    @patch("azurelinuxagent.common.conf.get_enable_fast_track", return_value=True)
-    def test_it_should_save_vm_settings_on_parse_errors(self, _):
+    def test_it_should_save_vm_settings_on_parse_errors(self):
         with mock_wire_protocol(mockwiredata.DATA_FILE_VM_SETTINGS) as protocol:
             invalid_vm_settings_file = "hostgaplugin/vm_settings-parse_error.json"
             data_file = mockwiredata.DATA_FILE_VM_SETTINGS.copy()
@@ -145,3 +144,126 @@ class GoalStateTestCase(AgentTestCase):
             actual = fileutil.read_file(vm_settings_file)
 
             self.assertEqual(expected, actual, "The vmSettings were not saved correctly")
+
+    @staticmethod
+    @contextlib.contextmanager
+    def _create_protocol_ws_and_hgap_in_sync():
+        """
+        Creates a mock protocol in which the HostGAPlugin and the WireServer are in sync, both of them returning
+        the same Fabric goal state.
+        """
+        data_file = mockwiredata.DATA_FILE_VM_SETTINGS.copy()
+
+        with mock_wire_protocol(data_file) as protocol:
+            timestamp = datetime.datetime.utcnow()
+            incarnation = '111'
+            etag = '111111'
+            protocol.mock_wire_data.set_incarnation(incarnation, timestamp=timestamp)
+            protocol.mock_wire_data.set_etag(etag, timestamp=timestamp)
+            protocol.mock_wire_data.set_vm_settings_source(GoalStateSource.Fabric)
+
+            # Do a few checks on the mock data to ensure we catch changes in internal implementations
+            # that may invalidate this setup.
+            vm_settings, _ = protocol.client.get_host_plugin().fetch_vm_settings()
+            if vm_settings.etag != etag:
+                raise Exception("The HostGAPlugin is no in sync. Expected ETag {0}. Got {1}".format(etag, vm_settings.etag))
+            if vm_settings.source != GoalStateSource.Fabric:
+                raise Exception("The HostGAPlugin should be returning a Fabric goal state. Got {0}".format(vm_settings.source))
+
+            goal_state = GoalState(protocol.client)
+            if goal_state.incarnation != incarnation:
+                raise Exception("The WireServer is no in sync. Expected incarnation {0}. Got {1}".format(incarnation, goal_state.incarnation))
+
+            if goal_state.extensions_goal_state.correlation_id != vm_settings.correlation_id:
+                raise Exception(
+                    "The correlation ID in the WireServer and HostGAPlugin are not in sync. WS: {0} HGAP: {1}".format(
+                        goal_state.extensions_goal_state.correlation_id, vm_settings.correlation_id))
+
+            yield protocol
+
+    def _assert_goal_state(self, goal_state, goal_state_id, channel=None, source=None):
+        self.assertIn(goal_state_id, goal_state.extensions_goal_state.id, "Incorrect Goal State ID")
+        if channel is not None:
+            self.assertEqual(channel, goal_state.extensions_goal_state.channel, "Incorrect Goal State channel")
+        if source is not None:
+            self.assertEqual(source, goal_state.extensions_goal_state.source, "Incorrect Goal State source")
+
+
+    def test_it_should_ignore_fabric_goal_states_from_the_host_ga_plugin(self):
+        with GoalStateTestCase._create_protocol_ws_and_hgap_in_sync() as protocol:
+            #
+            # Verify __init__()
+            #
+            expected_incarnation = '111'  # test setup initializes to this value
+            timestamp = datetime.datetime.utcnow() + datetime.timedelta(seconds=15)
+            protocol.mock_wire_data.set_etag('22222', timestamp)
+
+            goal_state = GoalState(protocol.client)
+
+            self._assert_goal_state(goal_state, expected_incarnation, channel=GoalStateChannel.WireServer)
+
+            #
+            # Verify update()
+            #
+            timestamp += datetime.timedelta(seconds=15)
+            protocol.mock_wire_data.set_etag('333333', timestamp)
+
+            goal_state.update()
+
+            self._assert_goal_state(goal_state, expected_incarnation, channel=GoalStateChannel.WireServer)
+
+    def test_it_should_use_fast_track_goal_states_from_the_host_ga_plugin(self):
+        with GoalStateTestCase._create_protocol_ws_and_hgap_in_sync() as protocol:
+            protocol.mock_wire_data.set_vm_settings_source(GoalStateSource.FastTrack)
+
+            #
+            # Verify __init__()
+            #
+            expected_etag = '22222'
+            timestamp = datetime.datetime.utcnow() + datetime.timedelta(seconds=15)
+            protocol.mock_wire_data.set_etag(expected_etag, timestamp)
+
+            goal_state = GoalState(protocol.client)
+
+            self._assert_goal_state(goal_state, expected_etag, channel=GoalStateChannel.HostGAPlugin)
+
+            #
+            # Verify update()
+            #
+            expected_etag = '333333'
+            timestamp += datetime.timedelta(seconds=15)
+            protocol.mock_wire_data.set_etag(expected_etag, timestamp)
+
+            goal_state.update()
+
+            self._assert_goal_state(goal_state, expected_etag, channel=GoalStateChannel.HostGAPlugin)
+
+    def test_it_should_use_the_most_recent_goal_state(self):
+        with GoalStateTestCase._create_protocol_ws_and_hgap_in_sync() as protocol:
+            goal_state = GoalState(protocol.client)
+
+            # The most recent goal state is FastTrack
+            timestamp = datetime.datetime.utcnow() + datetime.timedelta(seconds=15)
+            protocol.mock_wire_data.set_vm_settings_source(GoalStateSource.FastTrack)
+            protocol.mock_wire_data.set_etag('222222', timestamp)
+
+            goal_state.update()
+
+            self._assert_goal_state(goal_state, '222222', channel=GoalStateChannel.HostGAPlugin, source=GoalStateSource.FastTrack)
+
+            # The most recent goal state is Fabric
+            timestamp += datetime.timedelta(seconds=15)
+            protocol.mock_wire_data.set_incarnation('222', timestamp)
+
+            goal_state.update()
+
+            self._assert_goal_state(goal_state, '222', channel=GoalStateChannel.WireServer, source=GoalStateSource.Fabric)
+
+            # The most recent goal state is Fabric, but it is coming from the HostGAPlugin (should be ignored)
+            timestamp += datetime.timedelta(seconds=15)
+            protocol.mock_wire_data.set_vm_settings_source(GoalStateSource.Fabric)
+            protocol.mock_wire_data.set_etag('333333', timestamp)
+
+            goal_state.update()
+
+            self._assert_goal_state(goal_state, '222', channel=GoalStateChannel.WireServer, source=GoalStateSource.Fabric)

--- a/tests/protocol/test_hostplugin.py
+++ b/tests/protocol/test_hostplugin.py
@@ -858,12 +858,12 @@ class TestHostPluginVmSettings(HttpRequestPredicates, AgentTestCase):
         with mock_wire_protocol(mockwiredata.DATA_FILE_VM_SETTINGS) as protocol:
             protocol.set_http_handlers(http_get_handler=http_get_handler)
             with self.assertRaisesRegexCM(ProtocolError, r'GET vmSettings \[correlation ID: .* eTag: .*\]: \[HTTP Failed\] \[500: None].*TEST ERROR.*'):
-                protocol.client.get_host_plugin().fetch_vm_settings(False)
+                protocol.client.get_host_plugin().fetch_vm_settings()
 
     @staticmethod
     def _fetch_vm_settings_ignoring_errors(protocol):
         try:
-            protocol.client.get_host_plugin().fetch_vm_settings(False)
+            protocol.client.get_host_plugin().fetch_vm_settings()
         except (ProtocolError, VmSettingsNotSupported):
             pass
 
@@ -933,7 +933,7 @@ class TestHostPluginVmSettings(HttpRequestPredicates, AgentTestCase):
 
             def fetch_vm_settings():
                 try:
-                    host_plugin.fetch_vm_settings(True)
+                    host_plugin.fetch_vm_settings()
                 except ProtocolError:
                     pass  # All calls produce an error; ignore it
 

--- a/tests/protocol/test_hostplugin.py
+++ b/tests/protocol/test_hostplugin.py
@@ -867,8 +867,7 @@ class TestHostPluginVmSettings(HttpRequestPredicates, AgentTestCase):
         except (ProtocolError, VmSettingsNotSupported):
             pass
 
-    @patch("azurelinuxagent.common.conf.get_enable_fast_track", return_value=True)
-    def test_it_should_keep_track_of_errors_in_vm_settings_requests(self, _):
+    def test_it_should_keep_track_of_errors_in_vm_settings_requests(self):
         mock_response = None
 
         def http_get_handler(url, *_, **__):
@@ -916,8 +915,7 @@ class TestHostPluginVmSettings(HttpRequestPredicates, AgentTestCase):
 
             self.assertEqual(expected, summary, "The count of errors is incorrect")
 
-    @patch("azurelinuxagent.common.conf.get_enable_fast_track", return_value=True)
-    def test_it_should_limit_the_number_of_errors_it_reports(self, _):
+    def test_it_should_limit_the_number_of_errors_it_reports(self):
         with mock_wire_protocol(mockwiredata.DATA_FILE_VM_SETTINGS) as protocol:
             def http_get_handler(url, *_, **__):
                 if self.is_host_plugin_vm_settings_request(url):
@@ -962,8 +960,7 @@ class TestHostPluginVmSettings(HttpRequestPredicates, AgentTestCase):
                 log_messages = get_log_messages()
                 self.assertEqual(1, len(log_messages), "Expected additional errors to be reported to the local log in the next period (got: {0})".format(telemetry_messages))
 
-    @patch("azurelinuxagent.common.conf.get_enable_fast_track", return_value=True)
-    def test_it_should_stop_issuing_vm_settings_requests_when_api_is_not_supported(self, _):
+    def test_it_should_stop_issuing_vm_settings_requests_when_api_is_not_supported(self):
         with mock_wire_protocol(mockwiredata.DATA_FILE_VM_SETTINGS) as protocol:
             def http_get_handler(url, *_, **__):
                 if self.is_host_plugin_vm_settings_request(url):

--- a/tests/protocol/test_wire.py
+++ b/tests/protocol/test_wire.py
@@ -1158,10 +1158,6 @@ class UpdateGoalStateTestCase(HttpRequestPredicates, AgentTestCase):
         with mock_wire_protocol(data_file) as protocol:
             self._assert_is_extensions_goal_state_from_extensions_config(protocol.get_goal_state().extensions_goal_state)
 
-    def test_it_should(self):
-        pass  ### CONTINUE HERE
-
-
 
 class UpdateHostPluginFromGoalStateTestCase(AgentTestCase):
     """

--- a/tests/protocol/test_wire.py
+++ b/tests/protocol/test_wire.py
@@ -1160,6 +1160,9 @@ class UpdateGoalStateTestCase(HttpRequestPredicates, AgentTestCase):
         with mock_wire_protocol(data_file) as protocol:
             self._assert_is_extensions_goal_state_from_extensions_config(protocol.get_goal_state().extensions_goal_state)
 
+    def test_it_should(self):
+
+
 
 class UpdateHostPluginFromGoalStateTestCase(AgentTestCase):
     """

--- a/tests/protocol/test_wire.py
+++ b/tests/protocol/test_wire.py
@@ -1161,6 +1161,7 @@ class UpdateGoalStateTestCase(HttpRequestPredicates, AgentTestCase):
             self._assert_is_extensions_goal_state_from_extensions_config(protocol.get_goal_state().extensions_goal_state)
 
     def test_it_should(self):
+        pass  ### CONTINUE HERE
 
 
 

--- a/tests/protocol/test_wire.py
+++ b/tests/protocol/test_wire.py
@@ -1097,8 +1097,7 @@ class UpdateGoalStateTestCase(HttpRequestPredicates, AgentTestCase):
             self.assertEqual(protocol.client.get_host_plugin().container_id, new_container_id)
             self.assertEqual(protocol.client.get_host_plugin().role_config_name, new_role_config_name)
 
-    @patch("azurelinuxagent.common.conf.get_enable_fast_track", return_value=True)
-    def test_it_should_retry_get_vm_settings_on_resource_gone_error(self, _):
+    def test_it_should_retry_get_vm_settings_on_resource_gone_error(self):
         # Requests to the hostgaplugin incude the Container ID and the RoleConfigName as headers; when the hostgaplugin returns GONE (HTTP status 410) the agent
         # needs to get a new goal state and retry the request with updated values for the Container ID and RoleConfigName headers.
         with mock_wire_protocol(mockwiredata.DATA_FILE_VM_SETTINGS) as protocol:
@@ -1126,8 +1125,7 @@ class UpdateGoalStateTestCase(HttpRequestPredicates, AgentTestCase):
             self.assertEqual("GET_VM_SETTINGS_TEST_CONTAINER_ID", request_headers[1][hostplugin._HEADER_CONTAINER_ID], "The retry request did not include the expected header for the ContainerId")
             self.assertEqual("GET_VM_SETTINGS_TEST_ROLE_CONFIG_NAME", request_headers[1][hostplugin._HEADER_HOST_CONFIG_NAME], "The retry request did not include the expected header for the RoleConfigName")
 
-    @patch("azurelinuxagent.common.conf.get_enable_fast_track", return_value=True)
-    def test_it_should_use_vm_settings_by_default(self, _):
+    def test_it_should_use_vm_settings_by_default(self):
         with mock_wire_protocol(mockwiredata.DATA_FILE_VM_SETTINGS) as protocol:
             extensions_goal_state = protocol.get_goal_state().extensions_goal_state
             self.assertTrue(

--- a/tests/utils/test_archive.py
+++ b/tests/utils/test_archive.py
@@ -6,7 +6,7 @@ import zipfile
 from datetime import datetime, timedelta
 
 import azurelinuxagent.common.logger as logger
-from azurelinuxagent.common.utils import fileutil
+from azurelinuxagent.common.utils import fileutil, timeutil
 from azurelinuxagent.common.utils.archive import StateArchiver, _MAX_ARCHIVED_STATES
 from tests.tools import AgentTestCase, patch
 
@@ -198,20 +198,13 @@ class TestArchive(AgentTestCase):
         except:
             raise AssertionError("the value '{0}' is not an ISO8601 formatted timestamp".format(timestamp_str))
 
-    @staticmethod
-    def _total_seconds(delta):
-        """
-        Compute the total_seconds for a timedelta because 2.6 does not have total_seconds.
-        """
-        return (0.0 + delta.microseconds + (delta.seconds + delta.days * 24 * 60 * 60) * 10 ** 6) / 10 ** 6
-
     def assert_datetime_close_to(self, time1, time2, within):
         if time1 <= time2:
             diff = time2 - time1
         else:
             diff = time1 - time2
 
-        secs = self._total_seconds(within - diff)
+        secs = timeutil.total_seconds(within - diff)
         if secs < 0:
             self.fail("the timestamps are outside of the tolerance of by {0} seconds".format(secs))
 


### PR DESCRIPTION
The goal states returned by the HostGAPlugin and the WireServer can be out of sync. This presents a problem when the most recent goal state includes an updated tenant certificate (this is always a Fabric goal state). In this case, we need to ensure that we first download the certificate and the process the extensions.

To achieve this, we now ignore Fabric goal states from the HostGAPlugin and we process the most recent goal state from the 2 goal states we receive from WireServer/HostGAPlugin.

This PR also includes some minor cleanup of portions of the Fast Track code. I'll add comments in the PR to point those out.