### PR TITLE
Bug fix: Silence goal state fetch errors after 3 logs

### DIFF
--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -489,11 +489,11 @@ class UpdateHandler(object):
             self._goal_state = protocol.get_goal_state()
 
             if self._update_goal_state_error_count > 0:
-                self._update_goal_state_error_count = 0
                 message = u"Fetching the goal state recovered from previous errors. Fetched {0} (certificates: {1})".format(
                     self._goal_state.extensions_goal_state.id, self._goal_state.certs.summary)
                 add_event(AGENT_NAME, op=WALAEventOperation.FetchGoalState, version=CURRENT_VERSION, is_success=True, message=message, log_event=False)
                 logger.info(message)
+                self._update_goal_state_error_count = 0
 
             try:
                 self._supports_fast_track = conf.get_enable_fast_track() and protocol.client.get_host_plugin().check_vm_settings_support()


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

#2562 Added functionality to silence errors from fetching the goal state after 3 main loop iterations without recovery. This PR fixes a missed case.

<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).