### PR TITLE
Reset dhcp config to send host information on SUSE distros

### DIFF
--- a/azurelinuxagent/pa/deprovision/factory.py
+++ b/azurelinuxagent/pa/deprovision/factory.py
@@ -22,6 +22,7 @@ from .arch import ArchDeprovisionHandler
 from .clearlinux import ClearLinuxDeprovisionHandler
 from .coreos import CoreOSDeprovisionHandler
 from .default import DeprovisionHandler
+from .suse import SUSEDeprovisionHandler
 from .ubuntu import UbuntuDeprovisionHandler, Ubuntu1804DeprovisionHandler
 
 
@@ -39,6 +40,8 @@ def get_deprovision_handler(distro_name=DISTRO_NAME,
         return CoreOSDeprovisionHandler()
     if "Clear Linux" in distro_full_name:
         return ClearLinuxDeprovisionHandler()  # pylint: disable=E1120
+    if distro_name in ("suse", "sle_hpc", "sles", "opensuse"):
+        return SUSEDeprovisionHandler()
 
     return DeprovisionHandler()
 

--- a/azurelinuxagent/pa/deprovision/suse.py
+++ b/azurelinuxagent/pa/deprovision/suse.py
@@ -1,0 +1,33 @@
+# Microsoft Azure Linux Agent
+#
+# Copyright 2022 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Requires Python 2.6+ and Openssl 1.0+
+#
+
+import azurelinuxagent.common.utils.fileutil as fileutil
+from azurelinuxagent.pa.deprovision.default import DeprovisionHandler, \
+                                                   DeprovisionAction
+
+class SUSEDeprovisionHandler(DeprovisionHandler):
+    def __init__(self):
+        super(SUSEDeprovisionHandler, self).__init__()
+
+    def reset_hostname(self, warnings, actions):
+        localhost = ["AUTO"]
+        actions.append(DeprovisionAction(self.osutil.set_hostname,
+                                         localhost))
+        actions.append(DeprovisionAction(self.osutil.set_dhcp_hostname,
+                                         localhost))


### PR DESCRIPTION
- Reset the dhcp configuration to send the host information when an instance
  is being deprovisioned. This ensures that instances from a managed VM
  created from a running instance send the proper information to the DHCP
  server. Thanks Joao Silva.

<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).