### PR TITLE
update traceback.format_exception etype argument

### DIFF
--- a/azurelinuxagent/common/utils/textutil.py
+++ b/azurelinuxagent/common/utils/textutil.py
@@ -445,7 +445,7 @@ def format_exception(exception):
     if tb is None or (sys.version_info[0] == 2 and e != exception):
         msg += "[Traceback not available]"
     else:
-        msg += ''.join(traceback.format_exception(etype=type(exception), value=exception, tb=tb))
+        msg += ''.join(traceback.format_exception(type(exception), value=exception, tb=tb))
 
     return msg
 

--- a/tests/utils/test_text_util.py
+++ b/tests/utils/test_text_util.py
@@ -206,6 +206,26 @@ class TestTextUtil(AgentTestCase):
         self.assertRaises(ValueError, textutil.format_memory_value, 'KiloBytes', 1)
         self.assertRaises(TypeError, textutil.format_memory_value, 'bytes', None)
 
+    def test_format_exception(self):
+        """
+        Test formatting of exception into human-readable format
+        """
+
+        def raise_exception(count=3):
+            if count <= 1:
+                raise Exception("Test Exception")
+            raise_exception(count - 1)
+
+        msg = ""
+        try:
+            raise_exception()
+        except Exception as e:
+            msg = textutil.format_exception(e)
+
+        self.assertIn("Test Exception", msg)
+        # Raise exception at count 1 after two nested calls since count starts at 3
+        self.assertEqual(2, msg.count("raise_exception(count - 1)"))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

`Changed in version 3.10: The etype parameter has been renamed to exc and is now positional-only.
`
That is breaking the `traceback.format_exception` call since we pass value as keyword argument.

In older versions the etype parameter is mandatory argument.  So, changing from keyword argument to positional argument should fix the problem in all 3. * Versions.

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).