### PR TITLE
Ignore network unreachable error in hostname test

### DIFF
--- a/.github/workflows/ci_pr.yml
+++ b/.github/workflows/ci_pr.yml
@@ -136,6 +136,7 @@ jobs:
         #   so we suppress "bad-option-value".
         # * 3.9 will produce "no-member" for several properties/methods that are added to the mocks used by the unit tests (e.g
         #   "E1101: Instance of 'WireProtocol' has no 'aggregate_status' member") so we suppress that warning.
+        # * On 3.9 pylint crashes when parsing azurelinuxagent/daemon/main.py (see https://github.com/pylint-dev/pylint/issues/9473), so we ignore it.
         # * 'no-self-use' ("R0201: Method could be a function") was moved to an optional extension on 3.8 and is no longer used by default. It needs
         #    to be suppressed for previous versions (3.0-3.7), though.
         #
@@ -144,7 +145,7 @@ jobs:
           PYLINT_OPTIONS="$PYLINT_OPTIONS --disable=bad-option-value"
         fi
         if [[ "${{ matrix.python-version }}" == "3.9" ]]; then
-          PYLINT_OPTIONS="$PYLINT_OPTIONS --disable=no-member"
+          PYLINT_OPTIONS="$PYLINT_OPTIONS --disable=no-member --ignore=azurelinuxagent/daemon/main.py"
         fi
         if [[ "${{ matrix.python-version }}" =~ ^3\.[0-7]$ ]]; then
           PYLINT_OPTIONS="$PYLINT_OPTIONS --disable=no-self-use"

--- a/.github/workflows/ci_pr.yml
+++ b/.github/workflows/ci_pr.yml
@@ -145,7 +145,7 @@ jobs:
           PYLINT_OPTIONS="$PYLINT_OPTIONS --disable=bad-option-value"
         fi
         if [[ "${{ matrix.python-version }}" == "3.9" ]]; then
-          PYLINT_OPTIONS="$PYLINT_OPTIONS --disable=no-member --ignore=azurelinuxagent/daemon/main.py"
+          PYLINT_OPTIONS="$PYLINT_OPTIONS --disable=no-member --ignore=main.py"
         fi
         if [[ "${{ matrix.python-version }}" =~ ^3\.[0-7]$ ]]; then
           PYLINT_OPTIONS="$PYLINT_OPTIONS --disable=no-self-use"

--- a/tests/ga/test_cgroupconfigurator.py
+++ b/tests/ga/test_cgroupconfigurator.py
@@ -644,11 +644,11 @@ cgroup on /sys/fs/cgroup/blkio type cgroup (rw,nosuid,nodev,noexec,relatime,blki
             
             # Popen can accept both strings and lists, handle both here.
             if isinstance(command, str):
-                systemd_command = command.replace('systemd-run', 'systemd-run syntax_error')
+                command = command.replace('systemd-run', 'systemd-run syntax_error')
             elif isinstance(command, list) and command[0] == 'systemd-run':
-                systemd_command = ['systemd-run', 'syntax_error'] + command[1:]
+                command = ['systemd-run', 'syntax_error'] + command[1:]
 
-            return original_popen(systemd_command, *args, **kwargs)
+            return original_popen(command, *args, **kwargs)
 
         expected_output = "[stdout]\n{0}\n\n\n[stderr]\n"
 

--- a/tests_e2e/tests/publish_hostname/publish_hostname.py
+++ b/tests_e2e/tests/publish_hostname/publish_hostname.py
@@ -209,11 +209,13 @@ class PublishHostname(AgentVmTest):
         ignore_rules = [
             #
             # We may see temporary network unreachable warnings since we are bringing the network interface down
+            #
             # 2024-02-16T09:27:14.114569Z WARNING MonitorHandler ExtHandler Error in SendHostPluginHeartbeat: [HttpError] [HTTP Failed] GET http://168.63.129.16:32526/health -- IOError [Errno 101] Network is unreachable -- 1 attempts made --- [NOTE: Will not log the same error for the next hour]
             # 2024-02-28T05:37:55.562065Z ERROR ExtHandler ExtHandler Error fetching the goal state: [ProtocolError] GET vmSettings [correlation ID: 28de1093-ecb5-4515-ba8e-2ed0c7778e34 eTag: 4648629460326038775]: Request failed: [Errno 101] Network is unreachable
+            # 2024-02-29T09:30:40.702293Z ERROR ExtHandler ExtHandler Error fetching the goal state: [ProtocolError] [Wireserver Exception] [HttpError] [HTTP Failed] GET http://168.63.129.16/machine/ -- IOError [Errno 101] Network is unreachable -- 6 attempts made
             #
             {
-                'message': r"GET (http://168.63.129.16:32526/health|vmSettings).*\[Errno 101\] Network is unreachable",
+                'message': r"GET (http://168.63.129.16:32526/health|vmSettings|http://168.63.129.16/machine).*\[Errno 101\] Network is unreachable",
             }
         ]
         return ignore_rules


### PR DESCRIPTION
Another variation of network unreachable that needs to be ignored.

This PR exposed a unit test failure and a pylint crash. Fixes are included.