### PR TITLE
Do not send localhost as the name for dhclient

### DIFF
--- a/azurelinuxagent/common/osutil/default.py
+++ b/azurelinuxagent/common/osutil/default.py
@@ -1154,6 +1154,9 @@ class DefaultOSUtil(object):
         self._run_command_without_raising(["hostname", hostname], log_error=False)
 
     def set_dhcp_hostname(self, hostname):
+        # ensure localhost is not sent to the dhcp server
+        if hostname.lower() == "localhost" or hostname.lower() == "localhost.localdomain":
+            hostname = ""
         autosend = r'^[^#]*?send\s*host-name.*?(<hostname>|gethostname[(,)])'
         dhclient_files = ['/etc/dhcp/dhclient.conf', '/etc/dhcp3/dhclient.conf', '/etc/dhclient.conf']
         for conf_file in dhclient_files:

--- a/azurelinuxagent/common/osutil/redhat.py
+++ b/azurelinuxagent/common/osutil/redhat.py
@@ -84,6 +84,9 @@ class Redhat6xOSUtil(DefaultOSUtil):
         self._run_command_without_raising(["hostname", hostname], log_error=False)
 
     def set_dhcp_hostname(self, hostname):
+        # ensure localhost is not sent to the dhcp server
+        if hostname.lower() == "localhost" or hostname.lower() == "localhost.localdomain":
+            hostname = ""
         ifname = self.get_if_name()
         filepath = "/etc/sysconfig/network-scripts/ifcfg-{0}".format(ifname)
         fileutil.update_conf_file(filepath,

--- a/azurelinuxagent/common/osutil/suse.py
+++ b/azurelinuxagent/common/osutil/suse.py
@@ -104,6 +104,12 @@ class SUSEOSUtil(SUSE11OSUtil):
         )
 
     def set_dhcp_hostname(self, hostname):
+        # ensure localhost is not sent to the dhcp server
+        if hostname.lower() == "localhost" or hostname.lower() == "localhost.localdomain":
+            # if the DHCLIENT_HOSTNAME_OPTION is empty it will not send a hostname to the dhcp server
+            # reference: https://manpages.opensuse.org/Tumbleweed/wicked/ifcfg-dhcp.5.en.html
+            hostname = ""
+        
         dhcp_config_file_path = '/etc/sysconfig/network/dhcp'
         hostname_send_setting = fileutil.get_line_startingwith(
             'DHCLIENT_HOSTNAME_OPTION', dhcp_config_file_path


### PR DESCRIPTION
The DHCP hostname is set to `localhost.localdomain` after running `waagent -deprovision`.  This causes localhost to be added to Azure DNS and a call to `nslookup localhost` from somewhere on the VNET can get another VMs private IP address.

This PR has a proposed solution for this.

<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Issue #2928 <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).