### PR TITLE
Remove debug info from waagent.status.json

### DIFF
--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -964,33 +964,6 @@ class ExtHandlersHandler(object):
                       message=msg)
             return None
 
-    def get_ext_handlers_status_debug_info(self, vm_status):
-        status_blob_text = self.protocol.get_status_blob_data()
-        if status_blob_text is None:
-            status_blob_text = ""
-
-        support_multi_config = {}
-        vm_status_data = get_properties(vm_status)
-        vm_handler_statuses = vm_status_data.get('vmAgent', {}).get('extensionHandlers')
-        for handler_status in vm_handler_statuses:
-            if handler_status.get('name') is not None:
-                support_multi_config[handler_status.get('name')] = handler_status.get('supports_multi_config')
-
-        debug_text = json.dumps({
-            "agentName": AGENT_NAME,
-            "daemonVersion": str(version.get_daemon_version()),
-            "pythonVersion": "Python: {0}.{1}.{2}".format(PY_VERSION_MAJOR, PY_VERSION_MINOR, PY_VERSION_MICRO),
-            "extensionSupportedFeatures": [name for name, _ in get_agent_supported_features_list_for_extensions().items()],
-            "supportsMultiConfig": support_multi_config
-        })
-
-        return '''{{
-    "__comment__": "The __status__ property is the actual status reported to CRP",
-    "__status__": {0},
-    "__debug__": {1}
-}}
-'''.format(status_blob_text, debug_text)
-
     def report_ext_handler_status(self, vm_status, ext_handler, goal_state_changed):
         ext_handler_i = ExtHandlerInstance(ext_handler, self.protocol)
 

--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -53,8 +53,7 @@ from azurelinuxagent.common.protocol.restapi import ExtensionStatus, ExtensionSu
 from azurelinuxagent.common.utils import textutil
 from azurelinuxagent.common.utils.archive import ARCHIVE_DIRECTORY_NAME
 from azurelinuxagent.common.utils.flexible_version import FlexibleVersion
-from azurelinuxagent.common.version import AGENT_NAME, CURRENT_VERSION, \
-    PY_VERSION_MAJOR, PY_VERSION_MICRO, PY_VERSION_MINOR
+from azurelinuxagent.common.version import AGENT_NAME, CURRENT_VERSION
 
 _HANDLER_NAME_PATTERN = r'^([^-]+)'
 _HANDLER_VERSION_PATTERN = r'(\d+(?:\.\d+)*)'

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -617,8 +617,10 @@ class UpdateHandler(object):
         if vm_status is not None:
             self._report_extensions_summary(vm_status)
             if self._goal_state is not None:
-                agent_status = exthandlers_handler.get_ext_handlers_status_debug_info(vm_status)
-                self._goal_state.save_to_history(agent_status, AGENT_STATUS_FILE)
+                status_blob_text = exthandlers_handler.protocol.get_status_blob_data()
+                if status_blob_text is None:
+                    status_blob_text = "{}"
+                self._goal_state.save_to_history(status_blob_text, AGENT_STATUS_FILE)
                 if self._goal_state.extensions_goal_state.is_outdated:
                     exthandlers_handler.protocol.client.get_host_plugin().clear_fast_track_state()
 

--- a/tests/ga/test_extension.py
+++ b/tests/ga/test_extension.py
@@ -3247,91 +3247,75 @@ class TestExtension(TestExtensionBase, HttpRequestPredicates):
                 )
 
             expected_status = {
-                "__comment__": "The __status__ property is the actual status reported to CRP",
-                "__status__": {
-                    "version": "1.1",
-                    "timestampUTC": "1970-01-01T00:00:00Z",
-                    "aggregateStatus": {
-                        "guestAgentStatus": {
-                            "version": AGENT_VERSION,
-                            "status": "Ready",
-                            "formattedMessage": {
-                                "lang": "en-US",
-                                "message": "Guest Agent is running"
-                            }
-                        },
-                        "handlerAggregateStatus": [
-                            {
-                                "handlerVersion": "1.0.0",
-                                "handlerName": "OSTCExtensions.ExampleHandlerLinux",
-                                "status": "Ready",
-                                "code": 0,
-                                "useExactVersion": True,
-                                "formattedMessage": {
-                                    "lang": "en-US",
-                                    "message": "Plugin enabled"
-                                },
-                                "runtimeSettingsStatus": {
-                                    "settingsStatus": {
-                                        "status": {
-                                            "name": "OSTCExtensions.ExampleHandlerLinux",
-                                            "configurationAppliedTime": None,
-                                            "operation": None,
-                                            "status": "success",
-                                            "code": 0,
-                                            "formattedMessage": {
-                                                "lang": "en-US",
-                                                "message": None
-                                            }
-                                        },
-                                        "version": 1.0,
-                                        "timestampUTC": "1970-01-01T00:00:00Z"
-                                    },
-                                    "sequenceNumber": 0
-                                }
-                            }
-                        ],
-                        "vmArtifactsAggregateStatus": {
-                            "goalStateAggregateStatus": {
-                                "formattedMessage": {
-                                    "lang": "en-US",
-                                    "message": "GoalState executed successfully"
-                                },
-                                "timestampUTC": "1970-01-01T00:00:00Z",
-                                "inSvdSeqNo": "1",
-                                "status": "Success",
-                                "code": 0
-                            }
+                "version": "1.1",
+                "timestampUTC": "1970-01-01T00:00:00Z",
+                "aggregateStatus": {
+                    "guestAgentStatus": {
+                        "version": AGENT_VERSION,
+                        "status": "Ready",
+                        "formattedMessage": {
+                            "lang": "en-US",
+                            "message": "Guest Agent is running"
                         }
                     },
-                    "guestOSInfo": None,
-                    "supportedFeatures": supported_features
-                },
-                "__debug__": {
-                    "agentName": AGENT_NAME,
-                    "daemonVersion": "0.0.0.0",
-                    "pythonVersion": "Python: {0}.{1}.{2}".format(PY_VERSION_MAJOR, PY_VERSION_MINOR, PY_VERSION_MICRO),
-                    "extensionSupportedFeatures": [name for name, _ in get_agent_supported_features_list_for_extensions().items()],
-                    "supportsMultiConfig": {
-                        "OSTCExtensions.ExampleHandlerLinux": False
+                    "handlerAggregateStatus": [
+                        {
+                            "handlerVersion": "1.0.0",
+                            "handlerName": "OSTCExtensions.ExampleHandlerLinux",
+                            "status": "Ready",
+                            "code": 0,
+                            "useExactVersion": True,
+                            "formattedMessage": {
+                                "lang": "en-US",
+                                "message": "Plugin enabled"
+                            },
+                            "runtimeSettingsStatus": {
+                                "settingsStatus": {
+                                    "status": {
+                                        "name": "OSTCExtensions.ExampleHandlerLinux",
+                                        "configurationAppliedTime": None,
+                                        "operation": None,
+                                        "status": "success",
+                                        "code": 0,
+                                        "formattedMessage": {
+                                            "lang": "en-US",
+                                            "message": None
+                                        }
+                                    },
+                                    "version": 1.0,
+                                    "timestampUTC": "1970-01-01T00:00:00Z"
+                                },
+                                "sequenceNumber": 0
+                            }
+                        }
+                    ],
+                    "vmArtifactsAggregateStatus": {
+                        "goalStateAggregateStatus": {
+                            "formattedMessage": {
+                                "lang": "en-US",
+                                "message": "GoalState executed successfully"
+                            },
+                            "timestampUTC": "1970-01-01T00:00:00Z",
+                            "inSvdSeqNo": "1",
+                            "status": "Success",
+                            "code": 0
+                        }
                     }
-                }
+                },
+                "guestOSInfo": None,
+                "supportedFeatures": supported_features
             }
 
-
             exthandlers_handler.run()
-            vm_status = exthandlers_handler.report_ext_handlers_status()
-            actual_status_json = json.loads(exthandlers_handler.get_ext_handlers_status_debug_info(vm_status))
+            exthandlers_handler.report_ext_handlers_status()
+
+            actual_status = json.loads(protocol.get_status_blob_data())
 
             # Don't compare the guestOSInfo
-            status_property = actual_status_json.get("__status__")
-            self.assertIsNotNone(status_property, "The status file is missing the __status__ property")
-            self.assertIsNotNone(status_property.get("guestOSInfo"), "The status file is missing the guestOSInfo property")
-            status_property["guestOSInfo"] = None
+            self.assertIsNotNone(actual_status.get("guestOSInfo"), "The status file is missing the guestOSInfo property")
+            actual_status["guestOSInfo"] = None
 
-            actual_status_json.pop('guestOSInfo', None)
-
-            self.assertEqual(expected_status, actual_status_json)
+            self.assertEqual(expected_status, actual_status)
 
     def test_it_should_process_extensions_only_if_allowed(self):
         def assert_extensions_called(exthandlers_handler, expected_call_count=0):

--- a/tests/ga/test_extension.py
+++ b/tests/ga/test_extension.py
@@ -28,16 +28,14 @@ import time
 import unittest
 
 from azurelinuxagent.common import conf
-from azurelinuxagent.common.agent_supported_feature import get_agent_supported_features_list_for_extensions, \
-    get_agent_supported_features_list_for_crp
+from azurelinuxagent.common.agent_supported_feature import get_agent_supported_features_list_for_crp
 from azurelinuxagent.ga.cgroupconfigurator import CGroupConfigurator
 from azurelinuxagent.common.datacontract import get_properties
 from azurelinuxagent.common.event import WALAEventOperation
 from azurelinuxagent.common.utils import fileutil
 from azurelinuxagent.common.utils.fileutil import read_file
 from azurelinuxagent.common.utils.flexible_version import FlexibleVersion
-from azurelinuxagent.common.version import PY_VERSION_MAJOR, PY_VERSION_MINOR, PY_VERSION_MICRO, AGENT_NAME, \
-    AGENT_VERSION
+from azurelinuxagent.common.version import AGENT_VERSION
 from azurelinuxagent.common.exception import ResourceGoneError, ExtensionDownloadError, ProtocolError, \
     ExtensionErrorCodes, ExtensionError, GoalStateAggregateStatusCodes
 from azurelinuxagent.common.protocol.restapi import ExtensionSettings, Extension, ExtHandlerStatus, \

--- a/tests/ga/test_update.py
+++ b/tests/ga/test_update.py
@@ -2198,7 +2198,6 @@ def _mock_exthandlers_handler(extension_statuses=None):
             exthandlers_handler.report_ext_handlers_status = Mock(return_value=create_vm_status(ExtensionStatusValue.success))
         else:
             exthandlers_handler.report_ext_handlers_status = Mock(side_effect=[create_vm_status(s) for s in extension_statuses])
-        exthandlers_handler.get_ext_handlers_status_debug_info = Mock(return_value='')
         yield exthandlers_handler
 
 


### PR DESCRIPTION
Removing the debug info from the status file we save to the history folder. This info is already available in the log/telemetry and is not needed. It recently caused issues in the agent's functionality because it is computed in the main loop.

The one piece of information that is not available in the log/telemetry is the extensions that support Multi-config, but that feature has been deprecated. If this info is needed, it should be added in the log/telemetry.