### PR TITLE
retry on quota reset check

### DIFF
--- a/tests_e2e/tests/scripts/ext_cgroups-check_cgroups_extensions.py
+++ b/tests_e2e/tests/scripts/ext_cgroups-check_cgroups_extensions.py
@@ -29,6 +29,7 @@ from tests_e2e.tests.lib.cgroup_helpers import verify_if_distro_supports_cgroup,
     print_cgroups
 from tests_e2e.tests.lib.logging import log
 from tests_e2e.tests.lib.remote_test import run_remote_test
+from tests_e2e.tests.lib.retry import retry_if_false
 
 
 def verify_custom_script_cgroup_assigned_correctly():
@@ -218,7 +219,7 @@ try:
     run_remote_test(main)
 except Exception as e:
     # It is possible that  agent cgroup can be disabled due to UNKNOWN process or throttled before we run this check, in that case, we should ignore the validation
-    if check_agent_quota_disabled() and check_cgroup_disabled_with_unknown_process():
+    if check_cgroup_disabled_with_unknown_process() and retry_if_false(check_agent_quota_disabled()):
         log.info("Cgroup is disabled due to UNKNOWN process, ignoring ext cgroups validations")
     else:
         raise


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
The test checks if agent reset the quota when we disable the cgroups. Test check can happen close to when agent doing reset or  reset quota may not reflect immediately. So added a retry to check few times
Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).