### PR TITLE
Drop support for Debian <= 7

### DIFF
--- a/azurelinuxagent/common/osutil/debian.py
+++ b/azurelinuxagent/common/osutil/debian.py
@@ -16,20 +16,7 @@
 # Requires Python 2.6+ and Openssl 1.0+
 #
 
-import os  # pylint: disable=W0611
-import re  # pylint: disable=W0611
-import pwd  # pylint: disable=W0611
-import shutil  # pylint: disable=W0611
-import socket  # pylint: disable=W0611
-import array  # pylint: disable=W0611
-import struct  # pylint: disable=W0611
-import fcntl  # pylint: disable=W0611
-import time  # pylint: disable=W0611
-import base64  # pylint: disable=W0611
-import azurelinuxagent.common.logger as logger  # pylint: disable=W0611
-import azurelinuxagent.common.utils.fileutil as fileutil  # pylint: disable=W0611
 import azurelinuxagent.common.utils.shellutil as shellutil
-import azurelinuxagent.common.utils.textutil as textutil  # pylint: disable=W0611
 from azurelinuxagent.common.osutil.default import DefaultOSUtil
 
 

--- a/azurelinuxagent/common/osutil/debian.py
+++ b/azurelinuxagent/common/osutil/debian.py
@@ -13,27 +13,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Requires Python 2.6+ and Openssl 1.0+
+# Requires Python 3.7+ and Openssl 1.0+
 #
 
 import azurelinuxagent.common.utils.shellutil as shellutil
 from azurelinuxagent.common.osutil.default import DefaultOSUtil
 
 
-class DebianOSBaseUtil(DefaultOSUtil):
+class DebianOSUtil(DefaultOSUtil):
 
     def __init__(self):
-        super(DebianOSBaseUtil, self).__init__()
+        super().__init__()
         self.jit_enabled = True
+        self.service_name = self.get_service_name()
+
+    @staticmethod
+    def get_service_name():
+        return "walinuxagent"
 
     def restart_ssh_service(self):
         return shellutil.run("systemctl --job-mode=ignore-dependencies try-reload-or-restart ssh", chk_err=False)
 
     def stop_agent_service(self):
-        return shellutil.run("service azurelinuxagent stop", chk_err=False)
+        return shellutil.run("systemctl stop {0}".format(self.service_name), chk_err=False)
 
     def start_agent_service(self):
-        return shellutil.run("service azurelinuxagent start", chk_err=False)
+        return shellutil.run("systemctl start {0}".format(self.service_name), chk_err=False)
 
     def start_network(self):
         pass
@@ -46,21 +51,3 @@ class DebianOSBaseUtil(DefaultOSUtil):
 
     def get_dhcp_lease_endpoint(self):
         return self.get_endpoint_from_leases_path('/var/lib/dhcp/dhclient.*.leases')
-
-
-class DebianOSModernUtil(DebianOSBaseUtil):
-
-    def __init__(self):
-        super(DebianOSModernUtil, self).__init__()
-        self.jit_enabled = True
-        self.service_name = self.get_service_name()
-
-    @staticmethod
-    def get_service_name():
-        return "walinuxagent"
-
-    def stop_agent_service(self):
-        return shellutil.run("systemctl stop {0}".format(self.service_name), chk_err=False)
-
-    def start_agent_service(self):
-        return shellutil.run("systemctl start {0}".format(self.service_name), chk_err=False)

--- a/azurelinuxagent/common/osutil/factory.py
+++ b/azurelinuxagent/common/osutil/factory.py
@@ -25,7 +25,7 @@ from .arch import ArchUtil
 from .bigip import BigIpOSUtil
 from .clearlinux import ClearLinuxUtil
 from .coreos import CoreOSUtil
-from .debian import DebianOSBaseUtil, DebianOSModernUtil
+from .debian import DebianOSUtil
 from .default import DefaultOSUtil
 from .devuan import DevuanOSUtil
 from .freebsd import FreeBSDOSUtil
@@ -84,7 +84,7 @@ def _get_osutil(distro_name, distro_code_name, distro_version, distro_full_name)
         return AlpineOSUtil()
 
     if distro_name == "kali":
-        return DebianOSBaseUtil()
+        return DebianOSUtil()
 
     if distro_name in ("flatcar", "coreos") or distro_code_name in ("flatcar", "coreos"):
         return CoreOSUtil()
@@ -98,10 +98,7 @@ def _get_osutil(distro_name, distro_code_name, distro_version, distro_full_name)
         return SUSEOSUtil()
 
     if distro_name == "debian":
-        if "sid" in distro_version or Version(distro_version) > Version("7"):
-            return DebianOSModernUtil()
-
-        return DebianOSBaseUtil()
+        return DebianOSUtil()
 
     # Devuan support only works with v4+ 
     # Reason is that Devuan v4 (Chimaera) uses python v3.9, in which the 

--- a/tests/common/osutil/test_factory.py
+++ b/tests/common/osutil/test_factory.py
@@ -20,7 +20,7 @@ from azurelinuxagent.common.osutil.arch import ArchUtil
 from azurelinuxagent.common.osutil.bigip import BigIpOSUtil
 from azurelinuxagent.common.osutil.clearlinux import ClearLinuxUtil
 from azurelinuxagent.common.osutil.coreos import CoreOSUtil
-from azurelinuxagent.common.osutil.debian import DebianOSBaseUtil, DebianOSModernUtil
+from azurelinuxagent.common.osutil.debian import DebianOSUtil
 from azurelinuxagent.common.osutil.devuan import DevuanOSUtil
 from azurelinuxagent.common.osutil.default import DefaultOSUtil
 from azurelinuxagent.common.osutil.factory import _get_osutil
@@ -134,8 +134,8 @@ class TestOsUtilFactory(AgentTestCase):
                           distro_code_name="",
                           distro_version="",
                           distro_full_name="")
-        self.assertTrue(isinstance(ret, DebianOSBaseUtil))
-        self.assertEqual(ret.get_service_name(), "waagent")
+        self.assertTrue(isinstance(ret, DebianOSUtil))
+        self.assertEqual(ret.get_service_name(), "walinuxagent")
 
     def test_get_osutil_it_should_return_coreos(self):
         ret = _get_osutil(distro_name="coreos",
@@ -173,19 +173,11 @@ class TestOsUtilFactory(AgentTestCase):
         self.assertTrue(isinstance(ret, SUSE11OSUtil))
         self.assertEqual(ret.get_service_name(), "waagent")
 
-    def test_get_osutil_it_should_return_debian(self):
         ret = _get_osutil(distro_name="debian",
                           distro_code_name="",
                           distro_full_name="",
-                          distro_version="7")
-        self.assertTrue(isinstance(ret, DebianOSBaseUtil))
-        self.assertEqual(ret.get_service_name(), "waagent")
-
-        ret = _get_osutil(distro_name="debian",
-                          distro_code_name="",
-                          distro_full_name="",
-                          distro_version="8")
-        self.assertTrue(isinstance(ret, DebianOSModernUtil))
+                          distro_version="")
+        self.assertTrue(isinstance(ret, DebianOSUtil))
         self.assertEqual(ret.get_service_name(), "walinuxagent")
 
     def test_get_osutil_it_should_return_devuan(self):


### PR DESCRIPTION
## Description

Debian 7 "Wheezy" is EOL since 2018. Just drop support for it completely.

### PR information
- [ ] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [x] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).