### PR TITLE
use 30 secs timeout for put vmagent log api

### DIFF
--- a/azurelinuxagent/common/protocol/hostplugin.py
+++ b/azurelinuxagent/common/protocol/hostplugin.py
@@ -266,7 +266,8 @@ class HostPluginProtocol(object):
         response = restutil.http_put(url,
                                      data=content,
                                      headers=self._build_log_headers(),
-                                     redact_data=True)
+                                     redact_data=True,
+                                     timeout=30)
 
         if restutil.request_failed(response):
             error_response = restutil.read_response_error(response)

--- a/azurelinuxagent/common/utils/restutil.py
+++ b/azurelinuxagent/common/utils/restutil.py
@@ -309,8 +309,8 @@ def redact_sas_tokens_in_urls(url):
     return SAS_TOKEN_RETRIEVAL_REGEX.sub(r"\1" + REDACTED_TEXT + r"\3", url)
 
 
-def _http_request(method, host, rel_uri, port=None, data=None, secure=False,
-                  headers=None, proxy_host=None, proxy_port=None, redact_data=False, timeout=10):
+def _http_request(method, host, rel_uri, timeout, port=None, data=None, secure=False,
+                  headers=None, proxy_host=None, proxy_port=None, redact_data=False):
 
     headers = {} if headers is None else headers
     headers['Connection'] = 'close'
@@ -358,14 +358,14 @@ def _http_request(method, host, rel_uri, port=None, data=None, secure=False,
 
 
 def http_request(method,
-                 url, data, headers=None,
+                 url, data, timeout,
+                 headers=None,
                  use_proxy=False,
                  max_retry=None,
                  retry_codes=None,
                  retry_delay=DELAY_IN_SECONDS,
                  redact_data=False,
-                 return_raw_response=False,
-                 timeout=10):
+                 return_raw_response=False):
     """
     NOTE: This method provides some logic to handle errors in the HTTP request, including checking the HTTP status of the response
           and handling some exceptions. If return_raw_response is set to True all the error handling will be skipped and the
@@ -447,14 +447,14 @@ def http_request(method,
             resp = _http_request(method,
                                  host,
                                  rel_uri,
+                                 timeout,
                                  port=port,
                                  data=data,
                                  secure=secure,
                                  headers=headers,
                                  proxy_host=proxy_host,
                                  proxy_port=proxy_port,
-                                 redact_data=redact_data,
-                                 timeout=timeout)
+                                 redact_data=redact_data)
 
             logger.verbose("[HTTP Response] Status Code {0}", resp.status)
 
@@ -512,7 +512,8 @@ def http_get(url,
              max_retry=None,
              retry_codes=None,
              retry_delay=DELAY_IN_SECONDS,
-             return_raw_response=False):
+             return_raw_response=False,
+             timeout=10):
     """
     NOTE: This method provides some logic to handle errors in the HTTP request, including checking the HTTP status of the response
           and handling some exceptions. If return_raw_response is set to True all the error handling will be skipped and the
@@ -525,7 +526,8 @@ def http_get(url,
     if retry_codes is None:
         retry_codes = RETRY_CODES
     return http_request("GET",
-                        url, None, headers=headers,
+                        url, None, timeout,
+                        headers=headers,
                         use_proxy=use_proxy,
                         max_retry=max_retry,
                         retry_codes=retry_codes,
@@ -538,14 +540,16 @@ def http_head(url,
               use_proxy=False,
               max_retry=None,
               retry_codes=None,
-              retry_delay=DELAY_IN_SECONDS):
+              retry_delay=DELAY_IN_SECONDS,
+              timeout=10):
 
     if max_retry is None:
         max_retry = DEFAULT_RETRIES
     if retry_codes is None:
         retry_codes = RETRY_CODES
     return http_request("HEAD",
-                        url, None, headers=headers,
+                        url, None, timeout,
+                        headers=headers,
                         use_proxy=use_proxy,
                         max_retry=max_retry,
                         retry_codes=retry_codes,
@@ -558,14 +562,16 @@ def http_post(url,
               use_proxy=False,
               max_retry=None,
               retry_codes=None,
-              retry_delay=DELAY_IN_SECONDS):
+              retry_delay=DELAY_IN_SECONDS,
+              timeout=10):
 
     if max_retry is None:
         max_retry = DEFAULT_RETRIES
     if retry_codes is None:
         retry_codes = RETRY_CODES
     return http_request("POST",
-                        url, data, headers=headers,
+                        url, data, timeout,
+                        headers=headers,
                         use_proxy=use_proxy,
                         max_retry=max_retry,
                         retry_codes=retry_codes,
@@ -587,13 +593,13 @@ def http_put(url,
     if retry_codes is None:
         retry_codes = RETRY_CODES
     return http_request("PUT",
-                        url, data, headers=headers,
+                        url, data, timeout,
+                        headers=headers,
                         use_proxy=use_proxy,
                         max_retry=max_retry,
                         retry_codes=retry_codes,
                         retry_delay=retry_delay,
-                        redact_data=redact_data,
-                        timeout=timeout)
+                        redact_data=redact_data)
 
 
 def http_delete(url,
@@ -601,14 +607,16 @@ def http_delete(url,
                 use_proxy=False,
                 max_retry=None,
                 retry_codes=None,
-                retry_delay=DELAY_IN_SECONDS):
+                retry_delay=DELAY_IN_SECONDS,
+                timeout=10):
 
     if max_retry is None:
         max_retry = DEFAULT_RETRIES
     if retry_codes is None:
         retry_codes = RETRY_CODES
     return http_request("DELETE",
-                        url, None, headers=headers,
+                        url, None, timeout,
+                        headers=headers,
                         use_proxy=use_proxy,
                         max_retry=max_retry,
                         retry_codes=retry_codes,

--- a/azurelinuxagent/common/utils/restutil.py
+++ b/azurelinuxagent/common/utils/restutil.py
@@ -310,7 +310,7 @@ def redact_sas_tokens_in_urls(url):
 
 
 def _http_request(method, host, rel_uri, port=None, data=None, secure=False,
-                  headers=None, proxy_host=None, proxy_port=None, redact_data=False):
+                  headers=None, proxy_host=None, proxy_port=None, redact_data=False, timeout=10):
 
     headers = {} if headers is None else headers
     headers['Connection'] = 'close'
@@ -334,13 +334,13 @@ def _http_request(method, host, rel_uri, port=None, data=None, secure=False,
     if secure:
         conn = httpclient.HTTPSConnection(conn_host,
                                           conn_port,
-                                          timeout=10)
+                                          timeout=timeout)
         if use_proxy:
             conn.set_tunnel(host, port)
     else:
         conn = httpclient.HTTPConnection(conn_host,
                                          conn_port,
-                                         timeout=10)
+                                         timeout=timeout)
 
     payload = data
     if redact_data:
@@ -364,7 +364,8 @@ def http_request(method,
                  retry_codes=None,
                  retry_delay=DELAY_IN_SECONDS,
                  redact_data=False,
-                 return_raw_response=False):
+                 return_raw_response=False,
+                 timeout=10):
     """
     NOTE: This method provides some logic to handle errors in the HTTP request, including checking the HTTP status of the response
           and handling some exceptions. If return_raw_response is set to True all the error handling will be skipped and the
@@ -452,7 +453,8 @@ def http_request(method,
                                  headers=headers,
                                  proxy_host=proxy_host,
                                  proxy_port=proxy_port,
-                                 redact_data=redact_data)
+                                 redact_data=redact_data,
+                                 timeout=timeout)
 
             logger.verbose("[HTTP Response] Status Code {0}", resp.status)
 
@@ -577,7 +579,8 @@ def http_put(url,
              max_retry=None,
              retry_codes=None,
              retry_delay=DELAY_IN_SECONDS,
-             redact_data=False):
+             redact_data=False,
+             timeout=10):
 
     if max_retry is None:
         max_retry = DEFAULT_RETRIES
@@ -589,7 +592,8 @@ def http_put(url,
                         max_retry=max_retry,
                         retry_codes=retry_codes,
                         retry_delay=retry_delay,
-                        redact_data=redact_data)
+                        redact_data=redact_data,
+                        timeout=timeout)
 
 
 def http_delete(url,

--- a/tests/protocol/mocks.py
+++ b/tests/protocol/mocks.py
@@ -70,10 +70,10 @@ def mock_wire_protocol(mock_wire_data_file, http_get_handler=None, http_post_han
     #
     original_http_request = restutil.http_request
 
-    def http_request(method, url, data, **kwargs):
+    def http_request(method, url, data, timeout, **kwargs):
         # call the original resutil.http_request if the request should be mocked
         if protocol.do_not_mock(method, url):
-            return original_http_request(method, url, data, **kwargs)
+            return original_http_request(method, url, data, timeout, **kwargs)
 
         # if there is a handler for the request, use it
         handler = None
@@ -109,7 +109,7 @@ def mock_wire_protocol(mock_wire_data_file, http_get_handler=None, http_post_han
         # if there was not a response for the request then fail it or call the original resutil.http_request
         if fail_on_unknown_request:
             raise ValueError('Unknown HTTP request: {0} [{1}]'.format(url, method))
-        return original_http_request(method, url, data, **kwargs)
+        return original_http_request(method, url, data, timeout, **kwargs)
 
     #
     # functions to start/stop the mocks

--- a/tests/protocol/test_goal_state.py
+++ b/tests/protocol/test_goal_state.py
@@ -68,7 +68,7 @@ class GoalStateTestCase(AgentTestCase, HttpRequestPredicates):
 
             request_headers = []  # we expect a retry with new headers and use this array to persist the headers of each request
 
-            def http_get_vm_settings(_method, _host, _relative_url, **kwargs):
+            def http_get_vm_settings(_method, _host, _relative_url, _timeout, **kwargs):
                 request_headers.append(kwargs["headers"])
                 if len(request_headers) == 1:
                     # Fail the first request with status GONE and update the mock data to return the new Container ID and RoleConfigName that should be

--- a/tests/protocol/test_wire.py
+++ b/tests/protocol/test_wire.py
@@ -405,7 +405,7 @@ class TestWireProtocol(AgentTestCase, HttpRequestPredicates):
 
         first_call = mock_http_request.call_args_list[0]
         args, kwargs = first_call
-        method, url, body_received = args  # pylint: disable=unused-variable
+        method, url, body_received, timeout = args  # pylint: disable=unused-variable
         headers = kwargs['headers']
 
         # the headers should include utf-8 encoding...

--- a/tests/utils/test_rest_util.py
+++ b/tests/utils/test_rest_util.py
@@ -352,7 +352,7 @@ class TestHttpOperations(AgentTestCase):
 
         HTTPConnection.return_value = mock_conn
 
-        resp = restutil._http_request("GET", "foo", "/bar")
+        resp = restutil._http_request("GET", "foo", "/bar", 10)
 
         HTTPConnection.assert_has_calls([
             call("foo", 80, timeout=10)
@@ -375,7 +375,7 @@ class TestHttpOperations(AgentTestCase):
 
         HTTPSConnection.return_value = mock_conn
 
-        resp = restutil._http_request("GET", "foo", "/bar", secure=True)
+        resp = restutil._http_request("GET", "foo", "/bar", 10, secure=True)
 
         HTTPConnection.assert_not_called()
         HTTPSConnection.assert_has_calls([
@@ -398,7 +398,7 @@ class TestHttpOperations(AgentTestCase):
 
         HTTPConnection.return_value = mock_conn
 
-        resp = restutil._http_request("GET", "foo", "/bar",
+        resp = restutil._http_request("GET", "foo", "/bar", 10,
                             proxy_host="foo.bar", proxy_port=23333)
 
         HTTPConnection.assert_has_calls([
@@ -530,7 +530,7 @@ class TestHttpOperations(AgentTestCase):
 
         HTTPSConnection.return_value = mock_conn
 
-        resp = restutil._http_request("GET", "foo", "/bar",
+        resp = restutil._http_request("GET", "foo", "/bar", 10,
                             proxy_host="foo.bar", proxy_port=23333,
                             secure=True)
 


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
exercise 30 secs timeout to reduce latency failure rates on PUT VMagent log api.
Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).