### PR TITLE
Change agent_cgroups to own Vm

### DIFF
--- a/tests_e2e/test_suites/agent_cgroups.yml
+++ b/tests_e2e/test_suites/agent_cgroups.yml
@@ -6,3 +6,4 @@ tests:
   - "agent_cgroups/agent_cgroups.py"
   - "agent_cgroups/agent_cpu_quota.py"
 images: "cgroups-endorsed"
+owns_vm: true

--- a/tests_e2e/test_suites/ext_cgroups.yml
+++ b/tests_e2e/test_suites/ext_cgroups.yml
@@ -11,3 +11,4 @@ locations: "AzureCloud:southcentralus"
 skip_on_clouds:
   - "AzureChinaCloud"
   - "AzureUSGovernment"
+owns_vm: true

--- a/tests_e2e/test_suites/ext_cgroups.yml
+++ b/tests_e2e/test_suites/ext_cgroups.yml
@@ -11,4 +11,3 @@ locations: "AzureCloud:southcentralus"
 skip_on_clouds:
   - "AzureChinaCloud"
   - "AzureUSGovernment"
-owns_vm: true


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
Cgroups scenario should own VM until the scenario is updated to cleanup any test-specific setup. Right now if ext_cgroups shares a VM, other scenarios on the VM are failing during check agent log:

> Detected 3 error(s) in the agent log on lisa-WALinuxAgent-20231030-083811-598-e23-n0 - First few errors:
> 2023-10-30T08:58:18.091399Z INFO MonitorHandler ExtHandler [CGW] Disabling resource usage monitoring. Reason: Check on cgroups failed:
> [CGroupsException] The agent's cgroup includes unexpected processes: ['[PID: 6380] /usr/bin/python3\x00/home/waagent/bin/agent_cpu_quota-start_service']
> 
> 2023-10-30T08:59:08.915482Z INFO MonitorHandler ExtHandler [CGW] Disabling resource usage monitoring. Reason: Check on cgroups failed:
> [CGroupsException] The agent's cgroup includes unexpected processes: ['[PID: 6666] /usr/bin/python3\x00/home/waagent/bin/agent_cpu_quota-start_service', '[PID: 6814] dd\x00if=/dev/zero\x00of=/dev/null\x00                                   ']
> [CGroupsException] The agent has been throttled for 5.729909 seconds
> 
> 2023-10-30T09:00:51.345288Z INFO MonitorHandler ExtHandler [CGW] Disabling resource usage monitoring. Reason: Check on cgroups failed:
> [CGroupsException] The agent's cgroup includes unexpected processes: ['[PID: 7396] /usr/bin/python3\x00/home/waagent/bin/agent_cpu_quota-start_service', '[PID: 7589] dd\x00if=/dev/zero\x00of=/dev/null\x00                                   ']
> [CGroupsException] The agent has been throttled for 12.1753441 seconds

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).