### PR TITLE
Remove usages of tempfile.mktemp

### DIFF
--- a/tests/common/utils/test_file_util.py
+++ b/tests/common/utils/test_file_util.py
@@ -80,7 +80,7 @@ class TestFileOperations(AgentTestCase):
         os.remove(test_file)
 
     def test_findre_in_file(self):
-        fp = tempfile.mktemp()
+        fp = os.path.join(self.tmp_dir, "test_findre_in_file")
         with open(fp, 'w') as f:
             f.write(
 '''
@@ -107,7 +107,7 @@ Third line with more words
             fileutil.findre_in_file(fp, "^Do not match.*"))
 
     def test_findstr_in_file(self):
-        fp = tempfile.mktemp()
+        fp = os.path.join(self.tmp_dir, "test_findstr_in_file")
         with open(fp, 'w') as f:
             f.write(
 '''

--- a/tests/pa/test_provision.py
+++ b/tests/pa/test_provision.py
@@ -55,8 +55,7 @@ class TestProvision(AgentTestCase):
 
     def test_customdata(self):
         base64data = 'Q3VzdG9tRGF0YQ=='
-        data = DefaultOSUtil().decode_customdata(base64data)
-        fileutil.write_file(tempfile.mktemp(), data)
+        DefaultOSUtil().decode_customdata(base64data)
 
     @patch('azurelinuxagent.common.conf.get_provision_enabled',
         return_value=False)

--- a/tests/pa/test_provision.py
+++ b/tests/pa/test_provision.py
@@ -17,7 +17,6 @@
 
 import os
 import re
-import tempfile
 import unittest
 
 import azurelinuxagent.common.conf as conf


### PR DESCRIPTION
Usages of tempfile.mktemp are being flagged by the code analysis tools. Removing them.