### PR TITLE
Add Python 3.10 to the pylint matrix

### DIFF
--- a/.github/workflows/ci_pr.yml
+++ b/.github/workflows/ci_pr.yml
@@ -14,8 +14,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - python-version: 2.6
-          - python-version: 3.4
+          - python-version: "2.6"
+          - python-version: "3.4"
 
     name: "Python ${{ matrix.python-version }} Unit Tests"
     runs-on: ubuntu-20.04
@@ -42,7 +42,7 @@ jobs:
 
     - name: Test with nosetests
       run: |
-        if [[ ${{ matrix.python-version }} == 2.6 ]]; then
+        if [[ ${{ matrix.python-version }} == "2.6" ]]; then
           source /home/waagent/virtualenv/python2.6.9/bin/activate
         else
           source /home/waagent/virtualenv/python3.4.8/bin/activate
@@ -86,21 +86,24 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - python-version: 3.5
+          - python-version: "3.5"
             PYLINTOPTS: "--rcfile=ci/3.6.pylintrc --ignore=tests_e2e,makepkg.py"
 
-          - python-version: 3.6
+          - python-version: "3.6"
             PYLINTOPTS: "--rcfile=ci/3.6.pylintrc --ignore=tests_e2e"
 
-          - python-version: 3.7
+          - python-version: "3.7"
             PYLINTOPTS: "--rcfile=ci/3.6.pylintrc --ignore=tests_e2e"
 
-          - python-version: 3.8
+          - python-version: "3.8"
             PYLINTOPTS: "--rcfile=ci/3.6.pylintrc --ignore=tests_e2e"
 
-          - python-version: 3.9
+          - python-version: "3.9"
             PYLINTOPTS: "--rcfile=ci/3.6.pylintrc"
             additional-nose-opts: "--with-coverage --cover-erase --cover-inclusive --cover-branches --cover-package=azurelinuxagent"
+
+          - python-version: "3.10"
+            PYLINTOPTS: "--rcfile=ci/3.10.pylintrc --ignore=tests"
 
     name: "Python ${{ matrix.python-version }} Unit Tests"
     runs-on: ubuntu-20.04
@@ -133,13 +136,13 @@ jobs:
         pylint $PYLINTOPTS --jobs=0 $PYLINTFILES
 
     - name: Test with nosetests
-      if: success() || (failure() && steps.install-dependencies.outcome == 'success')
+      if: matrix.python-version != '3.10' && (success() || (failure() && steps.install-dependencies.outcome == 'success'))
       run: |
         ./ci/nosetests.sh
         exit $?
 
     - name: Compile Coverage
-      if: matrix.python-version == 3.9
+      if: matrix.python-version == '3.9'
       run: |
         echo looking for coverage files :
         ls -alh | grep -i coverage
@@ -148,7 +151,7 @@ jobs:
         sudo env "PATH=$PATH" coverage report
 
     - name: Upload Coverage
-      if: matrix.python-version == 3.9
+      if: matrix.python-version ==  '3.9'
       uses: codecov/codecov-action@v3
       with:
         file: ./coverage.xml

--- a/azurelinuxagent/agent.py
+++ b/azurelinuxagent/agent.py
@@ -131,7 +131,7 @@ class Agent(object):
         """
         set_daemon_version(AGENT_VERSION)
         logger.set_prefix("Daemon")
-        threading.current_thread().setName("Daemon")
+        threading.current_thread().setName("Daemon")  # pylint: disable=deprecated-method
         child_args = None \
             if self.conf_file_path is None \
                 else "-configuration-path:{0}".format(self.conf_file_path)
@@ -171,7 +171,7 @@ class Agent(object):
         Run the update and extension handler
         """
         logger.set_prefix("ExtHandler")
-        threading.current_thread().setName("ExtHandler")
+        threading.current_thread().setName("ExtHandler")  # pylint: disable=deprecated-method
 
         #
         # Agents < 2.2.53 used to echo the log to the console. Since the extension handler could have been started by

--- a/azurelinuxagent/common/conf.py
+++ b/azurelinuxagent/common/conf.py
@@ -35,7 +35,7 @@ class ConfigurationProvider(object):
     """
 
     def __init__(self):
-        self.values = dict()
+        self.values = {}
 
     def load(self, content):
         if not content:

--- a/azurelinuxagent/common/event.py
+++ b/azurelinuxagent/common/event.py
@@ -282,7 +282,7 @@ def _encode_message(op, message):
 
 
 def _log_event(name, op, message, duration, is_success=True):
-    global _EVENT_MSG  # pylint: disable=W0603
+    global _EVENT_MSG  # pylint: disable=W0602, W0603
 
     if not is_success:
         logger.error(_EVENT_MSG, name, op, message, duration)
@@ -604,7 +604,7 @@ class EventLogger(object):
                          TelemetryEventParam(CommonTelemetryEventSchema.OpcodeName, event_timestamp.strftime(logger.Logger.LogTimeFormatInUTC)),
                          TelemetryEventParam(CommonTelemetryEventSchema.EventTid, threading.current_thread().ident),
                          TelemetryEventParam(CommonTelemetryEventSchema.EventPid, os.getpid()),
-                         TelemetryEventParam(CommonTelemetryEventSchema.TaskName, threading.current_thread().getName())]
+                         TelemetryEventParam(CommonTelemetryEventSchema.TaskName, threading.current_thread().getName())]  # pylint: disable=deprecated-method
 
         if event.eventId == TELEMETRY_EVENT_EVENT_ID and event.providerId == TELEMETRY_EVENT_PROVIDER_ID:
             # Currently only the GuestAgentExtensionEvents has these columns, the other tables dont have them so skipping

--- a/azurelinuxagent/common/logger.py
+++ b/azurelinuxagent/common/logger.py
@@ -137,7 +137,7 @@ class Logger(object):
             msg = msg_format
         time = datetime.utcnow().strftime(Logger.LogTimeFormatInUTC)
         level_str = LogLevel.STRINGS[level]
-        thread_name = currentThread().getName()
+        thread_name = currentThread().getName()  # pylint: disable=deprecated-method
         if self.prefix is not None:
             log_item = u"{0} {1} {2} {3} {4}\n".format(time, level_str, thread_name, self.prefix, msg)
         else:

--- a/azurelinuxagent/common/osutil/factory.py
+++ b/azurelinuxagent/common/osutil/factory.py
@@ -16,7 +16,7 @@
 #
 
 
-from distutils.version import LooseVersion as Version  # pylint: disable=no-name-in-module, import-error
+from distutils.version import LooseVersion as Version  # pylint: disable=no-name-in-module, import-error, disable=deprecated-module
 
 import azurelinuxagent.common.logger as logger
 from azurelinuxagent.common.version import DISTRO_NAME, DISTRO_CODE_NAME, DISTRO_VERSION, DISTRO_FULL_NAME

--- a/azurelinuxagent/common/osutil/freebsd.py
+++ b/azurelinuxagent/common/osutil/freebsd.py
@@ -150,7 +150,7 @@ class FreeBSDOSUtil(DefaultOSUtil):
             route_header_line = output_lines.index("Internet:") + 1
             # Parse the file structure and left justify the routes
             route_start_line = route_header_line + 1
-            route_line_length = max([len(line) for line in output_lines[route_header_line:]])
+            route_line_length = max(len(line) for line in output_lines[route_header_line:])
             netstat_route_list = [line.ljust(route_line_length) for line in output_lines[route_start_line:]]
             # Parse the headers
             _route_headers = output_lines[route_header_line].split()

--- a/azurelinuxagent/common/osutil/gaia.py
+++ b/azurelinuxagent/common/osutil/gaia.py
@@ -179,7 +179,7 @@ class GaiaOSUtil(DefaultOSUtil):
         return socket.inet_ntoa(struct.pack("!I", addr))
 
     def _get_prefix(self, mask):
-        return str(sum([bin(int(x)).count('1') for x in mask.split('.')]))
+        return str(sum(bin(int(x)).count('1') for x in mask.split('.')))
 
     def route_add(self, net, mask, gateway):
         logger.info('route_add {0} {1} {2}', net, mask, gateway)

--- a/azurelinuxagent/common/protocol/healthservice.py
+++ b/azurelinuxagent/common/protocol/healthservice.py
@@ -73,7 +73,7 @@ class HealthService(object):
         self.api = HealthService.API
         self.version = HealthService.VERSION
         self.source = HealthService.OBSERVER_NAME
-        self.observations = list()
+        self.observations = []
 
     @property
     def as_json(self):

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -682,8 +682,8 @@ class WireClient(object):
             if os.path.exists(target_directory):
                 try:
                     shutil.rmtree(target_directory)
-                except Exception as exception:
-                    logger.warn("Cannot delete {0}: {1}", target_directory, ustr(exception))
+                except Exception as rmtree_exception:
+                    logger.warn("Cannot delete {0}: {1}", target_directory, ustr(rmtree_exception))
             raise
         finally:
             try:
@@ -886,11 +886,11 @@ class WireClient(object):
                              message=msg,
                              log_event=True)
                 return ret
-            except (ResourceGoneError, InvalidContainerError) as error:
+            except (ResourceGoneError, InvalidContainerError) as host_error:
                 msg = "[PERIODIC] Request failed using the host plugin channel after goal state refresh. " \
                       "ContainerId changed from {0} to {1}, role config file changed from {2} to {3}. " \
                       "Exception type: {4}.".format(old_container_id, new_container_id, old_role_config_name,
-                                                    new_role_config_name, type(error).__name__)
+                                                    new_role_config_name, type(host_error).__name__)
                 add_periodic(delta=logger.EVERY_SIX_HOURS,
                              name=AGENT_NAME,
                              version=CURRENT_VERSION,

--- a/azurelinuxagent/common/singletonperthread.py
+++ b/azurelinuxagent/common/singletonperthread.py
@@ -8,7 +8,8 @@ class _SingletonPerThreadMetaClass(type):
 
     def __call__(cls, *args, **kwargs):
         with cls._lock:
-            obj_name = "%s__%s" % (cls.__name__, currentThread().getName())  # Object Name = className__threadName
+            # Object Name = className__threadName
+            obj_name = "%s__%s" % (cls.__name__, currentThread().getName())  # pylint: disable=deprecated-method
             if obj_name not in cls._instances:
                 cls._instances[obj_name] = super(_SingletonPerThreadMetaClass, cls).__call__(*args, **kwargs)
             return cls._instances[obj_name]

--- a/azurelinuxagent/common/utils/cryptutil.py
+++ b/azurelinuxagent/common/utils/cryptutil.py
@@ -132,7 +132,7 @@ class CryptUtil(object):
             keydata_base64 = base64.b64encode(bytebuffer(keydata))
             return ustr(b"ssh-rsa " +  keydata_base64 + b"\n",
                         encoding='utf-8')
-        except ImportError as e:
+        except ImportError:
             raise CryptError("Failed to load pyasn1.codec.der")
 
     def num_to_bytes(self, num):

--- a/azurelinuxagent/common/utils/flexible_version.py
+++ b/azurelinuxagent/common/utils/flexible_version.py
@@ -17,7 +17,7 @@
 # Requires Python 2.6+ and Openssl 1.0+
 #
 
-from distutils import version  # pylint: disable=no-name-in-module
+from distutils import version  # pylint: disable=no-name-in-module, disable=deprecated-module
 import re
 
 

--- a/azurelinuxagent/ga/cgroupconfigurator.py
+++ b/azurelinuxagent/ga/cgroupconfigurator.py
@@ -28,7 +28,7 @@ from azurelinuxagent.ga.cgroupapi import CGroupsApi, SystemdCgroupsApi, SystemdR
 from azurelinuxagent.ga.cgroupstelemetry import CGroupsTelemetry
 from azurelinuxagent.common.exception import ExtensionErrorCodes, CGroupsException, AgentMemoryExceededException
 from azurelinuxagent.common.future import ustr
-from azurelinuxagent.common.osutil import get_osutil, systemd
+from azurelinuxagent.common.osutil import systemd
 from azurelinuxagent.common.version import get_distro
 from azurelinuxagent.common.utils import shellutil, fileutil
 from azurelinuxagent.ga.extensionprocessutil import handle_process_completion
@@ -184,10 +184,6 @@ class CGroupConfigurator(object):
 
                 _log_cgroup_info("systemd version: {0}", systemd.get_version())
 
-                # This is temporarily disabled while we analyze telemetry. Likely it will be removed.
-                # self.__collect_azure_unit_telemetry()
-                # self.__collect_agent_unit_files_telemetry()
-
                 if not self.__check_no_legacy_cgroups():
                     return
 
@@ -223,65 +219,6 @@ class CGroupConfigurator(object):
                 _log_cgroup_warning("Error initializing cgroups: {0}", ustr(exception))
             finally:
                 self._initialized = True
-
-        @staticmethod
-        def __collect_azure_unit_telemetry():
-            azure_units = []
-
-            try:
-                units = shellutil.run_command(['systemctl', 'list-units', 'azure*', '-all'])
-                for line in units.split('\n'):
-                    match = re.match(r'\s?(azure[^\s]*)\s?', line, re.IGNORECASE)
-                    if match is not None:
-                        azure_units.append((match.group(1), line))
-            except shellutil.CommandError as command_error:
-                _log_cgroup_warning("Failed to list systemd units: {0}", ustr(command_error))
-
-            for unit_name, unit_description in azure_units:
-                unit_slice = "Unknown"
-                try:
-                    unit_slice = systemd.get_unit_property(unit_name, "Slice")
-                except Exception as exception:
-                    _log_cgroup_warning("Failed to query Slice for {0}: {1}", unit_name, ustr(exception))
-
-                _log_cgroup_info("Found an Azure unit under slice {0}: {1}", unit_slice, unit_description)
-
-            if len(azure_units) == 0:
-                try:
-                    cgroups = shellutil.run_command('systemd-cgls')
-                    for line in cgroups.split('\n'):
-                        if re.match(r'[^\x00-\xff]+azure\.slice\s*', line, re.UNICODE):
-                            logger.info(ustr("Found a cgroup for azure.slice\n{0}").format(cgroups))
-                            # Don't add the output of systemd-cgls to the telemetry, since currently it does not support Unicode
-                            add_event(op=WALAEventOperation.CGroupsInfo, message="Found a cgroup for azure.slice")
-                except shellutil.CommandError as command_error:
-                    _log_cgroup_warning("Failed to list systemd units: {0}", ustr(command_error))
-
-        @staticmethod
-        def __collect_agent_unit_files_telemetry():
-            agent_unit_files = []
-            agent_service_name = get_osutil().get_service_name()
-            try:
-                fragment_path = systemd.get_unit_property(agent_service_name, "FragmentPath")
-                if fragment_path != systemd.get_agent_unit_file():
-                    agent_unit_files.append(fragment_path)
-            except Exception as exception:
-                _log_cgroup_warning("Failed to query the agent's FragmentPath: {0}", ustr(exception))
-
-            try:
-                drop_in_paths = systemd.get_unit_property(agent_service_name, "DropInPaths")
-                for path in drop_in_paths.split():
-                    agent_unit_files.append(path)
-            except Exception as exception:
-                _log_cgroup_warning("Failed to query the agent's DropInPaths: {0}", ustr(exception))
-
-            for unit_file in agent_unit_files:
-                try:
-                    with open(unit_file, "r") as file_object:
-                        _log_cgroup_info("Found a custom unit file for the agent: {0}\n{1}", unit_file,
-                                         file_object.read())
-                except Exception as exception:
-                    _log_cgroup_warning("Can't read {0}: {1}", unit_file, ustr(exception))
 
         def __check_no_legacy_cgroups(self):
             """

--- a/azurelinuxagent/ga/collect_logs.py
+++ b/azurelinuxagent/ga/collect_logs.py
@@ -116,8 +116,8 @@ class CollectLogsHandler(ThreadHandlerInterface):
 
     def start(self):
         self.event_thread = threading.Thread(target=self.daemon)
-        self.event_thread.setDaemon(True)
-        self.event_thread.setName(self.get_thread_name())
+        self.event_thread.setDaemon(True)  # pylint: disable=deprecated-method
+        self.event_thread.setName(self.get_thread_name())  # pylint: disable=deprecated-method
         self.event_thread.start()
 
     def join(self):
@@ -303,8 +303,8 @@ class LogCollectorMonitorHandler(ThreadHandlerInterface):
 
     def start(self):
         self.event_thread = threading.Thread(target=self.daemon)
-        self.event_thread.setDaemon(True)
-        self.event_thread.setName(self.get_thread_name())
+        self.event_thread.setDaemon(True)  # pylint: disable=deprecated-method
+        self.event_thread.setName(self.get_thread_name())  # pylint: disable=deprecated-method
         self.event_thread.start()
 
     def daemon(self):

--- a/azurelinuxagent/ga/collect_telemetry_events.py
+++ b/azurelinuxagent/ga/collect_telemetry_events.py
@@ -499,7 +499,7 @@ class _CollectAndEnqueueEvents(PeriodicOperation):
         :param event: Extension event to trim.
         :return: Trimmed extension event; containing only extension-specific parameters.
         """
-        params_to_keep = dict().fromkeys([
+        params_to_keep = dict.fromkeys([
             GuestAgentExtensionEventsSchema.Name,
             GuestAgentExtensionEventsSchema.Version,
             GuestAgentExtensionEventsSchema.Operation,
@@ -542,8 +542,8 @@ class CollectTelemetryEventsHandler(ThreadHandlerInterface):
 
     def start(self):
         self.thread = threading.Thread(target=self.daemon)
-        self.thread.setDaemon(True)
-        self.thread.setName(CollectTelemetryEventsHandler.get_thread_name())
+        self.thread.setDaemon(True)  # pylint: disable=deprecated-method
+        self.thread.setName(CollectTelemetryEventsHandler.get_thread_name())  # pylint: disable=deprecated-method
         self.thread.start()
 
     def stop(self):

--- a/azurelinuxagent/ga/env.py
+++ b/azurelinuxagent/ga/env.py
@@ -213,8 +213,8 @@ class EnvHandler(ThreadHandlerInterface):
 
     def start(self):
         self.env_thread = threading.Thread(target=self.daemon)
-        self.env_thread.setDaemon(True)
-        self.env_thread.setName(self.get_thread_name())
+        self.env_thread.setDaemon(True)  # pylint: disable=deprecated-method
+        self.env_thread.setName(self.get_thread_name())  # pylint: disable=deprecated-method
         self.env_thread.start()
 
     def daemon(self):

--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -27,7 +27,7 @@ import stat
 import tempfile
 import time
 import zipfile
-from distutils.version import LooseVersion
+from distutils.version import LooseVersion  # pylint: disable=deprecated-module
 from collections import defaultdict
 from functools import partial
 

--- a/azurelinuxagent/ga/monitor.py
+++ b/azurelinuxagent/ga/monitor.py
@@ -281,8 +281,8 @@ class MonitorHandler(ThreadHandlerInterface):
 
     def start(self):
         self.monitor_thread = threading.Thread(target=self.daemon)
-        self.monitor_thread.setDaemon(True)
-        self.monitor_thread.setName(self.get_thread_name())
+        self.monitor_thread.setDaemon(True)  # pylint: disable=deprecated-method
+        self.monitor_thread.setName(self.get_thread_name())  # pylint: disable=deprecated-method
         self.monitor_thread.start()
 
     def daemon(self):

--- a/azurelinuxagent/ga/periodic_operation.py
+++ b/azurelinuxagent/ga/periodic_operation.py
@@ -70,7 +70,7 @@ class PeriodicOperation(object):
         Takes a list of operations, finds the operation that should be executed next (that with the closest next_run_time)
         and sleeps until it is time to execute that operation.
         """
-        next_operation_time = min([op.next_run_time() for op in operations])
+        next_operation_time = min(op.next_run_time() for op in operations)
 
         sleep_timedelta = next_operation_time - datetime.datetime.utcnow()
         # timedelta.total_seconds() is not available on Python 2.6, do the computation manually

--- a/azurelinuxagent/ga/send_telemetry_events.py
+++ b/azurelinuxagent/ga/send_telemetry_events.py
@@ -70,8 +70,8 @@ class SendTelemetryEventsHandler(ThreadHandlerInterface):
 
     def start(self):
         self._thread = threading.Thread(target=self._process_telemetry_thread)
-        self._thread.setDaemon(True)
-        self._thread.setName(self.get_thread_name())
+        self._thread.setDaemon(True)  # pylint: disable=deprecated-method
+        self._thread.setName(self.get_thread_name())  # pylint: disable=deprecated-method
         self._thread.start()
 
     def stop(self):

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -411,7 +411,7 @@ class UpdateHandler(object):
             logger.warn(textutil.format_exception(error))
             sys.exit(1)
             # additional return here because sys.exit is mocked in unit tests
-            return
+            return  # pylint: disable=unreachable
 
         self._shutdown()
         sys.exit(0)

--- a/azurelinuxagent/pa/deprovision/factory.py
+++ b/azurelinuxagent/pa/deprovision/factory.py
@@ -15,7 +15,7 @@
 # Requires Python 2.6+ and Openssl 1.0+
 #
 
-from distutils.version import LooseVersion as Version  # pylint: disable=no-name-in-module, import-error
+from distutils.version import LooseVersion as Version  # pylint: disable=no-name-in-module, import-error, deprecated-module
 
 from azurelinuxagent.common.version import DISTRO_NAME, DISTRO_VERSION, DISTRO_FULL_NAME
 from .arch import ArchDeprovisionHandler

--- a/azurelinuxagent/pa/rdma/factory.py
+++ b/azurelinuxagent/pa/rdma/factory.py
@@ -15,8 +15,7 @@
 # Requires Python 2.6+ and Openssl 1.0+
 #
 
-from distutils.version import LooseVersion as Version  # pylint: disable=no-name-in-module, import-error
-
+from distutils.version import LooseVersion as Version  # pylint: disable=no-name-in-module, import-error, deprecated-module
 import azurelinuxagent.common.logger as logger
 from azurelinuxagent.pa.rdma.rdma import RDMAHandler
 from azurelinuxagent.common.version import DISTRO_FULL_NAME, DISTRO_VERSION

--- a/azurelinuxagent/pa/rdma/suse.py
+++ b/azurelinuxagent/pa/rdma/suse.py
@@ -24,7 +24,8 @@ import azurelinuxagent.common.utils.shellutil as shellutil
 from azurelinuxagent.pa.rdma.rdma import RDMAHandler
 from azurelinuxagent.common.version import DISTRO_VERSION
 
-from distutils.version import LooseVersion as Version
+from distutils.version import LooseVersion as Version  # pylint: disable=deprecated-module
+
 
 class SUSERDMAHandler(RDMAHandler):
 

--- a/ci/3.10.pylintrc
+++ b/ci/3.10.pylintrc
@@ -1,0 +1,40 @@
+[MESSAGES CONTROL]
+
+disable=C, # (C) convention, for programming standard violation
+    broad-except, # W0703: *Catching too general exception %s*
+    broad-exception-raised, # W0719: Raising too general exception: Exception
+    consider-using-dict-comprehension, # R1717: *Consider using a dictionary comprehension*
+    consider-using-from-import, # R0402: Use 'from foo import bar' instead
+    consider-using-in, # R1714: *Consider merging these comparisons with "in" to %r*
+    consider-using-set-comprehension, # R1718: *Consider using a set comprehension*
+    consider-using-with, # R1732: *Emitted if a resource-allocating assignment or call may be replaced by a 'with' block*
+    duplicate-code, # R0801: *Similar lines in %s files*
+    fixme, # Used when a warning note as FIXME or TODO is detected
+    logging-format-interpolation, # W1202: Use lazy % formatting in logging functions
+    logging-fstring-interpolation, # W1203: Use lazy % or .format() formatting in logging functions
+    no-else-break, # R1723: *Unnecessary "%s" after "break"*
+    no-else-continue, # R1724: *Unnecessary "%s" after "continue"*
+    no-else-raise, # R1720: *Unnecessary "%s" after "raise"*
+    no-else-return, # R1705: *Unnecessary "%s" after "return"*
+    no-self-use, # R0201: Method could be a function
+    protected-access, # W0212: Access to a protected member of a client class
+    raise-missing-from, # W0707: *Consider explicitly re-raising using the 'from' keyword*
+    redundant-u-string-prefix, # The u prefix for strings is no longer necessary in Python >=3.0
+    simplifiable-if-expression, # R1719: *The if expression can be replaced with %s*
+    simplifiable-if-statement, # R1703: *The if statement can be replaced with %s*
+    super-with-arguments, # R1725: *Consider using Python 3 style super) without arguments*
+    too-few-public-methods, # R0903: *Too few public methods %s/%s)*
+    too-many-ancestors, # R0901: *Too many ancestors %s/%s)*
+    too-many-arguments, # R0913: *Too many arguments %s/%s)*
+    too-many-boolean-expressions, # R0916: *Too many boolean expressions in if statement %s/%s)*
+    too-many-branches, # R0912: *Too many branches %s/%s)*
+    too-many-instance-attributes, # R0902: *Too many instance attributes %s/%s)*
+    too-many-locals, # R0914: *Too many local variables %s/%s)*
+    too-many-nested-blocks, # R1702: *Too many nested blocks %s/%s)*
+    too-many-public-methods, # R0904: *Too many public methods %s/%s)*
+    too-many-return-statements, # R0911: *Too many return statements %s/%s)*
+    too-many-statements, # R0915: *Too many statements %s/%s)*
+    unspecified-encoding, # W1514: Using open without explicitly specifying an encoding
+    use-a-generator, # R1729: *Use a generator instead '%s%s)'*
+    useless-object-inheritance, # R0205: *Class %r inherits from object, can be safely removed from bases in python3*
+    useless-return, # R1711: *Useless return at end of function or method*

--- a/tests_e2e/tests/agent_ext_workflow/extension_workflow.py
+++ b/tests_e2e/tests/agent_ext_workflow/extension_workflow.py
@@ -114,7 +114,7 @@ class ExtensionWorkflow(AgentVmTest):
         def assert_data_in_instance_view(self, instance_view: VirtualMachineExtensionInstanceView):
             log.info("Asserting extension status ...")
             status_message = instance_view.statuses[0].message
-            log.info("Status message: %s" % status_message)
+            log.info("Status message: %s", status_message)
 
             with soft_assertions():
                 expected_ext_version = "%s-%s" % (self.name, self.version)

--- a/tests_e2e/tests/agent_update/rsm_update.py
+++ b/tests_e2e/tests/agent_update/rsm_update.py
@@ -197,7 +197,7 @@ class RsmUpdateBvt(AgentVmTest):
         }
 
         log.info("Attempting rsm upgrade post request to endpoint: {0} with data: {1}".format(url, data))
-        response = requests.post(url, data=json.dumps(data), headers=headers)
+        response = requests.post(url, data=json.dumps(data), headers=headers, timeout=300)
         if response.status_code == 202:
             log.info("RSM upgrade request accepted")
         else:

--- a/tests_e2e/tests/ext_sequencing/ext_sequencing.py
+++ b/tests_e2e/tests/ext_sequencing/ext_sequencing.py
@@ -70,7 +70,7 @@ class ExtSequencing(AgentVmssTest):
 
     @staticmethod
     def _get_dependency_map(extensions: List[Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
-        dependency_map: Dict[str, Dict[str, Any]] = dict()
+        dependency_map: Dict[str, Dict[str, Any]] = {}
 
         for ext in extensions:
             ext_name = ext['name']
@@ -115,7 +115,7 @@ class ExtSequencing(AgentVmssTest):
 
     @staticmethod
     def _validate_extension_sequencing(dependency_map: Dict[str, Dict[str, Any]], sorted_extension_names: List[str], relax_check: bool):
-        installed_ext = dict()
+        installed_ext = {}
 
         # Iterate through the extensions in the enabled order and validate if their depending extensions are already
         # enabled prior to that.
@@ -154,7 +154,7 @@ class ExtSequencing(AgentVmssTest):
 
     def run(self):
         instances_ip_address: List[VmssInstanceIpAddress] = self._context.vmss.get_instances_ip_address()
-        ssh_clients: Dict[str, SshClient] = dict()
+        ssh_clients: Dict[str, SshClient] = {}
         for instance in instances_ip_address:
             ssh_clients[instance.instance_name] = SshClient(ip_address=instance.ip_address, username=self._context.username, identity_file=self._context.identity_file)
 

--- a/tests_e2e/tests/lib/retry.py
+++ b/tests_e2e/tests/lib/retry.py
@@ -22,7 +22,8 @@ from tests_e2e.tests.lib.logging import log
 from tests_e2e.tests.lib.shell import CommandError
 
 
-def execute_with_retry(operation: Callable[[], Any]) -> Any:
+# R1710: Either all return statements in a function should return an expression, or none of them should. (inconsistent-return-statements)
+def execute_with_retry(operation: Callable[[], Any]) -> Any:  # pylint: disable=inconsistent-return-statements
     """
     Some Azure errors (e.g. throttling) are retryable; this method attempts the given operation retrying a few times
     (after a short delay) if the error includes the string "RetryableError"
@@ -79,7 +80,8 @@ def retry_if_false(operation: Callable[[], bool], attempts: int = 5, delay: int 
     return success
 
 
-def retry(operation: Callable[[], Any], attempts: int = 5, delay: int = 30) -> Any:
+# R1710: Either all return statements in a function should return an expression, or none of them should. (inconsistent-return-statements)
+def retry(operation: Callable[[], Any], attempts: int = 5, delay: int = 30) -> Any:  # pylint: disable=inconsistent-return-statements
     """
     This method attempts the given operation retrying a few times on exceptions. Returns the value returned by the operation.
     """

--- a/tests_e2e/tests/publish_hostname/publish_hostname.py
+++ b/tests_e2e/tests/publish_hostname/publish_hostname.py
@@ -105,7 +105,7 @@ class PublishHostname(AgentVmTest):
                                                                               self._context.username,
                                                                               self._vm_password))
 
-    def retry_ssh_if_connection_reset(self, command: str, use_sudo=False):
+    def retry_ssh_if_connection_reset(self, command: str, use_sudo=False):  # pylint: disable=inconsistent-return-statements
         # The agent may bring the network down and back up to publish the hostname, which can reset the ssh connection.
         # Adding retry here for connection reset.
         retries = 3

--- a/tests_e2e/tests/scripts/agent_cpu_quota-start_service.py
+++ b/tests_e2e/tests/scripts/agent_cpu_quota-start_service.py
@@ -34,7 +34,7 @@ class CpuConsumer(threading.Thread):
         self._stopped = False
 
     def run(self):
-        threading.current_thread().setName("*Stress*")
+        threading.current_thread().setName("*Stress*")  # pylint: disable=deprecated-method
 
         while not self._stopped:
             try:
@@ -47,15 +47,15 @@ class CpuConsumer(threading.Thread):
                 while i < 30 and not self._stopped:
                     time.sleep(1)
                     i += 1
-            except Exception as exception:
-                logger.error("{0}:\n{1}", exception, traceback.format_exc())
+            except Exception as run_exception:
+                logger.error("{0}:\n{1}", run_exception, traceback.format_exc())
 
     def stop(self):
         self._stopped = True
 
 
 try:
-    threading.current_thread().setName("*StartService*")
+    threading.current_thread().setName("*StartService*")  # pylint: disable=deprecated-method
     logger.set_prefix("E2ETest")
     logger.add_logger_appender(logger.AppenderType.FILE, logger.LogLevel.INFO, "/var/log/waagent.log")
 

--- a/tests_e2e/tests/scripts/agent_firewall-verify_all_firewall_rules.py
+++ b/tests_e2e/tests/scripts/agent_firewall-verify_all_firewall_rules.py
@@ -91,7 +91,8 @@ def delete_iptable_rules(commands: List[List[str]] = None) -> None:
         cmd = None
         for command in commands:
             cmd = command
-            retry(lambda: execute_cmd(cmd=cmd), attempts=3)
+            # W0640: Cell variable cmd defined in loop (cell-var-from-loop)
+            retry(lambda: execute_cmd(cmd=cmd), attempts=3)  # pylint: disable=W0640
     except Exception as e:
         raise Exception("Error -- Failed to Delete the ip table rule set {0}".format(e))
 

--- a/tests_e2e/tests/scripts/agent_persist_firewall-verify_firewalld_rules_readded.py
+++ b/tests_e2e/tests/scripts/agent_persist_firewall-verify_firewalld_rules_readded.py
@@ -43,7 +43,8 @@ def delete_firewalld_rules(commands=None):
         cmd = None
         for command in commands:
             cmd = command
-            retry(lambda: execute_cmd(cmd=cmd), attempts=3)
+            # W0640: Cell variable cmd defined in loop (cell-var-from-loop)
+            retry(lambda: execute_cmd(cmd=cmd), attempts=3)  # pylint: disable=W0640
     except Exception as e:
         raise Exception("Error -- Failed to Delete the firewalld rule set {0}".format(e))
 


### PR DESCRIPTION
I also added many suppresions of deprecated-method/deprecated-module. Those need to be addressed, but I will do it on separate PRs to facilitate the reviews.

I created 3.10.pylintrc out of 3.6.pylintrc with a few adjustments for new warnings that were added or old warnings that were removed on 3.10. I'll highlight those with comments in the review. Documentation for warnings (use search for specific warning): https://pylint.pycqa.org/en/latest/tutorial.html