### PR TITLE
Skip outdated Fabric goal states when HGAP does not support vmSettings

### DIFF
--- a/azurelinuxagent/common/protocol/extensions_goal_state.py
+++ b/azurelinuxagent/common/protocol/extensions_goal_state.py
@@ -53,6 +53,9 @@ class ExtensionsGoalState(object):
 
     NOTE: This is an abstract class. The corresponding concrete classes can be instantiated using the ExtensionsGoalStateFactory.
     """
+    def __init__(self):
+        self._is_outdated = False
+
     @property
     def id(self):
         """
@@ -60,6 +63,18 @@ class ExtensionsGoalState(object):
         was created from vmSettings.
         """
         raise NotImplementedError()
+
+    @property
+    def is_outdated(self):
+        """
+        A goal state can be outdated if, for example, the VM Agent is using Fast Track and support for it stops (e.g. the VM is migrated
+        to a node with an older version of the HostGAPlugin) and now the Agent is fetching goal states via the WireServer.
+        """
+        return self._is_outdated
+
+    @is_outdated.setter
+    def is_outdated(self, value):
+        self._is_outdated = value
 
     @property
     def svd_sequence_number(self):

--- a/azurelinuxagent/common/protocol/extensions_goal_state_from_extensions_config.py
+++ b/azurelinuxagent/common/protocol/extensions_goal_state_from_extensions_config.py
@@ -33,6 +33,7 @@ class ExtensionsGoalStateFromExtensionsConfig(ExtensionsGoalState):
     def __init__(self, incarnation, xml_text, wire_client):
         super(ExtensionsGoalStateFromExtensionsConfig, self).__init__()
         self._id = "incarnation_{0}".format(incarnation)
+        self._is_outdated = False
         self._incarnation = incarnation
         self._text = xml_text
         self._status_upload_blob = None

--- a/azurelinuxagent/common/protocol/hostplugin.py
+++ b/azurelinuxagent/common/protocol/hostplugin.py
@@ -453,6 +453,7 @@ class HostPluginProtocol(object):
 
         Raises
             * VmSettingsNotSupported if the HostGAPlugin does not support the vmSettings API
+            * VmSettingsSupportStopped if the HostGAPlugin stopped supporting the vmSettings API
             * VmSettingsParseError if the HostGAPlugin returned invalid vmSettings (e.g. syntax error)
             * ResourceGoneError if the container ID and roleconfig name need to be refreshed
             * ProtocolError if the request fails for any other reason (e.g. not supported, time out, server error)
@@ -477,7 +478,7 @@ class HostPluginProtocol(object):
             return "GET vmSettings [correlation ID: {0} eTag: {1}]: {2}".format(correlation_id, etag, msg)
 
         try:
-            # Raise if VmSettings are not supported, but check for periodically since the HostGAPlugin could have been updated since the last check
+            # Raise if VmSettings are not supported, but check again periodically since the HostGAPlugin could have been updated since the last check
             # Note that self._host_plugin_supports_vm_settings can be None, so we need to compare against False
             if self._supports_vm_settings == False and self._supports_vm_settings_next_check > datetime.datetime.now():
                 # Raise VmSettingsNotSupported directly instead of using raise_not_supported() to avoid resetting the timestamp for the next check

--- a/azurelinuxagent/common/protocol/hostplugin.py
+++ b/azurelinuxagent/common/protocol/hostplugin.py
@@ -16,23 +16,22 @@
 #
 # Requires Python 2.6+ and Openssl 1.0+
 #
-
 import base64
 import datetime
 import json
+import os.path
 import uuid
 
-from azurelinuxagent.common import logger
+from azurelinuxagent.common import logger, conf
 from azurelinuxagent.common.errorstate import ErrorState, ERROR_STATE_HOST_PLUGIN_FAILURE
 from azurelinuxagent.common.event import WALAEventOperation, add_event
 from azurelinuxagent.common.exception import HttpError, ProtocolError, ResourceGoneError
 from azurelinuxagent.common.utils.flexible_version import FlexibleVersion
 from azurelinuxagent.common.future import ustr, httpclient
 from azurelinuxagent.common.protocol.healthservice import HealthService
-from azurelinuxagent.common.protocol.extensions_goal_state import VmSettingsParseError
+from azurelinuxagent.common.protocol.extensions_goal_state import VmSettingsParseError, GoalStateSource
 from azurelinuxagent.common.protocol.extensions_goal_state_factory import ExtensionsGoalStateFactory
-from azurelinuxagent.common.utils import restutil
-from azurelinuxagent.common.utils import textutil
+from azurelinuxagent.common.utils import restutil, textutil, timeutil
 from azurelinuxagent.common.utils.textutil import remove_bom
 from azurelinuxagent.common.version import AGENT_NAME, AGENT_VERSION, PY_VERSION_MAJOR
 
@@ -86,11 +85,21 @@ class HostPluginProtocol(object):
         self.status_error_state = ErrorState(min_timedelta=ERROR_STATE_HOST_PLUGIN_FAILURE)
         self.fetch_last_timestamp = None
         self.status_last_timestamp = None
-        self._host_plugin_version = FlexibleVersion("0.0.0.0")  # Version 0 means "unknown"
-        self._host_plugin_supports_vm_settings = None   # Tri-state variable: None == Not Initialized, True == Supports, False == Does Not Support
-        self._host_plugin_supports_vm_settings_next_check = datetime.datetime.now()
+        self._version = FlexibleVersion("0.0.0.0")  # Version 0 means "unknown"
+        self._supports_vm_settings = None   # Tri-state variable: None == Not Initialized, True == Supports, False == Does Not Support
+        self._supports_vm_settings_next_check = datetime.datetime.now()
         self._vm_settings_error_reporter = _VmSettingsErrorReporter()
-        self._cached_vm_settings = None  # Cached value of the most recent ExtensionsGoalStateFromVmSettings
+        self._cached_vm_settings = None  # Cached value of the most recent vmSettings
+
+        # restore the state of Fast Track
+        if not os.path.exists(self._get_fast_track_state_file()):
+            self._supports_vm_settings = False
+            self._supports_vm_settings_next_check = datetime.datetime.now()
+            self._fast_track_timestamp = None
+        else:
+            self._supports_vm_settings = True
+            self._supports_vm_settings_next_check = datetime.datetime.now()
+            self._fast_track_timestamp = HostPluginProtocol._get_fast_track_timestamp()
 
     @staticmethod
     def _extract_deployment_id(role_config_name):
@@ -102,9 +111,9 @@ class HostPluginProtocol(object):
         Returns True if the HostGAPlugin supports the vmSettings API.
         """
         # _host_plugin_supports_vm_settings is set by fetch_vm_settings()
-        if self._host_plugin_supports_vm_settings is None:
+        if self._supports_vm_settings is None:
             _, _ = self.fetch_vm_settings()
-        return self._host_plugin_supports_vm_settings
+        return self._supports_vm_settings
 
     def update_container_id(self, new_container_id):
         self.container_id = new_container_id
@@ -405,34 +414,74 @@ class HostPluginProtocol(object):
             return s.decode('utf-8')
         return s
 
+    @staticmethod
+    def _get_fast_track_state_file():
+        # This file keeps the timestamp of the most recent goal state if it was retrieved via Fast Track
+        return os.path.join(conf.get_lib_dir(), "fast_track.json")
+
+    @staticmethod
+    def _save_fast_track_state(timestamp):
+        try:
+            with open(HostPluginProtocol._get_fast_track_state_file(), "w") as file_:
+                json.dump({"timestamp": timestamp}, file_)
+        except Exception as e:
+            logger.warn("Error updating the Fast Track state ({0}): {1}", HostPluginProtocol._get_fast_track_state_file(), ustr(e))
+
+    @staticmethod
+    def clear_fast_track_state():
+        try:
+            if os.path.exists(HostPluginProtocol._get_fast_track_state_file()):
+                os.remove(HostPluginProtocol._get_fast_track_state_file())
+        except Exception as e:
+            logger.warn("Error clearing the current state for Fast Track ({0}): {1}", HostPluginProtocol._get_fast_track_state_file(),
+                        ustr(e))
+
+    @staticmethod
+    def _get_fast_track_timestamp():
+        try:
+            with open(HostPluginProtocol._get_fast_track_state_file(), "r") as file_:
+                return json.load(file_)["timestamp"]
+        except Exception as e:
+            logger.warn("Can't retrieve the timestamp for the most recent Fast Track goal state ({0}), will assume the current time. Error: {1}",
+                HostPluginProtocol._get_fast_track_state_file(), ustr(e))
+        return timeutil.create_timestamp(datetime.datetime.utcnow())
+
     def fetch_vm_settings(self):
         """
-        Queries the vmSettings from the HostGAPlugin and returns an (ExtensionsGoalStateFromVmSettings, bool) tuple with the vmSettings and
+        Queries the vmSettings from the HostGAPlugin and returns an (ExtensionsGoalState, bool) tuple with the vmSettings and
         a boolean indicating if they are an updated (True) or a cached value (False).
 
         Raises
             * VmSettingsNotSupported if the HostGAPlugin does not support the vmSettings API
-            * VmSettingsError if the HostGAPlugin returned invalid vmSettings (e.g. syntax error)
+            * VmSettingsParseError if the HostGAPlugin returned invalid vmSettings (e.g. syntax error)
             * ResourceGoneError if the container ID and roleconfig name need to be refreshed
             * ProtocolError if the request fails for any other reason (e.g. not supported, time out, server error)
         """
-        def raise_not_supported(reset_state=False):
-            if reset_state:
-                self._host_plugin_supports_vm_settings = False
-                self._host_plugin_supports_vm_settings_next_check = datetime.datetime.now() + datetime.timedelta(hours=6)  # check again in 6 hours
-                # "Not supported" is not considered an error, so don't use self._vm_settings_error_reporter to report it
-                logger.info("vmSettings is not supported")
-                add_event(op=WALAEventOperation.HostPlugin, message="vmSettings is not supported", is_success=True)
-            raise VmSettingsNotSupported()
+        def raise_not_supported():
+            try:
+                if self._supports_vm_settings:
+                    # The most recent goal state was delivered using FastTrack, and suddenly the HostGAPlugin does not support the vmSettings API anymore.
+                    # This can happen if, for example, the VM is migrated across host nodes that are running different versions of the HostGAPlugin.
+                    logger.warn("The HostGAPlugin stopped supporting the vmSettings API. If there is a pending FastTrack goal state, it will not be executed.")
+                    add_event(op=WALAEventOperation.VmSettings, message="[VmSettingsSupportStopped] HostGAPlugin: {0}".format(self._version), is_success=False, log_event=False)
+                    raise VmSettingsSupportStopped(self._fast_track_timestamp)
+                else:
+                    logger.info("HostGAPlugin {0} does not support the vmSettings API. Will not use FastTrack.", self._version)
+                    add_event(op=WALAEventOperation.VmSettings, message="[VmSettingsNotSupported] HostGAPlugin: {0}".format(self._version), is_success=True)
+                    raise VmSettingsNotSupported()
+            finally:
+                self._supports_vm_settings = False
+                self._supports_vm_settings_next_check = datetime.datetime.now() + datetime.timedelta(hours=6)  # check again in 6 hours
 
         def format_message(msg):
             return "GET vmSettings [correlation ID: {0} eTag: {1}]: {2}".format(correlation_id, etag, msg)
 
         try:
-            # Raise if VmSettings are not supported but check for periodically since the HostGAPlugin could have been updated since the last check
+            # Raise if VmSettings are not supported, but check for periodically since the HostGAPlugin could have been updated since the last check
             # Note that self._host_plugin_supports_vm_settings can be None, so we need to compare against False
-            if self._host_plugin_supports_vm_settings == False and self._host_plugin_supports_vm_settings_next_check > datetime.datetime.now():
-                raise_not_supported()
+            if self._supports_vm_settings == False and self._supports_vm_settings_next_check > datetime.datetime.now():
+                # Raise VmSettingsNotSupported directly instead of using raise_not_supported() to avoid resetting the timestamp for the next check
+                raise VmSettingsNotSupported()
 
             etag = None if self._cached_vm_settings is None else self._cached_vm_settings.etag
             correlation_id = str(uuid.uuid4())
@@ -448,7 +497,7 @@ class HostPluginProtocol(object):
                 raise ResourceGoneError()
 
             if response.status == httpclient.NOT_FOUND:  # the HostGAPlugin does not support FastTrack
-                raise_not_supported(reset_state=True)
+                raise_not_supported()
 
             if response.status == httpclient.NOT_MODIFIED:  # The goal state hasn't changed, return the current instance
                 return self._cached_vm_settings, False
@@ -467,7 +516,7 @@ class HostPluginProtocol(object):
                 elif 500 <= response.status <= 599:
                     self._vm_settings_error_reporter.report_error(error_description, _VmSettingsError.ServerError)
                 else:
-                    self._vm_settings_error_reporter.report_error(error_description)
+                    self._vm_settings_error_reporter.report_error(error_description, _VmSettingsError.HttpError)
 
                 raise ProtocolError(error_description)
 
@@ -477,7 +526,6 @@ class HostPluginProtocol(object):
                     break
             else:  # since the vmSettings were updated, the response must include an etag
                 message = format_message("The vmSettings response does not include an Etag header")
-                self._vm_settings_error_reporter.report_error(message)
                 raise ProtocolError(message)
 
             response_content = ustr(response.read(), encoding='utf-8')
@@ -485,8 +533,8 @@ class HostPluginProtocol(object):
             vm_settings = ExtensionsGoalStateFactory.create_from_vm_settings(response_etag, response_content, correlation_id)
 
             # log the HostGAPlugin version
-            if vm_settings.host_ga_plugin_version != self._host_plugin_version:
-                self._host_plugin_version = vm_settings.host_ga_plugin_version
+            if vm_settings.host_ga_plugin_version != self._version:
+                self._version = vm_settings.host_ga_plugin_version
                 message = "HostGAPlugin version: {0}".format(vm_settings.host_ga_plugin_version)
                 logger.info(message)
                 add_event(op=WALAEventOperation.HostPlugin, message=message, is_success=True)
@@ -494,17 +542,20 @@ class HostPluginProtocol(object):
             # Don't support HostGAPlugin versions older than 123
             # TODO: update the minimum version to 1.0.8.123 before release
             if vm_settings.host_ga_plugin_version < FlexibleVersion("1.0.8.117"):
-                raise_not_supported(reset_state=True)
+                raise_not_supported()
 
-            self._host_plugin_supports_vm_settings = True
+            self._supports_vm_settings = True
             self._cached_vm_settings = vm_settings
+
+            if vm_settings.source == GoalStateSource.FastTrack:
+                self._fast_track_timestamp = vm_settings.created_on_timestamp
+                self._save_fast_track_state(vm_settings.created_on_timestamp)
+            else:
+                self.clear_fast_track_state()
+
             return vm_settings, True
 
-        except (ProtocolError, ResourceGoneError, VmSettingsNotSupported):
-            raise
-        except VmSettingsParseError as exception:
-            message = format_message(ustr(exception))
-            self._vm_settings_error_reporter.report_error(message)
+        except (ProtocolError, ResourceGoneError, VmSettingsNotSupported, VmSettingsParseError):
             raise
         except Exception as exception:
             if isinstance(exception, IOError) and "timed out" in ustr(exception):
@@ -519,19 +570,31 @@ class HostPluginProtocol(object):
 
 
 class VmSettingsNotSupported(TypeError):
-    pass
+    """
+    Indicates that the HostGAPlugin does not support the vmSettings API
+    """
+
+
+class VmSettingsSupportStopped(VmSettingsNotSupported):
+    """
+    Indicates that the HostGAPlugin supported the vmSettings API in previous calls, but now it does not support it for current call.
+    This can happen, for example, if the VM is migrated across nodes with different HostGAPlugin versions.
+    """
+    def __init__(self, timestamp):
+        super(VmSettingsSupportStopped, self).__init__()
+        self.timestamp = timestamp
 
 
 class _VmSettingsError(object):
-    ServerError   = 'ServerError'
-    ClientError   = 'ClientError'
-    Timeout       = 'Timeout'
-    RequestFailed = 'RequestFailed'
+    ClientError    = 'ClientError'
+    HttpError      = 'HttpError'
+    RequestFailed  = 'RequestFailed'
+    ServerError    = 'ServerError'
+    Timeout        = 'Timeout'
 
 
 class _VmSettingsErrorReporter(object):
-    _MaxLogErrors = 1  # Max number of errors by period reported to the local log
-    _MaxTelemetryErrors = 3  # Max number of errors  by period reported to telemetry
+    _MaxErrors = 3  # Max number of errors reported to telemetry (by period)
     _Period = datetime.timedelta(hours=1)  # How often to report the summary
 
     def __init__(self):
@@ -540,32 +603,32 @@ class _VmSettingsErrorReporter(object):
     def _reset(self):
         self._request_count = 0  # Total number of vmSettings HTTP requests
         self._error_count = 0   # Total number of errors issuing vmSettings requests (includes all kinds of errors)
-        self._server_error_count = 0  # Count of server side errors (HTTP status in the 500s)
         self._client_error_count = 0  # Count of client side errors (HTTP status in the 400s)
-        self._timeout_count = 0  # Count of timeouts on vmSettings requests
+        self._http_error_count = 0  # Count of HTTP errors other than 400s and 500s
         self._request_failure_count = 0  # Total count of requests that could not be issued (does not include timeouts or requests that were actually issued and failed, for example, with 500 or 400 statuses)
+        self._server_error_count = 0  # Count of server side errors (HTTP status in the 500s)
+        self._timeout_count = 0  # Count of timeouts on vmSettings requests
         self._next_period = datetime.datetime.now() + _VmSettingsErrorReporter._Period
 
     def report_request(self):
         self._request_count += 1
 
-    def report_error(self, error, category=None):
+    def report_error(self, error, category):
         self._error_count += 1
 
-        if self._error_count <= _VmSettingsErrorReporter._MaxLogErrors:
-            logger.info("[VmSettings] [Informational only, the Agent will continue normal operation] {0}", error)
+        if self._error_count <= _VmSettingsErrorReporter._MaxErrors:
+            add_event(op=WALAEventOperation.VmSettings, message="[{0}] {1}".format(category, error), is_success=False, log_event=False)
 
-        if self._error_count <= _VmSettingsErrorReporter._MaxTelemetryErrors:
-            add_event(op=WALAEventOperation.VmSettings, message=error, is_success=False, log_event=False)
-
-        if category == _VmSettingsError.ServerError:
-            self._server_error_count += 1
-        elif category == _VmSettingsError.ClientError:
+        if category == _VmSettingsError.ClientError:
             self._client_error_count += 1
-        elif category == _VmSettingsError.Timeout:
-            self._timeout_count += 1
+        elif category == _VmSettingsError.HttpError:
+            self._http_error_count += 1
         elif category == _VmSettingsError.RequestFailed:
             self._request_failure_count += 1
+        elif category == _VmSettingsError.ServerError:
+            self._server_error_count += 1
+        elif category == _VmSettingsError.Timeout:
+            self._timeout_count += 1
 
     def report_summary(self):
         if datetime.datetime.now() >= self._next_period:

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -567,7 +567,8 @@ class UpdateHandler(object):
         """
         True if we are currently processing a new extensions goal state
         """
-        return self._goal_state is not None and self._goal_state.extensions_goal_state.id != self._last_extensions_gs_id
+        egs = self._goal_state.extensions_goal_state
+        return self._goal_state is not None and egs.id != self._last_extensions_gs_id and not egs.is_outdated
 
     def _process_goal_state(self, exthandlers_handler, remote_access_handler):
         try:
@@ -670,6 +671,8 @@ class UpdateHandler(object):
             if self._goal_state is not None:
                 agent_status = exthandlers_handler.get_ext_handlers_status_debug_info(vm_status)
                 self._goal_state.save_to_history(agent_status, AGENT_STATUS_FILE)
+                if self._goal_state.extensions_goal_state.is_outdated:
+                    exthandlers_handler.protocol.client.get_host_plugin().clear_fast_track_state()
 
     def _report_extensions_summary(self, vm_status):
         try:


### PR DESCRIPTION
If the agent is using FastTrack and the VM is migrated from a node where the HGAP supports vmSettings to a node where it doesn't we need to ensure that the agent does not execute an outdated Fabric goal state.

The HostPluginProtocol now keeps track of the timestamp of the most recent FastTrack goal state. If the fetch_vm_settings() method detects that support for vmSettings is no longer available, it raises  VmSettingsSupportStopped.

GoalState.update() handles that exception by restoring the current Fabric goal state. If the timestamp of this goal state is older than the most recent FastTrack goal state, it marks the GS as "outdated".

The UpdateHandler will not execute extensions if the GS is outdated.

The timestamp for the FastTrack goal state is persisted to /var/lib/waagent/fast_track.json. This is needed to handle agent restarts. The file is deleted once the agent reports status (at that point the agent will report that it does not support FastTrack and CRP will switch to Fabric.

The PR includes cleanup of related code. I'll add comments pointing out this cleanup.