### PR TITLE
Parse missing agent manifests as empty

### DIFF
--- a/azurelinuxagent/common/protocol/extensions_goal_state_from_vm_settings.py
+++ b/azurelinuxagent/common/protocol/extensions_goal_state_from_vm_settings.py
@@ -266,7 +266,9 @@ class ExtensionsGoalStateFromVmSettings(ExtensionsGoalState):
         for family in families:
             name = family["name"]
             version = family.get("version")
-            uris = family["uris"]
+            uris = family.get("uris")
+            if uris is None:
+                uris = []
             manifest = VMAgentManifest(name, version)
             for u in uris:
                 manifest.uris.append(u)

--- a/tests/data/hostgaplugin/vm_settings-no_manifests.json
+++ b/tests/data/hostgaplugin/vm_settings-no_manifests.json
@@ -27,12 +27,7 @@
     },
     "gaFamilies": [
         {
-            "name": "Prod",
-            "uris": [
-                "https://zrdfepirv2dz5prdstr07a.blob.core.windows.net/7d89d439b79f4452950452399add2c90/Microsoft.OSTCLinuxAgent_Prod_uscentral_manifest.xml",
-                "https://rdfepirv2dm1prdstr09.blob.core.windows.net/7d89d439b79f4452950452399add2c90/Microsoft.OSTCLinuxAgent_Prod_uscentral_manifest.xml",
-                "https://zrdfepirv2dm5prdstr06a.blob.core.windows.net/7d89d439b79f4452950452399add2c90/Microsoft.OSTCLinuxAgent_Prod_uscentral_manifest.xml"
-            ]
+            "name": "Prod"
         }
     ],
     "extensionGoalStates": [

--- a/tests/protocol/test_extensions_goal_state_from_vm_settings.py
+++ b/tests/protocol/test_extensions_goal_state_from_vm_settings.py
@@ -69,9 +69,17 @@ class ExtensionsGoalStateFromVmSettingsTestCase(AgentTestCase):
             self.assertIsNone(extensions_goal_state.status_upload_blob, "Expected status upload blob to be None")
             self.assertEqual("BlockBlob", extensions_goal_state.status_upload_blob_type, "Expected status upload blob to be Block")
 
+    def test_it_should_parse_missing_agent_manifests_as_empty(self):
+        data_file = mockwiredata.DATA_FILE_VM_SETTINGS.copy()
+        data_file["vm_settings"] = "hostgaplugin/vm_settings-no_manifests.json"
+        with mock_wire_protocol(data_file) as protocol:
+            extensions_goal_state = protocol.get_goal_state().extensions_goal_state
+            self.assertEqual(1, len(extensions_goal_state.agent_manifests), "Expected exactly one agent manifest. Got: {0}".format(extensions_goal_state.agent_manifests))
+            self.assertListEqual([], extensions_goal_state.agent_manifests[0].uris, "Expected an empty list of agent manifests")
+
     def test_it_should_parse_missing_extension_manifests_as_empty(self):
         data_file = mockwiredata.DATA_FILE_VM_SETTINGS.copy()
-        data_file["vm_settings"] = "hostgaplugin/vm_settings-no_extension_manifests.json"
+        data_file["vm_settings"] = "hostgaplugin/vm_settings-no_manifests.json"
         with mock_wire_protocol(data_file) as protocol:
             extensions_goal_state = protocol.get_goal_state().extensions_goal_state
 


### PR DESCRIPTION
Old versions of the HGAP can sometimes produce goal states with missing agent manifests, which causes a parsing error while fetching the goal state. The fix parses that as an empty list.