### PR TITLE
Fix ext workflow GS completed regex

### DIFF
--- a/tests_e2e/tests/scripts/agent_ext_workflow-validate_no_lag_between_agent_start_and_gs_processing.py
+++ b/tests_e2e/tests/scripts/agent_ext_workflow-validate_no_lag_between_agent_start_and_gs_processing.py
@@ -43,7 +43,7 @@ def main():
 
         # Example: Agent WALinuxAgent-2.2.47.2 is running as the goal state agent
         agent_started_regex = r"Azure Linux Agent \(Goal State Agent version [0-9.]+\)"
-        gs_completed_regex = r"ProcessExtensionsGoalState completed\s\[(?P<id>[a-z_\d]{13,14})\s(?P<duration>\d+)\sms\]"
+        gs_completed_regex = r"ProcessExtensionsGoalState completed\s\[(?P<id>[a-z]+_\d+)\s(?P<duration>\d+)\sms\]"
 
         verified_atleast_one_log_line = False
         verified_atleast_one_agent_started_log_line = False


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
Validate no lag between Agent Start and GS Processing script uses a regex to look for the 'Extension Processing completed' log which can be either pattern:

- ⁠ProcessExtensionsGoalState completed [incarnation_2 4172 ms]
- ProcessExtensionsGoalState completed [etag_86567516065182014 8146 ms]

Previously only the first pattern was being matched 

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).