### PR TITLE
Fix osutil/default route_add to pass string array.

### DIFF
--- a/azurelinuxagent/common/osutil/default.py
+++ b/azurelinuxagent/common/osutil/default.py
@@ -1159,7 +1159,7 @@ class DefaultOSUtil(object):
         Add specified route 
         """
         try:
-            cmd = ["ip", "route", "add", net, "via", gateway]
+            cmd = ["ip", "route", "add", str(net), "via", gateway]
             return shellutil.run_command(cmd)
         except CommandError:
             return ""


### PR DESCRIPTION
Replaces #3046, which was opened against master.