### PR TITLE
Allow use of node 16

### DIFF
--- a/.github/workflows/ci_pr.yml
+++ b/.github/workflows/ci_pr.yml
@@ -29,7 +29,8 @@ jobs:
 
     env:
       NOSEOPTS: "--verbose"
-
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+    
     steps:
     - uses: actions/checkout@v3
 


### PR DESCRIPTION
The unit test runs for 2.6 and 3.4 are failing in the checkout action with
```
/usr/bin/docker exec  5cb43d0a75f65026a096ee99f24eb460be0a1ba1bb5114984b56d30105371ed9 sh -c "cat /etc/*release | grep ^ID"
/__e/node20/bin/node: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.27' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.25' not found (required by /__e/node20/bin/node)
```

The issue has been reported in 

https://github.com/actions/checkout/issues/1487
https://github.com/actions/checkout/issues/1809

And is likely caused by https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/

This PR uses the same workaround as, for example, https://github.com/Rust-GCC/gccrs/pull/3081