### PR TITLE
Disable multi-config test in AzureCloud

### DIFF
--- a/tests_e2e/test_suites/multi_config_ext.yml
+++ b/tests_e2e/test_suites/multi_config_ext.yml
@@ -7,3 +7,6 @@ tests:
   - "multi_config_ext/multi_config_ext.py"
 images:
   - "endorsed"
+# TODO: This test has been failing due to issues in the RC2 extension on AzureCloud. Re-enable once the extension has been fixed.
+skip_on_clouds:
+  - "AzureCloud"


### PR DESCRIPTION
This test has been failing due to issues in the RC2 extension on AzureCloud. Re-enable once the extension has been fixed.