### PR TITLE
Retry get instance view if only name property is present

### DIFF
--- a/tests_e2e/tests/lib/virtual_machine_extension_client.py
+++ b/tests_e2e/tests/lib/virtual_machine_extension_client.py
@@ -18,7 +18,7 @@
 #
 # This module includes facilities to execute VM extension operations (enable, remove, etc).
 #
-
+import json
 import uuid
 
 from assertpy import assert_that, soft_assertions
@@ -142,7 +142,7 @@ class VirtualMachineExtensionClient(AzureSdkClient):
             log.info("Instance view is incomplete: %s\nRetrying attempt to get instance view...", instance_view.serialize())
             instance_view = self.get_instance_view()
             attempt += 1
-        log.info("Instance view:\n%s", instance_view.serialize())
+        log.info("Instance view:\n%s", json.dumps(instance_view.serialize(), indent=4))
 
         with soft_assertions():
             if expected_version is not None:


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
Sometimes when we get the instance view during asserting the instance view, an incomplete instance view is returned:
2024-01-30T09:44:54Z.876 [INFO] Instance view: {'name': 'GuestAgentDcrTestExt'}

This causes issues during asserts. This PR adds retry logic to get the instance view if this happens

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).