### PR TITLE
Create individual log files for each (distro, test suite) pair

### DIFF
--- a/tests_e2e/orchestrator/lib/agent_test_suite.py
+++ b/tests_e2e/orchestrator/lib/agent_test_suite.py
@@ -282,7 +282,6 @@ class AgentTestSuite(TestSuite):
                     except AssertionError as e:
                         failed.append(test.__name__)
                         result = f"[Failed] {test_full_name}"
-                        self._log.error("%s", e)
                         agent_test_logger.error("%s", e)
                         self._log.error("%s", e)
                     except:  # pylint: disable=bare-except

--- a/tests_e2e/orchestrator/scripts/run-scenarios
+++ b/tests_e2e/orchestrator/scripts/run-scenarios
@@ -35,10 +35,15 @@ cp "$HOME/id_rsa" "$HOME/.ssh"
 chmod 700 "$HOME/.ssh/id_rsa"
 ssh-keygen -y -f "$HOME/.ssh/id_rsa" > "$HOME/.ssh/id_rsa.pub"
 
+#
 # Now start the runbook
+#
+lisa_logs="$HOME/logs/lisa"
+
 lisa \
   --runbook "$HOME/WALinuxAgent/tests_e2e/scenarios/runbooks/daily.yml" \
-  --log_path "$HOME/logs" \
-  --working_path "$HOME/logs" \
+  --log_path "$lisa_logs" \
+  --working_path "$lisa_logs" \
   -v subscription_id:"$SUBSCRIPTION_ID" \
-  -v identity_file:"$HOME/.ssh/id_rsa"
+  -v identity_file:"$HOME/.ssh/id_rsa" \
+  || true # force a success exit code to allow execution to continue when a test fails

--- a/tests_e2e/pipeline/scripts/execute_tests.sh
+++ b/tests_e2e/pipeline/scripts/execute_tests.sh
@@ -29,17 +29,17 @@ docker run --rm \
 sudo chown "$USER" "$BUILD_SOURCESDIRECTORY"
 sudo find "$BUILD_ARTIFACTSTAGINGDIRECTORY" -exec chown "$USER" {} \;
 
-# LISA organizes its logs in a tree similar to
+# The LISA run will produce a tree similar to
 #
-#    .../20221130
-#    .../20221130/20221130-160013-749
-#    .../20221130/20221130-160013-749/environments
-#    .../20221130/20221130-160013-749/lisa-20221130-160013-749.log
-#    .../20221130/20221130-160013-749/lisa.junit.xml
+#    $BUILD_ARTIFACTSTAGINGDIRECTORY/lisa/20221130
+#    $BUILD_ARTIFACTSTAGINGDIRECTORY/lisa/20221130/20221130-160013-749
+#    $BUILD_ARTIFACTSTAGINGDIRECTORY/lisa/20221130/20221130-160013-749/environments
+#    $BUILD_ARTIFACTSTAGINGDIRECTORY/lisa/20221130/20221130-160013-749/lisa-20221130-160013-749.log
+#    $BUILD_ARTIFACTSTAGINGDIRECTORY/lisa/20221130/20221130-160013-749/lisa.junit.xml
 #    etc
 #
-# Remove the first 2 levels of the tree (which indicate the time of the test run) to make navigation
+# Remove the 2 levels of the tree that indicate the time of the test run to make navigation
 # in the Azure Pipelines UI easier.
 #
-mv "$BUILD_ARTIFACTSTAGINGDIRECTORY"/[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]/*/* "$BUILD_ARTIFACTSTAGINGDIRECTORY"
-rm -r "$BUILD_ARTIFACTSTAGINGDIRECTORY"/[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]
+mv "$BUILD_ARTIFACTSTAGINGDIRECTORY"/lisa/[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]/*/* "$BUILD_ARTIFACTSTAGINGDIRECTORY"/lisa
+rm -r "$BUILD_ARTIFACTSTAGINGDIRECTORY"/lisa/[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]

--- a/tests_e2e/scenarios/lib/agent_test_context.py
+++ b/tests_e2e/scenarios/lib/agent_test_context.py
@@ -32,8 +32,7 @@ class AgentTestContext:
           concurrency level of the runbook.
     """
     class Paths:
-        # E1101: Instance of 'list' has no '_path' member (no-member)
-        DEFAULT_TEST_SOURCE_DIRECTORY = Path(tests_e2e.__path__._path[0])  # pylint: disable=E1101
+        DEFAULT_TEST_SOURCE_DIRECTORY = Path(tests_e2e.__path__[0])
 
         def __init__(
             self,

--- a/tests_e2e/scenarios/lib/logging.py
+++ b/tests_e2e/scenarios/lib/logging.py
@@ -14,24 +14,112 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import logging
 
 #
-# This module defines a single object, 'log', which test use for logging.
-#
-# When the test is invoked as part of a LISA test suite, 'log' references the LISA root logger.
-# Otherwise, it references a new Logger named 'waagent'.
+# This module defines a single object, 'log', of type AgentLogger, which the end-to-end tests and libraries use
+# for logging.
 #
 
-log: logging.Logger = logging.getLogger("lisa")
+from logging import FileHandler, Formatter, Handler, Logger, StreamHandler, INFO
+from pathlib import  Path
+from threading import current_thread
+from typing import Dict, Callable
 
-if not log.hasHandlers():
-    log = logging.getLogger("waagent")
-    console_handler = logging.StreamHandler()
-    log.addHandler(console_handler)
 
-log.setLevel(logging.INFO)
+class _AgentLoggingHandler(Handler):
+    """
+    AgentLoggingHandler is a helper class for AgentLogger.
 
-formatter = logging.Formatter('%(asctime)s.%(msecs)03d [%(levelname)s] [%(threadName)s] %(message)s', datefmt="%Y-%m-%dT%H:%M:%SZ")
-for handler in log.handlers:
-    handler.setFormatter(formatter)
+    This handler simply redirects logging to other handlers. It maintains a set of FileHandlers associated to specific
+    threads. When a thread emits a log record, the AgentLoggingHandler passes through the call to the FileHandlers
+    associated with that thread, or to a StreamHandler that outputs to stdout if there is not a FileHandler for that
+    thread.
+
+    Thread can set a FileHandler for themselves using _AgentLoggingHandler.set_current_thread_log() and remove that
+    handler using _AgentLoggingHandler.close_current_thread_log().
+
+    The _AgentLoggingHandler simply passes through calls to setLevel, setFormatter, flush, and close to the handlers
+    it maintains.
+
+    AgentLoggingHandler is meant to be primarily used in multithreaded scenarios and is thread-safe.
+    """
+    def __init__(self):
+        super().__init__()
+        self.formatter: Formatter = _AgentLoggingHandler.create_formatter()
+        self.default_handler = StreamHandler()
+        self.default_handler.setFormatter(self.formatter)
+        self.per_thread_handlers: Dict[int, FileHandler] = {}
+
+    @staticmethod
+    def create_formatter() -> Formatter:
+        return Formatter('%(asctime)s.%(msecs)03d [%(levelname)s] %(message)s', datefmt="%Y-%m-%dT%H:%M:%SZ")
+
+    def set_thread_log(self, thread_ident: int, log_file: Path) -> None:
+        self.close_current_thread_log()
+        handler: FileHandler = FileHandler(str(log_file))
+        handler.setFormatter(self.formatter)
+        self.per_thread_handlers[thread_ident] = handler
+
+    def close_thread_log(self, thread_ident: int) -> None:
+        handler = self.per_thread_handlers.pop(thread_ident, None)
+        if handler is not None:
+            handler.close()
+
+    def set_current_thread_log(self, log_file: Path) -> None:
+        self.set_thread_log(current_thread().ident, log_file)
+
+    def close_current_thread_log(self) -> None:
+        self.close_thread_log(current_thread().ident)
+
+    def emit(self, record) -> None:
+        handler = self.per_thread_handlers.get(current_thread().ident)
+        if handler is None:
+            handler = self.default_handler
+        handler.emit(record)
+
+    def setLevel(self, level) -> None:
+        self._for_each_handler(lambda h: h.setLevel(level))
+
+    def setFormatter(self, fmt) -> None:
+        self._for_each_handler(lambda h: h.setFormatter(fmt))
+
+    def flush(self) -> None:
+        self._for_each_handler(lambda h: h.flush())
+
+    def close(self) -> None:
+        self._for_each_handler(lambda h: h.close())
+
+    def _for_each_handler(self, op: Callable[[Handler], None]) -> None:
+        op(self.default_handler)
+        # copy of the values into a new list in case the dictionary changes while we are iterating
+        for handler in list(self.per_thread_handlers.values()):
+            op(handler)
+
+
+class AgentLogger(Logger):
+    """
+    AgentLogger is a Logger customized for agent test scenarios. When tests are executed from the command line
+    (for example, during development) the AgentLogger can be used with its default configuration, which simply
+    outputs to stdout. When tests are executed from the test framework, typically there are multiple test suites
+    executed concurrently on different threads, and each test suite must have its own log file; in that case,
+    each thread can call AgentLogger.set_current_thread_log() to send all the logging from that thread to a
+    particular file.
+    """
+    def __init__(self):
+        super().__init__(name="waagent", level=INFO)
+        self._handler: _AgentLoggingHandler = _AgentLoggingHandler()
+        self.addHandler(self._handler)
+
+    @staticmethod
+    def create_formatter() -> Formatter:
+        return _AgentLoggingHandler.create_formatter()
+
+    def set_current_thread_log(self, log_file: Path) -> None:
+        self._handler.set_current_thread_log(log_file)
+
+    def close_current_thread_log(self) -> None:
+        self._handler.close_current_thread_log()
+
+
+log: AgentLogger = AgentLogger()
+

--- a/tests_e2e/scenarios/lib/logging.py
+++ b/tests_e2e/scenarios/lib/logging.py
@@ -45,14 +45,10 @@ class _AgentLoggingHandler(Handler):
     """
     def __init__(self):
         super().__init__()
-        self.formatter: Formatter = _AgentLoggingHandler.create_formatter()
+        self.formatter: Formatter = Formatter('%(asctime)s.%(msecs)03d [%(levelname)s] %(message)s', datefmt="%Y-%m-%dT%H:%M:%SZ")
         self.default_handler = StreamHandler()
         self.default_handler.setFormatter(self.formatter)
         self.per_thread_handlers: Dict[int, FileHandler] = {}
-
-    @staticmethod
-    def create_formatter() -> Formatter:
-        return Formatter('%(asctime)s.%(msecs)03d [%(levelname)s] %(message)s', datefmt="%Y-%m-%dT%H:%M:%SZ")
 
     def set_thread_log(self, thread_ident: int, log_file: Path) -> None:
         self.close_current_thread_log()
@@ -110,9 +106,11 @@ class AgentLogger(Logger):
         self._handler: _AgentLoggingHandler = _AgentLoggingHandler()
         self.addHandler(self._handler)
 
-    @staticmethod
-    def create_formatter() -> Formatter:
-        return _AgentLoggingHandler.create_formatter()
+    def set_thread_log(self, thread_ident: int, log_file: Path) -> None:
+        self._handler.set_thread_log(thread_ident, log_file)
+
+    def close_thread_log(self, thread_ident: int) -> None:
+        self._handler.close_thread_log(thread_ident)
 
     def set_current_thread_log(self, log_file: Path) -> None:
         self._handler.set_current_thread_log(log_file)

--- a/tests_e2e/scenarios/runbooks/daily.yml
+++ b/tests_e2e/scenarios/runbooks/daily.yml
@@ -55,11 +55,11 @@ combinator:
   items:
     - name: marketplace_image
       value:
-#        - "Canonical UbuntuServer 18.04-LTS latest"
-#        - "Debian debian-10 10 latest"
-#        - "OpenLogic CentOS 7_9 latest"
-#        - "SUSE sles-15-sp2-basic gen2 latest"
-#        - "RedHat RHEL 7-RAW latest"
+        - "Canonical UbuntuServer 18.04-LTS latest"
+        - "Debian debian-10 10 latest"
+        - "OpenLogic CentOS 7_9 latest"
+        - "SUSE sles-15-sp2-basic gen2 latest"
+        - "RedHat RHEL 7-RAW latest"
         - "microsoftcblmariner cbl-mariner cbl-mariner-1 latest"
         - "microsoftcblmariner cbl-mariner cbl-mariner-2 latest"
         #

--- a/tests_e2e/scenarios/runbooks/daily.yml
+++ b/tests_e2e/scenarios/runbooks/daily.yml
@@ -55,13 +55,18 @@ combinator:
   items:
     - name: marketplace_image
       value:
-        - "Canonical UbuntuServer 18.04-LTS latest"
-        - "Debian debian-10 10 latest"
-        - "OpenLogic CentOS 7_9 latest"
-        - "SUSE sles-15-sp2-basic gen2 latest"
-        - "RedHat RHEL 7-RAW latest"
+#        - "Canonical UbuntuServer 18.04-LTS latest"
+#        - "Debian debian-10 10 latest"
+#        - "OpenLogic CentOS 7_9 latest"
+#        - "SUSE sles-15-sp2-basic gen2 latest"
+#        - "RedHat RHEL 7-RAW latest"
         - "microsoftcblmariner cbl-mariner cbl-mariner-1 latest"
         - "microsoftcblmariner cbl-mariner cbl-mariner-2 latest"
+        #
+        #  TODO: Addd this distro, currently available in eastus
+        #
+        # - "microsoftcblmariner cbl-mariner cbl-mariner-2-arm64 latest"
+        #
 
 concurrency: 10
 

--- a/tests_e2e/scenarios/runbooks/daily.yml
+++ b/tests_e2e/scenarios/runbooks/daily.yml
@@ -63,7 +63,7 @@ combinator:
         - "microsoftcblmariner cbl-mariner cbl-mariner-1 latest"
         - "microsoftcblmariner cbl-mariner cbl-mariner-2 latest"
         #
-        #  TODO: Addd this distro, currently available in eastus
+        #  TODO: Add this distro, currently available in eastus
         #
         # - "microsoftcblmariner cbl-mariner cbl-mariner-2-arm64 latest"
         #

--- a/tests_e2e/scenarios/tests/error_test.py
+++ b/tests_e2e/scenarios/tests/error_test.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+# Microsoft Azure Linux Agent
+#
+# Copyright 2018 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from tests_e2e.scenarios.lib.agent_test import AgentTest
+
+
+class ErrorTest(AgentTest):
+    """
+    A trivial test that errors out
+    """
+    def run(self):
+        raise Exception("* ERROR *")
+
+
+if __name__ == "__main__":
+    ErrorTest.run_from_command_line()

--- a/tests_e2e/scenarios/tests/fail_test.py
+++ b/tests_e2e/scenarios/tests/fail_test.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+
+# Microsoft Azure Linux Agent
+#
+# Copyright 2018 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from assertpy import fail
+from tests_e2e.scenarios.lib.agent_test import AgentTest
+
+
+class FailTest(AgentTest):
+    """
+    A trivial test that fails
+    """
+    def run(self):
+        fail("* FAILED *")
+
+
+if __name__ == "__main__":
+    FailTest.run_from_command_line()

--- a/tests_e2e/scenarios/tests/pass_test.py
+++ b/tests_e2e/scenarios/tests/pass_test.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+
+# Microsoft Azure Linux Agent
+#
+# Copyright 2018 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from tests_e2e.scenarios.lib.agent_test import AgentTest
+from tests_e2e.scenarios.lib.logging import log
+
+
+class PassTest(AgentTest):
+    """
+    A trivial test that passes.
+    """
+    def run(self):
+        log.info("* PASSED *")
+
+
+if __name__ == "__main__":
+    PassTest.run_from_command_line()

--- a/tests_e2e/scenarios/testsuites/agent_bvt.py
+++ b/tests_e2e/scenarios/testsuites/agent_bvt.py
@@ -22,6 +22,7 @@ from tests_e2e.scenarios.tests.bvts.run_command import RunCommandBvt
 
 # E0401: Unable to import 'lisa' (import-error)
 from lisa import (  # pylint: disable=E0401
+    Logger,
     Node,
     TestCaseMetadata,
     TestSuiteMetadata,
@@ -34,15 +35,13 @@ class AgentBvt(AgentTestSuite):
     Test suite for Agent BVTs
     """
     @TestCaseMetadata(description="", priority=0)
-    def main(self, node: Node) -> None:
+    def main(self, node: Node, log: Logger) -> None:
         self.execute(
             node,
+            log,
             [
                 ExtensionOperationsBvt,  # Tests the basic operations (install, enable, update, uninstall) using CustomScript
                 RunCommandBvt,
                 VmAccessBvt
             ]
         )
-
-
-


### PR DESCRIPTION
Now we create separate log files for each pair of (distro, test suite).

Test suites are executed concurrently on different threads. These changes include a thread-safe logging.Handler that multiplexes log output to the proper file. When writing multi-threaded tests a little extra setup is needed; I'll document that in the wiki and go over the documentation with the team.