### PR TITLE
Do not reset the mode of a extension's log directory

### DIFF
--- a/azurelinuxagent/common/utils/fileutil.py
+++ b/azurelinuxagent/common/utils/fileutil.py
@@ -99,13 +99,15 @@ def get_line_startingwith(prefix, filepath):
     return None
 
 
-def mkdir(dirpath, mode=None, owner=None):
+def mkdir(dirpath, mode=None, owner=None, reset_mode_and_owner=True):
     if not os.path.isdir(dirpath):
         os.makedirs(dirpath)
-    if mode is not None:
-        chmod(dirpath, mode)
-    if owner is not None:
-        chowner(dirpath, owner)
+        reset_mode_and_owner = True  # force setting the mode and owner
+    if reset_mode_and_owner:
+        if mode is not None:
+            chmod(dirpath, mode)
+        if owner is not None:
+            chowner(dirpath, owner)
 
 
 def chowner(path, owner):

--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -1051,7 +1051,7 @@ class ExtHandlerInstance(object):
 
     def __set_command_execution_log(self, extension, execution_log_max_size):
         try:
-            fileutil.mkdir(self.get_log_dir(), mode=0o755)
+            fileutil.mkdir(self.get_log_dir(), mode=0o755, reset_mode_and_owner=False)
         except IOError as e:
             self.logger.error(u"Failed to create extension log dir: {0}", e)
         else:


### PR DESCRIPTION
Currently, each time an extension is executed, the Agent resets the mode of its log directory. This is causing issues for customers that set custom modes on those directories.

With this fix, the Agent still sets the initial mode of the directory, but does not reset it when the extension is executed again.