### PR TITLE
honor rsm update with no time when agent receives new GS

### DIFF
--- a/azurelinuxagent/common/exception.py
+++ b/azurelinuxagent/common/exception.py
@@ -80,8 +80,9 @@ class AgentUpdateError(AgentError):
     When agent failed to update.
     """
 
-    def __init__(self, msg=None, inner=None):
+    def __init__(self, msg=None, inner=None, log_error=True):
         super(AgentUpdateError, self).__init__(msg, inner)
+        self.log_error = log_error
 
 
 class CGroupsException(AgentError):

--- a/azurelinuxagent/common/exception.py
+++ b/azurelinuxagent/common/exception.py
@@ -80,9 +80,17 @@ class AgentUpdateError(AgentError):
     When agent failed to update.
     """
 
-    def __init__(self, msg=None, inner=None, log_error=True):
+    def __init__(self, msg=None, inner=None):
         super(AgentUpdateError, self).__init__(msg, inner)
-        self.log_error = log_error
+
+
+class AgentFamilyMissingError(AgentError):
+    """
+    When agent family is missing.
+    """
+
+    def __init__(self, msg=None, inner=None):
+        super(AgentFamilyMissingError, self).__init__(msg, inner)
 
 
 class CGroupsException(AgentError):

--- a/azurelinuxagent/ga/agent_update_handler.py
+++ b/azurelinuxagent/ga/agent_update_handler.py
@@ -151,8 +151,8 @@ class AgentUpdateHandler(object):
             agent_family = self._get_agent_family_manifest(goal_state)
 
             # Updater will return True or False if we need to switch the updater
-            # If self-update receives RSM update request, it will switch to RSM updater
-            # If RSM updater stopped receiving RSM request, it will switch to self-update
+            # If self-update receives RSM update enabled, it will switch to RSM updater
+            # If RSM updater receives RSM update disabled, it will switch to self-update
             # No change in updater if GS not updated
             is_rsm_update_enabled = self._updater.is_rsm_update_enabled(agent_family, ext_gs_updated)
 

--- a/azurelinuxagent/ga/agent_update_handler.py
+++ b/azurelinuxagent/ga/agent_update_handler.py
@@ -189,7 +189,7 @@ class AgentUpdateHandler(object):
             if isinstance(err, AgentUpgradeExitException):
                 raise err
             elif isinstance(err, AgentUpdateError):
-                log_error = err.log_error
+                log_error = err.log_error  # pylint: disable=no-member
                 error_msg = ustr(err)
             else:
                 error_msg = "Unable to update Agent: {0}".format(textutil.format_exception(err))

--- a/azurelinuxagent/ga/agent_update_handler.py
+++ b/azurelinuxagent/ga/agent_update_handler.py
@@ -146,9 +146,9 @@ class AgentUpdateHandler(object):
             self._gs_id = goal_state.extensions_goal_state.id
             agent_family = self._get_agent_family_manifest(goal_state, ext_gs_updated)
 
-            # updater will return True or False if we need to switch the updater
+            # Updater will return True or False if we need to switch the updater
             # If self-update receives RSM update request, it will switch to RSM updater
-            # if RSM updater stopped receiving RSM request, it will switch to self-update
+            # If RSM updater stopped receiving RSM request, it will switch to self-update
             # No change in updater if GS not updated
             switch_to_rsm_updater = self._updater.is_gs_requested_rsm_update(agent_family, self._gs_id, ext_gs_updated)
 

--- a/azurelinuxagent/ga/agent_update_handler.py
+++ b/azurelinuxagent/ga/agent_update_handler.py
@@ -128,11 +128,13 @@ class AgentUpdateHandler(object):
                     agent_family_manifests.append(m)
 
         if not family_found:
-            raise AgentFamilyMissingError(u"Agent family: {0} not found in the goal state: {1}, skipping agent update".format(family, self._gs_id))
+            raise AgentFamilyMissingError(u"Agent family: {0} not found in the goal state: {1}, skipping agent update \n"
+                                          u"[Note: This error is permanent for this goal state and Will not log same error until we receive new goal state]".format(family, self._gs_id))
 
         if len(agent_family_manifests) == 0:
             raise AgentFamilyMissingError(
-                u"No manifest links found for agent family: {0} for goal state: {1}, skipping agent update".format(
+                u"No manifest links found for agent family: {0} for goal state: {1}, skipping agent update \n"
+                u"[Note: This error is permanent for this goal state and will not log same error until we receive new goal state]".format(
                     family, self._gs_id))
         return agent_family_manifests[0]
 

--- a/azurelinuxagent/ga/agent_update_handler.py
+++ b/azurelinuxagent/ga/agent_update_handler.py
@@ -151,7 +151,7 @@ class AgentUpdateHandler(object):
             agent_family = self._get_agent_family_manifest(goal_state)
 
             # Updater will return True or False if we need to switch the updater
-            # If self-update receives RSM update enabled, it will switch to RSM updater
+            # If self-updater receives RSM update enabled, it will switch to RSM updater
             # If RSM updater receives RSM update disabled, it will switch to self-update
             # No change in updater if GS not updated
             is_rsm_update_enabled = self._updater.is_rsm_update_enabled(agent_family, ext_gs_updated)

--- a/azurelinuxagent/ga/ga_version_updater.py
+++ b/azurelinuxagent/ga/ga_version_updater.py
@@ -30,14 +30,6 @@ from azurelinuxagent.common.version import AGENT_NAME, AGENT_DIR_PATTERN
 from azurelinuxagent.ga.guestagent import GuestAgent
 
 
-class RSMUpdates(object):
-    """
-    Enum for switching between RSM updates and self updates
-    """
-    Enabled = "Enabled"
-    Disabled = "Disabled"
-
-
 class GAVersionUpdater(object):
 
     def __init__(self, gs_id):
@@ -53,15 +45,14 @@ class GAVersionUpdater(object):
         """
         raise NotImplementedError
 
-    def check_and_switch_updater_if_changed(self, agent_family, gs_id, ext_gs_updated):
+    def is_gs_requested_rsm_update(self, agent_family, gs_id, ext_gs_updated):
         """
-        checks and raise the updater exception if we need to switch to self-update from rsm update or vice versa
+        return True if we need to switch to RSM-update from self-update and vice versa.
         @param agent_family: agent family
         @param gs_id: incarnation of the goal state
         @param ext_gs_updated: True if extension goal state updated else False
-        @return: RSMUpdates.Disabled: return when agent need to stop rsm updates and switch to self-update
-                 RSMUpdates.Enabled: return when agent need to switch to rsm update
-                 None: return when no need to switch
+        @return: False when agent need to stop rsm updates
+                 True: when agent need to switch to rsm update
         """
         raise NotImplementedError
 

--- a/azurelinuxagent/ga/ga_version_updater.py
+++ b/azurelinuxagent/ga/ga_version_updater.py
@@ -45,11 +45,10 @@ class GAVersionUpdater(object):
         """
         raise NotImplementedError
 
-    def is_gs_requested_rsm_update(self, agent_family, gs_id, ext_gs_updated):
+    def is_rsm_update_enabled(self, agent_family, ext_gs_updated):
         """
         return True if we need to switch to RSM-update from self-update and vice versa.
         @param agent_family: agent family
-        @param gs_id: incarnation of the goal state
         @param ext_gs_updated: True if extension goal state updated else False
         @return: False when agent need to stop rsm updates
                  True: when agent need to switch to rsm update
@@ -97,6 +96,13 @@ class GAVersionUpdater(object):
         Return version
         """
         return self._version
+
+    def sync_new_gs_id(self, gs_id):
+        """
+        Update gs_id
+        @param gs_id: goal state id
+        """
+        self._gs_id = gs_id
 
     def download_and_get_new_agent(self, protocol, agent_family, goal_state):
         """

--- a/azurelinuxagent/ga/rsm_version_updater.py
+++ b/azurelinuxagent/ga/rsm_version_updater.py
@@ -49,7 +49,7 @@ class RSMVersionUpdater(GAVersionUpdater):
         """
         return ext_gs_updated
 
-    def is_gs_requested_rsm_update(self, agent_family, gs_id, ext_gs_updated):
+    def is_rsm_update_enabled(self, agent_family, ext_gs_updated):
         """
         Checks if there is a new goal state and decide if we need to continue with rsm update or switch to self-update.
         Firstly it checks agent supports GA versioning or not. If not, we return false to switch to self-update.
@@ -57,7 +57,6 @@ class RSMVersionUpdater(GAVersionUpdater):
         if either isVersionFromRSM or isVMEnabledForRSMUpgrades or version is missing in the goal state, we ignore the update as we consider it as invalid goal state.
         """
         if ext_gs_updated:
-            self._gs_id = gs_id
             if not conf.get_enable_ga_versioning():
                 return False
 

--- a/azurelinuxagent/ga/self_update_version_updater.py
+++ b/azurelinuxagent/ga/self_update_version_updater.py
@@ -119,14 +119,13 @@ class SelfUpdateVersionUpdater(GAVersionUpdater):
             return False
         return True
 
-    def is_gs_requested_rsm_update(self, agent_family, gs_id, ext_gs_updated):
+    def is_rsm_update_enabled(self, agent_family, ext_gs_updated):
         """
         Checks if there is a new goal state and decide if we need to continue with self-update or switch to rsm update.
         if vm is not enabled for RSM updates or agent not supports GA versioning then we continue with self update, otherwise we return true to switch to rsm update.
         if isVersionFromRSM is missing but isVMEnabledForRSMUpgrades is present in the goal state, we ignore the update as we consider it as invalid goal state.
         """
         if ext_gs_updated:
-            self._gs_id = gs_id
             if conf.get_enable_ga_versioning() and agent_family.is_vm_enabled_for_rsm_upgrades is not None and agent_family.is_vm_enabled_for_rsm_upgrades:
                 if agent_family.is_version_from_rsm is None:
                     raise AgentUpdateError(

--- a/tests/ga/test_agent_update_handler.py
+++ b/tests/ga/test_agent_update_handler.py
@@ -366,6 +366,16 @@ class TestAgentUpdate(UpdateTestCase):
                                          'message'] and kwarg[
                                          'op'] == WALAEventOperation.AgentUpgrade]), "Agent manifest should not be in GS")
 
+            # making multiple agent update attempts and assert only one time logged
+            agent_update_handler.run(agent_update_handler._protocol.get_goal_state(), False)
+            agent_update_handler.run(agent_update_handler._protocol.get_goal_state(), False)
+
+            self.assertEqual(1, len([kwarg['message'] for _, kwarg in mock_telemetry.call_args_list if
+                                     "No manifest links found for agent family" in kwarg[
+                                         'message'] and kwarg[
+                                         'op'] == WALAEventOperation.AgentUpgrade]),
+                             "Agent manifest error should be logged once if it's same goal state")
+
     def test_it_should_report_update_status_with_success(self):
         data_file = DATA_FILE.copy()
         data_file["ext_conf"] = "wire/ext_conf_rsm_version.xml"

--- a/tests/ga/test_update.py
+++ b/tests/ga/test_update.py
@@ -1784,13 +1784,14 @@ class TestAgentUpgrade(UpdateTestCase):
             self.assertFalse(os.path.exists(self.agent_dir("99999.0.0.0")),
                              "New agent directory should not be found")
 
-    def test_it_should_skip_wait_to_update_if_rsm_version_available(self):
+    def test_it_should_skip_wait_to_update_immediately_if_rsm_version_available(self):
         no_of_iterations = 100
 
         def reload_conf(url, protocol):
             mock_wire_data = protocol.mock_wire_data
 
             # This function reloads the conf mid-run to mimic an actual customer scenario
+            # Setting the rsm request to be sent after some iterations
             if HttpRequestPredicates.is_goal_state_request(url) and mock_wire_data.call_counts["goalstate"] >= 5:
                 reload_conf.call_count += 1
 
@@ -1808,7 +1809,8 @@ class TestAgentUpgrade(UpdateTestCase):
 
         data_file = wire_protocol_data.DATA_FILE.copy()
         data_file['ga_manifest'] = "wire/ga_manifest_no_upgrade.xml"
-        with self.__get_update_handler(iterations=no_of_iterations, test_data=data_file, reload_conf=reload_conf) as (update_handler, mock_telemetry):
+        # Setting the prod frequency to mimic a real scenario
+        with self.__get_update_handler(iterations=no_of_iterations, test_data=data_file, reload_conf=reload_conf, autoupdate_frequency=6000) as (update_handler, mock_telemetry):
             update_handler._protocol.mock_wire_data.set_ga_manifest_version_version(str(CURRENT_VERSION))
             update_handler._protocol.mock_wire_data.set_incarnation(20)
             update_handler.run(debug=True)


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
The current code has an issue if previous updater is self-update and waiting for its manifest download timer(1hr) to finish to continue with rest of the update steps (that includes switching to rsm update).  That is blocking rsm update and eventually update timeout in CRP.

Moving this timer condition after we check for updater switch.

Now, in main loop we _may_ log agent family missing warnings on every iteration. So, to avoid frequent logging, added a condition to log only on new goal state.

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).