### PR TITLE
Add keyvault test to daily run + Specify tests suite as a list

### DIFF
--- a/tests_e2e/orchestrator/lib/agent_test_loader.py
+++ b/tests_e2e/orchestrator/lib/agent_test_loader.py
@@ -88,7 +88,7 @@ class AgentTestLoader(object):
     """
     Loads a given set of test suites from the YAML configuration files.
     """
-    def __init__(self, test_suites: str, cloud: str):
+    def __init__(self, test_suites: List[str], cloud: str):
         """
         Loads the specified 'test_suites', which are given as a string of comma-separated suite names or a YAML description
         of a single test_suite.
@@ -175,25 +175,9 @@ class AgentTestLoader(object):
                 if suite_skip_image not in self.images:
                     raise Exception(f"Invalid image reference in test suite {suite.name}: Can't find {suite_skip_image} in images.yml")
 
-
     @staticmethod
-    def _load_test_suites(test_suites: str) -> List[TestSuiteInfo]:
-        #
-        # Attempt to parse 'test_suites' as the YML description of a single suite
-        #
-        parsed = yaml.safe_load(test_suites)
-
-        #
-        # A comma-separated list (e.g. "foo", "foo, bar", etc.) is valid YAML, but it is parsed as a string. An actual test suite would
-        # be parsed as a dictionary. If it is a dict, take is as the YML description of a single test suite
-        #
-        if isinstance(parsed, dict):
-            return [AgentTestLoader._load_test_suite(parsed)]
-
-        #
-        # If test_suites is not YML, then it should be a comma-separated list of description files
-        #
-        description_files: List[Path] = [AgentTestLoader._SOURCE_CODE_ROOT/"test_suites"/f"{t.strip()}.yml" for t in test_suites.split(',')]
+    def _load_test_suites(test_suites: List[str]) -> List[TestSuiteInfo]:
+        description_files: List[Path] = [AgentTestLoader._SOURCE_CODE_ROOT/"test_suites"/f"{t}.yml" for t in test_suites]
         return [AgentTestLoader._load_test_suite(f) for f in description_files]
 
     @staticmethod

--- a/tests_e2e/orchestrator/runbook.yml
+++ b/tests_e2e/orchestrator/runbook.yml
@@ -26,10 +26,33 @@ variable:
     is_case_visible: true
 
   #
-  # Test suites to execute
+  # Test suites to execute.
+  #
+  # Use "test_suites" to specify from the command-line the test suites to execute. If not specifies, the "default_test_suites" are executed.
   #
   - name: test_suites
-    value: "agent_bvt, no_outbound_connections, extensions_disabled, agent_not_provisioned, fips, agent_ext_workflow, agent_status, multi_config_ext, agent_cgroups, ext_cgroups, agent_firewall, ext_telemetry_pipeline, ext_sequencing, agent_persist_firewall, publish_hostname, agent_update, recover_network_interface"
+    value: ""
+
+  - name: default_test_suites
+    value:
+      - agent_bvt
+      - agent_cgroups
+      - agent_ext_workflow
+      - agent_firewall
+      - agent_not_provisioned
+      - agent_persist_firewall
+      - agent_status
+      - agent_update
+      - ext_cgroups
+      - extensions_disabled
+      - ext_sequencing
+      - ext_telemetry_pipeline
+      - fips
+      - keyvault_certificates
+      - multi_config_ext
+      - no_outbound_connections
+      - publish_hostname
+      - recover_network_interface
 
   #
   # Parameters used to create test VMs
@@ -183,7 +206,7 @@ environment: $(c_environment)
 platform: $(c_platform)
 
 combinator:
-  type: agent_test_suites
+  type: agent_test_suite_combinator
   allow_ssh: $(allow_ssh)
   cloud: $(cloud)
   identity_file: $(identity_file)
@@ -193,6 +216,7 @@ combinator:
   resource_group_name: $(resource_group_name)
   subscription_id: $(subscription_id)
   test_suites: $(test_suites)
+  default_test_suites: $(default_test_suites)
   user: $(user)
   vm_name: $(vm_name)
   vm_size: $(vm_size)


### PR DESCRIPTION
It turns out I forgot to add the keyvault test to the daily runbook.

As we've added more tests to the runbook, listing them as a comma-separate list makes it harder to notice such errors. I changed the test suites to be an array instead, which makes it much easy to read.