### PR TITLE
handle non-boolean values in handlermanifest

### DIFF
--- a/azurelinuxagent/common/event.py
+++ b/azurelinuxagent/common/event.py
@@ -86,6 +86,7 @@ class WALAEventOperation:
     Downgrade = "Downgrade"
     Download = "Download"
     Enable = "Enable"
+    ExtensionHandlerManifest = "ExtensionHandlerManifest"
     ExtensionPolicy = "ExtensionPolicy"
     ExtensionProcessing = "ExtensionProcessing"
     ExtensionTelemetryEventProcessing = "ExtensionTelemetryEventProcessing"

--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -2308,7 +2308,7 @@ class HandlerManifest(object):
         for backward compatibility, 'true' (case-insensitive) is accepted, and other values default to False
         """
         if not isinstance(value, bool):
-            return True if value.lower() == "true" else default_val
+            return True if isinstance(value, str) and value.lower() == "true" else default_val
         return value
 
 

--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -2296,10 +2296,10 @@ class HandlerManifest(object):
         for key in ['reportHeartbeat', 'continueOnUpdateFailure', 'supportsMultipleExtensions']:
             value = self.data['handlerManifest'].get(key, False)
             if not isinstance(value, bool):
-                msg =("In the handler manifest: '{0}' has a non-boolean value {1} for boolean type. Please change it to a boolean value. "
+                msg =("In the handler manifest: '{0}' has a non-boolean value [{1}] for boolean type. Please change it to a boolean value. "
                       "For backward compatibility, 'true' (case insensitive) is accepted, and other values default to False.").format(key, value)
                 logger.warn(msg)
-                add_event(name=ext_name, is_success=False, message=msg, op=WALAEventOperation.ExtensionHandlerManifest)
+                add_event(name=ext_name, is_success=False, message=msg, op=WALAEventOperation.ExtensionHandlerManifest, log_event=False)
 
     @staticmethod
     def _parse_boolean_value(value, default_val=False):

--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -2242,7 +2242,7 @@ class HandlerManifest(object):
 
     def is_report_heartbeat(self):
         value = self.data['handlerManifest'].get('reportHeartbeat', False)
-        return self._parse_boolean_value(value)
+        return self._parse_boolean_value(value, default_val=False)
 
     def is_update_with_install(self):
         update_mode = self.data['handlerManifest'].get('updateMode')
@@ -2252,11 +2252,11 @@ class HandlerManifest(object):
 
     def is_continue_on_update_failure(self):
         value = self.data['handlerManifest'].get('continueOnUpdateFailure', False)
-        return self._parse_boolean_value(value)
+        return self._parse_boolean_value(value, default_val=False)
 
     def supports_multiple_extensions(self):
         value = self.data['handlerManifest'].get('supportsMultipleExtensions', False)
-        return self._parse_boolean_value(value)
+        return self._parse_boolean_value(value, default_val=False)
 
     def get_resource_limits(self, extension_name, str_version):
         """
@@ -2294,15 +2294,14 @@ class HandlerManifest(object):
         Check that the specified keys in the handler manifest has boolean values.
         """
         for key in ['reportHeartbeat', 'continueOnUpdateFailure', 'supportsMultipleExtensions']:
-            value = self.data['handlerManifest'].get(key, False)
-            if not isinstance(value, bool):
-                msg =("In the handler manifest: '{0}' has a non-boolean value [{1}] for boolean type. Please change it to a boolean value. "
-                      "For backward compatibility, 'true' (case insensitive) is accepted, and other values default to False.").format(key, value)
-                logger.warn(msg)
-                add_event(name=ext_name, is_success=False, message=msg, op=WALAEventOperation.ExtensionHandlerManifest, log_event=False)
+            value = self.data['handlerManifest'].get(key)
+            if value is not None and not isinstance(value, bool):
+                msg = "In the handler manifest: '{0}' has a non-boolean value [{1}] for boolean type. Please change it to a boolean value.".format(key, value)
+                logger.info(msg)
+                add_event(name=ext_name, message=msg, op=WALAEventOperation.ExtensionHandlerManifest, log_event=False)
 
     @staticmethod
-    def _parse_boolean_value(value, default_val=False):
+    def _parse_boolean_value(value, default_val):
         """
         Expects boolean value but
         for backward compatibility, 'true' (case-insensitive) is accepted, and other values default to False

--- a/tests/ga/test_extension.py
+++ b/tests/ga/test_extension.py
@@ -3436,6 +3436,117 @@ class TestExtension(TestExtensionBase, HttpRequestPredicates):
             self.assertIn('[stdout]\n{0}'.format(expected), message, "The extension's stdout was not redacted correctly")
             self.assertIn('[stderr]\n{0}'.format(expected), message, "The extension's stderr was not redacted correctly")
 
+class TestExtensionHandlerManifest(AgentTestCase):
+
+    def setUp(self):
+        AgentTestCase.setUp(self)
+
+    def test_handler_manifest_parsed_correctly(self):
+        handler_json = {
+            "installCommand": "install_cmd",
+            "uninstallCommand": "uninstall_cmd",
+            "updateCommand": "update_cmd",
+            "enableCommand": "enable_cmd",
+            "disableCommand": "disable_cmd",
+            "reportHeartbeat": True,
+            "continueOnUpdateFailure": True,
+            "supportsMultipleExtensions": True
+        }
+
+        manifest = HandlerManifest({'handlerManifest': handler_json})
+        self.assertEqual(manifest.get_install_command(), "install_cmd")
+        self.assertEqual(manifest.get_enable_command(), "enable_cmd")
+        self.assertEqual(manifest.get_uninstall_command(), "uninstall_cmd")
+        self.assertEqual(manifest.get_update_command(), "update_cmd")
+        self.assertEqual(manifest.get_disable_command(), "disable_cmd")
+        self.assertTrue(manifest.is_continue_on_update_failure())
+        self.assertTrue(manifest.is_report_heartbeat())
+        self.assertTrue(manifest.supports_multiple_extensions())
+
+    def test_handler_manifest_defaults(self):
+        # Set only the required fields
+        handler_json = {
+            "installCommand": "install_cmd",
+            "uninstallCommand": "uninstall_cmd",
+            "updateCommand": "update_cmd",
+            "enableCommand": "enable_cmd",
+            "disableCommand": "disable_cmd"
+        }
+        manifest = HandlerManifest({'handlerManifest': handler_json})
+        self.assertFalse(manifest.is_continue_on_update_failure())
+        self.assertFalse(manifest.is_report_heartbeat())
+        self.assertFalse(manifest.supports_multiple_extensions())
+
+    def test_handler_manifest_boolen_fields(self):
+        # Set the boolean fields to strings
+        handler_json = {
+            "installCommand": "install_cmd",
+            "uninstallCommand": "uninstall_cmd",
+            "updateCommand": "update_cmd",
+            "enableCommand": "enable_cmd",
+            "disableCommand": "disable_cmd",
+            "reportHeartbeat": "true",
+            "continueOnUpdateFailure": "true",
+            "supportsMultipleExtensions": "true"
+        }
+        manifest = HandlerManifest({'handlerManifest': handler_json})
+        self.assertTrue(manifest.is_continue_on_update_failure())
+        self.assertTrue(manifest.is_report_heartbeat())
+        self.assertTrue(manifest.supports_multiple_extensions())
+
+        # set the boolean fields to invalid values
+        handler_json = {
+            "installCommand": "install_cmd",
+            "uninstallCommand": "uninstall_cmd",
+            "updateCommand": "update_cmd",
+            "enableCommand": "enable_cmd",
+            "disableCommand": "disable_cmd",
+            "reportHeartbeat": "invalid",
+            "continueOnUpdateFailure": "invalid",
+            "supportsMultipleExtensions": "invalid"
+        }
+        manifest = HandlerManifest({'handlerManifest': handler_json})
+        self.assertFalse(manifest.is_continue_on_update_failure())
+        self.assertFalse(manifest.is_report_heartbeat())
+        self.assertFalse(manifest.supports_multiple_extensions())
+
+        # set the boolean fields to 'false' string
+        handler_json = {
+            "installCommand": "install_cmd",
+            "uninstallCommand": "uninstall_cmd",
+            "updateCommand": "update_cmd",
+            "enableCommand": "enable_cmd",
+            "disableCommand": "disable_cmd",
+            "reportHeartbeat": "false",
+            "continueOnUpdateFailure": "false",
+            "supportsMultipleExtensions": "false"
+        }
+
+        manifest = HandlerManifest({'handlerManifest': handler_json})
+        self.assertFalse(manifest.is_continue_on_update_failure())
+        self.assertFalse(manifest.is_report_heartbeat())
+        self.assertFalse(manifest.supports_multiple_extensions())
+
+    def test_report_msg_if_handler_manifest_contains_invalid_values(self):
+        # Set the boolean fields to invalid values
+        handler_json = {
+            "installCommand": "install_cmd",
+            "uninstallCommand": "uninstall_cmd",
+            "updateCommand": "update_cmd",
+            "enableCommand": "enable_cmd",
+            "disableCommand": "disable_cmd",
+            "reportHeartbeat": "invalid",
+            "continueOnUpdateFailure": "invalid",
+            "supportsMultipleExtensions": "invalid"
+        }
+        with patch("azurelinuxagent.ga.exthandlers.add_event") as mock_add_event:
+            manifest = HandlerManifest({'handlerManifest': handler_json})
+            manifest.report_invalid_boolean_properties("test_ext")
+            kw_messages = [kw for _, kw in mock_add_event.call_args_list if kw.get('op') == 'ExtensionHandlerManifest']
+            self.assertEqual(3, len(kw_messages))
+            self.assertIn("'reportHeartbeat' has a non-boolean value", kw_messages[0]['message'])
+            self.assertIn("'continueOnUpdateFailure' has a non-boolean value", kw_messages[1]['message'])
+            self.assertIn("'supportsMultipleExtensions' has a non-boolean value", kw_messages[2]['message'])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
We learned recently that some extensions are sending string value "true" or "false" for boolean flags in handlermanifest. This led to wrong matching in the agent. For ex: string "false" matched as true since we assume they are boolean value and condition _not flag_ became as flag has value or not instead flag has true or false

Addressing this pr with reporting warning plus default to false if they send non-boolean value except "true". For backward compatibility, 'true' (case insensitive) is accepted.

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).