### PR TITLE
Bug fixes for end-to-end tests

### DIFF
--- a/tests_e2e/orchestrator/lib/agent_test_suite.py
+++ b/tests_e2e/orchestrator/lib/agent_test_suite.py
@@ -135,7 +135,7 @@ class AgentTestSuite(LisaTestSuite):
 
         self.__context = self._Context(
             vm=VmIdentifier(
-                cloud=self._get_required_parameter(variables, "c_cloud"),
+                cloud=self._get_required_parameter(variables, "cloud"),
                 location=self._get_required_parameter(variables, "c_location"),
                 subscription=node.features._platform.subscription_id,
                 resource_group=node_context.resource_group_name,
@@ -454,8 +454,6 @@ class AgentTestSuite(LisaTestSuite):
         suite_full_name = f"{suite_name}-{self.context.environment_name}"
         suite_start_time: datetime.datetime = datetime.datetime.now()
 
-        success: bool = True  # True if all the tests succeed
-
         with _set_thread_name(suite_full_name):  # The thread name is added to the LISA log
             log_path: Path = self.context.log_path/f"{suite_full_name}.log"
             with set_current_thread_log(log_path):
@@ -550,7 +548,7 @@ class AgentTestSuite(LisaTestSuite):
                     if not suite_success:
                         self._mark_log_as_failed()
 
-        return success
+                return suite_success
 
     def _check_agent_log(self) -> bool:
         """

--- a/tests_e2e/orchestrator/lib/agent_test_suite_combinator.py
+++ b/tests_e2e/orchestrator/lib/agent_test_suite_combinator.py
@@ -181,7 +181,6 @@ class AgentTestSuitesCombinator(Combinator):
                         c_vm_tags["templates"] = suite_info.template
                     return {
                         "c_marketplace_image": c_marketplace_image,
-                        "c_cloud": self.runbook.cloud,
                         "c_location": c_location,
                         "c_vm_size": c_vm_size,
                         "c_vhd": c_vhd,

--- a/tests_e2e/orchestrator/runbook.yml
+++ b/tests_e2e/orchestrator/runbook.yml
@@ -52,6 +52,7 @@ variable:
     value: "agent_bvt, no_outbound_connections"
   - name: cloud
     value: "AzureCloud"
+    is_case_visible: true
   - name: image
     value: ""
   - name: location
@@ -82,9 +83,6 @@ variable:
     value: ""
   - name: c_vm_size
     value: ""
-  - name: c_cloud
-    value: ""
-    is_case_visible: true
   - name: c_location
     value: ""
     is_case_visible: true

--- a/tests_e2e/orchestrator/sample_runbooks/existing_vm.yml
+++ b/tests_e2e/orchestrator/sample_runbooks/existing_vm.yml
@@ -33,6 +33,7 @@ variable:
   #
   - name: cloud
     value: "AzureCloud"
+    is_case_visible: true
   - name: subscription_id
     value: ""
   - name: resource_group_name
@@ -88,9 +89,6 @@ variable:
     value: ""
   - name: c_shared_resource_group_location
     value: ""
-  - name: c_cloud
-    value: ""
-    is_case_visible: true
   - name: c_location
     value: ""
     is_case_visible: true

--- a/tests_e2e/tests/lib/vm_extension.py
+++ b/tests_e2e/tests/lib/vm_extension.py
@@ -107,9 +107,7 @@ class _VmExtensionBaseClass(ABC):
                 extension_parameters
             ).result(timeout=_TIMEOUT))
 
-        if result.provisioning_state not in ('Succeeded', 'Updating'):
-            raise Exception(f"Enable {self._identifier} failed. Provisioning state: {result.provisioning_state}")
-        log.info("Enable completed (provisioning state: %s).", result.provisioning_state)
+        log.info("Enable completed. Provisioning state: %s", result.provisioning_state)
 
     def get_instance_view(self) -> VirtualMachineExtensionInstanceView:  # TODO: Check type for scale sets
         """


### PR DESCRIPTION
* Logs were not being collected on test failures
* Intermittent errors checking the provisioning state when executing for extensions
* When invoking a runbook on an existing VM, the 'c_cloud' was missing