### PR TITLE
Always collect logs on end-to-end tests

### DIFF
--- a/tests_e2e/pipeline/pipeline.yml
+++ b/tests_e2e/pipeline/pipeline.yml
@@ -107,6 +107,7 @@ jobs:
       - bash: $(Build.SourcesDirectory)/tests_e2e/pipeline/scripts/execute_tests.sh
         displayName: "Execute tests"
         continueOnError: true
+        timeoutInMinutes: 5
         env:
           SUBSCRIPTION_ID: $(SUBSCRIPTION-ID)
           AZURE_CLIENT_ID: $(AZURE-CLIENT-ID)
@@ -124,6 +125,7 @@ jobs:
 
       - bash: $(Build.SourcesDirectory)/tests_e2e/pipeline/scripts/collect_artifacts.sh
         displayName: "Collect test artifacts"
+        condition: always()
         env:
           COLLECT_LISA_LOGS: ${{ parameters.collect_lisa_logs }}
 

--- a/tests_e2e/pipeline/pipeline.yml
+++ b/tests_e2e/pipeline/pipeline.yml
@@ -46,7 +46,7 @@ parameters:
   - name: collect_lisa_logs
     displayName: Collect LISA logs
     type: boolean
-    default: false
+    default: true
 
   - name: keep_environment
     displayName: Keep the test VMs (do not delete them)
@@ -107,7 +107,6 @@ jobs:
       - bash: $(Build.SourcesDirectory)/tests_e2e/pipeline/scripts/execute_tests.sh
         displayName: "Execute tests"
         continueOnError: true
-        timeoutInMinutes: 5
         env:
           SUBSCRIPTION_ID: $(SUBSCRIPTION-ID)
           AZURE_CLIENT_ID: $(AZURE-CLIENT-ID)
@@ -125,6 +124,7 @@ jobs:
 
       - bash: $(Build.SourcesDirectory)/tests_e2e/pipeline/scripts/collect_artifacts.sh
         displayName: "Collect test artifacts"
+        # Collect artifacts even if the previous step is cancelled (e.g. timeout)
         condition: always()
         env:
           COLLECT_LISA_LOGS: ${{ parameters.collect_lisa_logs }}


### PR DESCRIPTION
If ExecuteTests is cancelled (e.g. by a timeout), the rest of the pipeline is not executed and we do not collect logs for debugging. Marking log collection as "always()" to ensure it executes.

We are trying to debug a timeout and LISA logs will be needed. Enabled collection of those logs for all test runs.