### PR TITLE
Run remote date command to get test case start time

### DIFF
--- a/tests_e2e/tests/agent_ext_workflow/extension_workflow.py
+++ b/tests_e2e/tests/agent_ext_workflow/extension_workflow.py
@@ -19,7 +19,6 @@
 
 from azure.mgmt.compute.models import VirtualMachineExtensionInstanceView
 from assertpy import assert_that, soft_assertions
-from datetime import datetime
 from random import choice
 import uuid
 

--- a/tests_e2e/tests/agent_ext_workflow/extension_workflow.py
+++ b/tests_e2e/tests/agent_ext_workflow/extension_workflow.py
@@ -175,7 +175,7 @@ class ExtensionWorkflow(AgentVmTest):
             log.info("*******Verifying the extension install scenario*******")
 
             # Record the time we start the test
-            start_time = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+            start_time = self._ssh_client.run_command("date '+%Y-%m-%dT%TZ'").rstrip()
 
             # Create DcrTestExtension with version 1.1.5
             dcr_test_ext_id_1_1 = VmExtensionIdentifier(
@@ -224,7 +224,7 @@ class ExtensionWorkflow(AgentVmTest):
             log.info("*******Verifying the extension enable scenario*******")
 
             # Record the time we start the test
-            start_time = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+            start_time = self._ssh_client.run_command("date '+%Y-%m-%dT%TZ'").rstrip()
 
             # Enable test extension on the VM
             dcr_ext.modify_ext_settings_and_enable()
@@ -281,7 +281,7 @@ class ExtensionWorkflow(AgentVmTest):
             log.info("*******Verifying the extension uninstall scenario*******")
 
             # Record the time we start the test
-            start_time = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+            start_time = self._ssh_client.run_command("date '+%Y-%m-%dT%TZ'").rstrip()
 
             # Remove the test extension on the VM
             log.info("Delete %s from VM", dcr_test_ext_client)
@@ -306,7 +306,7 @@ class ExtensionWorkflow(AgentVmTest):
             log.info("*******Verifying the extension update with install scenario*******")
 
             # Record the time we start the test
-            start_time = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+            start_time = self._ssh_client.run_command("date '+%Y-%m-%dT%TZ'").rstrip()
 
             # Version 1.2.0 of the test extension has the same functionalities as 1.1.5 with
             # "updateMode": "UpdateWithInstall" in HandlerManifest.json to test update case
@@ -373,7 +373,7 @@ class ExtensionWorkflow(AgentVmTest):
             log.info("*******Verifying the extension update without install scenario*******")
 
             # Record the time we start the test
-            start_time = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+            start_time = self._ssh_client.run_command("date '+%Y-%m-%dT%TZ'").rstrip()
 
             # Version 1.3.0 of the test extension has the same functionalities as 1.1.5 with
             # "updateMode": "UpdateWithoutInstall" in HandlerManifest.json to test update case


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
Using date command to get current time on test VM for test case start time, because we occasionally run into issues with the orchestrator VM and test VM times being out of sync

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).