### PR TITLE
Increase concurrency level for end-to-end tests

### DIFF
--- a/tests_e2e/orchestrator/runbook.yml
+++ b/tests_e2e/orchestrator/runbook.yml
@@ -139,7 +139,7 @@ combinator:
   location: $(location)
   vm_size: $(vm_size)
 
-concurrency: 16
+concurrency: 32
 
 notifier:
   - type: agent.junit


### PR DESCRIPTION
Some test runs are timing out. Increasing concurrency level to test more VMs in parallel.