### PR TITLE
Collect test artifacts as a separate step in the test pipeline

### DIFF
--- a/tests_e2e/pipeline/pipeline.yml
+++ b/tests_e2e/pipeline/pipeline.yml
@@ -43,6 +43,11 @@ parameters:
     - failed
     - no
 
+  - name: collect_lisa_logs
+    displayName: Collect LISA logs
+    type: boolean
+    default: true
+
   - name: keep_environment
     displayName: Keep the test VMs (do not delete them)
     type: string
@@ -116,6 +121,11 @@ jobs:
           LOCATION: ${{ parameters.location }}
           TEST_SUITES: ${{ parameters.test_suites }}
           VM_SIZE: ${{ parameters.vm_size }}
+
+      - bash: $(Build.SourcesDirectory)/tests_e2e/pipeline/scripts/collect_artifacts.sh
+        displayName: "Collect test artifacts"
+        env:
+          COLLECT_LISA_LOGS: ${{ parameters.collect_lisa_logs }}
 
       - publish: $(Build.ArtifactStagingDirectory)
         artifact: 'artifacts'

--- a/tests_e2e/pipeline/scripts/collect_artifacts.sh
+++ b/tests_e2e/pipeline/scripts/collect_artifacts.sh
@@ -62,8 +62,7 @@ mv "$LOGS_DIRECTORY"/lisa/*/*/agent.junit.xml "$BUILD_ARTIFACTSTAGINGDIRECTORY"/
 #
 # Move the rest of the LISA logs to "lisa_logs"
 #
-echo "COLLECT_LISA_LOGS=$COLLECT_LISA_LOGS"
-if [[ $COLLECT_LISA_LOGS == 'true' ]]; then
+if [[ ${COLLECT_LISA_LOGS,,} == 'true' ]]; then  # case-insensitive comparison
   mkdir "$BUILD_ARTIFACTSTAGINGDIRECTORY"/lisa_logs
   mv "$LOGS_DIRECTORY"/lisa/*/*/* "$BUILD_ARTIFACTSTAGINGDIRECTORY"/lisa_logs
 fi

--- a/tests_e2e/pipeline/scripts/collect_artifacts.sh
+++ b/tests_e2e/pipeline/scripts/collect_artifacts.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+#
+# Moves the relevant logs to the staging directory
+#
+set -euxo pipefail
+
+#
+# The execute_test.sh script gives ownership of the log directory to the 'waagent' user in
+# the Docker container; re-take ownership
+#
+sudo find "$LOGS_DIRECTORY" -exec chown "$USER" {} \;
+
+#
+# Move the logs for failed tests to a temporary location
+#
+mkdir "$BUILD_ARTIFACTSTAGINGDIRECTORY"/tmp
+for log in $(grep -l MARKER-LOG-WITH-ERRORS "$LOGS_DIRECTORY"/*.log); do
+  mv "$log" "$BUILD_ARTIFACTSTAGINGDIRECTORY"/tmp
+done
+
+#
+# Move the environment logs to "environment_logs"
+#
+if ls "$LOGS_DIRECTORY"/env-*.log > /dev/null 2>&1; then
+  mkdir "$BUILD_ARTIFACTSTAGINGDIRECTORY"/environment_logs
+  mv "$LOGS_DIRECTORY"/env-*.log "$BUILD_ARTIFACTSTAGINGDIRECTORY"/environment_logs
+fi
+
+#
+# Move the rest of the logs to "test_logs"
+#
+if ls "$LOGS_DIRECTORY"/*.log > /dev/null 2>&1; then
+  mkdir "$BUILD_ARTIFACTSTAGINGDIRECTORY"/test_logs
+  mv "$LOGS_DIRECTORY"/*.log "$BUILD_ARTIFACTSTAGINGDIRECTORY"/test_logs
+fi
+
+#
+# Move the logs for failed tests to the main directory
+#
+if ls "$BUILD_ARTIFACTSTAGINGDIRECTORY"/tmp/*.log > /dev/null 2>&1; then
+  mv "$BUILD_ARTIFACTSTAGINGDIRECTORY"/tmp/*.log "$BUILD_ARTIFACTSTAGINGDIRECTORY"
+fi
+rmdir "$BUILD_ARTIFACTSTAGINGDIRECTORY"/tmp
+
+#
+# Move the logs collected from the test VMs to vm_logs
+#
+if ls "$LOGS_DIRECTORY"/*.tgz > /dev/null 2>&1; then
+  mkdir "$BUILD_ARTIFACTSTAGINGDIRECTORY"/vm_logs
+  mv "$LOGS_DIRECTORY"/*.tgz "$BUILD_ARTIFACTSTAGINGDIRECTORY"/vm_logs
+fi
+
+#
+# Move the main LISA log and the JUnit report to "runbook_logs"
+#
+# Note that files created by LISA are under .../lisa/<date>/<unique_name>"
+#
+mkdir "$BUILD_ARTIFACTSTAGINGDIRECTORY"/runbook_logs
+mv "$LOGS_DIRECTORY"/lisa/*/*/lisa-*.log "$BUILD_ARTIFACTSTAGINGDIRECTORY"/runbook_logs
+mv "$LOGS_DIRECTORY"/lisa/*/*/agent.junit.xml "$BUILD_ARTIFACTSTAGINGDIRECTORY"/runbook_logs
+
+#
+# Move the rest of the LISA logs to "lisa_logs"
+#
+echo "COLLECT_LISA_LOGS=$COLLECT_LISA_LOGS"
+if [[ $COLLECT_LISA_LOGS == 'true' ]]; then
+  mkdir "$BUILD_ARTIFACTSTAGINGDIRECTORY"/lisa_logs
+  mv "$LOGS_DIRECTORY"/lisa/*/*/* "$BUILD_ARTIFACTSTAGINGDIRECTORY"/lisa_logs
+fi
+

--- a/tests_e2e/pipeline/scripts/execute_tests.sh
+++ b/tests_e2e/pipeline/scripts/execute_tests.sh
@@ -26,8 +26,8 @@ chmod a+w "$BUILD_SOURCESDIRECTORY"
 #
 # Create the directory where the Docker container will create the test logs and give ownership to 'waagent'
 #
-echo "##vso[task.setvariable variable=logs_directory]$HOME/logs"
-#LOGS_DIRECTORY="$HOME/logs"
+LOGS_DIRECTORY="$HOME/logs"
+echo "##vso[task.setvariable variable=logs_directory]$LOGS_DIRECTORY"
 mkdir "$LOGS_DIRECTORY"
 sudo chown "$WAAGENT_UID" "$LOGS_DIRECTORY"
 


### PR DESCRIPTION
Test execution times out from time to time; when this happens, Azure Pipelines terminates the task and artifacts are not collected. I separated the collection of test artifacts to its own separate step. Also, LISA logs may be needed to debug those timeouts; I added a pipeline parameter to collect all LISA logs and defaulted it to True. Once the investigation is completed, I'll change the default to False.