### PR TITLE
Added new options to verify if network is up at boot time

### DIFF
--- a/tests_e2e/tests/scripts/agent_persist_firewall-access_wireserver
+++ b/tests_e2e/tests/scripts/agent_persist_firewall-access_wireserver
@@ -19,6 +19,11 @@
 # Helper script which tries to access Wireserver on system reboot. Also prints out iptable rules if non-root and still
 # able to access Wireserver
 
+if [[ $# -ne 1 ]]; then
+    echo "Usage: agent_persist_firewall-access_wireserver <test-user>"
+    exit 1
+fi
+TEST_USER=$1
 USER=$(whoami)
 echo "$(date --utc +%FT%T.%3NZ): Running as user: $USER"
 
@@ -27,12 +32,25 @@ function check_online
     ping 8.8.8.8 -c 1 -i .2 -t 30 > /dev/null 2>&1 && echo 0 || echo 1
 }
 
+function ping_localhost
+{
+    ping 127.0.0.1 -c 1 -i .2 -t 30 > /dev/null 2>&1 && echo 0 || echo 1
+}
+
+function socket_connection
+{
+    output=$(python3 /home/"$TEST_USER"/bin/agent_persist_firewall-check_connectivity.py 2>&1)
+    echo $output
+}
+
 # Check more, sleep less
 MAX_CHECKS=10
 # Initial starting value for checks
 CHECKS=0
 IS_ONLINE=$(check_online)
 
+echo "Checking network connectivity..."
+echo "Running ping to 8.8.8.8 option"
 # Loop while we're not online.
 while [ "$IS_ONLINE" -eq 1 ]; do
 
@@ -48,6 +66,19 @@ while [ "$IS_ONLINE" -eq 1 ]; do
 
 done
 
+# logging other options output to compare and evaluate which option is more stable when ping to 8.8.8.8 failed
+if [ "$IS_ONLINE" -eq 1 ]; then
+    echo "Checking other options to see if network is accessible"
+    echo "Running ping to localhost option"
+    PING_LOCAL=$(ping_localhost)
+    if [ "$PING_LOCAL" -eq 1 ]; then
+        echo "Ping to localhost failed"
+    else
+        echo "Ping to localhost succeeded"
+    fi
+    echo "Running socket connection to wireserver:53 option"
+    socket_connection
+fi
 if [ "$IS_ONLINE" -eq 1 ]; then
     # We will never be able to get online. Kill script.
     echo "Unable to connect to network, exiting now"
@@ -60,7 +91,7 @@ echo "Trying to contact Wireserver as $USER to see if accessible"
 
 echo ""
 echo "IPTables before accessing Wireserver"
-sudo iptables -t security -L -nxv
+sudo iptables -t security -L -nxv -w
 echo ""
 
 WIRE_IP=$(cat /var/lib/waagent/WireServerEndpoint 2>/dev/null || echo '168.63.129.16' | tr -d '[:space:]')

--- a/tests_e2e/tests/scripts/agent_persist_firewall-check_connectivity.py
+++ b/tests_e2e/tests/scripts/agent_persist_firewall-check_connectivity.py
@@ -1,0 +1,30 @@
+import socket
+import sys
+
+WIRESERVER_ENDPOINT_FILE = '/var/lib/waagent/WireServerEndpoint'
+WIRESERVER_IP = '168.63.129.16'
+
+
+def get_wireserver_ip() -> str:
+    try:
+        with open(WIRESERVER_ENDPOINT_FILE, 'r') as f:
+            wireserver_ip = f.read()
+    except Exception:
+        wireserver_ip = WIRESERVER_IP
+    return wireserver_ip
+
+
+def main():
+    try:
+        wireserver_ip = get_wireserver_ip()
+        socket.setdefaulttimeout(3)
+        socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect((wireserver_ip, 53))
+
+        print('Socket connection to wire server:53 success')
+    except:  # pylint: disable=W0702
+        print('Socket connection to wire server:53 failed')
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests_e2e/tests/scripts/agent_persist_firewall-test_setup
+++ b/tests_e2e/tests/scripts/agent_persist_firewall-test_setup
@@ -25,6 +25,6 @@ if [[ $# -ne 1 ]]; then
     exit 1
 fi
 
-echo "@reboot /home/$1/bin/agent_persist_firewall-access_wireserver > /tmp/reboot-cron-root.log 2>&1" | crontab -u root -
-echo "@reboot /home/$1/bin/agent_persist_firewall-access_wireserver > /tmp/reboot-cron-$1.log 2>&1" | crontab -u $1 -
+echo "@reboot /home/$1/bin/agent_persist_firewall-access_wireserver $1 > /tmp/reboot-cron-root.log 2>&1" | crontab -u root -
+echo "@reboot /home/$1/bin/agent_persist_firewall-access_wireserver $1 > /tmp/reboot-cron-$1.log 2>&1" | crontab -u $1 -
 update-waagent-conf OS.EnableFirewall=y


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
As we know we do the firewall setup before network is up in order to prevent non-root user access to wireserver once network is up. 
This validation we do with cronjob script at boot time in persist firewall scenario. The script verifies the network is up and then validates goal state fetch.
Today we verify the network is up by ping to 8.8.8.8. Sometimes this check is unstable, and we suspect factors like routing tables, network security rules, etc that may be producing noise. 

This pr adding other options in order to compare which option is more stable. For now, it just logs the connection status when ping to 8.8.8.8 is failed.

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).