### PR TITLE
Address pylint warning deprecated-method

### DIFF
--- a/azurelinuxagent/agent.py
+++ b/azurelinuxagent/agent.py
@@ -131,7 +131,7 @@ class Agent(object):
         """
         set_daemon_version(AGENT_VERSION)
         logger.set_prefix("Daemon")
-        threading.current_thread().setName("Daemon")  # pylint: disable=deprecated-method
+        threading.current_thread().name = "Daemon"
         child_args = None \
             if self.conf_file_path is None \
                 else "-configuration-path:{0}".format(self.conf_file_path)
@@ -171,7 +171,7 @@ class Agent(object):
         Run the update and extension handler
         """
         logger.set_prefix("ExtHandler")
-        threading.current_thread().setName("ExtHandler")  # pylint: disable=deprecated-method
+        threading.current_thread().name = "ExtHandler"
 
         #
         # Agents < 2.2.53 used to echo the log to the console. Since the extension handler could have been started by

--- a/azurelinuxagent/common/event.py
+++ b/azurelinuxagent/common/event.py
@@ -604,7 +604,7 @@ class EventLogger(object):
                          TelemetryEventParam(CommonTelemetryEventSchema.OpcodeName, event_timestamp.strftime(logger.Logger.LogTimeFormatInUTC)),
                          TelemetryEventParam(CommonTelemetryEventSchema.EventTid, threading.current_thread().ident),
                          TelemetryEventParam(CommonTelemetryEventSchema.EventPid, os.getpid()),
-                         TelemetryEventParam(CommonTelemetryEventSchema.TaskName, threading.current_thread().getName())]  # pylint: disable=deprecated-method
+                         TelemetryEventParam(CommonTelemetryEventSchema.TaskName, threading.current_thread().name)]
 
         if event.eventId == TELEMETRY_EVENT_EVENT_ID and event.providerId == TELEMETRY_EVENT_PROVIDER_ID:
             # Currently only the GuestAgentExtensionEvents has these columns, the other tables dont have them so skipping

--- a/azurelinuxagent/common/logger.py
+++ b/azurelinuxagent/common/logger.py
@@ -19,7 +19,7 @@ Log utils
 """
 import sys
 from datetime import datetime, timedelta
-from threading import currentThread
+from threading import current_thread
 
 from azurelinuxagent.common.future import ustr
 
@@ -137,7 +137,7 @@ class Logger(object):
             msg = msg_format
         time = datetime.utcnow().strftime(Logger.LogTimeFormatInUTC)
         level_str = LogLevel.STRINGS[level]
-        thread_name = currentThread().getName()  # pylint: disable=deprecated-method
+        thread_name = current_thread().name
         if self.prefix is not None:
             log_item = u"{0} {1} {2} {3} {4}\n".format(time, level_str, thread_name, self.prefix, msg)
         else:

--- a/azurelinuxagent/common/singletonperthread.py
+++ b/azurelinuxagent/common/singletonperthread.py
@@ -1,4 +1,4 @@
-from threading import Lock, currentThread
+from threading import Lock, current_thread
 
 
 class _SingletonPerThreadMetaClass(type):
@@ -9,7 +9,7 @@ class _SingletonPerThreadMetaClass(type):
     def __call__(cls, *args, **kwargs):
         with cls._lock:
             # Object Name = className__threadName
-            obj_name = "%s__%s" % (cls.__name__, currentThread().getName())  # pylint: disable=deprecated-method
+            obj_name = "%s__%s" % (cls.__name__, current_thread().name)
             if obj_name not in cls._instances:
                 cls._instances[obj_name] = super(_SingletonPerThreadMetaClass, cls).__call__(*args, **kwargs)
             return cls._instances[obj_name]

--- a/azurelinuxagent/ga/collect_logs.py
+++ b/azurelinuxagent/ga/collect_logs.py
@@ -116,8 +116,8 @@ class CollectLogsHandler(ThreadHandlerInterface):
 
     def start(self):
         self.event_thread = threading.Thread(target=self.daemon)
-        self.event_thread.setDaemon(True)  # pylint: disable=deprecated-method
-        self.event_thread.setName(self.get_thread_name())  # pylint: disable=deprecated-method
+        self.event_thread.daemon = True
+        self.event_thread.name = self.get_thread_name()
         self.event_thread.start()
 
     def join(self):
@@ -303,8 +303,8 @@ class LogCollectorMonitorHandler(ThreadHandlerInterface):
 
     def start(self):
         self.event_thread = threading.Thread(target=self.daemon)
-        self.event_thread.setDaemon(True)  # pylint: disable=deprecated-method
-        self.event_thread.setName(self.get_thread_name())  # pylint: disable=deprecated-method
+        self.event_thread.daemon = True
+        self.event_thread.name = self.get_thread_name()
         self.event_thread.start()
 
     def daemon(self):

--- a/azurelinuxagent/ga/collect_telemetry_events.py
+++ b/azurelinuxagent/ga/collect_telemetry_events.py
@@ -542,8 +542,8 @@ class CollectTelemetryEventsHandler(ThreadHandlerInterface):
 
     def start(self):
         self.thread = threading.Thread(target=self.daemon)
-        self.thread.setDaemon(True)  # pylint: disable=deprecated-method
-        self.thread.setName(CollectTelemetryEventsHandler.get_thread_name())  # pylint: disable=deprecated-method
+        self.thread.daemon = True
+        self.thread.name = CollectTelemetryEventsHandler.get_thread_name()
         self.thread.start()
 
     def stop(self):

--- a/azurelinuxagent/ga/env.py
+++ b/azurelinuxagent/ga/env.py
@@ -213,8 +213,8 @@ class EnvHandler(ThreadHandlerInterface):
 
     def start(self):
         self.env_thread = threading.Thread(target=self.daemon)
-        self.env_thread.setDaemon(True)  # pylint: disable=deprecated-method
-        self.env_thread.setName(self.get_thread_name())  # pylint: disable=deprecated-method
+        self.env_thread.daemon = True
+        self.env_thread.name = self.get_thread_name()
         self.env_thread.start()
 
     def daemon(self):

--- a/azurelinuxagent/ga/monitor.py
+++ b/azurelinuxagent/ga/monitor.py
@@ -281,8 +281,8 @@ class MonitorHandler(ThreadHandlerInterface):
 
     def start(self):
         self.monitor_thread = threading.Thread(target=self.daemon)
-        self.monitor_thread.setDaemon(True)  # pylint: disable=deprecated-method
-        self.monitor_thread.setName(self.get_thread_name())  # pylint: disable=deprecated-method
+        self.monitor_thread.daemon = True
+        self.monitor_thread.name = self.get_thread_name()
         self.monitor_thread.start()
 
     def daemon(self):

--- a/azurelinuxagent/ga/send_telemetry_events.py
+++ b/azurelinuxagent/ga/send_telemetry_events.py
@@ -70,8 +70,8 @@ class SendTelemetryEventsHandler(ThreadHandlerInterface):
 
     def start(self):
         self._thread = threading.Thread(target=self._process_telemetry_thread)
-        self._thread.setDaemon(True)  # pylint: disable=deprecated-method
-        self._thread.setName(self.get_thread_name())  # pylint: disable=deprecated-method
+        self._thread.daemon = True
+        self._thread.name = self.get_thread_name()
         self._thread.start()
 
     def stop(self):

--- a/tests/ga/test_send_telemetry_events.py
+++ b/tests/ga/test_send_telemetry_events.py
@@ -340,7 +340,7 @@ class TestSendTelemetryEventsHandler(AgentTestCase, HttpRequestPredicates):
             with patch("os.path.getmtime", return_value=test_mtime):
                 with patch('os.getpid', return_value=test_eventpid):
                     with patch("threading.Thread.ident", new_callable=PropertyMock(return_value=test_eventtid)):
-                        with patch("threading.Thread.getName", return_value=test_taskname):
+                        with patch("threading.Thread.name", new_callable=PropertyMock(return_value=test_taskname)):
                             monitor_handler.run()
 
             TestSendTelemetryEventsHandler._stop_handler(telemetry_handler)

--- a/tests_e2e/tests/scripts/agent_cpu_quota-start_service.py
+++ b/tests_e2e/tests/scripts/agent_cpu_quota-start_service.py
@@ -34,7 +34,7 @@ class CpuConsumer(threading.Thread):
         self._stopped = False
 
     def run(self):
-        threading.current_thread().setName("*Stress*")  # pylint: disable=deprecated-method
+        threading.current_thread().name = "*Stress*"
 
         while not self._stopped:
             try:
@@ -55,7 +55,7 @@ class CpuConsumer(threading.Thread):
 
 
 try:
-    threading.current_thread().setName("*StartService*")  # pylint: disable=deprecated-method
+    threading.current_thread().name = "*StartService*"
     logger.set_prefix("E2ETest")
     logger.add_logger_appender(logger.AppenderType.FILE, logger.LogLevel.INFO, "/var/log/waagent.log")
 


### PR DESCRIPTION
get/setDaemon, get/setName, and currentThread in the threading module have been deprecated in favor of daemon, name, and current_thread.