### PR TITLE
Fix No known host error message for DCR v2

### DIFF
--- a/dcr/templates/setup-vm-and-execute-tests.yml
+++ b/dcr/templates/setup-vm-and-execute-tests.yml
@@ -32,7 +32,7 @@ jobs:
         displayName: 'Install SSH Key to agent'
         name: "InstallKey"
         inputs:
-          knownHostsEntry: 'githib.com $(SSH_PUBLIC)'
+          knownHostsEntry: 'github.com $(SSH_PUBLIC)' # Adding a dummy known host for github.com as leaving it empty is not allowed by this task
           sshPublicKey: '$(SSH_PUBLIC)'
           sshKeySecureFile: 'id_rsa'
 

--- a/dcr/templates/setup-vm-and-execute-tests.yml
+++ b/dcr/templates/setup-vm-and-execute-tests.yml
@@ -32,7 +32,7 @@ jobs:
         displayName: 'Install SSH Key to agent'
         name: "InstallKey"
         inputs:
-          knownHostsEntry: '$(SSH_PUBLIC)'
+          knownHostsEntry: ''
           sshPublicKey: '$(SSH_PUBLIC)'
           sshKeySecureFile: 'id_rsa'
 
@@ -52,7 +52,7 @@ jobs:
           architecture: 'x64'
 
       - script: |
-          rm -rf ~/.ssh/known_hosts
+          # rm -rf ~/.ssh/known_hosts
           mkdir -p "$(Build.ArtifactStagingDirectory)/harvest"
         displayName: "Clear known host keys and create directories"
 

--- a/dcr/templates/setup-vm-and-execute-tests.yml
+++ b/dcr/templates/setup-vm-and-execute-tests.yml
@@ -32,7 +32,7 @@ jobs:
         displayName: 'Install SSH Key to agent'
         name: "InstallKey"
         inputs:
-          knownHostsEntry: ''
+          knownHostsEntry: 'githib.com $(SSH_PUBLIC)'
           sshPublicKey: '$(SSH_PUBLIC)'
           sshKeySecureFile: 'id_rsa'
 

--- a/dcr/templates/setup-vm-and-execute-tests.yml
+++ b/dcr/templates/setup-vm-and-execute-tests.yml
@@ -52,9 +52,8 @@ jobs:
           architecture: 'x64'
 
       - script: |
-          # rm -rf ~/.ssh/known_hosts
           mkdir -p "$(Build.ArtifactStagingDirectory)/harvest"
-        displayName: "Clear known host keys and create directories"
+        displayName: "Create harvest directories"
 
       - bash: $(Build.SourcesDirectory)/dcr/scripts/build_agent_zip.sh
         displayName: "Build Agent Zip"


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Currently, if any step fails in the DCR v2 run, the Install SSH PostJob shows this error - `##[error]Error: ENOENT: no such file or directory, unlink '/home/vsts/.ssh/known_hosts'`

This error is unrelated to the actual failure and might cause confusion during debug. 

This PR fixes this issue.

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).