### PR TITLE
Remove check for "ibXX" interface format to expand support

### DIFF
--- a/azurelinuxagent/pa/rdma/rdma.py
+++ b/azurelinuxagent/pa/rdma/rdma.py
@@ -368,10 +368,6 @@ class RDMADeviceHandler(object):
         count = 0
 
         for nic in nics:
-            # look for IBoIP interface of format ibXXX
-            if not re.match(r"ib\w+", nic):
-                continue
-
             mac_addr = None
             with open(os.path.join(net_dir, nic, "address")) as address_file:
                 mac_addr = address_file.read()

--- a/azurelinuxagent/pa/rdma/rdma.py
+++ b/azurelinuxagent/pa/rdma/rdma.py
@@ -377,8 +377,12 @@ class RDMADeviceHandler(object):
                 continue
 
             mac_addr = mac_addr.upper()
-
-            match = re.match(r".+(\w\w):(\w\w):(\w\w):\w\w:\w\w:(\w\w):(\w\w):(\w\w)\n", mac_addr)
+            
+            # if this is an IB interface, match IB-specific regex
+            if re.match(r"ib\w+", nic):
+                match = re.match(r".+(\w\w):(\w\w):(\w\w):\w\w:\w\w:(\w\w):(\w\w):(\w\w)\n", mac_addr)
+            else:
+                match = re.match(r"^(\w\w):(\w\w):(\w\w):(\w\w):(\w\w):(\w\w)$", mac_addr)
             if not match:
                 logger.error("RDMA: failed to parse address for device {0} address {1}".format(nic, mac_addr))
                 continue


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
### ABANDONING: New PR: https://github.com/Azure/WALinuxAgent/pull/3150
IBManager will continue to be used for a new ethernet-backend offering from AzureHPC. While the key name remains the same (IPoIB_data), the interfaces will be of the format ethXX. Removing the check that skips anything that isn't ibXX. We are not at the risk of proceeding for any other nics since the IPoIB_data will only have the applicable ones from IBManager, and despite reading from the system for the loop, we match it against the array parsed from the IPoIB_data KVP.

In addition, the regex for the virtual MAC address itself is relaxed with this changeset. For IB, the address is padded (for GUID construction). Non-IB interfaces will have 6-octet formats. If-else logic has been added to extend support beyond IB.

Tested on lab VM (in absence of host-agent).

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [x] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).