### PR TITLE
Fix daily pipeline failures for recover_network_interface

### DIFF
--- a/tests_e2e/test_suites/images.yml
+++ b/tests_e2e/test_suites/images.yml
@@ -122,9 +122,20 @@ images:
          AzureChinaCloud: []
          AzureUSGovernment: []
    oracle_610: "Oracle Oracle-Linux 6.10 latest"
-   oracle_75: "Oracle Oracle-Linux 7.5 latest"
-   oracle_79: "Oracle Oracle-Linux ol79-gen2 latest"
-   oracle_82: "Oracle Oracle-Linux ol82-gen2 latest"
+   oracle_75:
+      urn: "Oracle Oracle-Linux 7.5 latest"
+      locations:
+         AzureChinaCloud: []
+         AzureUSGovernment: []
+   oracle_79:
+      urn: "Oracle Oracle-Linux ol79-gen2 latest"
+      locations:
+         AzureChinaCloud: []
+   oracle_82:
+      urn: "Oracle Oracle-Linux ol82-gen2 latest"
+      locations:
+         AzureChinaCloud: []
+         AzureUSGovernment: []
    rhel_610: "RedHat RHEL 6.10 latest"
    rhel_75:
       urn: "RedHat RHEL 7.5 latest"

--- a/tests_e2e/tests/ext_telemetry_pipeline/ext_telemetry_pipeline.py
+++ b/tests_e2e/tests/ext_telemetry_pipeline/ext_telemetry_pipeline.py
@@ -56,12 +56,12 @@ class ExtTelemetryPipeline(AgentVmTest):
         log.info("")
         log.info("Add CSE to the test VM...")
         cse = VirtualMachineExtensionClient(self._context.vm, VmExtensionIds.CustomScript, resource_name="CustomScript")
-        cse.enable(settings={'commandToExecute': "echo 'enable'"})
+        cse.enable(settings={'commandToExecute': "echo 'enable'"}, protected_settings={})
         cse.assert_instance_view()
 
         log.info("")
         log.info("Add CSE to the test VM again...")
-        cse.enable(settings={'commandToExecute': "echo 'enable again'"})
+        cse.enable(settings={'commandToExecute': "echo 'enable again'"}, protected_settings={})
         cse.assert_instance_view()
 
         # Check agent log to verify ETP is enabled

--- a/tests_e2e/tests/recover_network_interface/recover_network_interface.py
+++ b/tests_e2e/tests/recover_network_interface/recover_network_interface.py
@@ -103,11 +103,7 @@ class RecoverNetworkInterface(AgentVmTest):
         log.info("")
         log.info("Using CSE to bring the primary network interface down and call the OSUtil to bring the interface back up. Command to execute: {0}".format(script))
         custom_script = VirtualMachineExtensionClient(self._context.vm, VmExtensionIds.CustomScript, resource_name="CustomScript")
-        custom_script.enable(
-            protected_settings={
-                'commandToExecute': script
-            }
-        )
+        custom_script.enable(settings={'commandToExecute': script})
 
         # Check that the interface was down and brought back up in instance view
         log.info("")

--- a/tests_e2e/tests/recover_network_interface/recover_network_interface.py
+++ b/tests_e2e/tests/recover_network_interface/recover_network_interface.py
@@ -103,7 +103,7 @@ class RecoverNetworkInterface(AgentVmTest):
         log.info("")
         log.info("Using CSE to bring the primary network interface down and call the OSUtil to bring the interface back up. Command to execute: {0}".format(script))
         custom_script = VirtualMachineExtensionClient(self._context.vm, VmExtensionIds.CustomScript, resource_name="CustomScript")
-        custom_script.enable(settings={'commandToExecute': script})
+        custom_script.enable(protected_settings={'commandToExecute': script}, settings={})
 
         # Check that the interface was down and brought back up in instance view
         log.info("")


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

- ⁠When RecoverNetworkInterface shares a VM with ExtTelemetryPipeline there is the following failure in CSE enable: 'Enable failed: failed to get configuration: invalid configuration: 'commandToExecute' was specified both in public and protected settings; it must be specified only once.' ExtTelemetryPipeline adds cse with unprotected settings, and RecoverNetworkInterface adds cse with protected settings. I changed RecoverNetworkInterface to add cse with unprotected settings, since protected was not necessary
- Some oracle images are not available in China/Gov. Remove them from those clouds

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).