### PR TITLE
update current memory usage check on log collector cgroup

### DIFF
--- a/azurelinuxagent/ga/collect_logs.py
+++ b/azurelinuxagent/ga/collect_logs.py
@@ -336,18 +336,14 @@ class LogCollectorMonitorHandler(ThreadHandlerInterface):
 
     def _verify_memory_limit(self, metrics):
         current_usage = 0
-        max_usage = 0
         for metric in metrics:
             if metric.counter == MetricsCounter.TOTAL_MEM_USAGE:
                 current_usage += metric.value
             elif metric.counter == MetricsCounter.SWAP_MEM_USAGE:
                 current_usage += metric.value
-            elif metric.counter == MetricsCounter.MAX_MEM_USAGE:
-                max_usage = metric.value
 
-        current_max = max(current_usage, max_usage)
-        if current_max > LOGCOLLECTOR_MEMORY_LIMIT:
-            msg = "Log collector memory limit {0} bytes exceeded. The max reported usage is {1} bytes.".format(LOGCOLLECTOR_MEMORY_LIMIT, current_max)
+        if current_usage > LOGCOLLECTOR_MEMORY_LIMIT:
+            msg = "Log collector memory limit {0} bytes exceeded. The max reported usage is {1} bytes.".format(LOGCOLLECTOR_MEMORY_LIMIT, current_usage)
             logger.info(msg)
             add_event(
                 name=AGENT_NAME,


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
Systemd cgroup slice somehow gets left behind not cleaned up after logcollector finished. Due to this, max_memory_usage counter not cleaned up for next log collector run. When we check for memory limit, we may get old value and disable the log collector based on that which is not right. So, I updated that logic and consider only memory.stat(RSS+cache+SWAP) to check current memory_usage.

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).