### PR TITLE
waagent.service: set ConditionVirtualization=|microsoft

### DIFF
--- a/bin/waagent2.0
+++ b/bin/waagent2.0
@@ -1569,6 +1569,7 @@ After=network.target
 After=sshd.service
 ConditionFileIsExecutable=/usr/sbin/waagent
 ConditionPathExists=/etc/waagent.conf
+ConditionVirtualization=|microsoft
 
 [Service]
 Type=simple

--- a/init/arch/waagent.service
+++ b/init/arch/waagent.service
@@ -5,6 +5,7 @@ After=network-online.target
 
 ConditionFileIsExecutable=/usr/bin/waagent
 ConditionPathExists=/etc/waagent.conf
+ConditionVirtualization=|microsoft
 
 [Service]
 Type=simple

--- a/init/clearlinux/waagent.service
+++ b/init/clearlinux/waagent.service
@@ -5,6 +5,7 @@ After=network-online.target
 
 ConditionFileIsExecutable=/usr/bin/waagent
 ConditionPathExists=/usr/share/defaults/waagent/waagent.conf
+ConditionVirtualization=|microsoft
 
 [Service]
 Type=simple

--- a/init/coreos/cloud-config.yml
+++ b/init/coreos/cloud-config.yml
@@ -26,6 +26,7 @@ coreos:
         Description=Microsoft Azure Agent
         Wants=network-online.target sshd-keygen.service
         After=network-online.target sshd-keygen.service
+        ConditionVirtualization=|microsoft
 
         [Service]
         Type=simple

--- a/init/mariner/waagent.service
+++ b/init/mariner/waagent.service
@@ -5,6 +5,7 @@ After=systemd-networkd-wait-online.service cloud-init.service
 
 ConditionFileIsExecutable=/usr/bin/waagent
 ConditionPathExists=/etc/waagent.conf
+ConditionVirtualization=|microsoft
 
 [Service]
 Type=simple

--- a/init/photonos/waagent.service
+++ b/init/photonos/waagent.service
@@ -5,6 +5,7 @@ After=systemd-networkd-wait-online.service cloud-init.service
 
 ConditionFileIsExecutable=/usr/bin/waagent
 ConditionPathExists=/etc/waagent.conf
+ConditionVirtualization=|microsoft
 
 [Service]
 Type=simple

--- a/init/redhat/py2/waagent.service
+++ b/init/redhat/py2/waagent.service
@@ -5,6 +5,7 @@ After=network-online.target
 
 ConditionFileIsExecutable=/usr/sbin/waagent
 ConditionPathExists=/etc/waagent.conf
+ConditionVirtualization=|microsoft
 
 [Service]
 Type=simple

--- a/init/redhat/waagent.service
+++ b/init/redhat/waagent.service
@@ -5,6 +5,7 @@ After=network-online.target
 
 ConditionFileIsExecutable=/usr/sbin/waagent
 ConditionPathExists=/etc/waagent.conf
+ConditionVirtualization=|microsoft
 
 [Service]
 Type=simple

--- a/init/sles/waagent.service
+++ b/init/sles/waagent.service
@@ -5,6 +5,7 @@ After=network-online.target
 
 ConditionFileIsExecutable=/usr/sbin/waagent
 ConditionPathExists=/etc/waagent.conf
+ConditionVirtualization=|microsoft
 
 [Service]
 Type=simple

--- a/init/ubuntu/walinuxagent.service
+++ b/init/ubuntu/walinuxagent.service
@@ -12,6 +12,7 @@ Wants=network-online.target sshd.service sshd-keygen.service
 
 ConditionFileIsExecutable=/usr/sbin/waagent
 ConditionPathExists=/etc/waagent.conf
+ConditionVirtualization=|microsoft
 
 [Service]
 Type=simple

--- a/init/waagent.service
+++ b/init/waagent.service
@@ -5,6 +5,7 @@ After=network-online.target
 
 ConditionFileIsExecutable=/usr/sbin/waagent
 ConditionPathExists=/etc/waagent.conf
+ConditionVirtualization=|microsoft
 
 [Service]
 Type=simple


### PR DESCRIPTION
Only start waagent service when running under Microsoft virtualization.

Set it as a triggering condition to make it easier for downstreams or
test setups to add another condition (i.e. run outside of hyperv).

Signed-off-by: Chris Patterson <cpatterson@microsoft.com>