### PR TITLE
redhat: Use NetworkManager to set DHCP hostnames on recent RHEL distros

### DIFF
--- a/azurelinuxagent/common/osutil/redhat.py
+++ b/azurelinuxagent/common/osutil/redhat.py
@@ -164,3 +164,15 @@ class RedhatOSModernUtil(RedhatOSUtil):
                 time.sleep(wait)
             else:
                 logger.warn("exceeded restart retries")
+
+    def set_dhcp_hostname(self, hostname):
+        """
+        Recent RHEL distributions use network manager instead of sysconfig files
+        to configure network interfaces
+        """
+        ifname = self.get_if_name()
+
+        return_code = shellutil.run("nmcli device modify {0} ipv4.dhcp-hostname {1} ipv6.dhcp-hostname {1}".format(ifname, hostname))
+
+        if return_code != 0:
+            logger.error("failed to set DHCP hostname for interface {0}: return code {1}".format(ifname, return_code))


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

Recent versions of RHEL 8 and RHEL 9 (i.e. RHEL8.6/9.1) started using NetworkManager to configure
network intefaces instead of sysconfig files. Configurations are no longer
stored in /etc/sysconfig/ifcfg-{interface}. Setting DHCP hostnames through these files causes provisioning with WALA to fail.

Fix this for setting DHCP hostnames in those RHEL versions.

<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [x] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).