### PR TITLE
Fix method name in update test

### DIFF
--- a/tests_e2e/tests/agent_update/rsm_update.py
+++ b/tests_e2e/tests/agent_update/rsm_update.py
@@ -114,7 +114,7 @@ class RsmUpdateBvt(AgentTest):
 
     @staticmethod
     def _verify_agent_update_flag_enabled(vm: VirtualMachineClient) -> bool:
-        result: VirtualMachine = vm.get_description()
+        result: VirtualMachine = vm.get_model()
         flag: bool = result.os_profile.linux_configuration.enable_vm_agent_platform_updates
         if flag is None:
             return False


### PR DESCRIPTION
VirtualMachineClient.get_description() was renamed to get_model. Updating method call.