### PR TITLE
Allow Log Collector to run without CPU/Memory limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ For CoreOS, use:
 
 `-start`: Run waagent as a background process
 
-`-collect-logs [-full]`: Runs the log collector utility that collects relevant agent logs for debugging and stores them in the agent folder on disk. Exact location will be shown when run. Use flag `-full` for more exhaustive log collection. 
+`-collect-logs [-full] [-uncapped]`: Runs the log collector utility that collects relevant agent logs for debugging and stores them in the agent folder on disk. Exact location will be shown when run. Use flag `-full` for more exhaustive log collection. Use flag `-uncapped` to allow the log collector utility to run without CPU/Memory constraints.
 
 ## Configuration
 
@@ -196,6 +196,7 @@ ResourceDisk.SwapSizeMB=0
 Logs.Verbose=n
 Logs.Collect=y
 Logs.CollectPeriod=3600
+Logs.Uncapped=n
 OS.AllowHTTP=n
 OS.RootDeviceScsiTimeout=300
 OS.EnableFIPS=n
@@ -465,6 +466,13 @@ _Default: 3600_
 This configures how frequently to collect and upload logs. Default is each hour.
 
 NOTE: This only takes effect if the Logs.Collect option is enabled.
+
+#### __Logs.Uncapped__
+
+_Type: Boolean_
+_Default: n_
+
+If set, the log collector utility will run without defined cgroup limits.
 
 #### __OS.AllowHTTP__
 

--- a/azurelinuxagent/agent.py
+++ b/azurelinuxagent/agent.py
@@ -204,9 +204,12 @@ class Agent(object):
         else:
             logger.info("Running log collector mode normal")
 
+        # Calls on get_inuse_cgroup_version to determine cgroup version
+        is_cgroupv2 = DefaultOSUtil._is_cgroupv2(self)
+        
         # Check the cgroups unit
         cpu_cgroup_path, memory_cgroup_path, log_collector_monitor = None, None, None
-        if CollectLogsHandler.should_validate_cgroups():
+        if not is_cgroupv2 and CollectLogsHandler.should_validate_cgroups():
             cgroups_api = SystemdCgroupsApi()
             cpu_cgroup_path, memory_cgroup_path = cgroups_api.get_process_cgroup_paths("self")
 
@@ -222,8 +225,7 @@ class Agent(object):
 
                 sys.exit(logcollector.INVALID_CGROUPS_ERRCODE)
 
-        # Calls on get_inuse_cgroup_version to determine cgroup version
-        is_cgroupv2 = DefaultOSUtil._is_cgroupv2(self)
+
 
         try:
             log_collector = LogCollector(is_full_mode, cpu_cgroup_path, memory_cgroup_path)

--- a/azurelinuxagent/agent.py
+++ b/azurelinuxagent/agent.py
@@ -227,9 +227,9 @@ class Agent(object):
 
         try:
             log_collector = LogCollector(is_full_mode, cpu_cgroup_path, memory_cgroup_path)
-                # if cgroupv2 is active or collect-logs param is invoked uncapped flag,
+                # if cgroupv2 is active and collect-logs param is invoked uncapped flag,
                 # LogCollectorMonitor won't be used
-            if (is_cgroupv2 or is_uncapped_mode) is not True:
+            if (is_cgroupv2 and is_uncapped_mode) is not True:
                 log_collector_monitor = get_log_collector_monitor_handler(log_collector.cgroups)
                 log_collector_monitor.run()
             archive = log_collector.collect_logs_and_get_archive()

--- a/azurelinuxagent/common/conf.py
+++ b/azurelinuxagent/common/conf.py
@@ -266,6 +266,8 @@ def get_logs_console(conf=__conf__):
 def get_collect_logs(conf=__conf__):
     return conf.get_switch("Logs.Collect", True)
 
+def get_collect_logs_uncapped(conf=__conf__):
+    return conf.get_switch("Logs.Uncapped", False)
 
 def get_collect_logs_period(conf=__conf__):
     return conf.get_int("Logs.CollectPeriod", 3600)

--- a/azurelinuxagent/common/logcollector.py
+++ b/azurelinuxagent/common/logcollector.py
@@ -30,6 +30,7 @@ from azurelinuxagent.common.cgroup import CpuCgroup, AGENT_LOG_COLLECTOR, Memory
 from azurelinuxagent.common.conf import get_lib_dir, get_ext_log_dir, get_agent_log_file
 from azurelinuxagent.common.event import initialize_event_logger_vminfo_common_parameters
 from azurelinuxagent.common.future import ustr
+from azurelinuxagent.common.osutil.default import DefaultOSUtil
 from azurelinuxagent.common.logcollector_manifests import MANIFEST_NORMAL, MANIFEST_FULL
 
 # Please note: be careful when adding agent dependencies in this module.
@@ -77,7 +78,8 @@ class LogCollector(object):
         self._create_base_dirs()
         self._set_logger()
         self._initialize_telemetry()
-        self.cgroups = self._set_resource_usage_cgroups(cpu_cgroup_path, memory_cgroup_path)
+        # if CGroupv2 is in play, ignore resource usage limitation 
+        self.cgroups = self._set_resource_usage_cgroups(cpu_cgroup_path, memory_cgroup_path) if DefaultOSUtil._is_cgroupv2 == False else None
 
     @staticmethod
     def _mkdir(dirname):

--- a/azurelinuxagent/common/logcollector.py
+++ b/azurelinuxagent/common/logcollector.py
@@ -327,14 +327,14 @@ class LogCollector(object):
                     _LOGGER.warning("Archive too big, done with adding files.")
                     break
 
-                    if os.path.getsize(file_path) <= _FILE_SIZE_LIMIT:
-                        final_files_to_collect.append(file_path)
-                        _LOGGER.info("Adding file %s, size %s b", file_path, file_size)
-                    else:
-                        truncated_file_path = self._truncate_large_file(file_path)
-                        if truncated_file_path:
-                            _LOGGER.info("Adding truncated file %s, size %s b", truncated_file_path, file_size)
-                            final_files_to_collect.append(truncated_file_path)
+                if os.path.getsize(file_path) <= _FILE_SIZE_LIMIT:
+                    final_files_to_collect.append(file_path)
+                    _LOGGER.info("Adding file %s, size %s b", file_path, file_size)
+                else:
+                    truncated_file_path = self._truncate_large_file(file_path)
+                    if truncated_file_path:
+                        _LOGGER.info("Adding truncated file %s, size %s b", truncated_file_path, file_size)
+                        final_files_to_collect.append(truncated_file_path)
             else:
                 if os.path.exists(os.readlink(file_path)):
                     _LOGGER.info("Skipping file %s", file_path)

--- a/azurelinuxagent/common/osutil/default.py
+++ b/azurelinuxagent/common/osutil/default.py
@@ -1471,6 +1471,16 @@ class DefaultOSUtil(object):
             return state
 
     @staticmethod
+    def _is_cgroupv2(self):
+        try:
+            output = shellutil.run_get_output("stat -fc %T /sys/fs/cgroup/")
+        except shellutil.CommandError as cmd_err:
+            logger.warn("failed to determine in-use CGroup version, falling back to v1")
+
+         # Index 0 is the exit code, 1 the stdout
+        return True if output[1].strip() == 'cgroup2fs' else False
+
+    @staticmethod
     def _update_nic_state_all(state, command_output):
         for entry in command_output.splitlines():
             # Sample output:

--- a/azurelinuxagent/ga/collect_logs.py
+++ b/azurelinuxagent/ga/collect_logs.py
@@ -37,7 +37,7 @@ from azurelinuxagent.common.utils.shellutil import CommandError
 from azurelinuxagent.common.osutil.default import DefaultOSUtil
 from azurelinuxagent.common.version import PY_VERSION_MAJOR, PY_VERSION_MINOR, AGENT_NAME, CURRENT_VERSION
 
-_INITIAL_LOG_COLLECTION_DELAY = 5 * 1  # Five minutes of delay
+_INITIAL_LOG_COLLECTION_DELAY = 5 * 60  # Five minutes of delay
 
 _UNCAPPED_FLAG = "-uncapped"
 

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -609,12 +609,12 @@ class UpdateHandler(object):
         # update self._goal_state
         if not self._try_update_goal_state(protocol):
             # agent updates and status reporting should be done even when the goal state is not updated
-            #self.__update_guest_agent(protocol)
+            self.__update_guest_agent(protocol)
             self._report_status(exthandlers_handler)
             return
 
         # check for agent updates
-        #self.__update_guest_agent(protocol)
+        self.__update_guest_agent(protocol)
 
         try:
             if self._processing_new_extensions_goal_state():

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -609,12 +609,12 @@ class UpdateHandler(object):
         # update self._goal_state
         if not self._try_update_goal_state(protocol):
             # agent updates and status reporting should be done even when the goal state is not updated
-            self.__update_guest_agent(protocol)
+            #self.__update_guest_agent(protocol)
             self._report_status(exthandlers_handler)
             return
 
         # check for agent updates
-        self.__update_guest_agent(protocol)
+        #self.__update_guest_agent(protocol)
 
         try:
             if self._processing_new_extensions_goal_state():


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

The log collector will not run for distros running under CGroup2 due to LogCollectorMonitor dependency from CGroup1 metrics. This change will allow the LC to run, bypassing the monitor and resource usage, being effectively unconstrained.

Two distinct ways to run:
- Set Logs.Uncapped=y on waagent.conf
- Invoke waagent -collect-logs [-full] -uncapped

During testing, found an issue where a linked file to be collected no longer existed (removed after successful bootstrapping), causing an unhandled exception + logcollection to fail. Fixed with validation if symlink path file exists before appending to files to collect.

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).