### PR TITLE
Add logging statements for mrseq migration during update

### DIFF
--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -1210,7 +1210,10 @@ class ExtHandlerInstance(object):
 
         old_ext_mrseq_file = os.path.join(old_ext_dir, "mrseq")
         if os.path.isfile(old_ext_mrseq_file):
+            logger.info("Migrating {0} to {1}.", old_ext_mrseq_file, new_ext_dir)
             shutil.copy2(old_ext_mrseq_file, new_ext_dir)
+        else:
+            logger.info("{0} does not exist, no migration is needed.", old_ext_mrseq_file)
 
         old_ext_status_dir = old_ext_handler_i.get_status_dir()
         new_ext_status_dir = self.get_status_dir()


### PR DESCRIPTION
Some extensions depend on mrseq; adding logging statements to facilitate debugging