### PR TITLE
Bug fix for fetching a goal state with empty certificates property

### DIFF
--- a/azurelinuxagent/common/protocol/goal_state.py
+++ b/azurelinuxagent/common/protocol/goal_state.py
@@ -82,7 +82,7 @@ class GoalState(object):
             self._container_id = None
             self._hosting_env = None
             self._shared_conf = None
-            self._certs = None
+            self._certs = EmptyCertificates()
             self._remote_access = None
 
             self.update(silent=silent)
@@ -348,7 +348,7 @@ class GoalState(object):
             shared_conf = SharedConfig(xml_text)
             self._history.save_shared_conf(xml_text)
 
-            certs = None
+            certs = EmptyCertificates()
             certs_uri = findtext(xml_doc, "Certificates")
             if certs_uri is not None:
                 xml_text = self._wire_client.fetch_config(certs_uri, self._wire_client.get_header_for_cert())
@@ -506,6 +506,11 @@ class Certificates(object):
         fileutil.write_file(file_name, "".join(buf))
         return file_name
 
+class EmptyCertificates(Certificates):
+    def __init__(self):
+        self.cert_list = CertList()
+        self.summary = []  # debugging info
+        self.warnings = []
 
 class RemoteAccess(object):
     """

--- a/azurelinuxagent/common/protocol/goal_state.py
+++ b/azurelinuxagent/common/protocol/goal_state.py
@@ -506,7 +506,7 @@ class Certificates(object):
         fileutil.write_file(file_name, "".join(buf))
         return file_name
 
-class EmptyCertificates(Certificates):
+class EmptyCertificates:
     def __init__(self):
         self.cert_list = CertList()
         self.summary = []  # debugging info

--- a/tests/data/wire/goal_state_no_certs.xml
+++ b/tests/data/wire/goal_state_no_certs.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<GoalState xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="goalstate10.xsd">
+   <Version>2010-12-15</Version>
+   <Incarnation>1</Incarnation>
+   <Machine>
+     <ExpectedState>Started</ExpectedState>
+     <LBProbePorts>
+       <Port>16001</Port>
+     </LBProbePorts>
+   </Machine>
+   <Container>
+     <ContainerId>c6d5526c-5ac2-4200-b6e2-56f2b70c5ab2</ContainerId>
+     <RoleInstanceList>
+       <RoleInstance>
+         <InstanceId>b61f93d0-e1ed-40b2-b067-22c243233448.MachineRole_IN_0</InstanceId>
+         <State>Started</State>
+         <Configuration>
+         <HostingEnvironmentConfig>http://168.63.129.16:80/machine/865a6683-91d8-450f-99ae/bc8b9d47%2Db5ed%2D4704%2D85d9%2Dfd74cc967ec2.%5Fcanary?comp=config&amp;type=hostingEnvironmentConfig&amp;incarnation=1</HostingEnvironmentConfig>
+          <SharedConfig>http://168.63.129.16:80/machine/865a6683-91d8-450f-99ae/bc8b9d47%2Db5ed%2D4704%2D85d9%2Dfd74cc967ec2.%5Fcanary?comp=config&amp;type=sharedConfig&amp;incarnation=1</SharedConfig>
+          <ExtensionsConfig>http://168.63.129.16:80/machine/865a6683-91d8-450f-99ae/bc8b9d47%2Db5ed%2D4704%2D85d9%2Dfd74cc967ec2.%5Fcanary?comp=config&amp;type=extensionsConfig&amp;incarnation=1</ExtensionsConfig>
+          <FullConfig>http://168.63.129.16:80/machine/865a6683-91d8-450f-99ae/bc8b9d47%2Db5ed%2D4704%2D85d9%2Dfd74cc967ec2.%5Fcanary?comp=config&amp;type=fullConfig&amp;incarnation=1</FullConfig>
+          <ConfigName>bc8b9d47-b5ed-4704-85d9-fd74cc967ec2.5.bc8b9d47-b5ed-4704-85d9-fd74cc967ec2.5._canary.1.xml</ConfigName>
+         </Configuration>
+       </RoleInstance>
+     </RoleInstanceList>
+   </Container>
+ </GoalState>

--- a/tests/ga/test_update.py
+++ b/tests/ga/test_update.py
@@ -28,7 +28,7 @@ _ORIGINAL_POPEN = subprocess.Popen
 
 from mock import PropertyMock
 
-from azurelinuxagent.common import conf, protocol
+from azurelinuxagent.common import conf
 from azurelinuxagent.common.event import EVENTS_DIRECTORY, WALAEventOperation
 from azurelinuxagent.common.exception import ProtocolError, UpdateError, ResourceGoneError, HttpError
 from azurelinuxagent.common.future import ustr, httpclient

--- a/tests/ga/test_update.py
+++ b/tests/ga/test_update.py
@@ -28,7 +28,7 @@ _ORIGINAL_POPEN = subprocess.Popen
 
 from mock import PropertyMock
 
-from azurelinuxagent.common import conf
+from azurelinuxagent.common import conf, protocol
 from azurelinuxagent.common.event import EVENTS_DIRECTORY, WALAEventOperation
 from azurelinuxagent.common.exception import ProtocolError, UpdateError, ResourceGoneError, HttpError
 from azurelinuxagent.common.future import ustr, httpclient
@@ -1564,6 +1564,52 @@ class TestUpdate(UpdateTestCase):
         eh = Extension(name=name)
         eh.version = version
         return ExtHandlerInstance(eh, protocol)
+    
+    def test_update_handler_recovers_from_error_with_no_certs(self):
+        data = DATA_FILE.copy()
+        data['goal_state'] = 'wire/goal_state_no_certs.xml'
+
+        def fail_gs_fetch(url, *_, **__):
+            if HttpRequestPredicates.is_goal_state_request(url):
+                return MockHttpResponse(status=500)
+            return None
+
+        with mock_wire_protocol(data) as protocol:
+
+            def fail_fetch_on_second_iter(iteration):
+                if iteration == 2:
+                    protocol.set_http_handlers(http_get_handler=fail_gs_fetch)
+                if iteration > 2: # Zero out the fail handler for subsequent iterations.
+                    protocol.set_http_handlers(http_get_handler=None)
+
+            with mock_update_handler(protocol, 3, on_new_iteration=fail_fetch_on_second_iter) as update_handler:
+                with patch("azurelinuxagent.ga.update.logger.error") as patched_error:
+                    with patch("azurelinuxagent.ga.update.logger.info") as patched_info:
+                        def match_unexpected_errors():
+                            unexpected_msg_fragment = "Error fetching the goal state:"
+
+                            matching_errors = []
+                            for (args, _) in filter(lambda a: len(a) > 0, patched_error.call_args_list):
+                                if unexpected_msg_fragment in args[0]:
+                                    matching_errors.append(args[0])
+
+                            self.assertLessEqual(len(matching_errors), 1, "Guest Agent did not recover, with new error(s): {}"\
+                                .format(matching_errors[1:]))
+
+                        def match_expected_info():
+                            expected_msg_fragment = "Fetching the goal state recovered from previous errors"
+
+                            for (call_args, _) in filter(lambda a: len(a) > 0, patched_info.call_args_list):
+                                if expected_msg_fragment in call_args[0]:
+                                    break
+                            else:
+                                self.fail("Expected the guest agent to recover with '{}', but it didn't"\
+                                    .format(expected_msg_fragment))
+
+                        update_handler.run(debug=True)
+                        match_unexpected_errors() # Match on errors first, they can provide more info.
+                        match_expected_info()
+
 
     def test_it_should_recreate_handler_env_on_service_startup(self):
         iterations = 5

--- a/tests/ga/test_update.py
+++ b/tests/ga/test_update.py
@@ -1592,9 +1592,10 @@ class TestUpdate(UpdateTestCase):
                             for (args, _) in filter(lambda a: len(a) > 0, patched_error.call_args_list):
                                 if unexpected_msg_fragment in args[0]:
                                     matching_errors.append(args[0])
-
-                            self.assertLessEqual(len(matching_errors), 1, "Guest Agent did not recover, with new error(s): {}"\
-                                .format(matching_errors[1:]))
+                            
+                            if len(matching_errors) > 1:
+                                self.fail("Guest Agent did not recover, with new error(s): {}"\
+                                    .format(matching_errors[1:]))
 
                         def match_expected_info():
                             expected_msg_fragment = "Fetching the goal state recovered from previous errors"


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Some fabric goal states from the wireserver can miss the `<Certificates>` tag-- a valid scenario. The old code set the `certs` property of the goal state object to `None` in that case, which can cause a `NoneType` exception if the agent happens to be trying to recover from some sort of goal state fetch error. This would cause the guest agent to miss the goal state, which would eventually time out.

This new code introduces the idea of a `EmptyCertificates` class that we set the `certs` property to, instead of `None`. This new class has the same api as the original `Certificates` class (namely, `cert_list`, `summary`, and `warnings` properties).

<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).