### PR TITLE
Debian - Byte to string conversion for systemd service creation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -251,7 +251,7 @@ def get_data_files(name, version, fullname):  # pylint: disable=R0912
 def debian_has_systemd():
     try:
         return subprocess.check_output(
-            ['cat', '/proc/1/comm']).strip() == 'systemd'
+            ['cat', '/proc/1/comm']).strip().decode() == 'systemd'
     except subprocess.CalledProcessError:
         return False
 


### PR DESCRIPTION
## Description

Issue # (https://github.com/Azure/WALinuxAgent/issues/2573)

Added string decode for byte to string conversion while checking for presence of systemd

return from subprocess.check_output(['cat', '/proc/1/comm']).strip() for python3 ===> b'systemd'
return from subprocess.check_output(['cat', '/proc/1/comm']).strip() for python2 ===> 'systemd'

https://github.com/Azure/WALinuxAgent/issues/2573
-->

---

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [x] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).