### PR TITLE
Add check for noexec on Permission denied errors

### DIFF
--- a/azurelinuxagent/common/event.py
+++ b/azurelinuxagent/common/event.py
@@ -104,6 +104,7 @@ class WALAEventOperation:
     InitializeHostPlugin = "InitializeHostPlugin"
     Log = "Log"
     LogCollection = "LogCollection"
+    NoExec = "NoExec"
     OSInfo = "OSInfo"
     Partition = "Partition"
     PersistFirewallRules = "PersistFirewallRules"


### PR DESCRIPTION
On some VMs we get 'Permission denied' errors when executing extensions when the noexec flag is set on /var.

Added a check for this condition in order to improve the error messages. Sample messages (new message marked with >>>>>):

```
2023-06-26T23:33:00.228592Z INFO ExtHandler [Microsoft.EnterpriseCloud.Monitoring.OmsAgentForLinux-1.14.23] Install extension [omsagent_shim.sh -install]
2023-06-26T23:33:00.229100Z INFO ExtHandler [Microsoft.EnterpriseCloud.Monitoring.OmsAgentForLinux-1.14.23] Executing command: /var/lib/waagent/Microsoft.EnterpriseCloud.Monitoring.OmsAgentForLinux-1.14.23/omsagent_shim.sh -install 
>>>>>2023-06-26T23:33:02.235781Z WARNING ExtHandler ExtHandler The noexec flag is set on /var. This can prevent extensions from executing.
2023-06-26T23:33:02.236173Z ERROR ExtHandler ExtHandler Event: name=WALinuxAgent, op=NoExec, message=The noexec flag is set on /var. This can prevent extensions from executing., duration=0
2023-06-26T23:33:02.237477Z ERROR ExtHandler ExtHandler Event: name=Microsoft.EnterpriseCloud.Monitoring.OmsAgentForLinux, op=Install, message=[ExtensionOperationError] Non-zero exit code: 126, /var/lib/waagent/Microsoft.EnterpriseCloud.Monitoring.OmsAgentForLinux-1.14.23/omsagent_shim.sh -install
>>>>>WARNING: /var is mounted with the noexec flag, which can prevent execution of VM Extensions.
[stdout]


[stderr]
/bin/sh: line 1: /var/lib/waagent/Microsoft.EnterpriseCloud.Monitoring.OmsAgentForLinux-1.14.23/omsagent_shim.sh: Permission denied
, duration=0
2023-06-26T23:33:02.239591Z INFO ExtHandler ExtHandler ProcessExtensionsGoalState completed [incarnation_1 5460 ms]


```