### PR TITLE
Fix Ubuntu version codename for 24.04

### DIFF
--- a/tests/common/osutil/test_factory.py
+++ b/tests/common/osutil/test_factory.py
@@ -99,7 +99,7 @@ class TestOsUtilFactory(AgentTestCase):
         self.assertEqual(ret.get_service_name(), "walinuxagent")
 
         ret = _get_osutil(distro_name="ubuntu",
-                          distro_code_name="focal",
+                          distro_code_name="noble",
                           distro_version="24.04",
                           distro_full_name="")
         self.assertTrue(isinstance(ret, Ubuntu18OSUtil))


### PR DESCRIPTION
Hi team, 


<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

while checking the patches we carry on, I discovered that this should be "noble", not "focal" (our latest LTS, 24.04). I'm sending you this PR to fix it. This was part of #2980 .

---

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [x] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).