### PR TITLE
retry for agent log in install-agent setup

### DIFF
--- a/tests_e2e/orchestrator/scripts/install-agent
+++ b/tests_e2e/orchestrator/scripts/install-agent
@@ -167,8 +167,21 @@ fi
 echo "Restarting service..."
 agent-service stop
 
+# Agent log may not be present if install-agent setup run before pre-install agent start; So giving it a few minutes to show up
+for i in {1..5}
+do
+  if [ -f /var/log/waagent.log ]; then
+    break
+  fi
+  sleep 30
+done
 # Rename the previous log to ensure the new log starts with the agent we just installed
-mv /var/log/waagent.log /var/log/waagent."$(date --iso-8601=seconds)".log
+if [ -f /var/log/waagent.log ]; then
+  mv /var/log/waagent.log /var/log/waagent."$(date --iso-8601=seconds)".log
+else
+  echo "No waagent.log found"
+  exit 1
+fi
 
 agent-service start
 


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
Agent log may not be present if install-agent setup run before pre-install agent start; So, giving it a few minutes to show up


Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).