### PR TITLE
Require HostGAPlugin >= 133 for Fast Track

### DIFF
--- a/azurelinuxagent/common/protocol/hostplugin.py
+++ b/azurelinuxagent/common/protocol/hostplugin.py
@@ -491,7 +491,7 @@ class HostPluginProtocol(object):
         try:
             # Raise if VmSettings are not supported, but check again periodically since the HostGAPlugin could have been updated since the last check
             # Note that self._host_plugin_supports_vm_settings can be None, so we need to compare against False
-            if self._supports_vm_settings == False and self._supports_vm_settings_next_check > datetime.datetime.now():
+            if not self._supports_vm_settings and self._supports_vm_settings_next_check > datetime.datetime.now():
                 # Raise VmSettingsNotSupported directly instead of using raise_not_supported() to avoid resetting the timestamp for the next check
                 raise VmSettingsNotSupported()
 
@@ -551,8 +551,8 @@ class HostPluginProtocol(object):
                 logger.info(message)
                 add_event(op=WALAEventOperation.HostPlugin, message=message, is_success=True)
 
-            # Don't support HostGAPlugin versions older than 124
-            if vm_settings.host_ga_plugin_version < FlexibleVersion("1.0.8.124"):
+            # Don't support HostGAPlugin versions older than 133
+            if vm_settings.host_ga_plugin_version < FlexibleVersion("1.0.8.133"):
                 raise_not_supported()
 
             self._supports_vm_settings = True

--- a/tests/data/hostgaplugin/vm_settings-difference_in_required_features.json
+++ b/tests/data/hostgaplugin/vm_settings-difference_in_required_features.json
@@ -1,5 +1,5 @@
 {
-    "hostGAPluginVersion": "1.0.8.124",
+    "hostGAPluginVersion": "1.0.8.133",
     "vmSettingsSchemaVersion": "0.0",
     "activityId": "a33f6f53-43d6-4625-b322-1a39651a00c9",
     "correlationId": "9a47a2a2-e740-4bfc-b11b-4f2f7cfe7d2e",

--- a/tests/data/hostgaplugin/vm_settings-empty_depends_on.json
+++ b/tests/data/hostgaplugin/vm_settings-empty_depends_on.json
@@ -1,5 +1,5 @@
 {
-    "hostGAPluginVersion": "1.0.8.124",
+    "hostGAPluginVersion": "1.0.8.133",
     "vmSettingsSchemaVersion": "0.0",
     "activityId": "2e7f8b5d-f637-4721-b757-cb190d49b4e9",
     "correlationId": "1bef4c48-044e-4225-8f42-1d1eac1eb158",

--- a/tests/data/hostgaplugin/vm_settings-fabric-no_thumbprints.json
+++ b/tests/data/hostgaplugin/vm_settings-fabric-no_thumbprints.json
@@ -1,5 +1,5 @@
 {
-    "hostGAPluginVersion": "1.0.8.124",
+    "hostGAPluginVersion": "1.0.8.133",
     "vmSettingsSchemaVersion": "0.0",
     "activityId": "a33f6f53-43d6-4625-b322-1a39651a00c9",
     "correlationId": "9a47a2a2-e740-4bfc-b11b-4f2f7cfe7d2e",

--- a/tests/data/hostgaplugin/vm_settings-invalid_blob_type.json
+++ b/tests/data/hostgaplugin/vm_settings-invalid_blob_type.json
@@ -1,5 +1,5 @@
 {
-    "hostGAPluginVersion": "1.0.8.124",
+    "hostGAPluginVersion": "1.0.8.133",
     "vmSettingsSchemaVersion": "0.0",
     "activityId": "2e7f8b5d-f637-4721-b757-cb190d49b4e9",
     "correlationId": "1bef4c48-044e-4225-8f42-1d1eac1eb158",

--- a/tests/data/hostgaplugin/vm_settings-missing_cert.json
+++ b/tests/data/hostgaplugin/vm_settings-missing_cert.json
@@ -1,5 +1,5 @@
 {
-    "hostGAPluginVersion": "1.0.8.124",
+    "hostGAPluginVersion": "1.0.8.133",
     "vmSettingsSchemaVersion": "0.0",
     "activityId": "a33f6f53-43d6-4625-b322-1a39651a00c9",
     "correlationId": "9a47a2a2-e740-4bfc-b11b-4f2f7cfe7d2e",

--- a/tests/data/hostgaplugin/vm_settings-no_manifests.json
+++ b/tests/data/hostgaplugin/vm_settings-no_manifests.json
@@ -1,5 +1,5 @@
 {
-    "hostGAPluginVersion": "1.0.8.124",
+    "hostGAPluginVersion": "1.0.8.133",
     "vmSettingsSchemaVersion": "0.0",
     "activityId": "89d50bf1-fa55-4257-8af3-3db0c9f81ab4",
     "correlationId": "c143f8f0-a66b-4881-8c06-1efd278b0b02",

--- a/tests/data/hostgaplugin/vm_settings-no_status_upload_blob.json
+++ b/tests/data/hostgaplugin/vm_settings-no_status_upload_blob.json
@@ -1,5 +1,5 @@
 {
-    "hostGAPluginVersion": "1.0.8.124",
+    "hostGAPluginVersion": "1.0.8.133",
     "vmSettingsSchemaVersion": "0.0",
     "activityId": "a33f6f53-43d6-4625-b322-1a39651a00c9",
     "correlationId": "9a47a2a2-e740-4bfc-b11b-4f2f7cfe7d2e",

--- a/tests/data/hostgaplugin/vm_settings-out-of-sync.json
+++ b/tests/data/hostgaplugin/vm_settings-out-of-sync.json
@@ -1,5 +1,5 @@
 {
-    "hostGAPluginVersion": "1.0.8.124",
+    "hostGAPluginVersion": "1.0.8.133",
     "vmSettingsSchemaVersion": "0.0",
     "activityId": "AAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE",
     "correlationId": "EEEEEEEE-DDDD-CCCC-BBBB-AAAAAAAAAAAA",

--- a/tests/data/hostgaplugin/vm_settings-parse_error.json
+++ b/tests/data/hostgaplugin/vm_settings-parse_error.json
@@ -1,5 +1,5 @@
 {
-    "hostGAPluginVersion": "1.0.8.124",
+    "hostGAPluginVersion": "1.0.8.133",
     "vmSettingsSchemaVersion": THIS_IS_A_SYNTAX_ERROR,
     "activityId": "a33f6f53-43d6-4625-b322-1a39651a00c9",
     "correlationId": "9a47a2a2-e740-4bfc-b11b-4f2f7cfe7d2e",

--- a/tests/data/hostgaplugin/vm_settings-requested_version.json
+++ b/tests/data/hostgaplugin/vm_settings-requested_version.json
@@ -1,5 +1,5 @@
 {
-    "hostGAPluginVersion": "1.0.8.124",
+    "hostGAPluginVersion": "1.0.8.133",
     "vmSettingsSchemaVersion": "0.0",
     "activityId": "a33f6f53-43d6-4625-b322-1a39651a00c9",
     "correlationId": "9a47a2a2-e740-4bfc-b11b-4f2f7cfe7d2e",

--- a/tests/data/hostgaplugin/vm_settings.json
+++ b/tests/data/hostgaplugin/vm_settings.json
@@ -1,5 +1,5 @@
 {
-    "hostGAPluginVersion": "1.0.8.124",
+    "hostGAPluginVersion": "1.0.8.133",
     "vmSettingsSchemaVersion": "0.0",
     "activityId": "a33f6f53-43d6-4625-b322-1a39651a00c9",
     "correlationId": "9a47a2a2-e740-4bfc-b11b-4f2f7cfe7d2e",


### PR DESCRIPTION
HostGAPlugin < 133 will fail requests to download extension artifacts when using Fast Track. 