### PR TITLE
Fix polling period, handle extensions to run in extension slice and log extension run cgroup details

### DIFF
--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -1411,9 +1411,8 @@ class ExtHandlerInstance(object):
         env = {
             ExtCommandEnvVariable.UninstallReturnCode: uninstall_exit_code
         }
-        # This check to call the setup if AzureMonitorLinuxAgent extension already installed and not called setup before
-        if self.is_azuremonitorlinuxagent(self.get_full_name()) and \
-                not CGroupConfigurator.get_instance().is_extension_resource_limits_setup_completed(self.get_full_name()):
+        # This check to call the setup if extension already installed and not called setup before
+        if not CGroupConfigurator.get_instance().is_extension_resource_limits_setup_completed(self.get_full_name()):
             self.set_extension_resource_limits()
 
         self.set_operation(WALAEventOperation.Enable)


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

> Check resource metrics polling is within configured period
> Handle extensions to starts in extension slice if they are already installed.
> Log extension run cgroup details when it's starts

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).