### PR TITLE
Swap out legacycrypt for crypt-r for Python 3.13+

### DIFF
--- a/azurelinuxagent/common/osutil/default.py
+++ b/azurelinuxagent/common/osutil/default.py
@@ -38,13 +38,13 @@ import time
 from pwd import getpwall
 
 from azurelinuxagent.common.exception import OSUtilError
-# 'crypt' was removed in Python 3.13; use legacycrypt instead
+# 'crypt' was removed in Python 3.13; use crypt-r instead
 if sys.version_info[0] == 3 and sys.version_info[1] >= 13 or sys.version_info[0] > 3:
     try:
-        from legacycrypt import crypt
+        from crypt_r import crypt
     except ImportError:
         def crypt(password, salt):
-            raise OSUtilError("Please install the legacycrypt Python module to use this feature.")
+            raise OSUtilError("Please install the crypt-r Python module to use this feature.")
 else:
     from crypt import crypt  # pylint: disable=deprecated-module
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 distro; python_version >= '3.8'
 pyasn1
-legacycrypt; python_version >= '3.13'
+crypt-r; python_version >= '3.13'

--- a/setup.py
+++ b/setup.py
@@ -318,11 +318,11 @@ class install(_install):  # pylint: disable=C0103
 #   module was deprecated. Depending on the Linux distribution the
 #   implementation may be broken prior to Python 3.8 where the functionality
 #   will be removed from Python 3.
-# * In version 3.13 of Python, the crypt module was removed and legacycrypt is
+# * In version 3.13 of Python, the crypt module was removed and crypt-r is
 #   required instead.
 requires = [
     "distro;python_version>='3.8'",
-    "legacycrypt;python_version>='3.13'",
+    "crypt-r;python_version>='3.13'",
 ]
 
 modules = []  # pylint: disable=invalid-name


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

PR #3070 pulled in legacycrypt to replace the removed crypt module. legacycrypt hasn't been updated since it was initially pulled out of Python's stdlib in 2019 (Python 3.7). crypt-r pulls in the module as it was in Python 3.12. While there's been no major developments since 3.7, it's more likely to be kept updated for any breakages in future Python releases.

It's also already packaged for Fedora and means one less package for me to maintain so that would be nice.

---

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [x] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).