### PR TITLE
Keep failed VMs by default on pipeline runs

### DIFF
--- a/tests_e2e/pipeline/pipeline.yml
+++ b/tests_e2e/pipeline/pipeline.yml
@@ -51,7 +51,7 @@ parameters:
   - name: keep_environment
     displayName: Keep the test VMs (do not delete them)
     type: string
-    default: no
+    default: failed
     values:
     - always
     - failed


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
Keep failed VMs on daily pipeline runs. The cleanup pipeline will delete any existing VMs every 12 hours. This gives us until 1pm on business days to investigate any failures in the pipeline from the night before.

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).