### PR TITLE
Lisa should not cleanup failed environment if keep_environment=failed

### DIFF
--- a/tests_e2e/orchestrator/lib/agent_test_suite.py
+++ b/tests_e2e/orchestrator/lib/agent_test_suite.py
@@ -36,6 +36,7 @@ from lisa import (  # pylint: disable=E0401
     TestCaseMetadata,
     TestSuite as LisaTestSuite,
     TestSuiteMetadata,
+    SkippedException
 )
 from lisa.environment import EnvironmentStatus  # pylint: disable=E0401
 from lisa.messages import TestStatus, TestResultMessage  # pylint: disable=E0401
@@ -103,6 +104,14 @@ class KeepEnvironment(object):
     Always = 'always'   # Do not delete resources created by the test suite
     Failed = 'failed'   # Skip delete only on test failures
     No = 'no'           # Always delete resources created by the test suite
+
+
+class TestFailedException(Exception):
+    def __init__(self, env_name: str, test_cases: List[str]):
+        msg = "Test suite {0} failed.".format(env_name)
+        if test_cases:
+            msg += " Failed tests: " + ','.join(test_cases)
+        super().__init__(msg)
 
 
 class _TestNode(object):
@@ -539,6 +548,7 @@ class AgentTestSuite(LisaTestSuite):
             log_path: Path = self._log_path / f"env-{self._environment_name}.log"
             with set_current_thread_log(log_path):
                 start_time: datetime.datetime = datetime.datetime.now()
+                failed_cases = []
 
                 try:
                     # Log the environment's name and the variables received from the runbook (note that we need to expand the names of the test suites)
@@ -563,7 +573,10 @@ class AgentTestSuite(LisaTestSuite):
                         for suite in self._test_suites:
                             log.info("Executing test suite %s", suite.name)
                             self._lisa_log.info("Executing Test Suite %s", suite.name)
-                            test_suite_success = self._execute_test_suite(suite, test_context) and test_suite_success
+                            case_success = self._execute_test_suite(suite, test_context)
+                            test_suite_success = case_success and test_suite_success
+                            if not case_success:
+                                failed_cases.append(suite.name)
 
                     finally:
                         if self._collect_logs == CollectLogs.Always or self._collect_logs == CollectLogs.Failed and not test_suite_success:
@@ -587,6 +600,8 @@ class AgentTestSuite(LisaTestSuite):
                     self._clean_up(test_suite_success and not unexpected_error)
                     if unexpected_error:
                         self._mark_log_as_failed()
+                    if not test_suite_success or unexpected_error:
+                        raise TestFailedException(self._environment_name, failed_cases)
 
     def _execute_test_suite(self, suite: TestSuiteInfo, test_context: AgentTestContext) -> bool:
         """

--- a/tests_e2e/orchestrator/lib/agent_test_suite.py
+++ b/tests_e2e/orchestrator/lib/agent_test_suite.py
@@ -35,7 +35,7 @@ from lisa import (  # pylint: disable=E0401
     simple_requirement,
     TestCaseMetadata,
     TestSuite as LisaTestSuite,
-    TestSuiteMetadata
+    TestSuiteMetadata,
 )
 from lisa.environment import EnvironmentStatus  # pylint: disable=E0401
 from lisa.messages import TestStatus, TestResultMessage  # pylint: disable=E0401

--- a/tests_e2e/orchestrator/lib/agent_test_suite.py
+++ b/tests_e2e/orchestrator/lib/agent_test_suite.py
@@ -599,6 +599,11 @@ class AgentTestSuite(LisaTestSuite):
                     self._clean_up(test_suite_success and not unexpected_error)
                     if unexpected_error:
                         self._mark_log_as_failed()
+
+                    # Check if any test failures or unexpected errors occurred. If so, raise an Exception here so that
+                    # lisa marks the environment as failed. Otherwise, lisa would mark this environment as passed and
+                    # clean up regardless of the value of 'keep_environment'. This should be the last thing that
+                    # happens during suite execution.
                     if not test_suite_success or unexpected_error:
                         raise TestFailedException(self._environment_name, failed_cases)
 

--- a/tests_e2e/orchestrator/lib/agent_test_suite.py
+++ b/tests_e2e/orchestrator/lib/agent_test_suite.py
@@ -35,8 +35,7 @@ from lisa import (  # pylint: disable=E0401
     simple_requirement,
     TestCaseMetadata,
     TestSuite as LisaTestSuite,
-    TestSuiteMetadata,
-    SkippedException
+    TestSuiteMetadata
 )
 from lisa.environment import EnvironmentStatus  # pylint: disable=E0401
 from lisa.messages import TestStatus, TestResultMessage  # pylint: disable=E0401

--- a/tests_e2e/tests/lib/virtual_machine_client.py
+++ b/tests_e2e/tests/lib/virtual_machine_client.py
@@ -174,7 +174,7 @@ class VirtualMachineClient(AzureSdkClient):
                         return
                     log.info("The VM has not rebooted yet. Restart time: %s. Boot time: %s", before_restart, boot_time)
                 except CommandError as e:
-                    if (e.exit_code == 255 and "Connection refused" in str(e)) or "Unprivileged users are not permitted to log in yet" in str(e):
+                    if (e.exit_code == 255 and ("Connection refused" in str(e) or "Connection timed out" in str(e))) or "Unprivileged users are not permitted to log in yet" in str(e):
                         log.info("VM %s is not yet accepting SSH connections", self)
                     else:
                         raise


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
Resource groups for failed test suites were being cleaned up on our pipeline runs even when keep_environment=failed. 
Lisa will only mark an environment as failed if it catches an exception from the test suite. This PR updates the test suite to throw an exception if there are any test failures. 

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).