### PR TITLE
Use case-insensitive match when cleaning up test resource groups

### DIFF
--- a/tests_e2e/pipeline/pipeline-cleanup.yml
+++ b/tests_e2e/pipeline/pipeline-cleanup.yml
@@ -51,6 +51,6 @@ steps:
             --output json \
             --query value \
           | jq --arg date "$date" '.[] | select (.createdTime < $date).name' \
-          | grep '${{ parameters.name_pattern }}' \
+          | grep -i '${{ parameters.name_pattern }}' \
           | xargs -l -t -r az group delete --no-wait -y -n \
           || echo "No resource groups found to delete"


### PR DESCRIPTION
scale sets are created with all-lowercase names, the match needs to ignore case