### PR TITLE
Fix bug in get_dhcp_pid (CoreOS)

### DIFF
--- a/azurelinuxagent/common/osutil/coreos.py
+++ b/azurelinuxagent/common/osutil/coreos.py
@@ -17,7 +17,7 @@
 #
 
 import os
-import azurelinuxagent.common.utils.shellutil as shellutil
+from azurelinuxagent.common.utils import shellutil
 from azurelinuxagent.common.osutil.default import DefaultOSUtil
 
 
@@ -78,7 +78,9 @@ class CoreOSUtil(DefaultOSUtil):
         return shellutil.run("systemctl stop {0}".format(self.service_name), chk_err=False)
 
     def get_dhcp_pid(self):
-        return self._get_dhcp_pid(["systemctl", "show", "-p", "MainPID", "systemd-networkd"])
+        return self._get_dhcp_pid(
+            ["systemctl", "show", "-p", "MainPID", "systemd-networkd"],
+            transform_command_output=lambda o: o.replace("MainPID=", ""))
 
     def conf_sshd(self, disable_password):
         # In CoreOS, /etc/sshd_config is mount readonly.  Skip the setting.

--- a/azurelinuxagent/common/osutil/default.py
+++ b/azurelinuxagent/common/osutil/default.py
@@ -36,11 +36,11 @@ from pwd import getpwall
 
 import array
 
-import azurelinuxagent.common.conf as conf
-import azurelinuxagent.common.logger as logger
-import azurelinuxagent.common.utils.fileutil as fileutil
-import azurelinuxagent.common.utils.shellutil as shellutil
-import azurelinuxagent.common.utils.textutil as textutil
+from azurelinuxagent.common import conf
+from azurelinuxagent.common import logger
+from azurelinuxagent.common.utils import fileutil
+from azurelinuxagent.common.utils import shellutil
+from azurelinuxagent.common.utils import textutil
 
 from azurelinuxagent.common.exception import OSUtilError
 from azurelinuxagent.common.future import ustr, array_to_bytes
@@ -1137,9 +1137,12 @@ class DefaultOSUtil(object):
         return [int(n) for n in text.split()]
 
     @staticmethod
-    def _get_dhcp_pid(command):
+    def _get_dhcp_pid(command, transform_command_output=None):
         try:
-            return DefaultOSUtil._text_to_pid_list(shellutil.run_command(command))
+            output = shellutil.run_command(command)
+            if transform_command_output is not None:
+                output = transform_command_output(output)
+            return DefaultOSUtil._text_to_pid_list(output)
         except CommandError as exception:  # pylint: disable=W0612
             return []
 


### PR DESCRIPTION
CoreOs and derivatives (e.g. Flatcar) use "systemctl show -p MainPID systemd-networkd" to get the PID of the DHCP client. This command will return something similar to "`MainPID=<PID>`", while the existing code expects only an int (the "`<PID>`" part). This is a very old bug exposed by adding Flatcar to the tests.

The fix removes "MainPID=" from the command's output.

The PR also includes some fixes for pylint pointing out issues in import statements.