### PR TITLE
rename log file for agent publish scenario

### DIFF
--- a/tests_e2e/tests/agent_publish/agent_publish.py
+++ b/tests_e2e/tests/agent_publish/agent_publish.py
@@ -61,9 +61,9 @@ class AgentPublishTest(AgentVmTest):
         log.info('Agent info \n%s', stdout)
 
     def _prepare_agent(self) -> None:
-        log.info("Modifying agent update related config flags")
-        self._run_remote_test(self._ssh_client, "update-waagent-conf Debug.DownloadNewAgents=y AutoUpdate.GAFamily=Test AutoUpdate.Enabled=y Extensions.Enabled=y", use_sudo=True)
-        log.info('Updated agent-update DownloadNewAgents  GAFamily config flags')
+        log.info("Modifying agent update related config flags and rename the log file")
+        self._run_remote_test("sh -c 'agent-service stop && mv /var/log/waagent.log /var/log/waagent.$(date --iso-8601=seconds).log && update-waagent-conf Debug.DownloadNewAgents=y AutoUpdate.GAFamily=Test AutoUpdate.Enabled=y Extensions.Enabled=y'", use_sudo=True)
+        log.info('Renamed log file and updated agent-update DownloadNewAgents GAFamily config flags')
 
     def _check_update(self) -> None:
         log.info("Verifying for agent update status")

--- a/tests_e2e/tests/agent_publish/agent_publish.py
+++ b/tests_e2e/tests/agent_publish/agent_publish.py
@@ -61,7 +61,7 @@ class AgentPublishTest(AgentVmTest):
         log.info('Agent info \n%s', stdout)
 
     def _prepare_agent(self) -> None:
-        log.info("Modifying agent update related config flags and rename the log file")
+        log.info("Modifying agent update related config flags and renaming the log file")
         self._run_remote_test(self._ssh_client, "sh -c 'agent-service stop && mv /var/log/waagent.log /var/log/waagent.$(date --iso-8601=seconds).log && update-waagent-conf Debug.DownloadNewAgents=y AutoUpdate.GAFamily=Test AutoUpdate.Enabled=y Extensions.Enabled=y'", use_sudo=True)
         log.info('Renamed log file and updated agent-update DownloadNewAgents GAFamily config flags')
 

--- a/tests_e2e/tests/agent_publish/agent_publish.py
+++ b/tests_e2e/tests/agent_publish/agent_publish.py
@@ -62,7 +62,7 @@ class AgentPublishTest(AgentVmTest):
 
     def _prepare_agent(self) -> None:
         log.info("Modifying agent update related config flags and rename the log file")
-        self._run_remote_test("sh -c 'agent-service stop && mv /var/log/waagent.log /var/log/waagent.$(date --iso-8601=seconds).log && update-waagent-conf Debug.DownloadNewAgents=y AutoUpdate.GAFamily=Test AutoUpdate.Enabled=y Extensions.Enabled=y'", use_sudo=True)
+        self._run_remote_test(self._ssh_client, "sh -c 'agent-service stop && mv /var/log/waagent.log /var/log/waagent.$(date --iso-8601=seconds).log && update-waagent-conf Debug.DownloadNewAgents=y AutoUpdate.GAFamily=Test AutoUpdate.Enabled=y Extensions.Enabled=y'", use_sudo=True)
         log.info('Renamed log file and updated agent-update DownloadNewAgents GAFamily config flags')
 
     def _check_update(self) -> None:


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description 
 Agent publish scenario log contains other agent updates before we change agent to test type to validate published test agent. That information may confuse when we debug, so I rename the log file to have data after we update the family type to Test.

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).