### PR TITLE
suppress systemd-run error(Connection reset by peer) while validating ext cgroups

### DIFF
--- a/tests_e2e/tests/lib/cgroup_helpers.py
+++ b/tests_e2e/tests/lib/cgroup_helpers.py
@@ -144,12 +144,18 @@ def check_agent_quota_disabled():
     # Ubuntu 16 has an issue in expressing no quota as "infinity" https://github.com/systemd/systemd/issues/5965, so we are directly checking the quota value in cpu controller
     return cpu_quota == 'infinity' or get_unit_cgroup_cpu_quota_disabled(AGENT_SERVICE_NAME)
 
-def check_cgroup_disabled_with_unknown_process():
+def check_cgroup_disabled_due_to_systemd_error():
     """
-    Returns True if the cgroup is disabled with unknown process
-    """
-    return check_log_message("Disabling resource usage monitoring. Reason: Check on cgroups failed:.+UNKNOWN")
+    Returns True if the cgroup is disabled due to systemd error (Connection reset by peer)
 
+    Ex:
+    2024-12-18T06:43:23.867711Z INFO ExtHandler ExtHandler [CGW] Disabling resource usage monitoring. Reason: Failed to start Microsoft.Azure.Extensions.Edp.GATestExtGo-1.2.0.0 using systemd-run, will try invoking the extension directly. Error: [SystemdRunError] Systemd process exited with code 1 and output [stdout]
+
+    [stderr]
+    Warning! D-Bus connection terminated.
+    Failed to start transient scope unit: Connection reset by peer
+    """
+    return check_log_message("Failed to start.+using systemd-run, will try invoking the extension directly.+[SystemdRunError].+Connection reset by peer")
 
 def check_log_message(message, after_timestamp=datetime.datetime.min):
     """

--- a/tests_e2e/tests/scripts/ext_cgroups-check_cgroups_extensions.py
+++ b/tests_e2e/tests/scripts/ext_cgroups-check_cgroups_extensions.py
@@ -213,7 +213,7 @@ def main():
 try:
     main()
 except Exception as e:
-    # It is possible that agent cgroup can be disabled and reset the quotas if extension failed start using systemd-run. In that case, we should ignore the validation
+    # It is possible that agent cgroup can be disabled and reset the quotas if the extension failed to start using systemd-run. In that case, we should ignore the validation
     if check_cgroup_disabled_due_to_systemd_error() and retry_if_false(check_agent_quota_disabled):
         log.info("Cgroup is disabled due to systemd error while invoking the extension, ignoring ext cgroups validations")
     else:

--- a/tests_e2e/tests/scripts/ext_cgroups-check_cgroups_extensions.py
+++ b/tests_e2e/tests/scripts/ext_cgroups-check_cgroups_extensions.py
@@ -25,7 +25,7 @@ from tests_e2e.tests.lib.agent_log import AgentLog
 from tests_e2e.tests.lib.cgroup_helpers import verify_if_distro_supports_cgroup, \
     verify_agent_cgroup_assigned_correctly, BASE_CGROUP, EXT_CONTROLLERS, get_unit_cgroup_mount_path, \
     GATESTEXT_SERVICE, AZUREMONITORAGENT_SERVICE, check_agent_quota_disabled, \
-    check_cgroup_disabled_with_unknown_process, CGROUP_TRACKED_PATTERN, AZUREMONITOREXT_FULL_NAME, GATESTEXT_FULL_NAME, \
+    check_cgroup_disabled_due_to_systemd_error, CGROUP_TRACKED_PATTERN, AZUREMONITOREXT_FULL_NAME, GATESTEXT_FULL_NAME, \
     print_cgroups
 from tests_e2e.tests.lib.logging import log
 from tests_e2e.tests.lib.retry import retry_if_false
@@ -213,8 +213,8 @@ def main():
 try:
     main()
 except Exception as e:
-    # It is possible that  agent cgroup can be disabled due to UNKNOWN process or throttled before we run this check, in that case, we should ignore the validation
-    if check_cgroup_disabled_with_unknown_process() and retry_if_false(check_agent_quota_disabled):
-        log.info("Cgroup is disabled due to UNKNOWN process, ignoring ext cgroups validations")
+    # It is possible that agent cgroup can be disabled and reset the quotas if extension failed start using systemd-run. In that case, we should ignore the validation
+    if check_cgroup_disabled_due_to_systemd_error() and retry_if_false(check_agent_quota_disabled):
+        log.info("Cgroup is disabled due to systemd error while invoking the extension, ignoring ext cgroups validations")
     else:
         raise


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Cgroups may be disabled if there is a systemd-error while invoking any extension. As a result, extensions won't start in cgroups, and validation fail. This is expected behavior, so we are suppressing systemd error (Connection reset by peer)

Today, we did suppress for unknown process in agent cgroup but recently we improved the agent logic to determine unexpected processes. So, we shouldn't expect to see this unknown process error now and removing that in this pr.

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).