### PR TITLE
Log collector scenario should not pick up runs before service restart

### DIFF
--- a/tests_e2e/tests/log_collector/log_collector.py
+++ b/tests_e2e/tests/log_collector/log_collector.py
@@ -21,9 +21,9 @@ import time
 
 from assertpy import fail
 
-import tests_e2e.tests.lib.logging
 from azurelinuxagent.common.utils.shellutil import CommandError
 from tests_e2e.tests.lib.agent_test import AgentVmTest
+from tests_e2e.tests.lib.logging import log
 
 
 class LogCollector(AgentVmTest):
@@ -32,7 +32,16 @@ class LogCollector(AgentVmTest):
     """
     def run(self):
         ssh_client = self._context.create_ssh_client()
-        ssh_client.run_command("update-waagent-conf Logs.Collect=y Debug.EnableCgroupV2ResourceLimiting=y Debug.LogCollectorInitialDelay=60", use_sudo=True)
+
+        # Rename the agent log file so that the test does not pick up any incomplete log collector runs that started
+        # before the config is updated
+        # Enable Cgroup v2 resource limiting and reduce log collector iniital delay via config
+        log.info("Renaming agent log file and modifying log collector conf flags")
+        setup_script = ("agent-service stop &&  mv /var/log/waagent.log /var/log/waagent.$(date --iso-8601=seconds).log && "
+            "update-waagent-conf Logs.Collect=y Debug.EnableCgroupV2ResourceLimiting=y Debug.LogCollectorInitialDelay=60")
+        self._run_remote_test(ssh_client, f"sh -c '{setup_script}'", use_sudo=True)
+        log.info('Renamed log file and updated log collector config flags')
+
         # Wait for log collector to finish uploading logs
         for _ in range(3):
             time.sleep(90)
@@ -40,7 +49,7 @@ class LogCollector(AgentVmTest):
                 ssh_client.run_command("grep 'Successfully uploaded logs' /var/log/waagent.log")
                 break
             except CommandError:
-                tests_e2e.tests.lib.logging.log.info("The Agent has not finished log collection, will check again after a short delay")
+                log.info("The Agent has not finished log collection, will check again after a short delay")
         else:
             raise Exception("Timeout while waiting for the Agent to finish log collection")
 
@@ -70,7 +79,7 @@ class LogCollector(AgentVmTest):
         # Check that all expected logs exist and are in the correct order
         indent = lambda lines: "\n".join([f"        {ln}" for ln in lines])
         if len(lc_logs) == len(expected) and all([re.match(expected[i], lc_logs[i]) is not None for i in range(len(expected))]):
-            tests_e2e.tests.lib.logging.log.info("The log collector run completed as expected.\nLog messages:\n%s", indent(lc_logs))
+            log.info("The log collector run completed as expected.\nLog messages:\n%s", indent(lc_logs))
         else:
             fail(f"The log collector run did not complete as expected.\nExpected:\n{indent(expected)}\nActual:\n{indent(lc_logs)}")
 


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
The log collector scenario does a service restart to update config flags. In some cases, a log collector run starts but does not complete before the service restart. The test is picking up the incomplete run. 

This PR updates the scenario to rename the log before restarting the service so that the test only picks up log collector runs afte the service restart. 
 
Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).