### PR TITLE
fix(init): ensure waagent service starts after cloud-init.service

### DIFF
--- a/init/arch/waagent.service
+++ b/init/arch/waagent.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Azure Linux Agent
 Wants=network-online.target sshd.service sshd-keygen.service
-After=network-online.target
+After=network-online.target cloud-init.service
 
 ConditionFileIsExecutable=/usr/bin/waagent
 ConditionPathExists=/etc/waagent.conf

--- a/init/clearlinux/waagent.service
+++ b/init/clearlinux/waagent.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Azure Linux Agent
 Wants=network-online.target sshd.service sshd-keygen.service
-After=network-online.target
+After=network-online.target cloud-init.service
 
 ConditionFileIsExecutable=/usr/bin/waagent
 ConditionPathExists=/usr/share/defaults/waagent/waagent.conf

--- a/init/redhat/waagent.service
+++ b/init/redhat/waagent.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Azure Linux Agent
 Wants=network-online.target sshd.service sshd-keygen.service
-After=network-online.target
+After=network-online.target cloud-init.service
 
 ConditionFileIsExecutable=/usr/sbin/waagent
 ConditionPathExists=/etc/waagent.conf

--- a/init/sles/waagent.service
+++ b/init/sles/waagent.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Azure Linux Agent
 Wants=network-online.target sshd.service sshd-keygen.service
-After=network-online.target
+After=network-online.target cloud-init.service
 
 ConditionFileIsExecutable=/usr/sbin/waagent
 ConditionPathExists=/etc/waagent.conf

--- a/init/waagent.service
+++ b/init/waagent.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Azure Linux Agent
 Wants=network-online.target sshd.service sshd-keygen.service
-After=network-online.target
+After=network-online.target cloud-init.service
 
 ConditionFileIsExecutable=/usr/sbin/waagent
 ConditionPathExists=/etc/waagent.conf


### PR DESCRIPTION
cloud-init.service is responsible for setting up disks during provisioning.  Since waagent may perform operations to configure swap, wait until after cloud-init.service is complete.

This effectively updates all distros to match behavior already done for Mariner and Ubuntu.

<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).