### PR TITLE
Always publish artifacts and test results

### DIFF
--- a/tests_e2e/pipeline/pipeline.yml
+++ b/tests_e2e/pipeline/pipeline.yml
@@ -132,9 +132,11 @@ jobs:
       - publish: $(Build.ArtifactStagingDirectory)
         artifact: 'artifacts'
         displayName: 'Publish test artifacts'
+        condition: always()
 
       - task: PublishTestResults@2
         displayName: 'Publish test results'
+        condition: always()
         inputs:
           testResultsFormat: 'JUnit'
           testResultsFiles: 'runbook_logs/agent.junit.xml'


### PR DESCRIPTION
Publish artifacts and logs even if the parent step is cancelled.