### PR TITLE
Port NSBSD system to the latest version of waagent

### DIFF
--- a/azurelinuxagent/agent.py
+++ b/azurelinuxagent/agent.py
@@ -104,7 +104,7 @@ class Agent(object):
             if os.path.isfile(ext_log_dir):
                 raise Exception("{0} is a file".format(ext_log_dir))
             if not os.path.isdir(ext_log_dir):
-                fileutil.mkdir(ext_log_dir, mode=0o755, owner="root")
+                fileutil.mkdir(ext_log_dir, mode=0o755, owner=self.osutil.get_root_username())
         except Exception as e:
             logger.error(
                 "Exception occurred while creating extension "

--- a/azurelinuxagent/common/osutil/default.py
+++ b/azurelinuxagent/common/osutil/default.py
@@ -374,6 +374,9 @@ class DefaultOSUtil(object):
         except KeyError:
             return None
 
+    def get_root_username(self):
+        return "root"
+
     def is_sys_user(self, username):
         """
         Check whether use is a system user. 

--- a/azurelinuxagent/common/osutil/nsbsd.py
+++ b/azurelinuxagent/common/osutil/nsbsd.py
@@ -75,6 +75,9 @@ class NSBSDOSUtil(FreeBSDOSUtil):
         logger.info("{0} SSH password-based authentication methods."
                     .format("Disabled" if disable_password else "Enabled"))
 
+    def get_root_username(self):
+        return "admin"
+
     def useradd(self, username, expiration=None, comment=None):
         """
         Create user account with 'username'

--- a/azurelinuxagent/common/osutil/nsbsd.py
+++ b/azurelinuxagent/common/osutil/nsbsd.py
@@ -37,7 +37,7 @@ class NSBSDOSUtil(FreeBSDOSUtil):
             except ImportError:
                 raise OSUtilError("Python DNS resolver not available. Cannot proceed!")
 
-            self.resolver = dns.resolver.Resolver()
+            self.resolver = dns.resolver.Resolver(configure=False)
             servers = []
             cmd = "getconf /usr/Firewall/ConfigFiles/dns Servers | tail -n +2"
             ret, output = shellutil.run_get_output(cmd)  # pylint: disable=W0612
@@ -47,6 +47,7 @@ class NSBSDOSUtil(FreeBSDOSUtil):
                 server = server[:-1]  # remove last '='
                 cmd = "grep '{}' /etc/hosts".format(server) + " | awk '{print $1}'"
                 ret, ip = shellutil.run_get_output(cmd)
+                ip = ip.strip() # Remove new line char
                 servers.append(ip)
             self.resolver.nameservers = servers
             dns.resolver.override_system_resolver(self.resolver)

--- a/azurelinuxagent/common/osutil/nsbsd.py
+++ b/azurelinuxagent/common/osutil/nsbsd.py
@@ -28,6 +28,7 @@ class NSBSDOSUtil(FreeBSDOSUtil):
 
     def __init__(self):
         super(NSBSDOSUtil, self).__init__()
+        self.agent_conf_file_path = '/etc/waagent.conf'
 
         if self.resolver is None:
             # NSBSD doesn't have a system resolver, configure a python one


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

NSBSD system was lagging behind with an old version of both python and the azure agent. We updated the agent on our appliances, but had to make some small isolated changes to make it work, most of them remain in NSBSD dedicated part.

The only "intrusive" change is the new `get_root_username` function in osutil, as NSBSD root user is named `admin` and not `root`. This causes the log directory creation to fail since by default it is created for the `root` user.

Alternatively, the directory creation function (`fileutil.mkdir`) could directly take the uid,gid of the owner instead of resolving it on its own, which would allow us to pass `0` on both and not introduce a new function.

---

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] (N/A) If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [x] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).