### PR TITLE
download_fail unit test should use agent version in common instead of 9.9.9.9

### DIFF
--- a/tests/ga/test_guestagent.py
+++ b/tests/ga/test_guestagent.py
@@ -173,6 +173,7 @@ class TestGuestAgent(UpdateTestCase):
                 return MockHttpResponse(status=httpclient.SERVICE_UNAVAILABLE)
             return None
 
+        agent_version = self._get_agent_version()
         pkg = ExtHandlerPackage(version=str(self._get_agent_version()))
         pkg.uris.append(agent_uri)
 
@@ -185,7 +186,7 @@ class TestGuestAgent(UpdateTestCase):
 
         messages = [kwargs['message'] for _, kwargs in add_event.call_args_list if kwargs['op'] == 'Install' and kwargs['is_success'] == False]
         self.assertEqual(1, len(messages), "Expected exactly 1 install error/ Got: {0}".format(add_event.call_args_list))
-        self.assertIn('[UpdateError] Unable to download Agent WALinuxAgent-9.9.9.9', messages[0], "The install error does not include the expected message")
+        self.assertIn(str.format('[UpdateError] Unable to download Agent WALinuxAgent-{0}', agent_version), messages[0], "The install error does not include the expected message")
 
         self.assertFalse(agent.is_blacklisted, "Download failures should not blacklist the Agent")
 


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
download_fail unit test should use agent version in common instead of 9.9.9.9

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).