### PR TITLE
Save goal state history explicitly

### DIFF
--- a/azurelinuxagent/common/protocol/util.py
+++ b/azurelinuxagent/common/protocol/util.py
@@ -188,7 +188,7 @@ class ProtocolUtil(SingletonPerThread):
                 return
             logger.error("Failed to clear wiresever endpoint: {0}", e)
 
-    def _detect_protocol(self, init_goal_state=True):
+    def _detect_protocol(self, init_goal_state=True, save_to_history=False):
         """
         Probe protocol endpoints in turn.
         """
@@ -217,7 +217,7 @@ class ProtocolUtil(SingletonPerThread):
 
                 try:
                     protocol = WireProtocol(endpoint)
-                    protocol.detect(init_goal_state=init_goal_state)
+                    protocol.detect(init_goal_state=init_goal_state, save_to_history=save_to_history)
                     self._set_wireserver_endpoint(endpoint)
                     return protocol
 
@@ -268,7 +268,7 @@ class ProtocolUtil(SingletonPerThread):
         finally:
             self._lock.release()
 
-    def get_protocol(self, init_goal_state=True):
+    def get_protocol(self, init_goal_state=True, save_to_history=False):
         """
         Detect protocol by endpoint.
         :returns: protocol instance
@@ -296,7 +296,7 @@ class ProtocolUtil(SingletonPerThread):
 
             logger.info("Detect protocol endpoint")
 
-            protocol = self._detect_protocol(init_goal_state=init_goal_state)
+            protocol = self._detect_protocol(init_goal_state=init_goal_state, save_to_history=save_to_history)
 
             IOErrorCounter.set_protocol_endpoint(endpoint=protocol.get_endpoint())
             self._save_protocol(WIRE_PROTOCOL_NAME)

--- a/azurelinuxagent/common/protocol/util.py
+++ b/azurelinuxagent/common/protocol/util.py
@@ -188,7 +188,7 @@ class ProtocolUtil(SingletonPerThread):
                 return
             logger.error("Failed to clear wiresever endpoint: {0}", e)
 
-    def _detect_protocol(self, init_goal_state=True, save_to_history=False):
+    def _detect_protocol(self, save_to_history, init_goal_state=True):
         """
         Probe protocol endpoints in turn.
         """
@@ -296,7 +296,7 @@ class ProtocolUtil(SingletonPerThread):
 
             logger.info("Detect protocol endpoint")
 
-            protocol = self._detect_protocol(init_goal_state=init_goal_state, save_to_history=save_to_history)
+            protocol = self._detect_protocol(save_to_history=save_to_history, init_goal_state=init_goal_state)
 
             IOErrorCounter.set_protocol_endpoint(endpoint=protocol.get_endpoint())
             self._save_protocol(WIRE_PROTOCOL_NAME)

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -73,7 +73,7 @@ class WireProtocol(DataContract):
             raise ProtocolError("WireProtocol endpoint is None")
         self.client = WireClient(endpoint)
 
-    def detect(self, init_goal_state=True):
+    def detect(self, init_goal_state=True, save_to_history=False):
         self.client.check_wire_protocol_version()
 
         trans_prv_file = os.path.join(conf.get_lib_dir(),
@@ -86,7 +86,7 @@ class WireProtocol(DataContract):
         # Initialize the goal state, including all the inner properties
         if init_goal_state:
             logger.info('Initializing goal state during protocol detection')
-            self.client.reset_goal_state()
+            self.client.reset_goal_state(save_to_history=save_to_history)
 
     def update_host_plugin_from_goal_state(self):
         self.client.update_host_plugin_from_goal_state()
@@ -777,13 +777,13 @@ class WireClient(object):
             self._host_plugin.update_container_id(container_id)
             self._host_plugin.update_role_config_name(role_config_name)
 
-    def update_goal_state(self, silent=False):
+    def update_goal_state(self, silent=False, save_to_history=False):
         """
         Updates the goal state if the incarnation or etag changed
         """
         try:
             if self._goal_state is None:
-                self._goal_state = GoalState(self, silent=silent)
+                self._goal_state = GoalState(self, silent=silent, save_to_history=save_to_history)
             else:
                 self._goal_state.update(silent=silent)
 
@@ -792,7 +792,7 @@ class WireClient(object):
         except Exception as exception:
             raise ProtocolError("Error fetching goal state: {0}".format(ustr(exception)))
 
-    def reset_goal_state(self, goal_state_properties=GoalStateProperties.All, silent=False):
+    def reset_goal_state(self, goal_state_properties=GoalStateProperties.All, silent=False, save_to_history=False):
         """
         Resets the goal state
         """
@@ -800,7 +800,7 @@ class WireClient(object):
             if not silent:
                 logger.info("Forcing an update of the goal state.")
 
-            self._goal_state = GoalState(self, goal_state_properties=goal_state_properties, silent=silent)
+            self._goal_state = GoalState(self, goal_state_properties=goal_state_properties, silent=silent, save_to_history=save_to_history)
 
         except ProtocolError:
             raise
@@ -936,7 +936,7 @@ class WireClient(object):
 
         if extensions_goal_state.status_upload_blob is None:
             # the status upload blob is in ExtensionsConfig so force a full goal state refresh
-            self.reset_goal_state(silent=True)
+            self.reset_goal_state(silent=True, save_to_history=True)
             extensions_goal_state = self.get_goal_state().extensions_goal_state
 
             if extensions_goal_state.status_upload_blob is None:

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -339,7 +339,7 @@ class UpdateHandler(object):
             # Initialize the goal state; some components depend on information provided by the goal state and this
             # call ensures the required info is initialized (e.g. telemetry depends on the container ID.)
             #
-            protocol = self.protocol_util.get_protocol()
+            protocol = self.protocol_util.get_protocol(save_to_history=True)
 
             self._initialize_goal_state(protocol)
 
@@ -503,7 +503,7 @@ class UpdateHandler(object):
         try:
             max_errors_to_log = 3
 
-            protocol.client.update_goal_state(silent=self._update_goal_state_error_count >= max_errors_to_log)
+            protocol.client.update_goal_state(silent=self._update_goal_state_error_count >= max_errors_to_log, save_to_history=True)
 
             self._goal_state = protocol.get_goal_state()
 
@@ -530,8 +530,7 @@ class UpdateHandler(object):
             else:
                 if self._update_goal_state_last_error_report + timedelta(hours=6) > datetime.now():
                     self._update_goal_state_last_error_report = datetime.now()
-                    message = u"Fetching the goal state is still failing: {0}".format(textutil.format_exception(e))
-                    logger.error(message)
+                    message = u"Fetching the goal state is still failing: {0}".format(textutil.format_exception(e))                    logger.error(message)
                     add_event(op=WALAEventOperation.FetchGoalState, is_success=False, message=message, log_event=False)
             return False
 

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -530,7 +530,8 @@ class UpdateHandler(object):
             else:
                 if self._update_goal_state_last_error_report + timedelta(hours=6) > datetime.now():
                     self._update_goal_state_last_error_report = datetime.now()
-                    message = u"Fetching the goal state is still failing: {0}".format(textutil.format_exception(e))                    logger.error(message)
+                    message = u"Fetching the goal state is still failing: {0}".format(textutil.format_exception(e))
+                    logger.error(message)
                     add_event(op=WALAEventOperation.FetchGoalState, is_success=False, message=message, log_event=False)
             return False
 

--- a/tests/common/protocol/test_protocol_util.py
+++ b/tests/common/protocol/test_protocol_util.py
@@ -127,14 +127,14 @@ class TestProtocolUtil(AgentTestCase):
         endpoint_file = protocol_util._get_wireserver_endpoint_file_path()  # pylint: disable=unused-variable
 
         # Test wire protocol when no endpoint file has been written
-        protocol_util._detect_protocol()
+        protocol_util._detect_protocol(save_to_history=False)
         self.assertEqual(KNOWN_WIRESERVER_IP, protocol_util.get_wireserver_endpoint())
 
         # Test wire protocol on dhcp failure
         protocol_util.osutil.is_dhcp_available.return_value = True
         protocol_util.dhcp_handler.run.side_effect = DhcpError()
 
-        self.assertRaises(ProtocolError, protocol_util._detect_protocol)
+        self.assertRaises(ProtocolError, lambda: protocol_util._detect_protocol(save_to_history=False))
 
     @patch("azurelinuxagent.common.protocol.util.WireProtocol")
     def test_get_protocol(self, WireProtocol, _):

--- a/tests/ga/test_update.py
+++ b/tests/ga/test_update.py
@@ -2176,7 +2176,7 @@ def _create_update_handler():
 
 
 @contextlib.contextmanager
-def _mock_exthandlers_handler(extension_statuses=None):
+def _mock_exthandlers_handler(extension_statuses=None, save_to_history=False):
     """
     Creates an ExtHandlersHandler that doesn't actually handle any extensions, but that returns status for 1 extension.
     The returned ExtHandlersHandler uses a mock WireProtocol, and both the run() and report_ext_handlers_status() are
@@ -2191,7 +2191,7 @@ def _mock_exthandlers_handler(extension_statuses=None):
         vm_status.vmAgent.extensionHandlers[0].extension_status.status = extension_status
         return vm_status
 
-    with mock_wire_protocol(DATA_FILE) as protocol:
+    with mock_wire_protocol(DATA_FILE, save_to_history=save_to_history) as protocol:
         exthandlers_handler = ExtHandlersHandler(protocol)
         exthandlers_handler.run = Mock()
         if extension_statuses is None:
@@ -2238,7 +2238,7 @@ class ProcessGoalStateTestCase(AgentTestCase):
             self.assertEqual(3, agent_update_handler.run.call_count, "agent_update_handler.run() should have been called on the new goal state")
 
     def test_it_should_write_the_agent_status_to_the_history_folder(self):
-        with _mock_exthandlers_handler() as exthandlers_handler:
+        with _mock_exthandlers_handler(save_to_history=True) as exthandlers_handler:
             update_handler = _create_update_handler()
             remote_access_handler = Mock()
             remote_access_handler.run = Mock()

--- a/tests/lib/mock_wire_protocol.py
+++ b/tests/lib/mock_wire_protocol.py
@@ -22,7 +22,7 @@ from tests.lib import wire_protocol_data
 
 
 @contextlib.contextmanager
-def mock_wire_protocol(mock_wire_data_file, http_get_handler=None, http_post_handler=None, http_put_handler=None, do_not_mock=lambda method, url: False, fail_on_unknown_request=True):
+def mock_wire_protocol(mock_wire_data_file, http_get_handler=None, http_post_handler=None, http_put_handler=None, do_not_mock=lambda method, url: False, fail_on_unknown_request=True, save_to_history=False):
     """
     Creates a WireProtocol object that handles requests to the WireServer, the Host GA Plugin, and some requests to storage (requests that provide mock data
     in wire_protocol_data.py).
@@ -37,6 +37,8 @@ def mock_wire_protocol(mock_wire_data_file, http_get_handler=None, http_post_han
 
     The 'do_not_mock' lambda can be used to skip the mocks for specific requests; if the lambda returns True, the mocks won't be applied and the
     original common.utils.restutil.http_request will be invoked instead.
+
+    The 'save_to_history' parameter is passed thru in the call to WireProtocol.detect().
 
     The returned protocol object maintains a list of "tracked" urls. When a handler function returns a value than is not None the url for the
     request is automatically added to the tracked list. The handler function can add other items to this list using the track_url() method on
@@ -147,7 +149,7 @@ def mock_wire_protocol(mock_wire_data_file, http_get_handler=None, http_post_han
     # go do it
     try:
         protocol.start()
-        protocol.detect()
+        protocol.detect(save_to_history=save_to_history)
         yield protocol
     finally:
         protocol.stop()


### PR DESCRIPTION
We have multiple threads/processes fetching the goal state and all of those operations save the goal state to the history folder, which can end up messing up the history folder due to concurrency issues. 

We use the history folder to debug issues in extension handling, so we need only the main thread to save the goal state. I added a new parameter, 'save_to_history', which is False by default and only the extension handler thread sets to True. The parameter had to be propagated thru several layers in the code, as well as in the test mocks.