### PR TITLE
Fix install_requires list syntax

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -320,10 +320,11 @@ class install(_install):  # pylint: disable=C0103
 #   will be removed from Python 3.
 # * In version 3.13 of Python, the crypt module was removed and legacycrypt is
 #   required instead.
-requires = [
-    "distro;python_version>='3.8'",
-    "legacycrypt;python_version>='3.13'",
-]
+requires = []
+if sys.version_info[0] >= 3 and sys.version_info[1] >= 8:
+    requires.append('distro')
+if sys.version_info[0] >= 3 and sys.version_info[1] >= 13:
+    requires.append('legacycrypt')
 
 modules = []  # pylint: disable=invalid-name
 


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
This previous change updated the install_requires list in setup.py to use '<package>;platform_requirement' syntax: #3070 
As pointed out by this SO post, this syntax is only supported by setuptools v36.2+: https://stackoverflow.com/questions/21082091/install-requires-based-on-python-version

This PR reverts the change to use the previous syntax (check python version using sys.version_info and append packages to install_requires accordingly).

This change has been tested manually on CentOS 7.9. Automation will be added to test these changes in a future PR.

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).