### PR TITLE
wait for rg creation in e2e tests

### DIFF
--- a/tests_e2e/orchestrator/lib/agent_test_suite.py
+++ b/tests_e2e/orchestrator/lib/agent_test_suite.py
@@ -46,6 +46,7 @@ from lisa.sut_orchestrator.azure.platform_ import AzurePlatform  # pylint: disab
 
 import makepkg
 from azurelinuxagent.common.version import AGENT_VERSION
+from tests_e2e.tests.lib.retry import retry_if_false
 
 from tests_e2e.tests.lib.virtual_machine_client import VirtualMachineClient
 from tests_e2e.tests.lib.virtual_machine_scale_set_client import VirtualMachineScaleSetClient
@@ -913,6 +914,10 @@ class AgentTestSuite(LisaTestSuite):
         self._lisa_log.info("Creating resource group %s", self._resource_group_name)
         resource_group = ResourceGroupClient(cloud=self._cloud, location=self._location, subscription=self._subscription_id, name=self._resource_group_name)
         resource_group.create()
+        exist = retry_if_false(resource_group.is_exists)
+        if not exist:
+            self._lisa_log.error("Failed to create resource group %s", self._resource_group_name)
+            raise Exception("Failed to create resource group: {0}".format(self._resource_group_name))
         self._delete_scale_set = True
 
         self._lisa_log.info("Creating scale set %s", self._vmss_name)

--- a/tests_e2e/tests/lib/resource_group_client.py
+++ b/tests_e2e/tests/lib/resource_group_client.py
@@ -46,10 +46,7 @@ class ResourceGroupClient(AzureSdkClient):
         Creates a resource group
         """
         log.info("Creating resource group %s", self)
-        self._execute_async_operation(
-            operation=lambda: self._resource_client.resource_groups.create_or_update(self.name, {"location": self.location}),
-            operation_name=f"Create resource group {self}",
-            timeout=AzureSdkClient._DEFAULT_TIMEOUT)
+        self._resource_client.resource_groups.create_or_update(self.name, {"location": self.location})
 
     def deploy_template(self, template: Dict[str, Any], parameters: Dict[str, Any] = None):
         """
@@ -72,6 +69,12 @@ class ResourceGroupClient(AzureSdkClient):
         """
         log.info("Deleting resource group %s (no wait)", self)
         self._resource_client.resource_groups.begin_delete(self.name)  # Do not wait for the deletion to complete
+
+    def is_exists(self) -> bool:
+        """
+        Checks if the resource group exists
+        """
+        return self._resource_client.resource_groups.check_existence(self.name, {"location": self.location})
 
     def __str__(self):
         return f"{self.name}"

--- a/tests_e2e/tests/lib/resource_group_client.py
+++ b/tests_e2e/tests/lib/resource_group_client.py
@@ -74,7 +74,7 @@ class ResourceGroupClient(AzureSdkClient):
         """
         Checks if the resource group exists
         """
-        return self._resource_client.resource_groups.check_existence(self.name, {"location": self.location})
+        return self._resource_client.resource_groups.check_existence(self.name)
 
     def __str__(self):
         return f"{self.name}"

--- a/tests_e2e/tests/lib/resource_group_client.py
+++ b/tests_e2e/tests/lib/resource_group_client.py
@@ -47,7 +47,7 @@ class ResourceGroupClient(AzureSdkClient):
         """
         log.info("Creating resource group %s", self)
         self._execute_async_operation(
-            self._resource_client.resource_groups.create_or_update(self.name, {"location": self.location}),
+            operation=lambda: self._resource_client.resource_groups.create_or_update(self.name, {"location": self.location}),
             operation_name=f"Create resource group {self}",
             timeout=AzureSdkClient._DEFAULT_TIMEOUT)
 

--- a/tests_e2e/tests/lib/resource_group_client.py
+++ b/tests_e2e/tests/lib/resource_group_client.py
@@ -46,7 +46,10 @@ class ResourceGroupClient(AzureSdkClient):
         Creates a resource group
         """
         log.info("Creating resource group %s", self)
-        self._resource_client.resource_groups.create_or_update(self.name, {"location": self.location})
+        self._execute_async_operation(
+            self._resource_client.resource_groups.create_or_update(self.name, {"location": self.location}),
+            operation_name=f"Create resource group {self}",
+            timeout=AzureSdkClient._DEFAULT_TIMEOUT)
 
     def deploy_template(self, template: Dict[str, Any], parameters: Dict[str, Any] = None):
         """


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

issue is creating scale test before rg created

azure.core.exceptions.ResourceNotFoundError: (ResourceGroupNotFound) Resource group 'lisa-walinuxagent-20240430-040317-797-w7' could not be found. Code: ResourceGroupNotFound Message: Resource group 'lisa-walinuxagent-20240430-040317-797-w7' could not be found.

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).