### PR TITLE
Reduce the firewall check period in agent firewall tests

### DIFF
--- a/tests_e2e/tests/scripts/agent_firewall-verify_all_firewall_rules.py
+++ b/tests_e2e/tests/scripts/agent_firewall-verify_all_firewall_rules.py
@@ -144,7 +144,7 @@ def verify_all_rules_exist() -> None:
 
     log.info("-----Verifying all ip table rules are present in rule set")
     # Agent will re-add rules within OS.EnableFirewallPeriod, So waiting that time + some buffer
-    found: bool = retry_if_false(check_all_iptables, attempts=2, delay=FIREWALL_PERIOD+30)
+    found: bool = retry_if_false(check_all_iptables, attempts=2, delay=FIREWALL_PERIOD+15)
 
     if not found:
         fail("IP table rules missing in rule set.\n Current iptable rules:\n {0}".format(

--- a/tests_e2e/tests/scripts/agent_firewall-verify_all_firewall_rules.py
+++ b/tests_e2e/tests/scripts/agent_firewall-verify_all_firewall_rules.py
@@ -39,7 +39,7 @@ ROOT_USER = 'root'
 WIRESERVER_ENDPOINT_FILE = '/var/lib/waagent/WireServerEndpoint'
 WIRESERVER_IP = '168.63.129.16'
 VERSIONS_PATH = '/?comp=versions'
-FIREWALL_PERIOD = 60
+FIREWALL_PERIOD = 30
 
 
 class FirewallRules(object):


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Sometimes firewall tests failed with ssh timeouts. Having long firewall check period + retries may contribute to ssh timeout, so reducing the period and monitor for few runs if this fix helps.

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).