### PR TITLE
Support int type for eventPid and eventTid fields

### DIFF
--- a/azurelinuxagent/ga/collect_telemetry_events.py
+++ b/azurelinuxagent/ga/collect_telemetry_events.py
@@ -58,6 +58,8 @@ class ExtensionEventSchema(object):
            "EventTid":"2",
            "OperationId":"Guid (str)"
         }
+
+    From next version(2.10+) we accept integer values for EventPid and EventTid fields. But we still support string type for backward compatability
     """
     Version = "Version"
     Timestamp = "Timestamp"
@@ -323,15 +325,20 @@ class _ProcessExtensionEvents(PeriodicOperation):
         :param extension_event: The json event from file
         :return: Verified Json event that qualifies the contract.
         """
-
-        clean_string = lambda x: x.strip() if x is not None else x
+        def _clean_value(k, v):
+            if v is not None:
+                if isinstance(v, int):
+                    if k.lower() in [ExtensionEventSchema.EventPid.lower(), ExtensionEventSchema.EventTid.lower()]:
+                        return str(v)
+                return v.strip()
+            return v
 
         event_size = 0
         key_err_msg = "{0}: {1} not found"
 
         # Convert the dict to all lower keys to avoid schema confusion.
         # Only pick the params that we care about and skip the rest.
-        event = dict((k.lower(), clean_string(v)) for k, v in extension_event.items() if
+        event = dict((k.lower(), _clean_value(k, v)) for k, v in extension_event.items() if
                      k.lower() in self._EXTENSION_EVENT_REQUIRED_FIELDS)
 
         # Trim message and only pick the first 3k chars

--- a/tests/data/events/extension_events/int_type/1519934744.json
+++ b/tests/data/events/extension_events/int_type/1519934744.json
@@ -1,0 +1,10 @@
+{
+        "EventLevel": "INFO",
+        "Message": "Accept int value for eventpid and eventtid",
+        "Version": "1",
+        "TaskName": "Downloading files",
+        "EventPid": 3228,
+        "EventTid": 1,
+        "OpErAtiOnID": "519e4beb-018a-4bd9-8d8e-c5226cf7f56e",
+        "TimeStamp": "2023-03-13T01:21:05.1960563Z"
+}

--- a/tests/ga/test_collect_telemetry_events.py
+++ b/tests/ga/test_collect_telemetry_events.py
@@ -309,6 +309,16 @@ class TestExtensionTelemetryHandler(AgentTestCase, HttpRequestPredicates):
 
             self._assert_handler_data_in_event_list(telemetry_events, extensions_with_count)
 
+    def test_it_should_parse_int_type_for_eventpid_or_eventtid_properly(self):
+        with self._create_extension_telemetry_processor() as extension_telemetry_processor:
+            extensions_with_count = self._create_random_extension_events_dir_with_events(2, os.path.join(
+                self._TEST_DATA_DIR, "int_type"))
+
+            extension_telemetry_processor.run()
+            telemetry_events = self._get_handlers_with_version(extension_telemetry_processor.event_list)
+
+            self._assert_handler_data_in_event_list(telemetry_events, extensions_with_count)
+
     def _setup_and_assert_tests_for_max_sizes(self, no_of_extensions=2, expected_count=None):
         with self._create_extension_telemetry_processor() as extension_telemetry_processor:
             extensions_with_count = self._create_random_extension_events_dir_with_events(no_of_extensions,


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
Today we only support string value for eventPid and EventTid. As these fields are ids and ids are generally numeric in nature, so changing logic to support int values too. 

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).