### PR TITLE
Change format of history items

### DIFF
--- a/azurelinuxagent/common/utils/timeutil.py
+++ b/azurelinuxagent/common/utils/timeutil.py
@@ -3,14 +3,23 @@
 import datetime
 
 
-def create_timestamp(dt=None):
+def create_timestamp(dt=None, timespec='auto'):
     """
-    Returns a string with the given datetime iso format. If no datetime is given as parameter, it
-    uses datetime.utcnow().
+    Returns a string with the given datetime in iso format. If no datetime is given as parameter, it
+    uses datetime.utcnow(). The 'timespec' parameter is passed as argument to datetime.isoformat()
     """
     if dt is None:
         dt = datetime.datetime.utcnow()
-    return dt.isoformat()
+    return dt.isoformat(timespec=timespec)
+
+
+def create_history_timestamp(dt=None):
+    """
+    Returns a string with the given datetime formatted as a timestamp for the agent's history folder
+    """
+    if dt is None:
+        dt = datetime.datetime.utcnow()
+    return dt.isoformat(timespec='seconds').replace(":", "-")
 
 
 def datetime_to_ticks(dt):

--- a/azurelinuxagent/common/utils/timeutil.py
+++ b/azurelinuxagent/common/utils/timeutil.py
@@ -3,14 +3,14 @@
 import datetime
 
 
-def create_timestamp(dt=None, timespec='auto'):
+def create_timestamp(dt=None):
     """
     Returns a string with the given datetime in iso format. If no datetime is given as parameter, it
-    uses datetime.utcnow(). The 'timespec' parameter is passed as argument to datetime.isoformat()
+    uses datetime.utcnow().
     """
     if dt is None:
         dt = datetime.datetime.utcnow()
-    return dt.isoformat(timespec=timespec)
+    return dt.isoformat()
 
 
 def create_history_timestamp(dt=None):
@@ -19,7 +19,7 @@ def create_history_timestamp(dt=None):
     """
     if dt is None:
         dt = datetime.datetime.utcnow()
-    return dt.isoformat(timespec='seconds').replace(":", "-")
+    return dt.strftime('%Y-%m-%dT%H-%M-%S')
 
 
 def datetime_to_ticks(dt):

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -54,7 +54,7 @@ from azurelinuxagent.common.utils.archive import StateArchiver, AGENT_STATUS_FIL
 from azurelinuxagent.common.utils.flexible_version import FlexibleVersion
 from azurelinuxagent.common.utils.networkutil import AddFirewallRules
 from azurelinuxagent.common.utils.shellutil import CommandError
-from azurelinuxagent.common.version import AGENT_LONG_NAME, AGENT_NAME, AGENT_DIR_PATTERN, CURRENT_AGENT, \
+from azurelinuxagent.common.version import AGENT_LONG_NAME, AGENT_NAME, AGENT_DIR_PATTERN, CURRENT_AGENT, AGENT_VERSION, \
     CURRENT_VERSION, DISTRO_NAME, DISTRO_VERSION, get_lis_version, \
     has_logrotate, PY_VERSION_MAJOR, PY_VERSION_MINOR, PY_VERSION_MICRO, get_daemon_version
 from azurelinuxagent.ga.collect_logs import get_collect_logs_handler, is_log_collection_allowed
@@ -324,10 +324,9 @@ class UpdateHandler(object):
         """
 
         try:
-            logger.info("{0} Version: {1}", AGENT_LONG_NAME, CURRENT_AGENT)
+            logger.info("{0} (Goal State Agent version {1})", AGENT_LONG_NAME, AGENT_VERSION)
             logger.info("OS: {0} {1}", DISTRO_NAME, DISTRO_VERSION)
             logger.info("Python: {0}.{1}.{2}", PY_VERSION_MAJOR, PY_VERSION_MINOR, PY_VERSION_MICRO)
-            logger.info(u"Agent {0} is running as the goal state agent", CURRENT_AGENT)
 
             os_info_msg = u"Distro: {dist_name}-{dist_ver}; "\
                 u"OSUtil: {util_name}; AgentService: {service_name}; "\

--- a/tests/protocol/test_goal_state.py
+++ b/tests/protocol/test_goal_state.py
@@ -373,4 +373,4 @@ class GoalStateTestCase(AgentTestCase, HttpRequestPredicates):
 
                 self.assertTrue(
                     len(events) == 1,
-                    "Missing certificate 59A10F50FFE2A0408D3F03FE336C8FD5716CF25C was note reported. Telemetry: {0}".format([kwargs['message'] for _, kwargs in add_event.call_args_list]))
+                    "Missing certificate 59A10F50FFE2A0408D3F03FE336C8FD5716CF25C was not reported. Telemetry: {0}".format([kwargs['message'] for _, kwargs in add_event.call_args_list]))

--- a/tests/utils/test_archive.py
+++ b/tests/utils/test_archive.py
@@ -67,7 +67,10 @@ class TestArchive(AgentTestCase):
             test_directories.append(directory)
 
         test_subject = StateArchiver(self.tmp_dir)
-        test_subject.archive()
+        # NOTE: StateArchiver sorts the state directories by creation time, but the test files are created too fast and the
+        # time resolution is too coarse, so instead we mock getctime to simply return the path of the file
+        with patch("azurelinuxagent.common.utils.archive.os.path.getctime", side_effect=lambda path: path):
+            test_subject.archive()
 
         for directory in test_directories[0:2]:
             zip_file = directory + ".zip"
@@ -111,7 +114,7 @@ class TestArchive(AgentTestCase):
 
         test_subject = StateArchiver(self.tmp_dir)
         # NOTE: StateArchiver sorts the state directories by creation time, but the test files are created too fast and the
-        # time resolution is too coarse so instead we mock getctime to simply return the path of the file
+        # time resolution is too coarse, so instead we mock getctime to simply return the path of the file
         with patch("azurelinuxagent.common.utils.archive.os.path.getctime", side_effect=lambda path: path):
             test_subject.purge()
 

--- a/tests/utils/test_archive.py
+++ b/tests/utils/test_archive.py
@@ -110,7 +110,10 @@ class TestArchive(AgentTestCase):
         self.assertEqual(total, len(os.listdir(self.history_dir)))
 
         test_subject = StateArchiver(self.tmp_dir)
-        test_subject.purge()
+        # NOTE: StateArchiver sorts the state directories by creation time, but the test files are created too fast and the
+        # time resolution is too coarse so instead we mock getctime to simply return the path of the file
+        with patch("azurelinuxagent.common.utils.archive.os.path.getctime", side_effect=lambda path: path):
+            test_subject.purge()
 
         archived_entries = os.listdir(self.history_dir)
         self.assertEqual(_MAX_ARCHIVED_STATES, len(archived_entries))


### PR DESCRIPTION
This PR changes the format of the history items from

`2022-04-11T23:34:00.563193_3-11493024124256518279.zip
`

to

`2022-04-11T23-34-00__3-11493024124256518279.zip
`

i.e. use '-' instead of ':' in the time, remove the milliseconds, and use two '_' before the incarnation.

The motivation being that the incarnation number is hard to spot, and that the ':' doesn't play well with the shell (it gets in the way of autocomplete, and it won't select as a single token with double-click).

Also, it fixes a typo in a unit test and changes the format of the initial message in the Extension Handler log