### PR TITLE
Ext_sequencing scenario should check agent log for extension enable order

### DIFF
--- a/tests_e2e/tests/ext_sequencing/ext_sequencing.py
+++ b/tests_e2e/tests/ext_sequencing/ext_sequencing.py
@@ -253,8 +253,6 @@ class ExtSequencing(AgentVmssTest):
 
             log.info("------")
 
-        log.info("Test passed")
-
     def get_ignore_errors_before_timestamp(self) -> datetime:
         # Ignore errors in the agent log before the first test case starts
         if self._scenario_start == datetime.min:

--- a/tests_e2e/tests/ext_sequencing/ext_sequencing.py
+++ b/tests_e2e/tests/ext_sequencing/ext_sequencing.py
@@ -22,6 +22,7 @@
 # validates they are enabled in order of dependencies.
 #
 import copy
+import random
 import re
 import uuid
 from datetime import datetime
@@ -95,10 +96,8 @@ class ExtSequencing(AgentVmssTest):
         for ext in extensions:
             # Only check extensions which succeeded provisioning
             if "succeeded" in ext.statuses_summary[0].code:
-                enabled_time = ssh_client.run_command(f"ext_sequencing-get_ext_enable_time.py --ext '{extension_full_names[ext.name]}'", use_sudo=True)
-                formatted_time = datetime.strptime(enabled_time.strip(), u'%Y-%m-%dT%H:%M:%SZ')
-                if formatted_time < test_case_start:
-                    fail("Extension {0} was not enabled".format(extension_full_names[ext.name]))
+                enabled_time = ssh_client.run_command(f"ext_sequencing-get_ext_enable_time.py --ext '{extension_full_names[ext.name]}' --after_time '{test_case_start}'", use_sudo=True)
+                formatted_time = datetime.strptime(enabled_time.strip(), u'%Y-%m-%dT%H:%M:%S.%fZ')
                 enabled_times.append(
                     {
                         "name": ext.name,
@@ -184,7 +183,7 @@ class ExtSequencing(AgentVmssTest):
         }
 
         for case in self._test_cases:
-            test_case_start = datetime.now()
+            test_case_start = random.choice(list(ssh_clients.values())).run_command("date '+%Y-%m-%d %T'").rstrip()
             if self._scenario_start == datetime.min:
                 self._scenario_start = test_case_start
 
@@ -201,6 +200,7 @@ class ExtSequencing(AgentVmssTest):
             # test out
             log.info("")
             log.info("Test case: {0}".format(case.__name__.replace('_', ' ')))
+            log.info("Test case start time: {0}".format(test_case_start))
             ext_template = copy.deepcopy(base_extension_template)
             ext_template['resources'][0]['properties']['virtualMachineProfile']['extensionProfile'][
                 'extensions'] = extensions

--- a/tests_e2e/tests/ext_sequencing/ext_sequencing.py
+++ b/tests_e2e/tests/ext_sequencing/ext_sequencing.py
@@ -253,9 +253,11 @@ class ExtSequencing(AgentVmssTest):
 
             log.info("------")
 
+        log.info("Test passed")
+
     def get_ignore_errors_before_timestamp(self) -> datetime:
         # Ignore errors in the agent log before the first test case starts
-        return self._scenario_start
+        return datetime.strptime(self._scenario_start, u'%Y-%m-%d %H:%M:%S')
 
     def get_ignore_error_rules(self) -> List[Dict[str, Any]]:
         ignore_rules = [

--- a/tests_e2e/tests/ext_sequencing/ext_sequencing.py
+++ b/tests_e2e/tests/ext_sequencing/ext_sequencing.py
@@ -257,6 +257,8 @@ class ExtSequencing(AgentVmssTest):
 
     def get_ignore_errors_before_timestamp(self) -> datetime:
         # Ignore errors in the agent log before the first test case starts
+        if self._scenario_start == datetime.min:
+            return self._scenario_start
         return datetime.strptime(self._scenario_start, u'%Y-%m-%d %H:%M:%S')
 
     def get_ignore_error_rules(self) -> List[Dict[str, Any]]:

--- a/tests_e2e/tests/scripts/ext_sequencing-get_ext_enable_time.py
+++ b/tests_e2e/tests/scripts/ext_sequencing-get_ext_enable_time.py
@@ -46,7 +46,7 @@ def main():
         for agent_record in agent_log.read():
             if agent_record.timestamp >= after_time:
                 # The agent_record prefix for enable logs is the extension name, for example: [Microsoft.Azure.Extensions.CustomScript-2.1.10]
-                if agent_record.prefix:
+                if agent_record.prefix is not None:
                     ext_enabled = re.match(enable_log_regex, " ".join([agent_record.prefix, agent_record.message]))
 
                     if ext_enabled is not None:


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
Ext sequencing scenario should check the agent log to determine which order the extensions were enabled, instead of checking extension status file. Checking extension status file is not a good method of checking enable order, because extensions can return success without touching its status file.

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).