### PR TITLE
Do not mark goal state as processed when goal state fails to update

### DIFF
--- a/azurelinuxagent/common/protocol/goal_state.py
+++ b/azurelinuxagent/common/protocol/goal_state.py
@@ -209,7 +209,7 @@ class GoalState(object):
         else:  # vm_settings_updated
             most_recent = vm_settings
 
-        if self._extensions_goal_state is None or most_recent.created_on_timestamp > self._extensions_goal_state.created_on_timestamp:
+        if self._extensions_goal_state is None or most_recent.created_on_timestamp >= self._extensions_goal_state.created_on_timestamp:
             self._extensions_goal_state = most_recent
 
         #
@@ -221,7 +221,7 @@ class GoalState(object):
         # Track goal state comes after that, the extensions will need the new certificate. The Agent needs to refresh the goal state in that
         # case, to ensure it fetches the new certificate.
         #
-        if self.extensions_goal_state.source == GoalStateSource.FastTrack:
+        if self._extensions_goal_state.source == GoalStateSource.FastTrack:
             self._check_certificates()
 
     def _check_certificates(self):

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -606,19 +606,19 @@ class UpdateHandler(object):
         return self._goal_state is not None and egs.id != self._last_extensions_gs_id and not egs.is_outdated
 
     def _process_goal_state(self, exthandlers_handler, remote_access_handler):
-        try:
-            protocol = exthandlers_handler.protocol
+        protocol = exthandlers_handler.protocol
 
-            # update self._goal_state
-            if not self._try_update_goal_state(protocol):
-                # agent updates and status reporting should be done even when the goal state is not updated
-                self.__update_guest_agent(protocol)
-                self._report_status(exthandlers_handler)
-                return
-
-            # check for agent updates
+        # update self._goal_state
+        if not self._try_update_goal_state(protocol):
+            # agent updates and status reporting should be done even when the goal state is not updated
             self.__update_guest_agent(protocol)
+            self._report_status(exthandlers_handler)
+            return
 
+        # check for agent updates
+        self.__update_guest_agent(protocol)
+
+        try:
             if self._processing_new_extensions_goal_state():
                 if not self._extensions_summary.converged:
                     message = "A new goal state was received, but not all the extensions in the previous goal state have completed: {0}".format(self._extensions_summary)


### PR DESCRIPTION
If we fail to update the goal state, we should not mark it as processed (i.e. we should not update UpdateHandler._last_incarnation and UpdateHandler._last_extensions_gs_id).

