### PR TITLE
Enable logcollector in cgroup supported v2 distros(ub22+)

### DIFF
--- a/azurelinuxagent/common/conf.py
+++ b/azurelinuxagent/common/conf.py
@@ -682,7 +682,7 @@ def get_enable_cgroup_v2_resource_limiting(conf=__conf__):
     If True, the agent will enable resource monitoring and enforcement for the log collector on machines using cgroup v2.
     NOTE: This option is experimental and may be removed in later versions of the Agent.
     """
-    return conf.get_switch("Debug.EnableCgroupV2ResourceLimiting", False)
+    return conf.get_switch("Debug.EnableCgroupV2ResourceLimiting", True)
 
 
 def get_log_collector_initial_delay(conf=__conf__):

--- a/tests_e2e/tests/log_collector/log_collector.py
+++ b/tests_e2e/tests/log_collector/log_collector.py
@@ -35,10 +35,10 @@ class LogCollector(AgentVmTest):
 
         # Rename the agent log file so that the test does not pick up any incomplete log collector runs that started
         # before the config is updated
-        # Enable Cgroup v2 resource limiting and reduce log collector iniital delay via config
+        # Reduce log collector initial delay via config
         log.info("Renaming agent log file and modifying log collector conf flags")
         setup_script = ("agent-service stop &&  mv /var/log/waagent.log /var/log/waagent.$(date --iso-8601=seconds).log && "
-            "update-waagent-conf Logs.Collect=y Debug.EnableCgroupV2ResourceLimiting=y Debug.LogCollectorInitialDelay=60")
+            "update-waagent-conf Logs.Collect=y Debug.LogCollectorInitialDelay=60")
         ssh_client.run_command(f"sh -c '{setup_script}'", use_sudo=True)
         log.info('Renamed log file and updated log collector config flags')
 


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Currently cgroup supported v2 distros in agent are ub22 and later. This pr enable logcollector in those distros.

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).