### PR TITLE
reset the quotas when agent drop the cgroup support 

### DIFF
--- a/azurelinuxagent/common/cgroupconfigurator.py
+++ b/azurelinuxagent/common/cgroupconfigurator.py
@@ -18,6 +18,7 @@ import glob
 import json
 import os
 import re
+import shutil
 import subprocess
 import threading
 
@@ -149,6 +150,12 @@ class CGroupConfigurator(object):
             try:
                 if self._initialized:
                     return
+                # This check is to reset the quotas if agent goes from cgroup supported to unsupported distros later in time.
+                if not CGroupsApi.cgroups_supported():
+                    agent_drop_in_path = systemd.get_agent_drop_in_path()
+                    if os.path.exists(agent_drop_in_path) and os.path.isdir(agent_drop_in_path):
+                        shutil.rmtree(agent_drop_in_path)
+                        self.__reload_systemd_config()
 
                 # check whether cgroup monitoring is supported on the current distro
                 self._cgroups_supported = CGroupsApi.cgroups_supported()


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
Cleanup the drop file files to reset the quotas when agent drop the cgroup support from supported list of distros

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).