### PR TITLE
Detect outdated Fabric goal states when FastTrack is disabled

### DIFF
--- a/azurelinuxagent/common/protocol/goal_state.py
+++ b/azurelinuxagent/common/protocol/goal_state.py
@@ -191,7 +191,7 @@ class GoalState(object):
         self._extensions_goal_state = self._fetch_full_wire_server_goal_state(incarnation, xml_doc)
         if self._extensions_goal_state.created_on_timestamp < vm_settings_support_stopped_error.timestamp:
             self._extensions_goal_state.is_outdated = True
-            msg = "Fetched a Fabric goal state older than the most recent FastTrack goal state; will skip it. (Fabric: {0} FastTrack: {1})".format(
+            msg = "Fetched a Fabric goal state older than the most recent FastTrack goal state; will skip it.\nFabric:    {0}\nFastTrack: {1}".format(
                   self._extensions_goal_state.created_on_timestamp, vm_settings_support_stopped_error.timestamp)
             logger.info(msg)
             add_event(op=WALAEventOperation.VmSettings, message=msg, is_success=True)

--- a/azurelinuxagent/common/protocol/hostplugin.py
+++ b/azurelinuxagent/common/protocol/hostplugin.py
@@ -99,7 +99,7 @@ class HostPluginProtocol(object):
         else:
             self._supports_vm_settings = True
             self._supports_vm_settings_next_check = datetime.datetime.now()
-            self._fast_track_timestamp = HostPluginProtocol._get_fast_track_timestamp()
+            self._fast_track_timestamp = HostPluginProtocol.get_fast_track_timestamp()
 
     @staticmethod
     def _extract_deployment_id(role_config_name):
@@ -437,13 +437,20 @@ class HostPluginProtocol(object):
                         ustr(e))
 
     @staticmethod
-    def _get_fast_track_timestamp():
+    def get_fast_track_timestamp():
+        """
+        Returns the timestamp of the most recent FastTrack goal state retrieved by fetch_vm_settings(), or None if the most recent
+        goal state was Fabric or fetch_vm_settings() has not been invoked.
+        """
+        if not os.path.exists(HostPluginProtocol._get_fast_track_state_file()):
+            return None
+
         try:
             with open(HostPluginProtocol._get_fast_track_state_file(), "r") as file_:
                 return json.load(file_)["timestamp"]
         except Exception as e:
             logger.warn("Can't retrieve the timestamp for the most recent Fast Track goal state ({0}), will assume the current time. Error: {1}",
-                HostPluginProtocol._get_fast_track_state_file(), ustr(e))
+                    HostPluginProtocol._get_fast_track_state_file(), ustr(e))
         return timeutil.create_timestamp(datetime.datetime.utcnow())
 
     def fetch_vm_settings(self):

--- a/tests/ga/mocks.py
+++ b/tests/ga/mocks.py
@@ -1,0 +1,68 @@
+# Copyright 2018 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Requires Python 2.6+ and Openssl 1.0+
+#
+
+import contextlib
+
+from mock import PropertyMock
+from azurelinuxagent.ga.exthandlers import ExtHandlersHandler
+from azurelinuxagent.ga.remoteaccess import RemoteAccessHandler
+from azurelinuxagent.ga.update import UpdateHandler, get_update_handler
+from tests.tools import patch, Mock, mock_sleep
+
+
+@contextlib.contextmanager
+def mock_update_handler(protocol, iterations=1, on_new_iteration=lambda _: None, exthandlers_handler=None, remote_access_handler=None, enable_agent_updates=False):
+    """
+    Creates a mock UpdateHandler that executes its main loop for the given 'iterations'.
+    If 'on_new_iteration' is given, it is invoked at the beginning of each iteration passing the iteration number as argument.
+    Network requests (e.g. requests for the goal state) are done using the given 'protocol'.
+    The mock UpdateHandler uses mock no-op ExtHandlersHandler and RemoteAccessHandler, unless they are given by 'exthandlers_handler' and 'remote_access_handler'.
+    Agent updates are disabled, unless specified otherwise with 'enable_agent_updates'.
+    Background threads (monitor, env, telemetry, etc) are not started.
+    """
+    iteration_count = [0]
+
+    def is_running(*args):  # mock for property UpdateHandler.is_running, which controls the main loop
+        if len(args) == 0:
+            # getter
+            iteration_count[0] += 1
+            on_new_iteration(iteration_count[0])
+            return iteration_count[0] <= iterations
+        else:
+            # setter
+            return None
+
+    if exthandlers_handler is None:
+        exthandlers_handler = ExtHandlersHandler(protocol)
+
+    if remote_access_handler is None:
+        remote_access_handler = RemoteAccessHandler(protocol)
+
+    with patch("azurelinuxagent.ga.exthandlers.get_exthandlers_handler", return_value=exthandlers_handler):
+        with patch("azurelinuxagent.ga.remoteaccess.get_remote_access_handler", return_value=remote_access_handler):
+            with patch("azurelinuxagent.common.conf.get_autoupdate_enabled", return_value=enable_agent_updates):
+                with patch.object(UpdateHandler, "is_running", PropertyMock(side_effect=is_running)):
+                    with patch.object(UpdateHandler, "_check_daemon_running"):
+                        with patch.object(UpdateHandler, "_start_threads"):
+                            with patch.object(UpdateHandler, "_check_threads_running"):
+                                with patch('time.sleep', side_effect=lambda _: mock_sleep(0.001)):
+                                    with patch('sys.exit', side_effect=lambda _: 0):
+                                        update_handler = get_update_handler()
+                                        update_handler.protocol_util.get_protocol = Mock(return_value=protocol)
+
+                                        yield update_handler
+


### PR DESCRIPTION
If the user disables FastTrack (in waagent.conf), when we fetch the goal state from the WireServer we need to skip it if it is older than the most recent FastTrack goal state.

Also, created mock_update_handler to help tests that need to use UpdateHandler.run