### PR TITLE
New conf flag AutoUpdate.UpdateToLatestVersion support

### DIFF
--- a/azurelinuxagent/common/agent_supported_feature.py
+++ b/azurelinuxagent/common/agent_supported_feature.py
@@ -76,7 +76,7 @@ class _ETPFeature(AgentSupportedFeature):
 
 class _GAVersioningGovernanceFeature(AgentSupportedFeature):
     """
-    CRP would drive the RSM upgrade version if agent reports that it does support RSM upgrades with this flag otherwise CRP fallback to largest version.
+    CRP would drive the RSM update if agent reports that it does support RSM upgrades with this flag otherwise CRP fallback to largest version.
     Agent doesn't report supported feature flag if auto update is disabled or old version of agent running that doesn't understand GA versioning.
 
     Note: Especially Windows need this flag to report to CRP that GA doesn't support the updates. So linux adopted same flag to have a common solution.
@@ -84,7 +84,7 @@ class _GAVersioningGovernanceFeature(AgentSupportedFeature):
 
     __NAME = SupportedFeatureNames.GAVersioningGovernance
     __VERSION = "1.0"
-    __SUPPORTED = conf.get_autoupdate_enabled()
+    __SUPPORTED = conf.get_autoupdate_enabled() and conf.get_agent_update_to_latest_version()
 
     def __init__(self):
         super(_GAVersioningGovernanceFeature, self).__init__(name=self.__NAME,

--- a/azurelinuxagent/common/conf.py
+++ b/azurelinuxagent/common/conf.py
@@ -128,6 +128,7 @@ __SWITCH_OPTIONS__ = {
     "ResourceDisk.EnableSwap": False,
     "ResourceDisk.EnableSwapEncryption": False,
     "AutoUpdate.Enabled": True,
+    "AutoUpdate.UpdateToLatestVersion": True,
     "EnableOverProvisioning": True,
     #
     # "Debug" options are experimental and may be removed in later
@@ -136,7 +137,6 @@ __SWITCH_OPTIONS__ = {
     "Debug.CgroupLogMetrics": False,
     "Debug.CgroupDisableOnProcessCheckFailure": True,
     "Debug.CgroupDisableOnQuotaCheckFailure": True,
-    "Debug.DownloadNewAgents": True,
     "Debug.EnableAgentMemoryUsageCheck": False,
     "Debug.EnableFastTrack": True,
     "Debug.EnableGAVersioning": True
@@ -503,15 +503,14 @@ def get_monitor_network_configuration_changes(conf=__conf__):
     return conf.get_switch("Monitor.NetworkConfigurationChanges", False)
 
 
-def get_download_new_agents(conf=__conf__):
+def get_agent_update_to_latest_version(conf=__conf__):
     """
-    If True, the agent go through update logic to look for new agents to download otherwise it will stop agent updates.
-    NOTE: AutoUpdate.Enabled controls whether the Agent downloads new update and also whether any downloaded updates are started or not, while DownloadNewAgents controls only the former.
-    AutoUpdate.Enabled == false -> Agent preinstalled on the image will process extensions and will not update (regardless of DownloadNewAgents flag)
-    AutoUpdate.Enabled == true and DownloadNewAgents == true, any update already downloaded will be started, and agent look for future updates
-    AutoUpdate.Enabled == true and DownloadNewAgents == false, any update already downloaded will be started, but the agent will not look for future updates
+    If set to True, agent will update to the latest version
+    NOTE:
+        when turned on, both AutoEnabled.Enabled and UpdateToLatestVersion same meaning: update to latest version
+        when turned off, AutoEnabled.Enabled: reverts to pre-installed agent, UpdateToLatestVersion: uses latest version installed on the vm
     """
-    return conf.get_switch("Debug.DownloadNewAgents", True)
+    return conf.get_switch("AutoUpdate.UpdateToLatestVersion", True)
 
 
 def get_cgroup_check_period(conf=__conf__):

--- a/azurelinuxagent/ga/agent_update_handler.py
+++ b/azurelinuxagent/ga/agent_update_handler.py
@@ -141,8 +141,8 @@ class AgentUpdateHandler(object):
     def run(self, goal_state, ext_gs_updated):
 
         try:
-            # Ignore new agents if update is disabled. The latter flag only used in e2e tests.
-            if not conf.get_autoupdate_enabled() or not conf.get_download_new_agents():
+            # Ignore new agents if update is disabled.
+            if not conf.get_autoupdate_enabled() or not conf.get_agent_update_to_latest_version():
                 return
 
             # Update the state only on new goal state

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -752,6 +752,7 @@ class UpdateHandler(object):
             log_if_op_disabled("OS.EnableFirewall", conf.enable_firewall())
             log_if_op_disabled("Extensions.Enabled", conf.get_extensions_enabled())
             log_if_op_disabled("AutoUpdate.Enabled", conf.get_autoupdate_enabled())
+            log_if_op_disabled("AutoUpdate.UpdateToLatestVersion", conf.get_agent_update_to_latest_version())
 
             if conf.enable_firewall():
                 log_if_int_changed_from_default("OS.EnableFirewallPeriod", conf.get_enable_firewall_period())

--- a/config/alpine/waagent.conf
+++ b/config/alpine/waagent.conf
@@ -75,7 +75,14 @@ OS.OpensslPath=None
 OS.SshDir=/etc/ssh
 
 # Enable or disable goal state processing auto-update, default is enabled
+# When turned off, it reverts to the pre-installed agent that comes with image
+# Added new option AutoUpdate.UpdateToLatestVersion, and encourage users to transition to this new option
+# However, this flag is retained for legacy reasons
 # AutoUpdate.Enabled=y
+
+# Enable or disable goal state processing auto-update, default is enabled
+# When turned off, it remains on latest version installed on the vm
+# AutoUpdate.UpdateToLatestVersion=y
 
 # Determine the update family, this should not be changed
 # AutoUpdate.GAFamily=Prod

--- a/config/arch/waagent.conf
+++ b/config/arch/waagent.conf
@@ -100,7 +100,14 @@ OS.SshDir=/etc/ssh
 # OS.EnableRDMA=y
 
 # Enable or disable goal state processing auto-update, default is enabled
+# When turned off, it reverts to the pre-installed agent that comes with image
+# Added new option AutoUpdate.UpdateToLatestVersion, and encourage users to transition to this new option
+# However, this flag is retained for legacy reasons
 # AutoUpdate.Enabled=y
+
+# Enable or disable goal state processing auto-update, default is enabled
+# When turned off, it remains on latest version installed on the vm
+# AutoUpdate.UpdateToLatestVersion=y
 
 # Determine the update family, this should not be changed
 # AutoUpdate.GAFamily=Prod

--- a/config/bigip/waagent.conf
+++ b/config/bigip/waagent.conf
@@ -82,7 +82,14 @@ OS.SshdConfigPath=/config/ssh/sshd_config
 OS.EnableRDMA=n
 
 # Enable or disable goal state processing auto-update, default is enabled
+# When turned off, it reverts to the pre-installed agent that comes with image
+# Added new option AutoUpdate.UpdateToLatestVersion, and encourage users to transition to this new option
+# However, this flag is retained for legacy reasons
 AutoUpdate.Enabled=y
+
+# Enable or disable goal state processing auto-update, default is enabled
+# When turned off, it remains on latest version installed on the vm
+# AutoUpdate.UpdateToLatestVersion=y
 
 # Determine the update family, this should not be changed
 # AutoUpdate.GAFamily=Prod

--- a/config/clearlinux/waagent.conf
+++ b/config/clearlinux/waagent.conf
@@ -73,8 +73,16 @@ OS.OpensslPath=None
 # Set the path to SSH keys and configuration files
 OS.SshDir=/etc/ssh
 
-# Enable or disable self-update, default is enabled
+# Enable or disable goal state processing auto-update, default is enabled
+# When turned off, it reverts to the pre-installed agent that comes with image
+# Added new option AutoUpdate.UpdateToLatestVersion, and encourage users to transition to this new option
+# However, this flag is retained for legacy reasons
 AutoUpdate.Enabled=y
+
+# Enable or disable goal state processing auto-update, default is enabled
+# When turned off, it remains on latest version installed on the vm
+# AutoUpdate.UpdateToLatestVersion=y
+
 AutoUpdate.GAFamily=Prod
 
 # Determine if the overprovisioning feature is enabled. If yes, hold extension

--- a/config/coreos/waagent.conf
+++ b/config/coreos/waagent.conf
@@ -104,7 +104,14 @@ OS.OpensslPath=None
 # OS.EnableRDMA=y
 
 # Enable or disable goal state processing auto-update, default is enabled
+# When turned off, it reverts to the pre-installed agent that comes with image
+# Added new option AutoUpdate.UpdateToLatestVersion, and encourage users to transition to this new option
+# However, this flag is retained for legacy reasons
 # AutoUpdate.Enabled=y
+
+# Enable or disable goal state processing auto-update, default is enabled
+# When turned off, it remains on latest version installed on the vm
+# AutoUpdate.UpdateToLatestVersion=y
 
 # Determine the update family, this should not be changed
 # AutoUpdate.GAFamily=Prod

--- a/config/debian/waagent.conf
+++ b/config/debian/waagent.conf
@@ -110,7 +110,14 @@ OS.SshDir=/etc/ssh
 # OS.EnableRDMA=y
 
 # Enable or disable goal state processing auto-update, default is enabled
+# When turned off, it reverts to the pre-installed agent that comes with image
+# Added new option AutoUpdate.UpdateToLatestVersion, and encourage users to transition to this new option
+# However, this flag is retained for legacy reasons
 # AutoUpdate.Enabled=y
+
+# Enable or disable goal state processing auto-update, default is enabled
+# When turned off, it remains on latest version installed on the vm
+# AutoUpdate.UpdateToLatestVersion=y
 
 # Determine the update family, this should not be changed
 # AutoUpdate.GAFamily=Prod

--- a/config/devuan/waagent.conf
+++ b/config/devuan/waagent.conf
@@ -104,7 +104,14 @@ OS.SshDir=/etc/ssh
 # OS.EnableRDMA=y
 
 # Enable or disable goal state processing auto-update, default is enabled
+# When turned off, it reverts to the pre-installed agent that comes with image
+# Added new option AutoUpdate.UpdateToLatestVersion, and encourage users to transition to this new option
+# However, this flag is retained for legacy reasons
 # AutoUpdate.Enabled=y
+
+# Enable or disable goal state processing auto-update, default is enabled
+# When turned off, it remains on latest version installed on the vm
+# AutoUpdate.UpdateToLatestVersion=y
 
 # Determine the update family, this should not be changed
 # AutoUpdate.GAFamily=Prod

--- a/config/freebsd/waagent.conf
+++ b/config/freebsd/waagent.conf
@@ -102,7 +102,14 @@ OS.SudoersDir=/usr/local/etc/sudoers.d
 # OS.EnableRDMA=y
 
 # Enable or disable goal state processing auto-update, default is enabled
+# When turned off, it reverts to the pre-installed agent that comes with image
+# Added new option AutoUpdate.UpdateToLatestVersion, and encourage users to transition to this new option
+# However, this flag is retained for legacy reasons
 # AutoUpdate.Enabled=y
+
+# Enable or disable goal state processing auto-update, default is enabled
+# When turned off, it remains on latest version installed on the vm
+# AutoUpdate.UpdateToLatestVersion=y
 
 # Determine the update family, this should not be changed
 # AutoUpdate.GAFamily=Prod

--- a/config/gaia/waagent.conf
+++ b/config/gaia/waagent.conf
@@ -101,7 +101,14 @@ OS.SshDir=/etc/ssh
 OS.EnableRDMA=n
 
 # Enable or disable goal state processing auto-update, default is enabled
+# When turned off, it reverts to the pre-installed agent that comes with image
+# Added new option AutoUpdate.UpdateToLatestVersion, and encourage users to transition to this new option
+# However, this flag is retained for legacy reasons
 AutoUpdate.Enabled=n
+
+# Enable or disable goal state processing auto-update, default is enabled
+# When turned off, it remains on latest version installed on the vm
+# AutoUpdate.UpdateToLatestVersion=y
 
 # Determine the update family, this should not be changed
 # AutoUpdate.GAFamily=Prod

--- a/config/iosxe/waagent.conf
+++ b/config/iosxe/waagent.conf
@@ -100,7 +100,14 @@ OS.SshDir=/etc/ssh
 # OS.EnableRDMA=y
 
 # Enable or disable goal state processing auto-update, default is enabled
+# When turned off, it reverts to the pre-installed agent that comes with image
+# Added new option AutoUpdate.UpdateToLatestVersion, and encourage users to transition to this new option
+# However, this flag is retained for legacy reasons
 AutoUpdate.Enabled=y
+
+# Enable or disable goal state processing auto-update, default is enabled
+# When turned off, it remains on latest version installed on the vm
+# AutoUpdate.UpdateToLatestVersion=y
 
 # Determine the update family, this should not be changed
 # AutoUpdate.GAFamily=Prod

--- a/config/mariner/waagent.conf
+++ b/config/mariner/waagent.conf
@@ -76,7 +76,15 @@ OS.OpensslPath=None
 OS.SshDir=/etc/ssh
 
 # Enable or disable self-update, default is enabled
+# When turned off, it reverts to the pre-installed agent that comes with image
+# Added new option AutoUpdate.UpdateToLatestVersion, and encourage users to transition to this new option
+# However, this flag is retained for legacy reasons
 AutoUpdate.Enabled=y
+
+# Enable or disable goal state processing auto-update, default is enabled
+# When turned off, it remains on latest version installed on the vm
+# AutoUpdate.UpdateToLatestVersion=y
+
 AutoUpdate.GAFamily=Prod
 
 # Determine if the overprovisioning feature is enabled. If yes, hold extension

--- a/config/nsbsd/waagent.conf
+++ b/config/nsbsd/waagent.conf
@@ -98,7 +98,14 @@ Extension.LogDir=/log/azure
 # OS.EnableRDMA=y
 
 # Enable or disable goal state processing auto-update, default is enabled
+# When turned off, it reverts to the pre-installed agent that comes with image
+# Added new option AutoUpdate.UpdateToLatestVersion, and encourage users to transition to this new option
+# However, this flag is retained for legacy reasons
 AutoUpdate.Enabled=n
+
+# Enable or disable goal state processing auto-update, default is enabled
+# When turned off, it remains on latest version installed on the vm
+# AutoUpdate.UpdateToLatestVersion=y
 
 # Determine the update family, this should not be changed
 # AutoUpdate.GAFamily=Prod

--- a/config/openbsd/waagent.conf
+++ b/config/openbsd/waagent.conf
@@ -96,7 +96,14 @@ OS.PasswordPath=/etc/master.passwd
 # OS.EnableRDMA=y
 
 # Enable or disable goal state processing auto-update, default is enabled
+# When turned off, it reverts to the pre-installed agent that comes with image
+# Added new option AutoUpdate.UpdateToLatestVersion, and encourage users to transition to this new option
+# However, this flag is retained for legacy reasons
 # AutoUpdate.Enabled=y
+
+# Enable or disable goal state processing auto-update, default is enabled
+# When turned off, it remains on latest version installed on the vm
+# AutoUpdate.UpdateToLatestVersion=y
 
 # Determine the update family, this should not be changed
 # AutoUpdate.GAFamily=Prod

--- a/config/photonos/waagent.conf
+++ b/config/photonos/waagent.conf
@@ -71,7 +71,15 @@ OS.OpensslPath=None
 OS.SshDir=/etc/ssh
 
 # Enable or disable self-update, default is enabled
+# When turned off, it reverts to the pre-installed agent that comes with image
+# Added new option AutoUpdate.UpdateToLatestVersion, and encourage users to transition to this new option
+# However, this flag is retained for legacy reasons
 AutoUpdate.Enabled=y
+
+# Enable or disable goal state processing auto-update, default is enabled
+# When turned off, it remains on latest version installed on the vm
+# AutoUpdate.UpdateToLatestVersion=y
+
 AutoUpdate.GAFamily=Prod
 
 # Determine if the overprovisioning feature is enabled. If yes, hold extension

--- a/config/suse/waagent.conf
+++ b/config/suse/waagent.conf
@@ -113,7 +113,14 @@ OS.SshDir=/etc/ssh
 # OS.CheckRdmaDriver=y
 
 # Enable or disable goal state processing auto-update, default is enabled
+# When turned off, it reverts to the pre-installed agent that comes with image
+# Added new option AutoUpdate.UpdateToLatestVersion, and encourage users to transition to this new option
+# However, this flag is retained for legacy reasons
 # AutoUpdate.Enabled=y
+
+# Enable or disable goal state processing auto-update, default is enabled
+# When turned off, it remains on latest version installed on the vm
+# AutoUpdate.UpdateToLatestVersion=y
 
 # Determine the update family, this should not be changed
 # AutoUpdate.GAFamily=Prod

--- a/config/ubuntu/waagent.conf
+++ b/config/ubuntu/waagent.conf
@@ -101,7 +101,14 @@ OS.SshDir=/etc/ssh
 # OS.CheckRdmaDriver=y
 
 # Enable or disable goal state processing auto-update, default is enabled
+# When turned off, it reverts to the pre-installed agent that comes with image
+# Added new option AutoUpdate.UpdateToLatestVersion, and encourage users to transition to this new option
+# However, this flag is retained for legacy reasons
 # AutoUpdate.Enabled=y
+
+# Enable or disable goal state processing auto-update, default is enabled
+# When turned off, it remains on latest version installed on the vm
+# AutoUpdate.UpdateToLatestVersion=y
 
 # Determine the update family, this should not be changed
 # AutoUpdate.GAFamily=Prod

--- a/config/waagent.conf
+++ b/config/waagent.conf
@@ -122,7 +122,14 @@ OS.SshDir=/etc/ssh
 # OS.CheckRdmaDriver=y
 
 # Enable or disable goal state processing auto-update, default is enabled
+# When turned off, it reverts to the pre-installed agent that comes with image
+# Added new option AutoUpdate.UpdateToLatestVersion, and encourage users to transition to this new option
+# However, this flag is retained for legacy reasons
 # AutoUpdate.Enabled=y
+
+# Enable or disable goal state processing auto-update, default is enabled
+# When turned off, it remains on latest version installed on the vm
+# AutoUpdate.UpdateToLatestVersion=y
 
 # Determine the update family, this should not be changed
 # AutoUpdate.GAFamily=Prod

--- a/tests/ga/test_agent_update_handler.py
+++ b/tests/ga/test_agent_update_handler.py
@@ -459,3 +459,14 @@ class TestAgentUpdate(UpdateTestCase):
                 agent_update_handler.run(agent_update_handler._protocol.get_goal_state(), True)
 
             self.assertFalse(os.path.exists(state_file), "The rsm file should be removed (file: {0})".format(state_file))
+
+    def test_it_should_not_update_to_latest_if_flag_is_disabled(self):
+        self.prepare_agents(count=1)
+
+        data_file = DATA_FILE.copy()
+        data_file['ext_conf'] = "wire/ext_conf.xml"
+        with self._get_agent_update_handler(test_data=data_file) as (agent_update_handler, _):
+            with patch("azurelinuxagent.common.conf.get_agent_update_to_latest_version", return_value=False):
+                agent_update_handler.run(agent_update_handler._protocol.get_goal_state(), True)
+
+            self._assert_agent_directories_exist_and_others_dont_exist(versions=[str(CURRENT_VERSION)])

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -28,6 +28,7 @@ from tests.lib.tools import AgentTestCase, data_dir, Mock, patch
 EXPECTED_CONFIGURATION = \
 """AutoUpdate.Enabled = True
 AutoUpdate.GAFamily = Prod
+AutoUpdate.UpdateToLatestVersion = True
 Autoupdate.Frequency = 3600
 DVD.MountPoint = /mnt/cdrom/secure
 Debug.AgentCpuQuota = 50
@@ -41,7 +42,6 @@ Debug.CgroupDisableOnQuotaCheckFailure = True
 Debug.CgroupLogMetrics = False
 Debug.CgroupMonitorExpiryTime = 2022-03-31
 Debug.CgroupMonitorExtensionName = Microsoft.Azure.Monitor.AzureMonitorLinuxAgent
-Debug.DownloadNewAgents = True
 Debug.EnableAgentMemoryUsageCheck = False
 Debug.EnableFastTrack = True
 Debug.EnableGAVersioning = True

--- a/tests_e2e/orchestrator/scripts/collect-logs
+++ b/tests_e2e/orchestrator/scripts/collect-logs
@@ -10,13 +10,16 @@ logs_file_name="/tmp/waagent-logs.tgz"
 
 echo "Collecting logs to $logs_file_name ..."
 
+PYTHON=$(get-agent-python)
+waagent_conf=$($PYTHON -c 'from azurelinuxagent.common.osutil import get_osutil; print(get_osutil().agent_conf_file_path)')
+
 tar --exclude='journal/*' --exclude='omsbundle' --exclude='omsagent' --exclude='mdsd' --exclude='scx*' \
     --exclude='*.so' --exclude='*__LinuxDiagnostic__*' --exclude='*.zip' --exclude='*.deb' --exclude='*.rpm' \
     --warning=no-file-changed \
     -czf "$logs_file_name" \
     /var/log \
     /var/lib/waagent/ \
-    /etc/waagent.conf
+    $waagent_conf
 
 set -euxo pipefail
 

--- a/tests_e2e/orchestrator/scripts/install-agent
+++ b/tests_e2e/orchestrator/scripts/install-agent
@@ -113,9 +113,9 @@ python=$(get-agent-python)
 waagent_conf_path=$($python -c 'from azurelinuxagent.common.osutil import get_osutil; osutil=get_osutil(); print(osutil.agent_conf_file_path)')
 echo "Agent's conf path: $waagent_conf_path"
 sed -i 's/AutoUpdate.Enabled=n/AutoUpdate.Enabled=y/g' "$waagent_conf_path"
-# By default GAUpdates flag set to True, so that agent go through update logic to look for new agents.
+# By default UpdateToLatestVersion flag set to True, so that agent go through update logic to look for new agents.
 # But in e2e tests this flag needs to be off in test version 9.9.9.9 to stop the agent updates, so that our scenarios run on 9.9.9.9.
-# sed -i '$a Debug.DownloadNewAgents=n' "$waagent_conf_path"
+sed -i '$a AutoUpdate.UpdateToLatestVersion=n' "$waagent_conf_path"
 # Logging and exiting tests if Extensions.Enabled flag is disabled for other distros than debian
 if grep -q "Extensions.Enabled=n" $waagent_conf_path; then
   pypy_get_distro=$(pypy3 -c 'from azurelinuxagent.common.version import get_distro; print(get_distro())')

--- a/tests_e2e/tests/scripts/agent_update-self_update_test_setup
+++ b/tests_e2e/tests/scripts/agent_update-self_update_test_setup
@@ -22,7 +22,7 @@
 set -euo pipefail
 
 usage() (
-    echo "Usage: agent_update-self_update_test_setup -p|--package <path> -v|--version <version>"
+    echo "Usage: agent_update-self_update_test_setup -p|--package <path> -v|--version <version>  -u|--update_to_latest_version <y|n>"
     exit 1
 )
 
@@ -44,6 +44,14 @@ while [[ $# -gt 0 ]]; do
             version=$1
             shift
             ;;
+        -u|--update_to_latest_version)
+            shift
+            if [ "$#" -lt 1 ]; then
+                usage
+            fi
+            update_to_latest_version=$1
+            shift
+            ;;
         *)
             usage
     esac
@@ -53,7 +61,7 @@ if [ "$#" -ne 0 ] || [ -z ${package+x} ] || [ -z ${version+x} ]; then
 fi
 
 echo "updating the related to self-update flags"
-update-waagent-conf Debug.EnableGAVersioning=n Debug.SelfUpdateHotfixFrequency=120 Debug.SelfUpdateRegularFrequency=120 Autoupdate.Frequency=120
+update-waagent-conf AutoUpdate.UpdateToLatestVersion=$update_to_latest_version Debug.EnableGAVersioning=n Debug.SelfUpdateHotfixFrequency=120 Debug.SelfUpdateRegularFrequency=120 Autoupdate.Frequency=120
 agent-service stop
 mv /var/log/waagent.log /var/log/waagent.$(date --iso-8601=seconds).log
 


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

We have an ask from TEMU customer to update the agents at their convivence time. Current controlling with existing flag AutoUpdate.Enabled is not working how they wanted it. When you turn off, it will revert to preinstalled agent. But customer wanted to stay on latest version installed on the vm. The current flag should have been implemented that way, unfortunately it wasn't. We can't change that flag anymore as users might have taken dependency on the existing behavior.

New behavior was added as hidden feature for e2e testing. Now changing that to customer facing flag.

Also added e2e test for new flag behavior.

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).