### PR TITLE
Add support for Azure clouds

### DIFF
--- a/tests_e2e/orchestrator/lib/agent_test_suite_combinator.py
+++ b/tests_e2e/orchestrator/lib/agent_test_suite_combinator.py
@@ -26,6 +26,9 @@ class AgentTestSuitesCombinatorSchema(schema.Combinator):
     test_suites: str = field(
         default_factory=str, metadata=field_metadata(required=True)
     )
+    cloud: str = field(
+        default_factory=str, metadata=field_metadata(required=True)
+    )
     image: str = field(
         default_factory=str, metadata=field_metadata(required=True)
     )
@@ -58,6 +61,9 @@ class AgentTestSuitesCombinator(Combinator):
         self._environments = self.create_environment_list()
         self._index = 0
 
+        if self.runbook.cloud not in self._DEFAULT_LOCATIONS:
+            raise Exception(f"Invalid cloud: {self.runbook.cloud}")
+
     @classmethod
     def type_name(cls) -> str:
         return "agent_test_suites"
@@ -73,7 +79,11 @@ class AgentTestSuitesCombinator(Combinator):
             self._index += 1
         return result
 
-    _DEFAULT_LOCATION = "westus2"
+    _DEFAULT_LOCATIONS = {
+        "china": "china north 2",
+        "government": "usgovarizona",
+        "public": "westus2"
+    }
 
     def create_environment_list(self) -> List[Dict[str, Any]]:
         loader = AgentTestLoader(self.runbook.test_suites)
@@ -138,7 +148,7 @@ class AgentTestSuitesCombinator(Combinator):
                 elif len(image.locations) > 0:
                     location = image.locations[0]
                 else:
-                    location = AgentTestSuitesCombinator._DEFAULT_LOCATION
+                    location = AgentTestSuitesCombinator._DEFAULT_LOCATIONS[self.runbook.cloud]
 
                 # If the runbook specified a VM size, use it. Else if the image specifies a list of VM sizes, use any of them. Otherwise,
                 # set the size to empty and let LISA choose it.

--- a/tests_e2e/orchestrator/runbook.yml
+++ b/tests_e2e/orchestrator/runbook.yml
@@ -50,6 +50,8 @@ variable:
   # The test suites to execute
   - name: test_suites
     value: "agent_bvt"
+  - name: cloud
+    value: "public"
   - name: image
     value: ""
   - name: location
@@ -119,6 +121,7 @@ platform:
 combinator:
   type: agent_test_suites
   test_suites: $(test_suites)
+  cloud: $(cloud)
   image: $(image)
   location: $(location)
   vm_size: $(vm_size)

--- a/tests_e2e/pipeline/pipeline.yml
+++ b/tests_e2e/pipeline/pipeline.yml
@@ -1,3 +1,9 @@
+# variables:
+  #
+  # NOTE: When creating the pipeline, "connection_info" must be added as a variable pointing to the
+  #       corresponding key vault; see wiki for details.
+  #
+
 parameters:
     # See the test wiki for a description of the parameters
   - name: test_suites
@@ -44,23 +50,6 @@ parameters:
     - failed
     - no
 
-variables:
-  - name: azureConnection
-    value: 'azuremanagement'
-    # These variables exposed the above parameters as environment variables
-  - name: test_suites
-    value: ${{ parameters.test_suites }}
-  - name: image
-    value: ${{ parameters.image }}
-  - name: location
-    value: ${{ parameters.location }}
-  - name: vm_size
-    value: ${{ parameters.vm_size }}
-  - name: collect_logs
-    value: ${{ parameters.collect_logs }}
-  - name: keep_environment
-    value: ${{ parameters.keep_environment }}
-
 trigger:
   - develop
 
@@ -73,20 +62,6 @@ jobs:
   - job: "ExecuteTests"
 
     steps:
-      - task: DownloadSecureFile@1
-        name: downloadSshKey
-        displayName: "Download SSH key"
-        inputs:
-          secureFile: 'id_rsa'
-
-      - task: AzureKeyVault@2
-        displayName: "Fetch secrets from KV"
-        inputs:
-          azureSubscription: '$(azureConnection)'
-          KeyVaultName: 'dcrV2SPs'
-          SecretsFilter: '*'
-          RunAsPreJob: true
-
       - task: UsePythonVersion@0
         displayName: "Set Python Version"
         inputs:
@@ -94,15 +69,41 @@ jobs:
           addToPath: true
           architecture: 'x64'
 
+      # Extract the Azure cloud from the "connection_info" variable and store it in the "cloud" variable.
+      # The cloud name is used as a suffix of the value for "connection_info" and comes after the last '-'.
+      - bash: echo "##vso[task.setvariable variable=cloud]$(echo $CONNECTION_INFO | sed 's/^.*-//')"
+        displayName: "Set Cloud type"
+
+      - task: DownloadSecureFile@1
+        name: downloadSshKey
+        displayName: "Download SSH key"
+        inputs:
+          secureFile: 'id_rsa'
+
+      - task: AzureKeyVault@2
+        displayName: "Fetch connection info"
+        inputs:
+          azureSubscription: 'azuremanagement'
+          KeyVaultName: '$(connection_info)'
+          SecretsFilter: '*'
+
       - bash: $(Build.SourcesDirectory)/tests_e2e/pipeline/scripts/execute_tests.sh
         displayName: "Execute tests"
         continueOnError: true
         env:
-          # Add all KeyVault secrets explicitly as they're not added by default to the environment vars
+          SUBSCRIPTION_ID: $(SUBSCRIPTION-ID)
           AZURE_CLIENT_ID: $(AZURE-CLIENT-ID)
           AZURE_CLIENT_SECRET: $(AZURE-CLIENT-SECRET)
           AZURE_TENANT_ID: $(AZURE-TENANT-ID)
-          SUBSCRIPTION_ID: $(SUBSCRIPTION-ID)
+          CR_USER: $(CR-USER)
+          CR_SECRET: $(CR-SECRET)
+          CLOUD: ${{ variables.cloud }}
+          COLLECT_LOGS: ${{ parameters.collect_logs }}
+          IMAGE: ${{ parameters.image }}
+          KEEP_ENVIRONMENT: ${{ parameters.keep_environment }}
+          LOCATION: ${{ parameters.location }}
+          TEST_SUITES: ${{ parameters.test_suites }}
+          VM_SIZE: ${{ parameters.vm_size }}
 
       - publish: $(Build.ArtifactStagingDirectory)
         artifact: 'artifacts'

--- a/tests_e2e/pipeline/scripts/execute_tests.sh
+++ b/tests_e2e/pipeline/scripts/execute_tests.sh
@@ -24,9 +24,7 @@ sudo chown 1000 "$BUILD_ARTIFACTSTAGINGDIRECTORY"
 #
 # Pull the container image used to execute the tests
 #
-az login --service-principal --username "$AZURE_CLIENT_ID" --password "$AZURE_CLIENT_SECRET" --tenant "$AZURE_TENANT_ID" > /dev/null
-
-az acr login --name waagenttests
+az acr login --name waagenttests --username "$CR_USER" --password "$CR_SECRET"
 
 docker pull waagenttests.azurecr.io/waagenttests:latest
 
@@ -59,6 +57,7 @@ docker run --rm \
           --runbook \$HOME/WALinuxAgent/tests_e2e/orchestrator/runbook.yml \
           --log_path \$HOME/logs/lisa \
           --working_path \$HOME/logs/lisa \
+          -v cloud:$CLOUD \
           -v subscription_id:$SUBSCRIPTION_ID \
           -v identity_file:\$HOME/.ssh/id_rsa \
           -v test_suites:\"$TEST_SUITES\" \


### PR DESCRIPTION
This PR adds support for executing the Azure pipeline on different clouds.

It adds a new variable to the pipeline, 'connection_info' which points to the keyvault where the connection parameters are stored. 

It also separates the identity used to connect to the container registry from the identity used for management operations (create VMs, execute extensions, etc).

Lastly, it adds a new parameter, 'cloud' to the LISA runbook.