### PR TITLE
Daemon should remove stale published_hostname file and log useful warning

### DIFF
--- a/azurelinuxagent/pa/deprovision/default.py
+++ b/azurelinuxagent/pa/deprovision/default.py
@@ -159,7 +159,8 @@ class DeprovisionHandler(object):
             'Protocol',
             'SharedConfig.xml',
             'WireServerEndpoint',
-            'published_hostname'
+            'published_hostname',
+            'fast_track.json'
         ]
         known_files_glob = [
             'Extensions.*.xml',

--- a/azurelinuxagent/pa/deprovision/default.py
+++ b/azurelinuxagent/pa/deprovision/default.py
@@ -160,7 +160,8 @@ class DeprovisionHandler(object):
             'SharedConfig.xml',
             'WireServerEndpoint',
             'published_hostname',
-            'fast_track.json'
+            'fast_track.json',
+            'initial_goal_state'
         ]
         known_files_glob = [
             'Extensions.*.xml',

--- a/azurelinuxagent/pa/deprovision/default.py
+++ b/azurelinuxagent/pa/deprovision/default.py
@@ -161,7 +161,8 @@ class DeprovisionHandler(object):
             'WireServerEndpoint',
             'published_hostname',
             'fast_track.json',
-            'initial_goal_state'
+            'initial_goal_state',
+            'rsm_update.json'
         ]
         known_files_glob = [
             'Extensions.*.xml',

--- a/azurelinuxagent/pa/deprovision/default.py
+++ b/azurelinuxagent/pa/deprovision/default.py
@@ -158,7 +158,8 @@ class DeprovisionHandler(object):
             'partition',
             'Protocol',
             'SharedConfig.xml',
-            'WireServerEndpoint'
+            'WireServerEndpoint',
+            'published_hostname'
         ]
         known_files_glob = [
             'Extensions.*.xml',

--- a/azurelinuxagent/pa/provision/default.py
+++ b/azurelinuxagent/pa/provision/default.py
@@ -172,9 +172,11 @@ class ProvisionHandler(object):
         s = fileutil.read_file(ProvisionHandler.provisioned_file_path()).strip()
         if not self.osutil.is_current_instance_id(s):
             if len(s) > 0:
-                logger.warn("VM is provisioned, "
-                            "but the VM unique identifier has changed -- "
-                            "clearing cached state")
+                msg = "VM is provisioned, but the VM unique identifier has changed. This indicates the VM may be " \
+                      "created from an image that was not properly deprovisioned or generalized, which can result in " \
+                      "unexpected behavior from the guest agent -- clearing cached state"
+                logger.warn(msg)
+                self.report_event(msg)
                 from azurelinuxagent.pa.deprovision \
                     import get_deprovision_handler
                 deprovision_handler = get_deprovision_handler()

--- a/tests_e2e/pipeline/pipeline-cleanup.yml
+++ b/tests_e2e/pipeline/pipeline-cleanup.yml
@@ -23,7 +23,7 @@ parameters:
       - azuremanagement.government
 
 pool:
-  vmImage: ubuntu-latest
+  name: waagent-pool
 
 steps:
   - ${{ each service_connection in parameters.service_connections }}:


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
At service initialization the agent looks for the presence of published_hostname. If it exists, then it is assumed provisioning was done by the agent, and the hostname in published_hostname should be taken. If it does not exist, then it is assumed cloud-init did provisioning, and the hostname in set-hostname will be taken. This causes an issue if there is a stale published_hostname file on the machine. 

We detect if vm unique id has changed in daemon. This PR improves the logging when we detect this state to warn the customer that the VM was created from an image that was not properly generalized. The 'published_hostname' file is added to the list of files that will be cleaned up when this state is detected

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).