### PR TITLE
Fix publish hostname in china and gov clouds

### DIFF
--- a/tests_e2e/tests/publish_hostname/publish_hostname.py
+++ b/tests_e2e/tests/publish_hostname/publish_hostname.py
@@ -55,7 +55,7 @@ class PublishHostname(AgentVmTest):
 
     def check_and_install_dns_tools(self):
         lookup_cmd = "dig -x {0}".format(self._private_ip)
-        dns_regex = r"[\S\s]*;; ANSWER SECTION:\s.*PTR\s*(?P<hostname>.*).internal.*[\S\s]*"
+        dns_regex = r"[\S\s]*;; ANSWER SECTION:\s.*PTR\s*(?P<hostname>.*).internal.(cloudapp.net|chinacloudapp.cn|usgovcloudapp.net).*[\S\s]*"
 
         # Not all distros come with dig. Install dig if not on machine
         try:
@@ -66,7 +66,7 @@ class PublishHostname(AgentVmTest):
                 if "debian_9" in distro:
                     # Debian 9 hostname look up needs to be done with "host" instead of dig
                     lookup_cmd = "host {0}".format(self._private_ip)
-                    dns_regex = r".*pointer\s(?P<hostname>.*).internal.*"
+                    dns_regex = r".*pointer\s(?P<hostname>.*).internal.(cloudapp.net|chinacloudapp.cn|usgovcloudapp.net).*"
                 elif "debian" in distro:
                     self._ssh_client.run_command("apt install -y dnsutils", use_sudo=True)
                 elif "alma" in distro or "rocky" in distro:

--- a/tests_e2e/tests/publish_hostname/publish_hostname.py
+++ b/tests_e2e/tests/publish_hostname/publish_hostname.py
@@ -55,7 +55,7 @@ class PublishHostname(AgentVmTest):
 
     def check_and_install_dns_tools(self):
         lookup_cmd = "dig -x {0}".format(self._private_ip)
-        dns_regex = r"[\S\s]*;; ANSWER SECTION:\s.*PTR\s*(?P<hostname>.*).internal.cloudapp.net.[\S\s]*"
+        dns_regex = r"[\S\s]*;; ANSWER SECTION:\s.*PTR\s*(?P<hostname>.*).internal.*[\S\s]*"
 
         # Not all distros come with dig. Install dig if not on machine
         try:
@@ -66,7 +66,7 @@ class PublishHostname(AgentVmTest):
                 if "debian_9" in distro:
                     # Debian 9 hostname look up needs to be done with "host" instead of dig
                     lookup_cmd = "host {0}".format(self._private_ip)
-                    dns_regex = r".*pointer\s(?P<hostname>.*).internal.cloudapp.net."
+                    dns_regex = r".*pointer\s(?P<hostname>.*).internal.*"
                 elif "debian" in distro:
                     self._ssh_client.run_command("apt install -y dnsutils", use_sudo=True)
                 elif "alma" in distro or "rocky" in distro:

--- a/tests_e2e/tests/publish_hostname/publish_hostname.py
+++ b/tests_e2e/tests/publish_hostname/publish_hostname.py
@@ -55,7 +55,7 @@ class PublishHostname(AgentVmTest):
 
     def check_and_install_dns_tools(self):
         lookup_cmd = "dig -x {0}".format(self._private_ip)
-        dns_regex = r"[\S\s]*;; ANSWER SECTION:\s.*PTR\s*(?P<hostname>.*).internal.(cloudapp.net|chinacloudapp.cn|usgovcloudapp.net).*[\S\s]*"
+        dns_regex = r"[\S\s]*;; ANSWER SECTION:\s.*PTR\s*(?P<hostname>.*)\.internal\.(cloudapp\.net|chinacloudapp\.cn|usgovcloudapp\.net).*[\S\s]*"
 
         # Not all distros come with dig. Install dig if not on machine
         try:
@@ -66,7 +66,7 @@ class PublishHostname(AgentVmTest):
                 if "debian_9" in distro:
                     # Debian 9 hostname look up needs to be done with "host" instead of dig
                     lookup_cmd = "host {0}".format(self._private_ip)
-                    dns_regex = r".*pointer\s(?P<hostname>.*).internal.(cloudapp.net|chinacloudapp.cn|usgovcloudapp.net).*"
+                    dns_regex = r".*pointer\s(?P<hostname>.*)\.internal\.(cloudapp\.net|chinacloudapp\.cn|usgovcloudapp\.net).*"
                 elif "debian" in distro:
                     self._ssh_client.run_command("apt install -y dnsutils", use_sudo=True)
                 elif "alma" in distro or "rocky" in distro:


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
Publish hostname is failing in china and gov clouds because the domain names in these clouds are different than Public. 
The test was checking for the public cloud domain name (internal.cloudapp.net), but the domain names in China and Gov are the following:

- internal.chinacloudapp.cn
- internal.usgovcloudapp.net

Updated the regex to support any of these domain names


Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).