### PR TITLE
Avoiding mocked exception from being lost on test when using python 3.12: complete mocked info

### DIFF
--- a/tests/ga/test_exthandlers_exthandlerinstance.py
+++ b/tests/ga/test_exthandlers_exthandlerinstance.py
@@ -117,7 +117,7 @@ class ExtHandlerInstanceTestCase(AgentTestCase):
 
         def mock_remove(path, dir_fd=None):  # pylint: disable=unused-argument
             if path.endswith("extension_file2"):
-                raise IOError("A mocked error")
+                raise IOError(999,"A mocked error","extension_file2")
             original_remove_api(path)
 
         with patch.object(shutil.os, remove_api_name, mock_remove):


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

If another exception is raised (that is the case here when using python 3.12 due to changes in os.shutil.rmtree with the preference of onexc over onerror as error handler function - [What’s New In Python 3.12](https://docs.python.org/3/whatsnew/3.12.html)  , search rmtree-, the mocked exception is lost because it is incomplete.

The new changes on rmtree (the use of a stack plus the onexc error handler) interacts badly with the exception handling mock in the test, and raises a second exception associated with the scandir func (reach full tree and non-empty directory). This exception conflicts with the mocked exception

https://github.com/Azure/WALinuxAgent/blob/bf45d50a1deeb48e3eeeeb0d6af6daa8afba12f7/tests/ga/test_exthandlers_exthandlerinstance.py#L120

which is lost because it has neither a number (errno) nor a set strerror (the mocked string in the test is associated with args, and when format func implicitly uses str() on the exception object, it finds the entire attributes for the second completed exception):

https://github.com/Azure/WALinuxAgent/blob/bf45d50a1deeb48e3eeeeb0d6af6daa8afba12f7/azurelinuxagent/ga/exthandlers.py#L1487

so the mocked report event fails to get the correct exception and the assert fails:

https://github.com/Azure/WALinuxAgent/blob/bf45d50a1deeb48e3eeeeb0d6af6daa8afba12f7/tests/ga/test_exthandlers_exthandlerinstance.py#L127

Issue # 3148
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [x] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).