### PR TITLE
Fix for "local variable _COLLECT_NOEXEC_ERRORS referenced before assignment"

### DIFF
--- a/azurelinuxagent/ga/extensionprocessutil.py
+++ b/azurelinuxagent/ga/extensionprocessutil.py
@@ -107,6 +107,8 @@ def _check_noexec():
     """
     Check if /var is mounted with the noexec flag.
     """
+    global _COLLECT_NOEXEC_ERRORS
+
     try:
         agent_dir = conf.get_lib_dir()
         with open('/proc/mounts', 'r') as f:

--- a/azurelinuxagent/ga/extensionprocessutil.py
+++ b/azurelinuxagent/ga/extensionprocessutil.py
@@ -107,7 +107,9 @@ def _check_noexec():
     """
     Check if /var is mounted with the noexec flag.
     """
-    global _COLLECT_NOEXEC_ERRORS
+    # W0603: Using the global statement (global-statement)
+    # OK to disable; _COLLECT_NOEXEC_ERRORS is used only within _check_noexec, but needs to persist across calls.
+    global _COLLECT_NOEXEC_ERRORS  # pylint: disable=W0603
 
     try:
         agent_dir = conf.get_lib_dir()


### PR DESCRIPTION
The variable needs to be explicitly declared as global, or the assignment at line 136 will introduce a new local variable that is referenced at line 135. 