### PR TITLE
Log entire instance view when vm power state is missing

### DIFF
--- a/tests_e2e/tests/lib/virtual_machine_client.py
+++ b/tests_e2e/tests/lib/virtual_machine_client.py
@@ -171,7 +171,7 @@ class VirtualMachineClient(AzureSdkClient):
             instance_view = self.get_instance_view()
             power_state = [s.code for s in instance_view.statuses if "PowerState" in s.code]
             if len(power_state) != 1:
-                raise Exception(f"Could not find PowerState in the instance view statuses:\n{json.dumps(instance_view.statuses)}")
+                raise Exception(f"Could not find PowerState in the instance view statuses:\n{json.dumps(instance_view.serialize(), indent=2)}")
             log.info("VM's Power State: %s", power_state[0])
             if power_state[0] == "PowerState/running":
                 # We may get an instance view captured before the reboot actually happened; verify


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
The virtual machine client restart method raises exception when the VM Power State is not in the instance view status. Previously when this happened the method attempts to serialize instance_view.statuses, but this causes another exception since statuses is not serializable. 

This PR updates to log the entire instance view for debugging purposes. 

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).