### PR TITLE
Create placeholder GoalState.*.xml file

### DIFF
--- a/tests/utils/test_archive.py
+++ b/tests/utils/test_archive.py
@@ -134,10 +134,10 @@ class TestArchive(AgentTestCase):
     def test_purge_legacy_goal_state_history(self):
         with patch("azurelinuxagent.common.conf.get_lib_dir", return_value=self.tmp_dir):
             legacy_files = [
-                'GoalState.1.xml',
-                'VmSettings.1.json',
-                'Prod.1.manifest.xml',
-                'ExtensionsConfig.1.xml',
+                'GoalState.2.xml',
+                'VmSettings.2.json',
+                'Prod.2.manifest.xml',
+                'ExtensionsConfig.2.xml',
                 'Microsoft.Azure.Extensions.CustomScript.1.xml',
                 'SharedConfig.xml',
                 'HostingEnvironmentConfig.xml',


### PR DESCRIPTION
Some internal components took a dependency in the legacy GoalState.*.xml file. 

This PR creates a placeholder file to avoid impacting those components. This code can be removed when those components are updated to remove the dependency.