### PR TITLE
Fixes for end-to-end tests

### DIFF
--- a/tests_e2e/orchestrator/lib/agent_test_suite.py
+++ b/tests_e2e/orchestrator/lib/agent_test_suite.py
@@ -349,7 +349,7 @@ class AgentTestSuite(LisaTestSuite):
         #
         log.info('Installing tools on the test node')
         command = f"tar xf {target_path/tarball_path.name} && ~/bin/install-tools"
-        log.info("%s\n%s", command, self.context.ssh_client.run_command(command))
+        log.info("Remote command [%s] completed:\n%s", command, self.context.ssh_client.run_command(command))
 
         if self.context.is_vhd:
             log.info("Using a VHD; will not install the Test Agent.")

--- a/tests_e2e/orchestrator/scripts/install-agent
+++ b/tests_e2e/orchestrator/scripts/install-agent
@@ -77,18 +77,18 @@ fi
 python=$(get-agent-python)
 waagent=$(get-agent-bin-path)
 
-echo "============================================================"
+echo "========== Initial Status =========="
 echo "Service Name: $service_name"
 echo "Agent Path: $waagent"
 echo "Agent Version:"
 $python "$waagent" --version
 echo "Service Status:"
 service-status $service_name
-echo "============================================================"
 
 #
 # Install the package
 #
+echo "========== Installing Agent =========="
 echo "Installing $package as version $version..."
 unzip.py "$package" "/var/lib/waagent/WALinuxAgent-$version"
 
@@ -116,7 +116,8 @@ service-start $service_name
 echo "Verifying agent installation..."
 
 check-version() {
-  for i in {0..5}
+  # We need to wait for the extension handler to start, give it a couple of minutes
+  for i in {1..12}
   do
     if $python "$waagent" --version | grep -E "Goal state agent:\s+$version" > /dev/null; then
       return 0
@@ -131,10 +132,14 @@ if check-version "$version"; then
   printf "\nThe agent was installed successfully\n"
   exit_code=0
 else
-  printf "\nFailed to install agent.\n"
+  printf "************************************\n"
+  printf " * ERROR: Failed to install agent. *\n"
+  printf "************************************\n"
   exit_code=1
 fi
 
+printf "\n"
+echo "========== Final Status =========="
 $python "$waagent" --version
 printf "\n"
 service-status $service_name

--- a/tests_e2e/tests/lib/agent_log.py
+++ b/tests_e2e/tests/lib/agent_log.py
@@ -393,7 +393,7 @@ class AgentLog(object):
     #     Extension: 2021/03/30 19:45:31 Azure Monitoring Agent for Linux started to handle.
     #                2021/03/30 19:45:31 [Microsoft.Azure.Monitor.AzureMonitorLinuxAgent-1.7.0] cwd is /var/lib/waagent/Microsoft.Azure.Monitor.AzureMonitorLinuxAgent-1.7.0
     #
-    _NEWER_AGENT_RECORD = re.compile(r'(?P<when>[\d-]+T[\d:.]+Z)\s(?P<level>VERBOSE|INFO|WARNING|ERROR)\s(?P<thread>\S+)\s(?P<prefix>(Daemon)|(ExtHandler)|(\[\S+\]))\s(?P<message>.*)')
+    _NEWER_AGENT_RECORD = re.compile(r'(?P<when>[\d-]+T[\d:.]+Z)\s(?P<level>VERBOSE|INFO|WARNING|ERROR)\s(?P<thread>\S+)\s(?P<prefix>(Daemon)|(ExtHandler)|(LogCollector)|(\[\S+\]))\s(?P<message>.*)')
     _2_2_46_AGENT_RECORD = re.compile(r'(?P<when>[\d-]+T[\d:.]+Z)\s(?P<level>VERBOSE|INFO|WARNING|ERROR)\s(?P<thread>)(?P<prefix>Daemon|ExtHandler|\[\S+\])\s(?P<message>.*)')
     _OLDER_AGENT_RECORD = re.compile(r'(?P<when>[\d/]+\s[\d:.]+)\s(?P<level>VERBOSE|INFO|WARNING|ERROR)\s(?P<thread>)(?P<prefix>\S*)\s(?P<message>.*)')
     _EXTENSION_RECORD = re.compile(r'(?P<when>[\d/]+\s[\d:.]+)\s(?P<level>)(?P<thread>)((?P<prefix>\[[^\]]+\])\s)?(?P<message>.*)')


### PR DESCRIPTION
A couple of fixes for issues in the daily test runs

* The install-agent script is failing occasionally because the extension handler takes some time to start.
* Messages from the log collector are messing up the agent log parser
* Improved some messages to make the logs easier to read