### PR TITLE
Download certs on FT GS after check_certificates only when missing from disk

### DIFF
--- a/azurelinuxagent/common/protocol/goal_state.py
+++ b/azurelinuxagent/common/protocol/goal_state.py
@@ -208,7 +208,7 @@ class GoalState(object):
         try:
             self._update(force_update=False)
         except GoalStateInconsistentError as e:
-            message = "Detected an inconsistency in the goal state: {0}", ustr(e)
+            message = "Detected an inconsistency in the goal state: {0}".format(ustr(e))
             self.logger.warn(message)
             add_event(op=WALAEventOperation.GoalState, is_success=False, message=message)
 

--- a/azurelinuxagent/common/protocol/goal_state.py
+++ b/azurelinuxagent/common/protocol/goal_state.py
@@ -292,11 +292,9 @@ class GoalState(object):
         #
         if self._extensions_goal_state.source == GoalStateSource.FastTrack and self._goal_state_properties & GoalStateProperties.Certificates:
             self._check_certificates()
+            self._check_and_download_missing_certs_on_disk()
 
     def _check_certificates(self):
-        # Re-download certificates in case they have been removed from disk since last download
-        if self._certs_uri is not None:
-            self._download_certificates(self._certs_uri)
         # Check that certificates needed by extensions are in goal state certs.summary
         for extension in self.extensions_goal_state.extensions:
             for settings in extension.settings:
@@ -320,6 +318,32 @@ class GoalState(object):
             add_event(op=WALAEventOperation.GoalState, message=certs.warnings)
         self._history.save_certificates(json.dumps(certs.summary))
         return certs
+
+    def _check_and_download_missing_certs_on_disk(self):
+        # Re-download certificates if any have been removed from disk since last download
+        if self._certs_uri is not None:
+            certificates = self.certs.summary
+            certs_missing_from_disk = False
+
+            for c in certificates:
+                cert_path = os.path.join(conf.get_lib_dir(), c['thumbprint'] + '.crt')
+                if not os.path.isfile(cert_path):
+                    certs_missing_from_disk = True
+                    message = "Certificate required by goal state is not on disk: {0}".format(cert_path)
+                    self.logger.info(message)
+                    add_event(op=WALAEventOperation.GoalState, message=message)
+            if certs_missing_from_disk:
+                # Try to re-download certs. Sometimes download may fail if certs_uri is outdated/contains wrong
+                # container id (for example, when the VM is moved to a new container after resuming from
+                # hibernation). If download fails we should report and continue with goal state processing, as some
+                # extensions in the goal state may succeed.
+                try:
+                    self._download_certificates(self._certs_uri)
+                except Exception as e:
+                    message = "Unable to download certificates. Goal state processing will continue, some " \
+                              "extensions requiring certificates may fail. Error: {0}".format(ustr(e))
+                    self.logger.warn(message)
+                    add_event(op=WALAEventOperation.GoalState, is_success=False, message=message)
 
     def _restore_wire_server_goal_state(self, incarnation, xml_text, xml_doc, vm_settings_support_stopped_error):
         msg = 'The HGAP stopped supporting vmSettings; will fetched the goal state from the WireServer.'

--- a/azurelinuxagent/common/protocol/goal_state.py
+++ b/azurelinuxagent/common/protocol/goal_state.py
@@ -208,9 +208,15 @@ class GoalState(object):
         try:
             self._update(force_update=False)
         except GoalStateInconsistentError as e:
-            self.logger.warn("Detected an inconsistency in the goal state: {0}", ustr(e))
+            message = "Detected an inconsistency in the goal state: {0}", ustr(e)
+            self.logger.warn(message)
+            add_event(op=WALAEventOperation.GoalState, is_success=False, message=message)
+
             self._update(force_update=True)
-            self.logger.info("The goal state is consistent")
+
+            message = "The goal state is consistent"
+            self.logger.info(message)
+            add_event(op=WALAEventOperation.GoalState, message=message)
 
     def _update(self, force_update):
         #
@@ -219,7 +225,9 @@ class GoalState(object):
         timestamp = datetime.datetime.utcnow()
 
         if force_update:
-            self.logger.info("Refreshing goal state and vmSettings")
+            message = "Refreshing goal state and vmSettings"
+            self.logger.info(message)
+            add_event(op=WALAEventOperation.GoalState, message=message)
 
         incarnation, xml_text, xml_doc = GoalState._fetch_goal_state(self._wire_client)
         goal_state_updated = force_update or incarnation != self._incarnation

--- a/tests/common/protocol/test_goal_state.py
+++ b/tests/common/protocol/test_goal_state.py
@@ -157,7 +157,7 @@ class GoalStateTestCase(AgentTestCase, HttpRequestPredicates):
             protocol.set_http_handlers(http_get_handler=None)
             goal_state.update()
             self._assert_directory_contents(
-                self._find_history_subdirectory("234-987"), ["VmSettings.json", "Certificates.json"])
+                self._find_history_subdirectory("234-987"), ["VmSettings.json"])
 
     def test_it_should_redact_the_protected_settings_when_saving_to_the_history_directory(self):
         with mock_wire_protocol(wire_protocol_data.DATA_FILE_VM_SETTINGS) as protocol:
@@ -464,7 +464,7 @@ class GoalStateTestCase(AgentTestCase, HttpRequestPredicates):
             goal_state = GoalState(protocol.client)
 
             self.assertEqual(2, protocol.mock_wire_data.call_counts['goalstate'], "There should have been exactly 2 requests for the goal state (original + refresh)")
-            self.assertEqual(4, http_get_handler.certificate_requests, "There should have been exactly 4 requests for the goal state certificates (2x original + 2x refresh)")
+            self.assertEqual(2, http_get_handler.certificate_requests, "There should have been exactly 2 requests for the goal state certificates (original + refresh)")
 
             thumbprints = [c.thumbprint for c in goal_state.certs.cert_list.certificates]
 


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
We deployed a change with 2.9.1.1 which updated the agent to always re download certs on every fast track goal state (in case a cert was removed from disk) -> see change here https://github.com/Azure/WALinuxAgent/pull/2761

This introduced an issue for the hibernate VM case. When a VM resumes from hibernate state, it is moved to a new container. The agent processes a fasttrack goal state on hibernate resume, but the certs_uri references the VMs old containerId, so wireserver returns a 410 when we try to download certs with the certs_uri. We don't handle this 410, so the GS is not failed or retried gracefully.

This PR updates this behavior to: if FastTrack GS, check that certificates required by GS are in certs summary. If certs_uri is not None, check that all certs in certs summary are present on the disk -> if not, try to re-download certs, if any exceptions are raised do nothing except log and send to telemetry 

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).