### PR TITLE
Fix osutil/default route_add to pass string array.

### DIFF
--- a/azurelinuxagent/common/osutil/default.py
+++ b/azurelinuxagent/common/osutil/default.py
@@ -1127,7 +1127,7 @@ class DefaultOSUtil(object):
         Add specified route 
         """
         try:
-            cmd = ["ip", "route", "add", net, "via", gateway]
+            cmd = ["ip", "route", "add", str(net), "via", gateway]
             return shellutil.run_command(cmd)
         except CommandError:
             return ""


### PR DESCRIPTION

## Description
In `common/dhcp.py::DhcpHandler.conf_routes`, a default gateway is added via:

```
if self.gateway is not None and self.osutil.is_missing_default_route():
  self.osutil.route_add(0, 0, self.gateway)
```

In `osutil/default::DefaultOSUtil.route_add`, this creates a command and runs it with:

```
cmd = ["ip", "route", "add", net, "via", gateway]
return shellutil.run_command(cmd)
```

Since `net` is the integer 0, this results in the following issue:

```
  File "/usr/lib/python3/dist-packages/azurelinuxagent/common/dhcp.py", line 132, in conf_routes
    self.osutil.route_add(0, 0, self.gateway)
  File "/usr/lib/python3/dist-packages/azurelinuxagent/common/osutil/default.py", line 1138, in route_add
    return shellutil.run_command(cmd)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/azurelinuxagent/common/utils/shellutil.py", line 255, in run_command
    return __run_command(command_action=command_action, command=command, log_error=log_error, encode_output=encode_output)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/azurelinuxagent/common/utils/shellutil.py", line 182, in __run_command
    return_code, stdout, stderr = command_action()
                                  ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/azurelinuxagent/common/utils/shellutil.py", line 245, in command_action
    process = _popen(command, stdin=popen_stdin, stdout=stdout, stderr=stderr, shell=False)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/azurelinuxagent/common/utils/shellutil.py", line 352, in _popen
    process = subprocess.Popen(*args, **kwargs)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/subprocess.py", line 1024, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib/python3.11/subprocess.py", line 1834, in _execute_child
    self.pid = _fork_exec(
               ^^^^^^^^^^^
TypeError: expected str, bytes or os.PathLike object, not int
```

This fixes the issue by converting `net` to a string.

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [x] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).