### PR TITLE
Collect telemetry for firewall settings changed

### DIFF
--- a/azurelinuxagent/common/event.py
+++ b/azurelinuxagent/common/event.py
@@ -121,6 +121,7 @@ class WALAEventOperation:
     ReportEventUnicodeErrors = "ReportEventUnicodeErrors"
     ReportStatus = "ReportStatus"
     ReportStatusExtended = "ReportStatusExtended"
+    ResetFirewall = "ResetFirewall"
     Restart = "Restart"
     SequenceNumberMismatch = "SequenceNumberMismatch"
     SetCGroupsLimits = "SetCGroupsLimits"


### PR DESCRIPTION
Added a new telemetry event, "ResetFirewall", that is used when the Agent updates the firewall rules because they have been changed externally.

The previous event. "Firewall", is still used for first time setup after a machine boot.