### PR TITLE
Increase install-agent timeout for provisioning check

### DIFF
--- a/tests_e2e/orchestrator/scripts/install-agent
+++ b/tests_e2e/orchestrator/scripts/install-agent
@@ -87,7 +87,7 @@ echo "Service Status:"
 
 # We need to wait for the provisioning code to complete before stopping the agent's service to do the test setup
 started=false
-for i in {1..6}
+for i in {1..12}
 do
   if [[ -f /var/lib/waagent/provisioned ]]; then
     started=true


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
install-agent previously allowed the agent 3 minutes to start. In another PR, the check was changed to wait for provisioning to complete: https://github.com/Azure/WALinuxAgent/pull/3094

Timeout should be increased since provisioning completion is dependent on agent start. There has been at least one test failure due to timeout being too strict. 


Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).