### PR TITLE
Log Collector OOM kill bug fix

### DIFF
--- a/azurelinuxagent/ga/collect_logs.py
+++ b/azurelinuxagent/ga/collect_logs.py
@@ -76,11 +76,11 @@ def __get_kernel_supported():
     # platform.release() as well.
     kernel_version_pattern = r'^\d+(\.\d+)+'
 
-    kernel_version_str = re.search(kernel_version_pattern, platform.release())
-    if kernel_version_str is None:
+    kernel_version_match = re.search(kernel_version_pattern, platform.release())
+    if kernel_version_match is None:
         return False
     
-    kernel_version = FlexibleVersion(kernel_version_str)
+    kernel_version = FlexibleVersion(kernel_version_match.group())
 
     # Compare against minimum supported kernel version; on earlier kernels, OOM
     # behavior differs and can lead to OOM kills of the log collector process.


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Cgroups memory enforcement has different behavior on older kernels; whereas newer kernels use a form of memory throttling (keeping the log collector process under the set limit) the older kernels just invoke the OOM Killer on the process, which leads to a message in syslog. This PR disables the background log collector on those older kernels to prevent the OOM Kills.

<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).