### PR TITLE
Ignore dependencies when the extension does not have any settings

### DIFF
--- a/azurelinuxagent/common/event.py
+++ b/azurelinuxagent/common/event.py
@@ -109,6 +109,7 @@ class WALAEventOperation:
     OpenSsl = "OpenSsl"
     Partition = "Partition"
     PersistFirewallRules = "PersistFirewallRules"
+    ProvisionAfterExtensions = "ProvisionAfterExtensions"
     PluginSettingsVersionMismatch = "PluginSettingsVersionMismatch"
     InvalidExtensionConfig = "InvalidExtensionConfig"
     Provision = "Provision"

--- a/azurelinuxagent/ga/agent_update_handler.py
+++ b/azurelinuxagent/ga/agent_update_handler.py
@@ -273,9 +273,6 @@ class AgentUpdateHandler(object):
         """
         if not self._is_requested_version_update:
             if requested_version < CURRENT_VERSION:
-                msg = "Downgrade requested in the GoalState, but downgrades are not supported for self-update version:{0}, " \
-                      "skipping agent update".format(requested_version)
-                self.__log_event(LogLevel.INFO, msg)
                 return False
         return True
 


### PR DESCRIPTION
Until recently, CRP was ignoring extension dependencies when they originated from extensions with no settings. The fix for that issue exposed this bug in the Agent. When parsing the VmSettings, if a dependency is found, the agent always tries to access settings[0], causing an index out of range error.

As a temporary fix, the Agent will ignore the dependency in this case. The next release will include the full fix.

While checking the telemetry for this fix, I noticed a confusing message from self-update. I am removing it as part of this PR, too.