### PR TITLE
Fix pylint warning

### DIFF
--- a/azurelinuxagent/common/osutil/factory.py
+++ b/azurelinuxagent/common/osutil/factory.py
@@ -73,7 +73,7 @@ def _get_osutil(distro_name, distro_code_name, distro_version, distro_full_name)
             return Ubuntu14OSUtil()
         if ubuntu_version in [Version('16.04'), Version('16.10'), Version('17.04')]:
             return Ubuntu16OSUtil()
-        if ubuntu_version >= Version('18.04') and ubuntu_version <= Version('24.04'):
+        if Version('18.04') <= ubuntu_version <= Version('24.04'):
             return Ubuntu18OSUtil()
         if distro_full_name == "Snappy Ubuntu Core":
             return UbuntuSnappyOSUtil()


### PR DESCRIPTION
I merged PR 2825 with the below pylint below to avoid turnaround. This PR fixes the warning.

```
************* Module azurelinuxagent.common.osutil.factory
azurelinuxagent/common/osutil/factory.py:76:11: R17[16](https://github.com/Azure/WALinuxAgent/actions/runs/6927958437/job/18855308122#step:5:17): Simplify chained comparison between the operands (chained-comparison)
```