### PR TITLE
reset network service unit file if python version changes

### DIFF
--- a/tests/ga/test_persist_firewall_rules.py
+++ b/tests/ga/test_persist_firewall_rules.py
@@ -414,3 +414,18 @@ class TestPersistFirewallRulesHandler(AgentTestCase):
                                                                    mock_popen=self.__mock_network_setup_service_enabled)
             self.assertNotIn(test_ver, fileutil.read_file(handler.get_service_file_path()),
                              "Test version found incorrectly")
+
+    def test_it_should_reset_service_unit_file_if_python_version_changes(self):
+        with self._get_persist_firewall_rules_handler() as handler:
+            # 1st step - Setup the service with some python Version
+            python_ver = "test_python"
+            with patch("sys.executable", python_ver):
+                self.__setup_and_assert_network_service_setup_scenario(handler)
+                self.assertIn(python_ver, fileutil.read_file(handler.get_service_file_path()), "Python version not found")
+
+            # 2nd step - Re-run the setup and ensure the service file set up again even if service enabled
+            self.__executed_commands = []
+            self.__setup_and_assert_network_service_setup_scenario(handler,
+                                                                   mock_popen=self.__mock_network_setup_service_enabled)
+            self.assertNotIn(python_ver, fileutil.read_file(handler.get_service_file_path()),
+                             "Python version found incorrectly")


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

When python version updated, the waagent-network-setup.service still refer to old python version. We don't check the python version in the file vs what version agent used once the unit file is created, so we don't overwrite the unit file. This PR address that probelm

```
before update

2023-11-20T09:36:46.437260Z INFO Daemon Daemon Agent WALinuxAgent-2.3.0.2 forwarding signal 15 to WALinuxAgent-2.10.0.3
2023-11-20T09:36:46.557989Z INFO Daemon Daemon Azure Linux Agent Version:2.3.0.2
2023-11-20T09:36:46.558266Z INFO Daemon Daemon OS: redhat 7.9
2023-11-20T09:36:46.558347Z INFO Daemon Daemon Python: 2.7.5

after update

2023-12-21T19:00:19.225428Z INFO Daemon Daemon Agent WALinuxAgent-2.7.0.6 forwarding signal 15 to WALinuxAgent-2.10.0.3
2023-12-21T19:00:41.863028Z INFO Daemon Daemon Azure Linux Agent Version:2.7.0.6
2023-12-21T19:00:41.863576Z INFO Daemon Daemon OS: redhat 8.9
2023-12-21T19:00:41.863691Z INFO Daemon Daemon Python: 3.6.8

2023-12-21T17:54:53.054401Z INFO ExtHandler ExtHandler Logs from the waagent-network-setup.service since system boot:
 -- Logs begin at Thu 2022-12-15 22:19:36 UTC, end at Thu 2023-12-21 17:54:51 UTC. --
Dec 21 17:54:33 IPZPRFCFADLV002 systemd[1]: waagent-network-setup.service: Main process exited, code=exited, status=203/EXEC
Dec 21 17:54:33 IPZPRFCFADLV002 systemd[1]: waagent-network-setup.service: Failed with result 'exit-code'.
Dec 21 17:54:33 IPZPRFCFADLV002 systemd[1]: Failed to start Setup network rules for WALinuxAgent.
```

The PR also address the issue of `conditionfileexist` problem. Sometimes service does not get started at boot time due to binary file is not present when it runs and eventually failed with start condition failed. I have seen this behavior in redhat7.9. So, we need to specify systemd ordering and run after filesystem is ready by maintaining other existing order in the unit file.



Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).