### PR TITLE
Do not collect LISA logs by default

### DIFF
--- a/tests_e2e/pipeline/pipeline.yml
+++ b/tests_e2e/pipeline/pipeline.yml
@@ -46,7 +46,7 @@ parameters:
   - name: collect_lisa_logs
     displayName: Collect LISA logs
     type: boolean
-    default: true
+    default: false
 
   - name: keep_environment
     displayName: Keep the test VMs (do not delete them)


### PR DESCRIPTION
The timeout I was investigating was unrelated to LISA and has been fixed; no need to collect LISA logs by default.