### PR TITLE
Also support use of unittest.mock

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,7 +2,6 @@ codecov
 coverage
 mock==2.0.0; python_version == '2.6'
 mock==3.0.5; python_version >= '2.7' and python_version <= '3.5'
-mock==4.0.2; python_version >= '3.6'
 distro; python_version >= '3.8'
 nose
 nose-timer; python_version >= '2.7'

--- a/tests/common/dhcp/test_dhcp.py
+++ b/tests/common/dhcp/test_dhcp.py
@@ -15,7 +15,10 @@
 # Requires Python 2.6+ and Openssl 1.0+
 #
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import azurelinuxagent.common.dhcp as dhcp
 import azurelinuxagent.common.osutil.default as osutil
 from tests.tools import AgentTestCase, open_patch, patch

--- a/tests/common/osutil/test_default.py
+++ b/tests/common/osutil/test_default.py
@@ -22,7 +22,10 @@ import subprocess
 import tempfile
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 import azurelinuxagent.common.conf as conf
 import azurelinuxagent.common.osutil.default as osutil

--- a/tests/common/test_event.py
+++ b/tests/common/test_event.py
@@ -26,7 +26,10 @@ import threading
 import xml.dom
 from datetime import datetime, timedelta
 
-from mock import MagicMock
+try:
+    from unittest.mock import MagicMock
+except ImportError:
+    from mock import MagicMock
 
 from azurelinuxagent.common.utils import textutil, fileutil
 from azurelinuxagent.common import event, logger

--- a/tests/common/test_version.py
+++ b/tests/common/test_version.py
@@ -20,7 +20,10 @@ from __future__ import print_function
 import os
 import textwrap
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 import azurelinuxagent.common.conf as conf
 from azurelinuxagent.common.future import ustr

--- a/tests/distro/test_scvmm.py
+++ b/tests/distro/test_scvmm.py
@@ -20,7 +20,10 @@
 import os
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 import azurelinuxagent.daemon.scvmm as scvmm
 from azurelinuxagent.common import conf

--- a/tests/ga/mocks.py
+++ b/tests/ga/mocks.py
@@ -17,7 +17,10 @@
 
 import contextlib
 
-from mock import PropertyMock
+try:
+    from unittest.mock import PropertyMock
+except ImportError:
+    from mock import PropertyMock
 from azurelinuxagent.ga.exthandlers import ExtHandlersHandler
 from azurelinuxagent.ga.remoteaccess import RemoteAccessHandler
 from azurelinuxagent.ga.update import UpdateHandler, get_update_handler

--- a/tests/ga/test_collect_telemetry_events.py
+++ b/tests/ga/test_collect_telemetry_events.py
@@ -26,7 +26,10 @@ import string
 import uuid
 from collections import defaultdict
 
-from mock import patch, MagicMock
+try:
+    from unittest.mock import patch, MagicMock
+except ImportError:
+    from mock import patch, MagicMock
 
 from azurelinuxagent.common import conf
 from azurelinuxagent.common.event import EVENTS_DIRECTORY

--- a/tests/ga/test_remoteaccess_handler.py
+++ b/tests/ga/test_remoteaccess_handler.py
@@ -16,7 +16,10 @@
 #
 from datetime import timedelta, datetime
 
-from mock import Mock, MagicMock
+try:
+    from unittest.mock import Mock, MagicMock
+except ImportError:
+    from mock import Mock, MagicMock
 from azurelinuxagent.common.osutil.default import DefaultOSUtil
 from azurelinuxagent.common.protocol.goal_state import RemoteAccess
 from azurelinuxagent.common.protocol.util import ProtocolUtil

--- a/tests/ga/test_send_telemetry_events.py
+++ b/tests/ga/test_send_telemetry_events.py
@@ -24,7 +24,10 @@ import time
 import uuid
 from datetime import datetime, timedelta
 
-from mock import MagicMock, Mock, patch, PropertyMock
+try:
+    from unittest.mock import MagicMock, Mock, patch, PropertyMock
+except ImportError:
+    from mock import MagicMock, Mock, patch, PropertyMock
 
 from azurelinuxagent.common import logger
 from azurelinuxagent.common.datacontract import get_properties

--- a/tests/ga/test_update.py
+++ b/tests/ga/test_update.py
@@ -26,7 +26,10 @@ import azurelinuxagent.common.osutil.default as osutil
 
 _ORIGINAL_POPEN = subprocess.Popen
 
-from mock import PropertyMock
+try:
+    from unittest.mock import PropertyMock
+except ImportError:
+    from mock import PropertyMock
 
 from azurelinuxagent.common import conf
 from azurelinuxagent.common.event import EVENTS_DIRECTORY, WALAEventOperation

--- a/tests/utils/test_network_util.py
+++ b/tests/utils/test_network_util.py
@@ -16,7 +16,10 @@
 #
 import subprocess
 
-from mock.mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 import azurelinuxagent.common.utils.networkutil as networkutil
 from tests.tools import AgentTestCase


### PR DESCRIPTION
## Description

Python 3.4 and above include mock in the standard library, as 'unittest.mock'. Try and import that first, and then fall back to using the external mock library. Also, o not install mock for Python 3.6+ during CI.

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [x] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).