### PR TITLE
redhat: Use NetworkManager to set DHCP hostnames on recent RHEL distros

### DIFF
--- a/azurelinuxagent/common/osutil/redhat.py
+++ b/azurelinuxagent/common/osutil/redhat.py
@@ -266,6 +266,19 @@ class RedhatOSModernUtil(RedhatOSUtil):
         # TODO: Implement and test a way to recover the network interface for RedhatOSModernUtil
         pass
 
+
+    def set_dhcp_hostname(self, hostname):
+        """
+        Recent RHEL distributions use network manager instead of sysconfig files
+        to configure network interfaces
+        """
+        ifname = self.get_if_name()
+
+        return_code = shellutil.run("nmcli device modify {0} ipv4.dhcp-hostname {1} ipv6.dhcp-hostname {1}".format(ifname, hostname))
+
+        if return_code != 0:
+            logger.error("failed to set DHCP hostname for interface {0}: return code {1}".format(ifname, return_code))
+
     def publish_hostname(self, hostname, recover_nic=False):
         # RedhatOSUtil was updated to conditionally run NetworkManager restart in response to a race condition between
         # NetworkManager restart and the agent restarting the network interface during publish_hostname. Keeping the


### PR DESCRIPTION
Recent versions of RHEL 8 and RHEL 9 started using NetworkManager to configure network intefaces instead of sysconfig files. Configurations are no longer stored in /etc/sysconfig/ifcfg-{interface}.

Fix this for setting DHCP hostnames in those RHEL versions.

