### PR TITLE
Clean test VMs older than 12 hours

### DIFF
--- a/tests_e2e/pipeline/pipeline-cleanup.yml
+++ b/tests_e2e/pipeline/pipeline-cleanup.yml
@@ -13,7 +13,7 @@ parameters:
   - name: older_than
     displayName: Delete resources older than (use the syntax of the "date -d" command)
     type: string
-    default: 1 day ago
+    default: 12 hours ago
 
   - name: service_connections
     type: object


### PR DESCRIPTION
Some leftover test VMs are being kept for too long. Reduce the time they are kept alive.