### PR TITLE
undo get daemon version change

### DIFF
--- a/azurelinuxagent/common/version.py
+++ b/azurelinuxagent/common/version.py
@@ -21,7 +21,6 @@ import platform
 import sys
 
 import azurelinuxagent.common.conf as conf
-from azurelinuxagent.common import logger
 import azurelinuxagent.common.utils.shellutil as shellutil
 from azurelinuxagent.common.utils.flexible_version import FlexibleVersion
 from azurelinuxagent.common.future import ustr, get_linux_distribution

--- a/azurelinuxagent/common/version.py
+++ b/azurelinuxagent/common/version.py
@@ -49,22 +49,11 @@ def get_daemon_version():
     The value indicates the version of the daemon that started the current agent process or, if the current
     process is the daemon, the version of the current process.
     If the variable is not set (because the agent is < 2.2.53, or the process was not started by the daemon and
-    the process is not the daemon itself) the function returns version of agent which started by the python
+    the process is not the daemon itself) the function returns "0.0.0.0"
     """
     if __DAEMON_VERSION_ENV_VARIABLE in os.environ:
         return FlexibleVersion(os.environ[__DAEMON_VERSION_ENV_VARIABLE])
-    else:
-        # The agent process which execute the extensions can have different version(after upgrades) and importing version from that process may provide wrong version for daemon.
-        # so launching new process with sys.executable python provides the correct version for daemon which preinstalled in the image.
-        daemon_version = "0.0.0.0"
-        try:
-            cmd = ["{0}".format(sys.executable), "-c", "from azurelinuxagent.common.version import AGENT_VERSION; print(AGENT_VERSION)"]
-            daemon_version = shellutil.run_command(cmd)
-        except Exception as e:  # Make the best effort to get the daemon version, otherwise default to 0.0.0.0(unknown)
-            logger.info("Failed to get the daemon version. The error is: {0} \n[This error can be ignored since it has no impact on customer. So we return as unknown version: 0.0.0.0]", ustr(e))
-        # set the daemon version to the environment variable to cache it for future calls.
-        set_daemon_version(daemon_version)
-        return FlexibleVersion(os.environ[__DAEMON_VERSION_ENV_VARIABLE])
+    return FlexibleVersion("0.0.0.0")
 
 
 def get_f5_platform():

--- a/tests/common/test_version.py
+++ b/tests/common/test_version.py
@@ -136,16 +136,11 @@ class TestAgentVersion(AgentTestCase):
         finally:
             os.environ.pop(DAEMON_VERSION_ENV_VARIABLE)
 
-    def test_get_daemon_version_from_fallback_when_the_version_has_not_been_set(self):
-        with patch("azurelinuxagent.common.utils.shellutil.run_command", return_value="2.3.53") as mock_run_command:
-            self.assertEqual(
-                FlexibleVersion("2.3.53"), get_daemon_version(),
-                "The daemon version should be defined. Environment={0}".format(os.environ)
-            )
-            self.assertEqual(FlexibleVersion("2.3.53"), get_daemon_version(), "The daemon version should be 2.3.53")
-            self.assertEqual(1, mock_run_command.call_count, "The daemon version should be read from env value on second time")
-
-        os.environ.pop(DAEMON_VERSION_ENV_VARIABLE)
+    def test_get_daemon_version_should_return_zero_when_the_version_has_not_been_set(self):
+        self.assertEqual(
+            FlexibleVersion("0.0.0.0"), get_daemon_version(),
+            "The daemon version should not be defined. Environment={0}".format(os.environ)
+        )
 
 
 class TestCurrentAgentName(AgentTestCase):


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Recently added python call to get daemon version and that's causing sigfualts due to some python issue. This new change not giving many benefits except for tests. I don't want to change it for the sake of tests as I could do workaround for tests.

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).