### PR TITLE
Wait for service start when setting up test VMs; collect VM logs when…

### DIFF
--- a/tests_e2e/orchestrator/lib/agent_test_suite.py
+++ b/tests_e2e/orchestrator/lib/agent_test_suite.py
@@ -433,7 +433,11 @@ class AgentTestSuite(LisaTestSuite):
                             # its type is List[AgentTestSuite].
                             # E1133: Non-iterable value self.context.test_suites is used in an iterating context (not-an-iterable)
                             install_test_agent = all([suite.install_test_agent for suite in self.context.test_suites])   # pylint: disable=E1133
-                            self._setup_node(install_test_agent)
+                            try:
+                                self._setup_node(install_test_agent)
+                            except:
+                                test_suite_success = False
+                                raise
 
                         for suite in self.context.test_suites:  # pylint: disable=E1133
                             log.info("Executing test suite %s", suite.name)

--- a/tests_e2e/orchestrator/scripts/install-agent
+++ b/tests_e2e/orchestrator/scripts/install-agent
@@ -83,7 +83,22 @@ echo "Agent Path: $waagent"
 echo "Agent Version:"
 $python "$waagent" --version
 echo "Service Status:"
-service-status $service_name
+
+# Sometimes the service can take a while to start; give it a few minutes,
+started=false
+for i in {1..6}
+do
+  if service-status $service_name; then
+    started=true
+    break
+  fi
+  echo "Waiting for service to start..."
+  sleep 30
+done
+if [ $started == false ]; then
+  echo "Service failed to start."
+  exit 1
+fi
 
 #
 # Install the package


### PR DESCRIPTION
The install-agent script fails from time to time because the agent service has not started yet; added a few retries to handle this.

We were not collecting VM logs on setup failures (we were not marking the test suites as failed)