### PR TITLE
Remove wireserver fallback for imds calls

### DIFF
--- a/azurelinuxagent/common/event.py
+++ b/azurelinuxagent/common/event.py
@@ -429,7 +429,7 @@ class EventLogger(object):
             logger.warn("Failed to get VM info from goal state; will be missing from telemetry: {0}", ustr(e))
 
         try:
-            imds_client = get_imds_client(protocol.get_endpoint())
+            imds_client = get_imds_client()
             imds_info = imds_client.get_compute()
             parameters[CommonTelemetryEventSchema.Location].value = imds_info.location
             parameters[CommonTelemetryEventSchema.SubscriptionId].value = imds_info.subscriptionId

--- a/azurelinuxagent/ga/monitor.py
+++ b/azurelinuxagent/ga/monitor.py
@@ -216,10 +216,10 @@ class SendImdsHeartbeat(PeriodicOperation):
     Periodic operation to report the IDMS's health. The signal is 'Healthy' when we have successfully called and validated
     a response in the last _IMDS_HEALTH_PERIOD.
     """
-    def __init__(self, protocol_util, health_service):
+    def __init__(self, health_service):
         super(SendImdsHeartbeat, self).__init__(SendImdsHeartbeat._IMDS_HEARTBEAT_PERIOD)
         self.health_service = health_service
-        self.imds_client = get_imds_client(protocol_util.get_wireserver_endpoint())
+        self.imds_client = get_imds_client()
         self.imds_error_state = ErrorState(min_timedelta=SendImdsHeartbeat._IMDS_HEALTH_PERIOD)
 
     _IMDS_HEARTBEAT_PERIOD = datetime.timedelta(minutes=1)
@@ -298,7 +298,7 @@ class MonitorHandler(ThreadHandlerInterface):
                 PollResourceUsage(),
                 PollSystemWideResourceUsage(),
                 SendHostPluginHeartbeat(protocol, health_service),
-                SendImdsHeartbeat(protocol_util, health_service)
+                SendImdsHeartbeat(health_service)
             ]
 
             report_network_configuration_changes = ReportNetworkConfigurationChanges()

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -31,7 +31,6 @@ from datetime import datetime, timedelta
 
 from azurelinuxagent.common import conf
 from azurelinuxagent.common import logger
-from azurelinuxagent.common.protocol.imds import get_imds_client
 from azurelinuxagent.common.utils import fileutil, textutil
 from azurelinuxagent.common.agent_supported_feature import get_supported_feature_by_name, SupportedFeatureNames, \
     get_agent_supported_features_list_for_crp

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -475,25 +475,6 @@ class UpdateHandler(object):
                 add_event(op=WALAEventOperation.CloudInit, message=message, is_success=False, log_event=False)
             self._cloud_init_completed = True  # Mark as completed even on error since we will proceed to execute extensions
 
-    def _get_vm_size(self, protocol):
-        """
-        Including VMSize is meant to capture the architecture of the VM (i.e. arm64 VMs will
-        have arm64 included in their vmsize field and amd64 will have no architecture indicated).
-        """
-        if self._vm_size is None:
-
-            imds_client = get_imds_client()
-
-            try:
-                imds_info = imds_client.get_compute()
-                self._vm_size = imds_info.vmSize
-            except Exception as e:
-                err_msg = "Attempts to retrieve VM size information from IMDS are failing: {0}".format(textutil.format_exception(e))
-                logger.periodic_warn(logger.EVERY_SIX_HOURS, "[PERIODIC] {0}".format(err_msg))
-                return "unknown"
-
-        return self._vm_size
-
     def _get_vm_arch(self):
         return platform.machine()
 

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -482,7 +482,7 @@ class UpdateHandler(object):
         """
         if self._vm_size is None:
 
-            imds_client = get_imds_client(protocol.get_endpoint())
+            imds_client = get_imds_client()
 
             try:
                 imds_info = imds_client.get_compute()

--- a/tests/ga/test_update.py
+++ b/tests/ga/test_update.py
@@ -52,7 +52,7 @@ from azurelinuxagent.ga.update import  \
 from tests.lib.mock_update_handler import mock_update_handler
 from tests.lib.mock_wire_protocol import mock_wire_protocol, MockHttpResponse
 from tests.lib.wire_protocol_data import DATA_FILE, DATA_FILE_MULTIPLE_EXT, DATA_FILE_VM_SETTINGS
-from tests.lib.tools import AgentTestCase, AgentTestCaseWithGetVmSizeMock, data_dir, DEFAULT, patch, load_bin_data, Mock, MagicMock, \
+from tests.lib.tools import AgentTestCase, data_dir, DEFAULT, patch, load_bin_data, Mock, MagicMock, \
     clear_singleton_instances, is_python_version_26_or_34, skip_if_predicate_true
 from tests.lib import wire_protocol_data
 from tests.lib.http_request_predicates import HttpRequestPredicates
@@ -119,7 +119,7 @@ def _get_update_handler(iterations=1, test_data=None, protocol=None, autoupdate_
                 yield update_handler, protocol
 
 
-class UpdateTestCase(AgentTestCaseWithGetVmSizeMock):
+class UpdateTestCase(AgentTestCase):
     _test_suite_tmp_dir = None
     _agent_zip_dir = None
 
@@ -1928,7 +1928,7 @@ class TestAgentUpgrade(UpdateTestCase):
 @patch('azurelinuxagent.ga.update.get_collect_logs_handler')
 @patch('azurelinuxagent.ga.update.get_monitor_handler')
 @patch('azurelinuxagent.ga.update.get_env_handler')
-class MonitorThreadTest(AgentTestCaseWithGetVmSizeMock):
+class MonitorThreadTest(AgentTestCase):
     def setUp(self):
         super(MonitorThreadTest, self).setUp()
         self.event_patch = patch('azurelinuxagent.common.event.add_event')

--- a/tests/lib/tools.py
+++ b/tests/lib/tools.py
@@ -447,22 +447,6 @@ class AgentTestCase(unittest.TestCase):
         os.chmod(script_file, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
 
 
-class AgentTestCaseWithGetVmSizeMock(AgentTestCase):
-    
-    def setUp(self):
-        
-        self._get_vm_size_patch = patch('azurelinuxagent.ga.update.UpdateHandler._get_vm_size', return_value="unknown")
-        self._get_vm_size_patch.start()
-        
-        super(AgentTestCaseWithGetVmSizeMock, self).setUp()
-
-    def tearDown(self):
-
-        if self._get_vm_size_patch:
-            self._get_vm_size_patch.stop()
-
-        super(AgentTestCaseWithGetVmSizeMock, self).tearDown()
-
 def load_data(name):
     """Load test data"""
     path = os.path.join(data_dir, name)


### PR DESCRIPTION
The fallback to wireserver is no longer supported