### PR TITLE
Fix mock for cgroup unit test

### DIFF
--- a/tests/common/osutil/test_default.py
+++ b/tests/common/osutil/test_default.py
@@ -964,7 +964,7 @@ Match host 192.168.1.2\n\
 
                 self.assertFalse(osutil._enable_firewall)
 
-    @skip_if_predicate_true(is_python_version_26_or_34, "Disabled on Python 2.6 and 3.4 for now. Need to revisit to fix it")
+    @skip_if_predicate_true(is_python_version_26_or_34, "Disabled on Python 2.6 and 3.4, they run on containers where the OS commands needed by the test are not present.")
     def test_get_nic_state(self):
         state = osutil.DefaultOSUtil().get_nic_state()
         self.assertNotEqual(state, {})

--- a/tests/common/test_event.py
+++ b/tests/common/test_event.py
@@ -415,7 +415,7 @@ class TestEvent(HttpRequestPredicates, AgentTestCase):
         self.assertEqual(len(event_list), 1)
         self.assertEqual(TestEvent._get_event_message(event_list[0]), u'World\u05e2\u05d9\u05d5\u05ea \u05d0\u05d7\u05e8\u05d5\u05ea\u0906\u091c')
 
-    @skip_if_predicate_true(is_python_version_26_or_34, "Disabled on Python 2.6 and 3.4 for now. Need to revisit to fix it")
+    @skip_if_predicate_true(is_python_version_26_or_34, "Disabled on Python 2.6 and 3.4, they run on containers where the OS commands needed by the test are not present.")
     def test_collect_events_should_ignore_invalid_event_files(self):
         self._create_test_event_file("custom_script_1.tld")  # a valid event
         self._create_test_event_file("custom_script_utf-16.tld")

--- a/tests/ga/test_cgroupconfigurator.py
+++ b/tests/ga/test_cgroupconfigurator.py
@@ -647,6 +647,8 @@ cgroup on /sys/fs/cgroup/blkio type cgroup (rw,nosuid,nodev,noexec,relatime,blki
                 command = command.replace('systemd-run', 'systemd-run syntax_error')
             elif isinstance(command, list) and command[0] == 'systemd-run':
                 command = ['systemd-run', 'syntax_error'] + command[1:]
+            elif command == ['systemctl', 'daemon-reload']:
+                command = ['echo', 'systemctl', 'daemon-reload']
 
             return original_popen(command, *args, **kwargs)
 

--- a/tests/ga/test_cgroupconfigurator.py
+++ b/tests/ga/test_cgroupconfigurator.py
@@ -526,7 +526,7 @@ cgroup on /sys/fs/cgroup/blkio type cgroup (rw,nosuid,nodev,noexec,relatime,blki
 
                         self.assertEqual(len(CGroupsTelemetry._tracked), 0, "No cgroups should have been created")
 
-    @skip_if_predicate_true(is_python_version_26_or_34, "Disabled on Python 2.6 and 3.4 for now. Need to revisit to fix it")
+    @skip_if_predicate_true(is_python_version_26_or_34, "Disabled on Python 2.6 and 3.4, they run on containers where the OS commands needed by the test are not present.")
     @attr('requires_sudo')
     @patch('time.sleep', side_effect=lambda _: mock_sleep())
     def test_start_extension_command_should_not_use_fallback_option_if_extension_fails(self, *args):
@@ -564,7 +564,7 @@ cgroup on /sys/fs/cgroup/blkio type cgroup (rw,nosuid,nodev,noexec,relatime,blki
                     # wasn't truncated.
                     self.assertIn("Running scope as unit", ustr(context_manager.exception))
 
-    @skip_if_predicate_true(is_python_version_26_or_34, "Disabled on Python 2.6 and 3.4 for now. Need to revisit to fix it")
+    @skip_if_predicate_true(is_python_version_26_or_34, "Disabled on Python 2.6 and 3.4, they run on containers where the OS commands needed by the test are not present.")
     @attr('requires_sudo')
     @patch('time.sleep', side_effect=lambda _: mock_sleep())
     @patch("azurelinuxagent.ga.extensionprocessutil.TELEMETRY_MESSAGE_MAX_LEN", 5)
@@ -632,6 +632,7 @@ cgroup on /sys/fs/cgroup/blkio type cgroup (rw,nosuid,nodev,noexec,relatime,blki
                         self.assertEqual(context_manager.exception.code, ExtensionErrorCodes.PluginHandlerScriptTimedout)
                         self.assertIn("Timeout", ustr(context_manager.exception))
 
+    @skip_if_predicate_true(is_python_version_26_or_34, "Disabled on Python 2.6 and 3.4, they run on containers where the OS commands needed by the test are not present.")
     @patch('time.sleep', side_effect=lambda _: mock_sleep())
     def test_start_extension_command_should_capture_only_the_last_subprocess_output(self, _):
         with self._get_cgroup_configurator() as configurator:

--- a/tests/ga/test_update.py
+++ b/tests/ga/test_update.py
@@ -1037,7 +1037,7 @@ class TestUpdate(UpdateTestCase):
             "Not setting up persistent firewall rules as OS.EnableFirewall=False" == args[0] for (args, _) in
             patch_info.call_args_list), "Info not logged properly, got: {0}".format(patch_info.call_args_list))
 
-    @skip_if_predicate_true(is_python_version_26_or_34, "Disabled on Python 2.6 and 3.4 for now. Need to revisit to fix it")
+    @skip_if_predicate_true(is_python_version_26_or_34, "Disabled on Python 2.6 and 3.4, they run on containers where the OS commands needed by the test are not present.")
     def test_it_should_setup_persistent_firewall_rules_on_startup(self):
         iterations = 1
         executed_commands = []


### PR DESCRIPTION
''systemctl daemon-reload" requires root privileges and is not needed by this test; mocking it out.