### PR TITLE
send updatemode in heartbeat and don't send RSM supported feature flag if versioning disabled in agent

### DIFF
--- a/azurelinuxagent/common/agent_supported_feature.py
+++ b/azurelinuxagent/common/agent_supported_feature.py
@@ -78,13 +78,14 @@ class _GAVersioningGovernanceFeature(AgentSupportedFeature):
     """
     CRP would drive the RSM update if agent reports that it does support RSM upgrades with this flag otherwise CRP fallback to largest version.
     Agent doesn't report supported feature flag if auto update is disabled or old version of agent running that doesn't understand GA versioning.
+    or if explicitly support for versioning is disabled in agent
 
     Note: Especially Windows need this flag to report to CRP that GA doesn't support the updates. So linux adopted same flag to have a common solution.
     """
 
     __NAME = SupportedFeatureNames.GAVersioningGovernance
     __VERSION = "1.0"
-    __SUPPORTED = conf.get_auto_update_to_latest_version()
+    __SUPPORTED = conf.get_auto_update_to_latest_version() and conf.get_enable_ga_versioning()
 
     def __init__(self):
         super(_GAVersioningGovernanceFeature, self).__init__(name=self.__NAME,

--- a/azurelinuxagent/common/agent_supported_feature.py
+++ b/azurelinuxagent/common/agent_supported_feature.py
@@ -77,7 +77,7 @@ class _ETPFeature(AgentSupportedFeature):
 class _GAVersioningGovernanceFeature(AgentSupportedFeature):
     """
     CRP would drive the RSM update if agent reports that it does support RSM upgrades with this flag otherwise CRP fallback to largest version.
-    Agent doesn't report supported feature flag if auto update is disabled or old version of agent running that doesn't understand GA versioning.
+    Agent doesn't report supported feature flag if auto update is disabled or old version of agent running that doesn't understand GA versioning
     or if explicitly support for versioning is disabled in agent
 
     Note: Especially Windows need this flag to report to CRP that GA doesn't support the updates. So linux adopted same flag to have a common solution.

--- a/tests/ga/test_agent_update_handler.py
+++ b/tests/ga/test_agent_update_handler.py
@@ -407,6 +407,29 @@ class TestAgentUpdate(UpdateTestCase):
             self.assertEqual("9.9.9.10", vm_agent_update_status.expected_version)
             self.assertIn("Failed to download agent package from all URIs", vm_agent_update_status.message)
 
+    def test_it_should_not_report_error_status_if_new_rsm_version_is_same_as_current_after_last_update_attempt_failed(self):
+        data_file = DATA_FILE.copy()
+        data_file["ext_conf"] = "wire/ext_conf_rsm_version.xml"
+
+        with self._get_agent_update_handler(test_data=data_file, protocol_get_error=True) as (agent_update_handler, _):
+            agent_update_handler.run(agent_update_handler._protocol.get_goal_state(), True)
+            vm_agent_update_status = agent_update_handler.get_vmagent_update_status()
+            self.assertEqual(VMAgentUpdateStatuses.Error, vm_agent_update_status.status)
+            self.assertEqual(1, vm_agent_update_status.code)
+            self.assertEqual("9.9.9.10", vm_agent_update_status.expected_version)
+            self.assertIn("Failed to download agent package from all URIs", vm_agent_update_status.message)
+
+            # Send same version GS after last update attempt failed
+            agent_update_handler._protocol.mock_wire_data.set_version_in_agent_family(
+                str(CURRENT_VERSION))
+            agent_update_handler._protocol.mock_wire_data.set_incarnation(2)
+            agent_update_handler._protocol.client.update_goal_state()
+            agent_update_handler.run(agent_update_handler._protocol.get_goal_state(), True)
+            vm_agent_update_status = agent_update_handler.get_vmagent_update_status()
+            self.assertEqual(VMAgentUpdateStatuses.Success, vm_agent_update_status.status)
+            self.assertEqual(0, vm_agent_update_status.code)
+            self.assertEqual(str(CURRENT_VERSION), vm_agent_update_status.expected_version)
+
     def test_it_should_report_update_status_with_missing_rsm_version_error(self):
         data_file = DATA_FILE.copy()
         data_file['ext_conf'] = "wire/ext_conf_version_missing_in_agent_family.xml"

--- a/tests/ga/test_update.py
+++ b/tests/ga/test_update.py
@@ -2440,9 +2440,9 @@ class HeartbeatTestCase(AgentTestCase):
 
         with mock_wire_protocol(wire_protocol_data.DATA_FILE) as mock_protocol:
             update_handler = get_update_handler()
-
+            agent_update_handler = Mock()
             update_handler.last_telemetry_heartbeat = datetime.utcnow() - timedelta(hours=1)
-            update_handler._send_heartbeat_telemetry(mock_protocol)
+            update_handler._send_heartbeat_telemetry(mock_protocol, agent_update_handler)
             self.assertEqual(1, patch_add_event.call_count)
             self.assertTrue(any(call_args[0] == "[HEARTBEAT] Agent {0} is running as the goal state agent {1}"
                             for call_args in patch_info.call_args), "The heartbeat was not written to the agent's log")


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

PR includes minor changes related to RSM

- Added updatedmode: RSM/SelfUpdate flag in heartbeat
- Fixing supported feature flag for rsm, when agent does not support GA versioning, we still send as agent supports RSM to CRP. In that case, CRP may send rsm requests and those requests will not be honored by agent. So now don't send RSM supported feature flag if versioning disabled in agent.
- If agent update attempt failed few times and later if new GS contains rsm version is same as current version, we still sending cached last error msg as rsm status. Fixing that too
Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).