### PR TITLE
Save sharedconfig to disk

### DIFF
--- a/azurelinuxagent/common/utils/archive.py
+++ b/azurelinuxagent/common/utils/archive.py
@@ -46,11 +46,13 @@ _PLACEHOLDER_FILE_NAME = 'GoalState.1.xml'
 _MAX_ARCHIVED_STATES = 50
 
 _CACHE_PATTERNS = [
+    #
+    # Note that SharedConfig.xml is not included here; this file is used by other components (Azsec and Singularity/HPC Infiniband)
+    #
     re.compile(r"^VmSettings\.\d+\.json$"),
     re.compile(r"^(.*)\.(\d+)\.(agentsManifest)$", re.IGNORECASE),
     re.compile(r"^(.*)\.(\d+)\.(manifest\.xml)$", re.IGNORECASE),
     re.compile(r"^(.*)\.(\d+)\.(xml)$", re.IGNORECASE),
-    re.compile(r"^SharedConfig\.xml$", re.IGNORECASE),
     re.compile(r"^HostingEnvironmentConfig\.xml$", re.IGNORECASE),
     re.compile(r"^RemoteAccess\.xml$", re.IGNORECASE),
     re.compile(r"^waagent_status\.\d+\.json$"),
@@ -78,12 +80,12 @@ _GOAL_STATE_FILE_NAME = "GoalState.xml"
 _VM_SETTINGS_FILE_NAME = "VmSettings.json"
 _CERTIFICATES_FILE_NAME = "Certificates.json"
 _HOSTING_ENV_FILE_NAME = "HostingEnvironmentConfig.xml"
-_SHARED_CONF_FILE_NAME = "SharedConfig.xml"
 _REMOTE_ACCESS_FILE_NAME = "RemoteAccess.xml"
 _EXT_CONF_FILE_NAME = "ExtensionsConfig.xml"
 _MANIFEST_FILE_NAME = "{0}.manifest.xml"
 
 AGENT_STATUS_FILE = "waagent_status.json"
+SHARED_CONF_FILE_NAME = "SharedConfig.xml"
 
 # TODO: use @total_ordering once RHEL/CentOS and SLES 11 are EOL.
 # @total_ordering first appeared in Python 2.7 and 3.2
@@ -166,9 +168,10 @@ class StateArchiver(object):
     def purge_legacy_goal_state_history():
         lib_dir = conf.get_lib_dir()
         for current_file in os.listdir(lib_dir):
+            # Don't remove the placeholder goal state file.
             # TODO: See comment in GoalStateHistory._save_placeholder and remove this code when no longer needed
             if current_file == _PLACEHOLDER_FILE_NAME:
-                return
+                continue
             # END TODO
             full_path = os.path.join(lib_dir, current_file)
             for pattern in _CACHE_PATTERNS:
@@ -302,4 +305,4 @@ class GoalStateHistory(object):
         self.save(text, _HOSTING_ENV_FILE_NAME)
 
     def save_shared_conf(self, text):
-        self.save(text, _SHARED_CONF_FILE_NAME)
+        self.save(text, SHARED_CONF_FILE_NAME)

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -378,6 +378,7 @@ class UpdateHandler(object):
             self._ensure_firewall_rules_persisted(dst_ip=protocol.get_endpoint())
             self._add_accept_tcp_firewall_rule_if_not_enabled(dst_ip=protocol.get_endpoint())
             self._reset_legacy_blacklisted_agents()
+            self._cleanup_legacy_goal_state_history()
 
             # Get all thread handlers
             telemetry_handler = get_send_telemetry_events_handler(self.protocol_util)
@@ -395,8 +396,6 @@ class UpdateHandler(object):
             self._start_threads(all_thread_handlers)
 
             logger.info("Goal State Period: {0} sec. This indicates how often the agent checks for new goal states and reports status.", self._goal_state_period)
-
-            self._cleanup_legacy_goal_state_history()
 
             while self.is_running:
                 self._check_daemon_running(debug)

--- a/tests/utils/test_archive.py
+++ b/tests/utils/test_archive.py
@@ -154,7 +154,7 @@ class TestArchive(AgentTestCase):
 
             StateArchiver.purge_legacy_goal_state_history()
 
-            self.assertTrue(os.path.exists(shared_config), "{0} should not have been removed".format(f))
+            self.assertTrue(os.path.exists(shared_config), "{0} should not have been removed".format(shared_config))
 
             for f in legacy_files:
                 self.assertFalse(os.path.exists(f), "Legacy file {0} was not removed".format(f))


### PR DESCRIPTION
As part of the changes for Fast Track, the agent does not shave SharedConfig.xml under /var/lib/waagent.

It turned out that HPC has a dependency on this file to obtain some network configuration information. This changelist creates the file again, while the dependency from HPC is removed.