### PR TITLE
Skip capture of VM information on test runs

### DIFF
--- a/tests_e2e/orchestrator/docker/Dockerfile
+++ b/tests_e2e/orchestrator/docker/Dockerfile
@@ -67,7 +67,7 @@ RUN \
     cd $HOME                                                                                                  && \
     git clone https://github.com/microsoft/lisa.git                                                           && \
     cd lisa                                                                                                   && \
-    git checkout 7396cbd6d9b31a99b13c184f735ce9827334f21b                                                     && \
+    git checkout 2c16e32001fdefb9572dff61241451b648259dbf                                                     && \
                                                                                                                  \
     python3 -m pip install --upgrade pip                                                                      && \
     python3 -m pip install --editable .[azure,libvirt] --config-settings editable_mode=compat                 && \

--- a/tests_e2e/orchestrator/lib/agent_junit.py
+++ b/tests_e2e/orchestrator/lib/agent_junit.py
@@ -37,6 +37,7 @@ from lisa.messages import (  # pylint: disable=E0401
 @dataclass
 class AgentJUnitSchema(schema.Notifier):
     path: str = "agent.junit.xml"
+    include_subtest: bool = True
 
 
 class AgentJUnit(JUnit):

--- a/tests_e2e/orchestrator/lib/agent_test_suite_combinator.py
+++ b/tests_e2e/orchestrator/lib/agent_test_suite_combinator.py
@@ -276,7 +276,8 @@ class AgentTestSuitesCombinator(Combinator):
             "c_env_name": self.runbook.vm_name,
             "c_platform": [
                 {
-                    "type": "ready"
+                    "type": "ready",
+                    "capture_vm_information": False
                 }
             ],
             "c_environment": {
@@ -331,7 +332,8 @@ class AgentTestSuitesCombinator(Combinator):
             },
             "c_platform": [
                 {
-                    "type": "ready"
+                    "type": "ready",
+                    "capture_vm_information": False
                 }
             ],
             "c_location": self.runbook.location,
@@ -356,6 +358,7 @@ class AgentTestSuitesCombinator(Combinator):
                     "admin_username": self.runbook.user,
                     "admin_private_key_file": self.runbook.identity_file,
                     "keep_environment": self.runbook.keep_environment,
+                    "capture_vm_information": False,
                     "azure": {
                         "deploy": True,
                         "cloud": self.runbook.cloud,
@@ -406,7 +409,8 @@ class AgentTestSuitesCombinator(Combinator):
         return {
             "c_platform": [
                 {
-                    "type": "ready"
+                    "type": "ready",
+                    "capture_vm_information": False
                 }
             ],
 


### PR DESCRIPTION
Updating LISA to take advantage of the new capture_vm_information flag: when turned off, LISA will skip collecting the debug information from the test VMs at the end of the test run (which was causing us to timeout when there are SSH issues).

The new LISA has a breaking change in the schema for Notifiers: a new property, include_subtest. I added it to our notifier as well.