### PR TITLE
Fix log collector unit tests on 3.5

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -458,11 +458,11 @@ class TestAgent(AgentTestCase):
 
     @patch("azurelinuxagent.agent.LogCollector")
     @patch("azurelinuxagent.ga.collect_logs.LogCollectorMonitorHandler.get_max_recorded_metrics")
-    def test_collect_log_should_output_resource_usage_summary(self, mock_get_metrics_summary, mock_log_collector):
+    def test_collect_log_should_output_resource_usage_summary(self, mock_get_max_recorded_metrics, mock_log_collector):
         try:
             CollectLogsHandler.enable_monitor_cgroups_check()
             mock_log_collector.return_value.collect_logs_and_get_archive.return_value = (Mock(), Mock())  # LogCollector.collect_logs_and_get_archive returns a tuple
-            mock_get_metrics_summary.return_value = "metric summary"
+            mock_get_max_recorded_metrics.return_value = {}
 
             # Mock cgroup so process is in the log collector slice
             def mock_cgroup(*args, **kwargs):  # pylint: disable=W0613
@@ -484,8 +484,8 @@ class TestAgent(AgentTestCase):
                     agent = Agent(False, conf_file_path=os.path.join(data_dir, "test_waagent.conf"))
                     agent.collect_logs(is_full_mode=True)
 
-                    mock_log_collector.assert_called_once()
-                    mock_get_metrics_summary.assert_called_once()
+                    self.assertEqual(1, mock_log_collector.call_count, "LogCollector should be called once")
+                    self.assertEqual(1, mock_get_max_recorded_metrics.call_count, "get_max_recorded_metrics should be called once")
 
         finally:
             CollectLogsHandler.disable_monitor_cgroups_check()

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -298,7 +298,7 @@ class TestAgent(AgentTestCase):
                     agent = Agent(False, conf_file_path=os.path.join(data_dir, "test_waagent.conf"))
                     agent.collect_logs(is_full_mode=True)
 
-                    mock_log_collector.assert_called_once()
+                    self.assertEqual(1, mock_log_collector.call_count, "LogCollector should be called once")
 
         finally:
             CollectLogsHandler.disable_monitor_cgroups_check()


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
assert_called_once() not supported on python < 3.6 
Also update return value of get_max_recorded_metrics 

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).