### PR TITLE
suppress pylint warn contextmanager-generator-missing-cleanup

### DIFF
--- a/.github/workflows/ci_pr.yml
+++ b/.github/workflows/ci_pr.yml
@@ -139,16 +139,15 @@ jobs:
         # * On 3.9 pylint crashes when parsing azurelinuxagent/daemon/main.py (see https://github.com/pylint-dev/pylint/issues/9473), so we ignore it.
         # * 'no-self-use' ("R0201: Method could be a function") was moved to an optional extension on 3.8 and is no longer used by default. It needs
         #    to be suppressed for previous versions (3.0-3.7), though.
-        #
+        # * 'contextmanager-generator-missing-cleanup' are false positives if yield is used inside an if-else block for contextmanager generator functions.
+        #   (https://pylint.readthedocs.io/en/latest/user_guide/messages/warning/contextmanager-generator-missing-cleanup.html). 
+        #   This is not implemented on versions (3.0-3.7) Bad option value 'contextmanager-generator-missing-cleanup' (bad-option-value)
         PYLINT_OPTIONS="--rcfile=ci/pylintrc --jobs=0"
-        if [[ "${{ matrix.python-version }}" == "3.5" ]]; then
-          PYLINT_OPTIONS="$PYLINT_OPTIONS --disable=bad-option-value"
-        fi
         if [[ "${{ matrix.python-version }}" == "3.9" ]]; then
           PYLINT_OPTIONS="$PYLINT_OPTIONS --disable=no-member --ignore=main.py"
         fi
         if [[ "${{ matrix.python-version }}" =~ ^3\.[0-7]$ ]]; then
-          PYLINT_OPTIONS="$PYLINT_OPTIONS --disable=no-self-use"
+          PYLINT_OPTIONS="$PYLINT_OPTIONS --disable=no-self-use,bad-option-value"
         fi
 
         echo "PYLINT_OPTIONS: $PYLINT_OPTIONS"

--- a/tests/ga/test_multi_config_extension.py
+++ b/tests/ga/test_multi_config_extension.py
@@ -284,6 +284,7 @@ class TestMultiConfigExtensions(_MultiConfigBaseTestClass):
         third_ext = extension_emulator(name="OSTCExtensions.ExampleHandlerLinux.thirdExtension")
         fourth_ext = extension_emulator(name="Microsoft.Powershell.ExampleExtension")
 
+        # pylint: disable=contextmanager-generator-missing-cleanup
         with self._setup_test_env(mock_manifest=True) as (exthandlers_handler, protocol, no_of_extensions):
             with enable_invocations(first_ext, second_ext, third_ext, fourth_ext) as invocation_record:
                 exthandlers_handler.run()
@@ -1070,6 +1071,7 @@ class TestMultiConfigExtensionSequencing(_MultiConfigBaseTestClass):
         dependent_sc_ext = extension_emulator(name="Microsoft.Powershell.ExampleExtension")
         independent_sc_ext = extension_emulator(name="Microsoft.Azure.Geneva.GenevaMonitoring", version="1.1.0")
 
+        # pylint: disable=contextmanager-generator-missing-cleanup
         with self._setup_test_env() as (exthandlers_handler, protocol, no_of_extensions):
             yield exthandlers_handler, protocol, no_of_extensions, first_ext, second_ext, third_ext, dependent_sc_ext, independent_sc_ext
 

--- a/tests/ga/test_multi_config_extension.py
+++ b/tests/ga/test_multi_config_extension.py
@@ -284,8 +284,8 @@ class TestMultiConfigExtensions(_MultiConfigBaseTestClass):
         third_ext = extension_emulator(name="OSTCExtensions.ExampleHandlerLinux.thirdExtension")
         fourth_ext = extension_emulator(name="Microsoft.Powershell.ExampleExtension")
 
-        # pylint: disable=contextmanager-generator-missing-cleanup
-        with self._setup_test_env(mock_manifest=True) as (exthandlers_handler, protocol, no_of_extensions):
+        # In _setup_test_env() contextmanager, yield is used inside an if-else block and that's creating a false positive pylint warning
+        with self._setup_test_env(mock_manifest=True) as (exthandlers_handler, protocol, no_of_extensions):  # pylint: disable=contextmanager-generator-missing-cleanup
             with enable_invocations(first_ext, second_ext, third_ext, fourth_ext) as invocation_record:
                 exthandlers_handler.run()
                 exthandlers_handler.report_ext_handlers_status()
@@ -1071,8 +1071,8 @@ class TestMultiConfigExtensionSequencing(_MultiConfigBaseTestClass):
         dependent_sc_ext = extension_emulator(name="Microsoft.Powershell.ExampleExtension")
         independent_sc_ext = extension_emulator(name="Microsoft.Azure.Geneva.GenevaMonitoring", version="1.1.0")
 
-        # pylint: disable=contextmanager-generator-missing-cleanup
-        with self._setup_test_env() as (exthandlers_handler, protocol, no_of_extensions):
+        # In _setup_test_env() contextmanager, yield is used inside an if-else block and that's creating a false positive pylint warning
+        with self._setup_test_env() as (exthandlers_handler, protocol, no_of_extensions):  # pylint: disable=contextmanager-generator-missing-cleanup
             yield exthandlers_handler, protocol, no_of_extensions, first_ext, second_ext, third_ext, dependent_sc_ext, independent_sc_ext
 
     def test_it_should_process_dependency_chain_extensions_properly(self):

--- a/tests/ga/test_update.py
+++ b/tests/ga/test_update.py
@@ -1200,6 +1200,7 @@ class TestUpdate(UpdateTestCase):
     @contextlib.contextmanager
     def _setup_test_for_ext_event_dirs_retention(self):
         try:
+            # pylint: disable=contextmanager-generator-missing-cleanup
             with _get_update_handler(test_data=DATA_FILE_MULTIPLE_EXT, autoupdate_enabled=False) as (update_handler, protocol):
                 with patch("azurelinuxagent.common.agent_supported_feature._ETPFeature.is_supported", True):
                     update_handler.run(debug=True)
@@ -1483,7 +1484,7 @@ class TestAgentUpgrade(UpdateTestCase):
                              reload_conf=None, autoupdate_frequency=0.001, hotfix_frequency=1.0, normal_frequency=2.0):
 
         test_data = DATA_FILE if test_data is None else test_data
-
+        # pylint: disable=contextmanager-generator-missing-cleanup
         with _get_update_handler(iterations, test_data) as (update_handler, protocol):
 
             protocol.aggregate_status = None

--- a/tests/ga/test_update.py
+++ b/tests/ga/test_update.py
@@ -1200,8 +1200,8 @@ class TestUpdate(UpdateTestCase):
     @contextlib.contextmanager
     def _setup_test_for_ext_event_dirs_retention(self):
         try:
-            # pylint: disable=contextmanager-generator-missing-cleanup
-            with _get_update_handler(test_data=DATA_FILE_MULTIPLE_EXT, autoupdate_enabled=False) as (update_handler, protocol):
+            # In _get_update_handler() contextmanager, yield is used inside an if-else block and that's creating a false positive pylint warning
+            with _get_update_handler(test_data=DATA_FILE_MULTIPLE_EXT, autoupdate_enabled=False) as (update_handler, protocol):  # pylint: disable=contextmanager-generator-missing-cleanup
                 with patch("azurelinuxagent.common.agent_supported_feature._ETPFeature.is_supported", True):
                     update_handler.run(debug=True)
                     expected_events_dirs = glob.glob(os.path.join(conf.get_ext_log_dir(), "*", EVENTS_DIRECTORY))
@@ -1484,8 +1484,8 @@ class TestAgentUpgrade(UpdateTestCase):
                              reload_conf=None, autoupdate_frequency=0.001, hotfix_frequency=1.0, normal_frequency=2.0):
 
         test_data = DATA_FILE if test_data is None else test_data
-        # pylint: disable=contextmanager-generator-missing-cleanup
-        with _get_update_handler(iterations, test_data) as (update_handler, protocol):
+        # In _get_update_handler() contextmanager, yield is used inside an if-else block and that's creating a false positive pylint warning
+        with _get_update_handler(iterations, test_data) as (update_handler, protocol):  # pylint: disable=contextmanager-generator-missing-cleanup
 
             protocol.aggregate_status = None
 


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
Fix for new warning from latest pylint.
_`_tests/ga/test_update.py:1203:12: W0135: The context used in function '_setup_test_for_ext_event_dirs_retention' will not be exited. (contextmanager-generator-missing-cleanup)_`_

It looks like false positive according to documentation https://pylint.readthedocs.io/en/latest/user_guide/messages/warning/contextmanager-generator-missing-cleanup.html

_The check can create false positives if yield is used inside an if-else block without custom cleanup. Use pylint: disable for these._

This warning not implemented in earlier versions of python (3.0 -3.7) So I disabled the warning with (bad-option-value) in GitHub workflow

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).