### PR TITLE
Replacing crypt with legacycrypt

### DIFF
--- a/azurelinuxagent/common/utils/textutil.py
+++ b/azurelinuxagent/common/utils/textutil.py
@@ -17,7 +17,7 @@
 # Requires Python 2.6+ and Openssl 1.0+
 
 import base64
-import crypt
+import legacycrypt as crypt
 import hashlib
 import random
 import re

--- a/bin/waagent2.0
+++ b/bin/waagent2.0
@@ -23,7 +23,7 @@
 # http://msdn.microsoft.com/en-us/library/cc227259%28PROT.13%29.aspx
 #
 
-import crypt
+import legacycrypt as crypt
 import random
 import array
 import base64

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 distro; python_version >= '3.8'
 pyasn1
+legacycrypt


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Issue # https://bugzilla.redhat.com/show_bug.cgi?id=2246085 <!-- if any -->
<!--
-->
the package fails to build with python 3.13 due to crypt module is going to be deprecated, so to address this issue and not break anything in the code or how this treat the hashing, this PR is replacing crypt with legacycrypt



---

### PR information
- [x ] The title of the PR is clear and informative.
- [ x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [x ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).