### PR TITLE
Send telemetry for apparent dead code

### DIFF
--- a/azurelinuxagent/common/event.py
+++ b/azurelinuxagent/common/event.py
@@ -123,6 +123,8 @@ class WALAEventOperation:
     ReportEventUnicodeErrors = "ReportEventUnicodeErrors"
     ReportStatus = "ReportStatus"
     ReportStatusExtended = "ReportStatusExtended"
+    RequestedStateDisabled = "RequestedStateDisabled"
+    RequestedVersionMismatch = "RequestedVersionMismatch"
     ResetFirewall = "ResetFirewall"
     Restart = "Restart"
     SetCGroupsLimits = "SetCGroupsLimits"

--- a/tests/ga/test_extension.py
+++ b/tests/ga/test_extension.py
@@ -1583,7 +1583,7 @@ class TestExtension_Deprecated(TestExtensionBase):
                 ext_handler = ext_handlers[0]
                 self.assertEqual('OSTCExtensions.ExampleHandlerLinux', ext_handler.name)
                 self.assertEqual(config_version, ext_handler.version, "config version.")
-                ExtHandlerInstance(ext_handler, protocol).decide_version()
+                ExtHandlerInstance(ext_handler, protocol).decide_version(None, None, None)
                 self.assertEqual(decision_version, ext_handler.version, "decision version.")
 
     def test_ext_handler_version_decide_between_minor_versions(self, *args):
@@ -1623,7 +1623,7 @@ class TestExtension_Deprecated(TestExtensionBase):
             ext_handler_instance = ExtHandlerInstance(ext_handler, protocol)
             ext_handler_instance.get_installed_version = Mock(return_value=installed_version)
 
-            ext_handler_instance.decide_version()
+            ext_handler_instance.decide_version(None, None, None)
             self.assertEqual(expected_version, ext_handler.version)
 
     @patch('azurelinuxagent.common.conf.get_extensions_enabled', return_value=False)


### PR DESCRIPTION
There are a couple of places that, to the best of our knowledge, are dead code. Adding telemetry in case we ever hit them.

Those 2 points are relevant as we implement support for policy.