### PR TITLE
Add x-ms-verify-from-artifacts-blob to extensionsArtifact calls

### DIFF
--- a/azurelinuxagent/common/protocol/extensions_goal_state.py
+++ b/azurelinuxagent/common/protocol/extensions_goal_state.py
@@ -17,7 +17,7 @@
 # Requires Python 2.6+ and Openssl 1.0+
 import datetime
 
-import azurelinuxagent.common.logger as logger
+from azurelinuxagent.common import logger
 from azurelinuxagent.common.AgentGlobals import AgentGlobals
 from azurelinuxagent.common.exception import AgentError
 from azurelinuxagent.common.utils import textutil
@@ -126,7 +126,7 @@ class ExtensionsGoalState(object):
         raise NotImplementedError()
 
     @property
-    def agent_manifests(self):
+    def agent_families(self):
         raise NotImplementedError()
 
     @property
@@ -233,7 +233,7 @@ class EmptyExtensionsGoalState(ExtensionsGoalState):
         return False
 
     @property
-    def agent_manifests(self):
+    def agent_families(self):
         return []
 
     @property

--- a/azurelinuxagent/common/protocol/extensions_goal_state_from_extensions_config.py
+++ b/azurelinuxagent/common/protocol/extensions_goal_state_from_extensions_config.py
@@ -24,7 +24,7 @@ from azurelinuxagent.common.event import add_event, WALAEventOperation
 from azurelinuxagent.common.exception import ExtensionsConfigError
 from azurelinuxagent.common.future import ustr
 from azurelinuxagent.common.protocol.extensions_goal_state import ExtensionsGoalState, GoalStateChannel, GoalStateSource
-from azurelinuxagent.common.protocol.restapi import ExtensionSettings, Extension, VMAgentManifest, ExtensionState, InVMGoalStateMetaData
+from azurelinuxagent.common.protocol.restapi import ExtensionSettings, Extension, VMAgentFamily, ExtensionState, InVMGoalStateMetaData
 from azurelinuxagent.common.utils.textutil import parse_doc, parse_json, findall, find, findtext, getattrib, gettext, format_exception, \
     is_str_none_or_whitespace, is_str_empty
 
@@ -43,7 +43,7 @@ class ExtensionsGoalStateFromExtensionsConfig(ExtensionsGoalState):
         self._activity_id = None
         self._correlation_id = None
         self._created_on_timestamp = None
-        self._agent_manifests = []
+        self._agent_families = []
         self._extensions = []
 
         try:
@@ -59,14 +59,14 @@ class ExtensionsGoalStateFromExtensionsConfig(ExtensionsGoalState):
         ga_families = findall(ga_families_list, "GAFamily")
 
         for ga_family in ga_families:
-            family = findtext(ga_family, "Name")
+            name = findtext(ga_family, "Name")
             version = findtext(ga_family, "Version")
             uris_list = find(ga_family, "Uris")
             uris = findall(uris_list, "Uri")
-            manifest = VMAgentManifest(family, version)
+            family = VMAgentFamily(name, version)
             for uri in uris:
-                manifest.uris.append(gettext(uri))
-            self._agent_manifests.append(manifest)
+                family.uris.append(gettext(uri))
+            self._agent_families.append(family)
 
         self.__parse_plugins_and_settings_and_populate_ext_handlers(xml_doc)
 
@@ -172,8 +172,8 @@ class ExtensionsGoalStateFromExtensionsConfig(ExtensionsGoalState):
         return self._on_hold
 
     @property
-    def agent_manifests(self):
-        return self._agent_manifests
+    def agent_families(self):
+        return self._agent_families
 
     @property
     def extensions(self):

--- a/azurelinuxagent/common/protocol/extensions_goal_state_from_vm_settings.py
+++ b/azurelinuxagent/common/protocol/extensions_goal_state_from_vm_settings.py
@@ -20,11 +20,11 @@ import json
 import re
 import sys
 
+from azurelinuxagent.common import logger
 from azurelinuxagent.common.AgentGlobals import AgentGlobals
 from azurelinuxagent.common.future import ustr
-import azurelinuxagent.common.logger as logger
 from azurelinuxagent.common.protocol.extensions_goal_state import ExtensionsGoalState, GoalStateChannel, VmSettingsParseError
-from azurelinuxagent.common.protocol.restapi import VMAgentManifest, Extension, ExtensionRequestedState, ExtensionSettings
+from azurelinuxagent.common.protocol.restapi import VMAgentFamily, Extension, ExtensionRequestedState, ExtensionSettings
 from azurelinuxagent.common.utils.flexible_version import FlexibleVersion
 
 
@@ -48,7 +48,7 @@ class ExtensionsGoalStateFromVmSettings(ExtensionsGoalState):
         self._status_upload_blob_type = None
         self._required_features = []
         self._on_hold = False
-        self._agent_manifests = []
+        self._agent_families = []
         self._extensions = []
 
         try:
@@ -134,8 +134,8 @@ class ExtensionsGoalStateFromVmSettings(ExtensionsGoalState):
         return self._on_hold
 
     @property
-    def agent_manifests(self):
-        return self._agent_manifests
+    def agent_families(self):
+        return self._agent_families
 
     @property
     def extensions(self):
@@ -269,10 +269,10 @@ class ExtensionsGoalStateFromVmSettings(ExtensionsGoalState):
             uris = family.get("uris")
             if uris is None:
                 uris = []
-            manifest = VMAgentManifest(name, version)
+            agent_family = VMAgentFamily(name, version)
             for u in uris:
-                manifest.uris.append(u)
-            self._agent_manifests.append(manifest)
+                agent_family.uris.append(u)
+            self._agent_families.append(agent_family)
 
     def _parse_extensions(self, vm_settings):
         # Sample (NOTE: The first sample is single-config, the second multi-config):

--- a/azurelinuxagent/common/protocol/hostplugin.py
+++ b/azurelinuxagent/common/protocol/hostplugin.py
@@ -55,6 +55,7 @@ _HEADER_VERSION = "x-ms-version"
 _HEADER_HOST_CONFIG_NAME = "x-ms-host-config-name"
 _HEADER_ARTIFACT_LOCATION = "x-ms-artifact-location"
 _HEADER_ARTIFACT_MANIFEST_LOCATION = "x-ms-artifact-manifest-location"
+_HEADER_VERIFY_FROM_ARTIFACTS_BLOB = "x-ms-verify-from-artifacts-blob"
 
 MAXIMUM_PAGEBLOB_PAGE_SIZE = 4 * 1024 * 1024  # Max page size: 4MB
 
@@ -183,19 +184,21 @@ class HostPluginProtocol(object):
 
         return url, headers
 
-    def get_artifact_request(self, artifact_url, artifact_manifest_url=None):
+    def get_artifact_request(self, artifact_url, use_verify_header, artifact_manifest_url=None):
         if not self.ensure_initialized():
             raise ProtocolError("HostGAPlugin: Host plugin channel is not available")
 
         if textutil.is_str_none_or_whitespace(artifact_url):
             raise ProtocolError("HostGAPlugin: No extension artifact url was provided")
 
-        url = URI_FORMAT_GET_EXTENSION_ARTIFACT.format(self.endpoint,
-                                                       HOST_PLUGIN_PORT)
-        headers = {_HEADER_VERSION: API_VERSION,
-                   _HEADER_CONTAINER_ID: self.container_id,
-                   _HEADER_HOST_CONFIG_NAME: self.role_config_name,
-                   _HEADER_ARTIFACT_LOCATION: artifact_url}
+        url = URI_FORMAT_GET_EXTENSION_ARTIFACT.format(self.endpoint, HOST_PLUGIN_PORT)
+        headers = {
+            _HEADER_VERSION: API_VERSION,
+               _HEADER_CONTAINER_ID: self.container_id,
+               _HEADER_HOST_CONFIG_NAME: self.role_config_name,
+               _HEADER_ARTIFACT_LOCATION: artifact_url}
+        if use_verify_header:
+            headers[_HEADER_VERIFY_FROM_ARTIFACTS_BLOB] = "true"
 
         if artifact_manifest_url is not None:
             headers[_HEADER_ARTIFACT_MANIFEST_LOCATION] = artifact_manifest_url

--- a/azurelinuxagent/common/protocol/restapi.py
+++ b/azurelinuxagent/common/protocol/restapi.py
@@ -68,9 +68,9 @@ class CertList(DataContract):
         self.certificates = DataContractList(Cert)
 
 
-class VMAgentManifest(object):
-    def __init__(self, family, version=None):
-        self.family = family
+class VMAgentFamily(object):
+    def __init__(self, name, version=None):
+        self.name = name
         # This is the Requested version as specified by the Goal State, it defaults to 0.0.0.0 if not specified in GS
         self.requested_version_string = VERSION_0 if version is None else version
         self.uris = []
@@ -91,7 +91,7 @@ class VMAgentManifest(object):
         return self.__str__()
 
     def __str__(self):
-        return "[family: '{0}' uris: {1}]".format(self.family, self.uris)
+        return "[name: '{0}' uris: {1}]".format(self.name, self.uris)
 
 
 class ExtensionState(object):

--- a/azurelinuxagent/common/utils/archive.py
+++ b/azurelinuxagent/common/utils/archive.py
@@ -7,8 +7,8 @@ import re
 import shutil
 import zipfile
 
-import azurelinuxagent.common.logger as logger
-import azurelinuxagent.common.conf as conf
+from azurelinuxagent.common import conf
+from azurelinuxagent.common import logger
 from azurelinuxagent.common.utils import fileutil, timeutil
 
 # pylint: disable=W0105
@@ -306,3 +306,6 @@ class GoalStateHistory(object):
 
     def save_shared_conf(self, text):
         self.save(text, SHARED_CONF_FILE_NAME)
+
+    def save_manifest(self, name, text):
+        self.save(text, _MANIFEST_FILE_NAME.format(name))

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -985,7 +985,8 @@ class UpdateHandler(object):
 
     def _load_agents(self):
         path = os.path.join(conf.get_lib_dir(), "{0}-*".format(AGENT_NAME))
-        return [GuestAgent(is_fast_track_goal_state=self._goal_state.extensions_goal_state.source == GoalStateSource.FastTrack, path=agent_dir)
+        is_fast_track_goal_state = None if self._goal_state is None else self._goal_state.extensions_goal_state.source == GoalStateSource.FastTrack
+        return [GuestAgent(is_fast_track_goal_state=is_fast_track_goal_state, path=agent_dir)
                 for agent_dir in glob.iglob(path) if os.path.isdir(agent_dir)]
 
     def _partition(self):

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -985,8 +985,7 @@ class UpdateHandler(object):
 
     def _load_agents(self):
         path = os.path.join(conf.get_lib_dir(), "{0}-*".format(AGENT_NAME))
-        is_fast_track_goal_state = None if self._goal_state is None else self._goal_state.extensions_goal_state.source == GoalStateSource.FastTrack
-        return [GuestAgent(is_fast_track_goal_state=is_fast_track_goal_state, path=agent_dir)
+        return [GuestAgent(path=agent_dir)
                 for agent_dir in glob.iglob(path) if os.path.isdir(agent_dir)]
 
     def _partition(self):
@@ -1468,7 +1467,15 @@ class UpdateHandler(object):
 
 
 class GuestAgent(object):
-    def __init__(self, is_fast_track_goal_state, path=None, pkg=None, host=None):
+    def __init__(self, path=None, pkg=None, is_fast_track_goal_state=False, host=None):
+        """
+        If 'path' is given, the object is initialized to the version installed under that path.
+
+        If 'pkg' is given, the version specified in the package information is downloaded and the object is
+        initialized to that version.
+
+        'is_fast_track_goal_state' and 'host' are using only when a package is downloaded.
+        """
         self._is_fast_track_goal_state = is_fast_track_goal_state
         self.pkg = pkg
         self.host = host

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -31,12 +31,10 @@ import uuid
 import zipfile
 from datetime import datetime, timedelta
 
-import azurelinuxagent.common.conf as conf
-import azurelinuxagent.common.logger as logger
+from azurelinuxagent.common import conf
+from azurelinuxagent.common import logger
 from azurelinuxagent.common.protocol.imds import get_imds_client
-import azurelinuxagent.common.utils.fileutil as fileutil
-import azurelinuxagent.common.utils.restutil as restutil
-import azurelinuxagent.common.utils.textutil as textutil
+from azurelinuxagent.common.utils import fileutil, restutil, textutil
 from azurelinuxagent.common.agent_supported_feature import get_supported_feature_by_name, SupportedFeatureNames
 from azurelinuxagent.common.cgroupconfigurator import CGroupConfigurator
 from azurelinuxagent.common.event import add_event, initialize_event_logger_vminfo_common_parameters, \
@@ -45,6 +43,7 @@ from azurelinuxagent.common.exception import ResourceGoneError, UpdateError, Exi
 from azurelinuxagent.common.future import ustr
 from azurelinuxagent.common.osutil import get_osutil, systemd
 from azurelinuxagent.common.persist_firewall_rules import PersistFirewallRulesHandler
+from azurelinuxagent.common.protocol.goal_state import GoalStateSource
 from azurelinuxagent.common.protocol.hostplugin import HostPluginProtocol, VmSettingsNotSupported
 from azurelinuxagent.common.protocol.restapi import VMAgentUpdateStatus, VMAgentUpdateStatuses, ExtHandlerPackageList, \
     VERSION_0
@@ -576,7 +575,7 @@ class UpdateHandler(object):
             # The call to get_latest_agent_greater_than_daemon() also finds all agents in directory and sets the self.agents property.
             # This state is used to find the GuestAgent object with the current version later if requested version is available in last GS.
             available_agent = self.get_latest_agent_greater_than_daemon()
-            requested_version, _ = self.__get_requested_version_and_manifest_from_last_gs(protocol)
+            requested_version, _ = self.__get_requested_version_and_agent_family_from_last_gs()
             if requested_version is not None:
                 # If requested version specified, upgrade/downgrade to the specified version instantly as this is
                 # driven by the goal state (as compared to the agent periodically checking for new upgrades every hour)
@@ -662,7 +661,7 @@ class UpdateHandler(object):
         except Exception as exception:
             logger.warn("Error removing legacy history files: {0}", ustr(exception))
 
-    def __get_vmagent_update_status(self, protocol, goal_state_changed):
+    def __get_vmagent_update_status(self, goal_state_changed):
         """
         This function gets the VMAgent update status as per the last GoalState.
         Returns: None if the last GS does not ask for requested version else VMAgentUpdateStatus
@@ -673,7 +672,7 @@ class UpdateHandler(object):
         update_status = None
 
         try:
-            requested_version, manifest = self.__get_requested_version_and_manifest_from_last_gs(protocol)
+            requested_version, manifest = self.__get_requested_version_and_agent_family_from_last_gs()
             if manifest is None and goal_state_changed:
                 logger.info("Unable to report update status as no matching manifest found for family: {0}".format(
                     conf.get_autoupdate_gafamily()))
@@ -699,7 +698,7 @@ class UpdateHandler(object):
         return update_status
 
     def _report_status(self, exthandlers_handler):
-        vm_agent_update_status = self.__get_vmagent_update_status(exthandlers_handler.protocol, self._processing_new_extensions_goal_state())
+        vm_agent_update_status = self.__get_vmagent_update_status(self._processing_new_extensions_goal_state())
         # report_ext_handlers_status does its own error handling and returns None if an error occurred
         vm_status = exthandlers_handler.report_ext_handlers_status(
             goal_state_changed=self._processing_new_extensions_goal_state(),
@@ -986,7 +985,7 @@ class UpdateHandler(object):
 
     def _load_agents(self):
         path = os.path.join(conf.get_lib_dir(), "{0}-*".format(AGENT_NAME))
-        return [GuestAgent(path=agent_dir)
+        return [GuestAgent(is_fast_track_goal_state=self._goal_state.extensions_goal_state.source == GoalStateSource.FastTrack, path=agent_dir)
                 for agent_dir in glob.iglob(path) if os.path.isdir(agent_dir)]
 
     def _partition(self):
@@ -1068,22 +1067,21 @@ class UpdateHandler(object):
                 str(e))
         return
 
-    @staticmethod
-    def __get_requested_version_and_manifest_from_last_gs(protocol):
+    def __get_requested_version_and_agent_family_from_last_gs(self):
         """
         Get the requested version and corresponding manifests from last GS if supported
         Returns: (Requested Version, Manifest) if supported and available
                  (None, None) if no manifests found in the last GS
                  (None, manifest) if not supported or not specified in GS
         """
-        family = conf.get_autoupdate_gafamily()
-        manifest_list, _ = protocol.get_vmagent_manifests()
-        manifests = [m for m in manifest_list if m.family == family and len(m.uris) > 0]
-        if len(manifests) == 0:
+        family_name = conf.get_autoupdate_gafamily()
+        agent_families = self._goal_state.extensions_goal_state.agent_families
+        agent_families = [m for m in agent_families if m.name == family_name and len(m.uris) > 0]
+        if len(agent_families) == 0:
             return None, None
-        if conf.get_enable_ga_versioning() and manifests[0].is_requested_version_specified:
-            return manifests[0].requested_version, manifests[0]
-        return None, manifests[0]
+        if conf.get_enable_ga_versioning() and agent_families[0].is_requested_version_specified:
+            return agent_families[0].requested_version, agent_families[0]
+        return None, agent_families[0]
 
     def _download_agent_if_upgrade_available(self, protocol, base_version=CURRENT_VERSION):
         """
@@ -1130,18 +1128,18 @@ class UpdateHandler(object):
                 return False
             return True
 
-        family = conf.get_autoupdate_gafamily()
+        agent_family_name = conf.get_autoupdate_gafamily()
         gs_updated = False
         daemon_version = self.__get_daemon_version_for_update()
         try:
             # Fetch the agent manifests from the latest Goal State
             goal_state_id = self._goal_state.extensions_goal_state.id
             gs_updated = self._processing_new_extensions_goal_state()
-            requested_version, manifest = self.__get_requested_version_and_manifest_from_last_gs(protocol)
-            if manifest is None:
+            requested_version, agent_family = self.__get_requested_version_and_agent_family_from_last_gs()
+            if agent_family is None:
                 logger.verbose(
                     u"No manifest links found for agent family: {0} for goal state {1}, skipping update check".format(
-                        family, goal_state_id))
+                        agent_family_name, goal_state_id))
                 return False
         except Exception as err:
             # If there's some issues in fetching the agent manifests, report it only on goal state change
@@ -1166,7 +1164,7 @@ class UpdateHandler(object):
                 return False
 
             logger.info("No requested version specified, checking for all versions for agent update (family: {0})",
-                        family)
+                        agent_family_name)
             self.last_attempt_time = now
 
         try:
@@ -1183,7 +1181,8 @@ class UpdateHandler(object):
                 logger.info(msg)
                 add_event(AGENT_NAME, op=WALAEventOperation.AgentUpgrade, is_success=True, message=msg)
             else:
-                pkg_list = protocol.get_vmagent_pkgs(manifest)
+                agent_manifest = self._goal_state.fetch_agent_manifest(agent_family.name, agent_family.uris)
+                pkg_list = agent_manifest.pkg_list
                 packages_to_download = pkg_list.versions
 
             # Verify the requested version is in GA family manifest (if specified)
@@ -1202,7 +1201,7 @@ class UpdateHandler(object):
             # Set the agents to those available for download at least as current as the existing agent
             # or to the requested version (if specified)
             host = self._get_host_plugin(protocol=protocol)
-            agents_to_download = [GuestAgent(pkg=pkg, host=host) for pkg in packages_to_download]
+            agents_to_download = [GuestAgent(is_fast_track_goal_state=self._goal_state.extensions_goal_state.source == GoalStateSource.FastTrack, pkg=pkg, host=host) for pkg in packages_to_download]
 
             # Filter out the agents that were downloaded/extracted successfully. If the agent was not installed properly,
             # we delete the directory and the zip package from the filesystem
@@ -1468,7 +1467,8 @@ class UpdateHandler(object):
 
 
 class GuestAgent(object):
-    def __init__(self, path=None, pkg=None, host=None):
+    def __init__(self, is_fast_track_goal_state, path=None, pkg=None, host=None):
+        self._is_fast_track_goal_state = is_fast_track_goal_state
         self.pkg = pkg
         self.host = host
         version = None
@@ -1614,7 +1614,7 @@ class GuestAgent(object):
                 else:
                     logger.verbose("Using host plugin as default channel")
 
-                uri, headers = self.host.get_artifact_request(uri, self.host.manifest_uri)
+                uri, headers = self.host.get_artifact_request(uri, use_verify_header=self._is_fast_track_goal_state, artifact_manifest_url=self.host.manifest_uri)
                 try:
                     if self._fetch(uri, headers=headers, use_proxy=False, retry_codes=restutil.HGAP_GET_EXTENSION_ARTIFACT_RETRY_CODES):
                         if not HostPluginProtocol.is_default_channel:
@@ -1692,7 +1692,7 @@ class GuestAgent(object):
             try:
                 manifests = json.load(manifest_file)
             except Exception as e:
-                msg = u"Agent {0} has a malformed {1}".format(self.name, AGENT_MANIFEST_FILE)
+                msg = u"Agent {0} has a malformed {1} ({2})".format(self.name, AGENT_MANIFEST_FILE, ustr(e))
                 raise UpdateError(msg)
             if type(manifests) is list:
                 if len(manifests) <= 0:

--- a/ci/3.6.pylintrc
+++ b/ci/3.6.pylintrc
@@ -3,18 +3,22 @@
 [MESSAGES CONTROL]
 
 disable=C, # (C) convention, for programming standard violation
+    broad-except, # (W0703): *Catching too general exception %s*
     consider-using-dict-comprehension, # (R1717): *Consider using a dictionary comprehension*
     consider-using-in, # (R1714): *Consider merging these comparisons with "in" to %r*
     consider-using-set-comprehension, # (R1718): *Consider using a set comprehension*
     consider-using-with, # (R1732): *Emitted if a resource-allocating assignment or call may be replaced by a 'with' block*
     duplicate-code, # (R0801): *Similar lines in %s files*
-    no-init, # (W0232): Class has no __init__ method
+    fixme, # Used when a warning note as FIXME or TODO is detected
     no-else-break, # (R1723): *Unnecessary "%s" after "break"*
     no-else-continue, # (R1724): *Unnecessary "%s" after "continue"*
     no-else-raise, # (R1720): *Unnecessary "%s" after "raise"*
     no-else-return, # (R1705): *Unnecessary "%s" after "return"*
+    no-init, # (W0232): Class has no __init__ method
     no-self-use, # (R0201): *Method could be a function*
     protected-access, # (W0212): Access to a protected member of a client class
+    raise-missing-from, # (W0707): *Consider explicitly re-raising using the 'from' keyword*
+    redundant-u-string-prefix, # The u prefix for strings is no longer necessary in Python >=3.0
     simplifiable-if-expression, # (R1719): *The if expression can be replaced with %s*
     simplifiable-if-statement, # (R1703): *The if statement can be replaced with %s*
     super-with-arguments, # (R1725): *Consider using Python 3 style super() without arguments*
@@ -29,9 +33,8 @@ disable=C, # (C) convention, for programming standard violation
     too-many-public-methods, # (R0904): *Too many public methods (%s/%s)*
     too-many-return-statements, # (R0911): *Too many return statements (%s/%s)*
     too-many-statements, # (R0915): *Too many statements (%s/%s)*
+    unspecified-encoding, # (W1514): Using open without explicitly specifying an encoding
+    use-a-generator, # (R1729): *Use a generator instead '%s(%s)'*
     useless-object-inheritance, # (R0205): *Class %r inherits from object, can be safely removed from bases in python3*
     useless-return, # (R1711): *Useless return at end of function or method*
-    use-a-generator, # (R1729): *Use a generator instead '%s(%s)'*
-    broad-except, # (W0703): *Catching too general exception %s*
-    raise-missing-from, # (W0707): *Consider explicitly re-raising using the 'from' keyword*
-    fixme, # Used when a warning note as FIXME or TODO is detected
+

--- a/tests/ga/test_extension.py
+++ b/tests/ga/test_extension.py
@@ -1361,7 +1361,7 @@ class TestExtension_Deprecated(TestExtensionBase):
     def test_ext_handler_download_failure_permanent_ProtocolError(self, mock_add_event, mock_error_state, *args):
         test_data = mockwiredata.WireProtocolData(mockwiredata.DATA_FILE)
         exthandlers_handler, protocol = self._create_mock(test_data, *args)  # pylint: disable=no-value-for-parameter
-        protocol.get_ext_handler_pkgs = Mock(side_effect=ProtocolError)
+        protocol.get_goal_state().fetch_extension_manifest = Mock(side_effect=ProtocolError)
 
         mock_error_state.return_value = True
 
@@ -2496,7 +2496,7 @@ class TestExtensionSequencing(AgentTestCase):
         """
         Creates extensions with the given dependencyLevel
         """
-        handler_map = dict()
+        handler_map = {}
         all_handlers = []
         for handler_name, level in dependency_levels:
             if handler_map.get(handler_name) is None:
@@ -3308,7 +3308,7 @@ class TestAdditionalLocationsExtensions(AgentTestCase):
             wire._DOWNLOAD_TIMEOUT = datetime.timedelta(minutes=0)
             try:
                 with self.assertRaises(ExtensionDownloadError):
-                    protocol.client.fetch_manifest(ext_handlers[0].manifest_uris)
+                    protocol.client.fetch_manifest(ext_handlers[0].manifest_uris, use_verify_header=False)
             finally:
                 wire._DOWNLOAD_TIMEOUT = download_timeout
 

--- a/tests/ga/test_exthandlers_download_extension.py
+++ b/tests/ga/test_exthandlers_download_extension.py
@@ -10,6 +10,8 @@ from azurelinuxagent.common.exception import ExtensionDownloadError, ExtensionEr
 from azurelinuxagent.common.protocol.restapi import Extension, ExtHandlerPackage
 from azurelinuxagent.common.protocol.wire import WireProtocol
 from azurelinuxagent.ga.exthandlers import ExtHandlerInstance, ExtHandlerState
+from tests.protocol import mockwiredata
+from tests.protocol.mocks import mock_wire_protocol
 from tests.tools import AgentTestCase, patch, Mock
 
 
@@ -38,6 +40,12 @@ class DownloadExtensionTestCase(AgentTestCase):
         protocol = WireProtocol("http://Microsoft.CPlat.Core.RunCommandLinux/foo-bar")
         protocol.client.get_host_plugin = Mock()
         protocol.client.get_artifact_request = Mock(return_value=(None, None))
+
+        # create a dummy goal state, since downloads are done via the GoalState class
+        with mock_wire_protocol(mockwiredata.DATA_FILE) as p:
+            goal_state = p.get_goal_state()
+            goal_state._wire_client = protocol.client
+            protocol.client._goal_state = goal_state
 
         self.pkg = ExtHandlerPackage()
         self.pkg.uris = [

--- a/tests/protocol/test_hostplugin.py
+++ b/tests/protocol/test_hostplugin.py
@@ -23,9 +23,7 @@ import os.path
 import sys
 import unittest
 
-import azurelinuxagent.common.protocol.hostplugin as hostplugin
-import azurelinuxagent.common.protocol.restapi as restapi
-import azurelinuxagent.common.protocol.wire as wire
+from azurelinuxagent.common.protocol import hostplugin, restapi, wire
 from azurelinuxagent.common import conf
 from azurelinuxagent.common.errorstate import ErrorState
 from azurelinuxagent.common.exception import HttpError, ResourceGoneError, ProtocolError
@@ -609,7 +607,7 @@ class TestHostPlugin(HttpRequestPredicates, AgentTestCase):
             self.assertTrue(host_client.health_service is not None)
 
             with patch.object(wire.HostPluginProtocol, "get_api_versions", return_value=api_versions) as patch_get:  # pylint: disable=unused-variable
-                actual_url, actual_headers = host_client.get_artifact_request(sas_url)
+                actual_url, actual_headers = host_client.get_artifact_request(sas_url, use_verify_header=False)
                 self.assertTrue(host_client.is_initialized)
                 self.assertFalse(host_client.api_versions is None)
                 self.assertEqual(expected_url, actual_url)


### PR DESCRIPTION
The HostGAPlugin requires the x-ms-verify-from-artifacts-blob header in extensionsArtifact requests for Fast Track Goal states.

This PR adds that header. Most of the changes in the PR are code refactoring that makes this simple, plus some refactoring that has been delayed in previous changes, as well as a few changes for Python 3.10