### PR TITLE
Eliminate duplicate list of test suites to run

### DIFF
--- a/tests_e2e/orchestrator/runbook.yml
+++ b/tests_e2e/orchestrator/runbook.yml
@@ -49,7 +49,7 @@ variable:
   #
   # The test suites to execute
   - name: test_suites
-    value: "agent_bvt, no_outbound_connections, extensions_disabled, agent_not_provisioned, fips"
+    value: "agent_bvt, no_outbound_connections, extensions_disabled, agent_not_provisioned, agent_update, fips"
   - name: cloud
     value: "AzureCloud"
     is_case_visible: true

--- a/tests_e2e/pipeline/pipeline.yml
+++ b/tests_e2e/pipeline/pipeline.yml
@@ -5,17 +5,20 @@
   #
 
 parameters:
+    #
     # See the test wiki for a description of the parameters
-  - name: test_suites
-    displayName: Test Suites
-    type: string
-    default: agent_bvt, no_outbound_connections, extensions_disabled, agent_not_provisioned, agent_update, fips
+    #
     # NOTES:
     #         * 'image', 'location' and 'vm_size' override any values in the test suites/images definition
     #            files. Those parameters are useful for 1-off tests, like testing a VHD or checking if
     #            an image is supported in a particular location.
     #         * Azure Pipelines do not allow empty string for the parameter value, using "-" instead.
     #
+  - name: test_suites
+    displayName: Test Suites (comma-separated list of test suites to run)
+    type: string
+    default: "-"
+
   - name: image
     displayName: Image (image/image set name, URN, or VHD)
     type: string

--- a/tests_e2e/pipeline/scripts/execute_tests.sh
+++ b/tests_e2e/pipeline/scripts/execute_tests.sh
@@ -39,6 +39,11 @@ docker pull waagenttests.azurecr.io/waagenttests:latest
 
 # Azure Pipelines does not allow an empty string as the value for a pipeline parameter; instead we use "-" to indicate
 # an empty value. Change "-" to "" for the variables that capture the parameter values.
+if [[ $TEST_SUITES == "-" ]]; then
+    TEST_SUITES=""  # Don't set the test_suites variable
+else
+    TEST_SUITES="-v test_suites:\"$TEST_SUITES\""
+fi
 if [[ $IMAGE == "-" ]]; then
     IMAGE=""
 fi
@@ -69,13 +74,13 @@ docker run --rm \
           -v cloud:$CLOUD \
           -v subscription_id:$SUBSCRIPTION_ID \
           -v identity_file:\$HOME/.ssh/id_rsa \
-          -v test_suites:\"$TEST_SUITES\" \
           -v log_path:\$HOME/logs \
           -v collect_logs:\"$COLLECT_LOGS\" \
           -v keep_environment:\"$KEEP_ENVIRONMENT\" \
           -v image:\"$IMAGE\" \
           -v location:\"$LOCATION\" \
-          -v vm_size:\"$VM_SIZE\"" \
+          -v vm_size:\"$VM_SIZE\" \
+          $TEST_SUITES" \
 || echo "exit $?" > /tmp/exit.sh
 
 #

--- a/tests_e2e/test_suites/no_outbound_connections.yml
+++ b/tests_e2e/test_suites/no_outbound_connections.yml
@@ -11,9 +11,9 @@ name: "NoOutboundConnections"
 tests:
   - source: "no_outbound_connections/check_no_outbound_connections.py"
     blocks_suite: true  # If the NSG is not setup correctly, there is no point in executing the rest of the tests.
-  - "bvts/extension_operations.py"
-  - "bvts/run_command.py"
-  - "bvts/vm_access.py"
+  - "agent_bvt/extension_operations.py"
+  - "agent_bvt/run_command.py"
+  - "agent_bvt/vm_access.py"
   - "no_outbound_connections/check_fallback_to_hgap.py"
 images: "random(endorsed)"
 template: "no_outbound_connections/template.py"


### PR DESCRIPTION
Currently new tests new to be added to pipeline.yml and runbook.yml. With this change, they need to be added to runbook.yml only.

The PR also fixes the paths for the tests in no_outbound_connections.yml, and adds agent_update to runbook.yml.