### PR TITLE
fix for installing agent in e2e tests

### DIFF
--- a/tests_e2e/orchestrator/scripts/install-agent
+++ b/tests_e2e/orchestrator/scripts/install-agent
@@ -166,7 +166,7 @@ agent-service stop
 mv /var/log/waagent.log /var/log/waagent."$(date --iso-8601=seconds)".log
 
 echo "Cleaning up the existing agents"
-rm -rf /var/lib/waagent/WALinuxAgent-*
+rm -rfv /var/lib/waagent/WALinuxAgent-*
 
 echo "Installing $package as version $version..."
 unzip.py "$package" "/var/lib/waagent/WALinuxAgent-$version"

--- a/tests_e2e/orchestrator/scripts/install-agent
+++ b/tests_e2e/orchestrator/scripts/install-agent
@@ -101,12 +101,6 @@ if [ $started == false ]; then
   exit 1
 fi
 
-#
-# Install the package
-#
-echo "========== Installing Agent =========="
-echo "Installing $package as version $version..."
-unzip.py "$package" "/var/lib/waagent/WALinuxAgent-$version"
 
 python=$(get-agent-python)
 # Ensure that AutoUpdate is enabled. some distros, e.g. Flatcar have a waagent.conf in different path
@@ -162,13 +156,20 @@ if [[ $(uname -a) == *"flatcar"* ]]; then
 fi
 
 #
-# Restart the service
+# Install the package
 #
-echo "Restarting service..."
+echo "========== Installing Agent =========="
+
 agent-service stop
 
 # Rename the previous log to ensure the new log starts with the agent we just installed
 mv /var/log/waagent.log /var/log/waagent."$(date --iso-8601=seconds)".log
+
+echo "Cleaning up the existing agents"
+rm -rf /var/lib/waagent/WALinuxAgent-*
+
+echo "Installing $package as version $version..."
+unzip.py "$package" "/var/lib/waagent/WALinuxAgent-$version"
 
 agent-service start
 


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Fixing

1. Existing agent purging the test agent when it's found a regular agent update beacuse we copy the test agent to agent folder before stopping the agent. So moving the copy after stop
2. Unable to install test agent if version lower than existing agents, so cleaning the existing agents from agent folder.

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).