### PR TITLE
Redact access tokens from extension's output

### DIFF
--- a/azurelinuxagent/common/utils/extensionprocessutil.py
+++ b/azurelinuxagent/common/utils/extensionprocessutil.py
@@ -88,6 +88,9 @@ def handle_process_completion(process, command, timeout, stdout, stderr, error_c
     return process_output
 
 
+SAS_TOKEN_RE = re.compile(r'(https://\S+\?)((sv|st|se|sr|sp|sip|spr|sig)=\S+)+', flags=re.IGNORECASE)
+
+
 def read_output(stdout, stderr):
     """
     Read the output of the process sent to stdout and stderr and trim them to the max appropriate length.
@@ -106,7 +109,7 @@ def read_output(stdout, stderr):
 
         def redact(s):
             # redact query strings that look like SAS tokens
-            return re.sub(r'(https://\S+\?)((sv|st|se|sr|sp|sip|spr|sig)=\S+)+', r'\1<redacted>', s, flags=re.IGNORECASE)
+            return SAS_TOKEN_RE.sub(r'\1<redacted>', s)
 
         return format_stdout_stderr(redact(stdout), redact(stderr))
     except Exception as e:

--- a/azurelinuxagent/common/utils/extensionprocessutil.py
+++ b/azurelinuxagent/common/utils/extensionprocessutil.py
@@ -18,6 +18,7 @@
 #
 
 import os
+import re
 import signal
 import time
 
@@ -103,7 +104,11 @@ def read_output(stdout, stderr):
         stderr = ustr(stderr.read(TELEMETRY_MESSAGE_MAX_LEN), encoding='utf-8',
                       errors='backslashreplace')
 
-        return format_stdout_stderr(stdout, stderr)
+        def redact(s):
+            # redact query strings that look like SAS tokens
+            return re.sub(r'(https://\S+\?)((sv|st|se|sr|sp|sip|spr|sig)=\S+)+', r'\1<redacted>', s, flags=re.IGNORECASE)
+
+        return format_stdout_stderr(redact(stdout), redact(stderr))
     except Exception as e:
         return format_stdout_stderr("", "Cannot read stdout/stderr: {0}".format(ustr(e)))
 

--- a/tests/ga/test_extension.py
+++ b/tests/ga/test_extension.py
@@ -3418,7 +3418,7 @@ class TestExtension(TestExtensionBase, HttpRequestPredicates):
                     self._assert_handler_status(protocol.report_vm_status, "Ready", 1, "1.0.0")
                     self.assertEqual("1", protocol.report_vm_status.call_args[0][0].vmAgent.vm_artifacts_aggregate_status.goal_state_aggregate_status.in_svd_seq_no, "SVD sequence number mismatch")
 
-    def test_it_should_(self):
+    def test_it_should_redact_access_tokens_in_extension_output(self):
         original = r'''ONE https://foo.blob.core.windows.net/bar?sv=2000&ss=bfqt&srt=sco&sp=rw&se=2025&st=2022&spr=https&sig=SI%3D
             TWO:HTTPS://bar.blob.core.com/foo/bar/foo.txt?sv=2018&sr=b&sig=Yx%3D&st=2023%3A52Z&se=9999%3A59%3A59Z&sp=r TWO
             https://bar.com/foo?uid=2018&sr=b THREE'''


### PR DESCRIPTION
Redact URIs that look like SAS tokens when capturing the stdout/stderr of extensions.