### PR TITLE
Install missing dependency (jq) on Azure Pipeline Agents

### DIFF
--- a/tests_e2e/pipeline/pipeline-cleanup.yml
+++ b/tests_e2e/pipeline/pipeline-cleanup.yml
@@ -56,4 +56,8 @@ steps:
           | xargs -l -t -r az group delete --subscription "${subscription_id}" --no-wait -y -n \
           | tee deleted
 
-          [ -s deleted ] || echo "No resource groups found to delete"
+          if [ ! -s deleted ]
+          then
+            echo "No resource groups found to delete"
+          fi
+

--- a/tests_e2e/pipeline/pipeline-cleanup.yml
+++ b/tests_e2e/pipeline/pipeline-cleanup.yml
@@ -45,12 +45,15 @@ steps:
 
           rest_endpoint=$(az cloud show --query "endpoints.resourceManager" -o tsv)
           
+          pattern="${{ parameters.name_pattern }}"
+          
           az rest --method GET \
             --url "${rest_endpoint}/subscriptions/${subscription_id}/resourcegroups" \
             --url-parameters api-version=2021-04-01 \$expand=createdTime \
             --output json \
             --query value \
-          | jq --arg date "$date" '.[] | select (.createdTime < $date).name' \
-          | grep -i '${{ parameters.name_pattern }}' \
-          | xargs -l -t -r az group delete --no-wait -y -n \
-          || echo "No resource groups found to delete"
+          | jq --arg date "$date" '.[] | select (.createdTime < $date).name | match("'${pattern}'"; "g").string' \
+          | xargs -l -t -r az group delete --subscription "${subscription_id}" --no-wait -y -n \
+          | tee deleted
+
+          [ -s deleted ] || echo "No resource groups found to delete"

--- a/tests_e2e/pipeline/pipeline-cleanup.yml
+++ b/tests_e2e/pipeline/pipeline-cleanup.yml
@@ -53,11 +53,4 @@ steps:
             --output json \
             --query value \
           | jq --arg date "$date" '.[] | select (.createdTime < $date).name | match("'${pattern}'"; "g").string' \
-          | xargs -l -t -r az group delete --subscription "${subscription_id}" --no-wait -y -n \
-          | tee deleted
-
-          if [ ! -s deleted ]
-          then
-            echo "No resource groups found to delete"
-          fi
-
+          | xargs -l -t -r az group delete --subscription "${subscription_id}" --no-wait -y -n

--- a/tests_e2e/pipeline/scripts/setup-agent.sh
+++ b/tests_e2e/pipeline/scripts/setup-agent.sh
@@ -18,7 +18,7 @@
 #
 
 #
-# Script to setup the agent VM for the Azure Pipelines agent pool; it simply installs the Azure CLI and the Docker Engine.
+# Script to setup the agent VM for the Azure Pipelines agent pool; it simply installs the Azure CLI, the Docker Engine and jq.
 #
 
 set -euox pipefail
@@ -48,3 +48,7 @@ sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plug
 
 # Verify that Docker Engine is installed correctly by running the hello-world image.
 sudo docker run hello-world
+
+# Install jq; it is used by the cleanup pipeline to parse the JSON output of the Azure CLI
+sudo apt-get install -y jq
+


### PR DESCRIPTION
The cleanup pipeline was failing because 'jq' was not installed on the Azure Pipeline Agents:

\+ rest_endpoint=https://management.azure.com/
\+ grep -i 'lisa-WALinuxAgent-.*'
\+ xargs -l -t -r az group delete --no-wait -y -n
\+ jq --arg date 2024-01-08T15:19:02.438014177Z '.[] | select (.createdTime < $date).name'
**/agent/_work/_temp/azureclitaskscript170641.sh: line 18: jq: command not found**
\+ az rest --method GET --url https://management.azure.com//subscriptions/.../resourcegroups --url-parameters api-version=2021-04-01 '$expand=createdTime' --output json --query value
\+ echo 'No resource groups found to delete'
No resource groups found to delete

The failure was not reported because we were forcing success of the command (via the || operator) to work around the case where grep exits with code 1 because no items match the pattern.

This PR updates the setup script for the Agents and uses jq instead of grep to match the groups to delete.
