### PR TITLE
Expose run name as a runbook variable

### DIFF
--- a/tests_e2e/orchestrator/runbook.yml
+++ b/tests_e2e/orchestrator/runbook.yml
@@ -1,4 +1,4 @@
-name: WALinuxAgent
+name: $(name)
 
 testcase:
   - criteria:
@@ -8,6 +8,8 @@ extension:
   - "./lib"
 
 variable:
+  - name: name
+    value: "WALinuxAgent"
   #
   # These variables define parameters handled by LISA.
   #


### PR DESCRIPTION
@maddieford @nagworld9 - Please setup this variable for developer runs. Resource groups and VMs will include this as part of their name.
`
    lisa  --runbook $runbook ...  -v name:FOO`