### PR TITLE
Do not report TestFailedException in test results

### DIFF
--- a/tests_e2e/orchestrator/lib/agent_junit.py
+++ b/tests_e2e/orchestrator/lib/agent_junit.py
@@ -55,6 +55,9 @@ class AgentJUnit(JUnit):
             if "Unexpected error in AgentTestSuite" in message.message:
                 # Ignore these errors, they are already reported as AgentTestResultMessages
                 return
+            if "TestFailedException" in message.message:
+                # Ignore these errors, they are already reported as test failures
+                return
             # Change the suite name to "_Runbook_" for LISA messages in order to separate them
             # from actual test results.
             message.suite_full_name = "_Runbook_"


### PR DESCRIPTION
We recently added a TestFailedException to force LISA to fail when there are test failures, but this produces an extra error in the test results (the original test failure, plus the TestFailedException).

This PR skips test results produced by TestFailedExceptions.