### PR TITLE
Do not skip tests on Python 2.6 & 3.4

### DIFF
--- a/tests/common/osutil/test_default.py
+++ b/tests/common/osutil/test_default.py
@@ -31,7 +31,7 @@ from azurelinuxagent.common.future import ustr
 from azurelinuxagent.common.osutil import get_osutil
 from azurelinuxagent.common.utils import fileutil
 from tests.lib.mock_environment import MockEnvironment
-from tests.lib.tools import AgentTestCase, patch, open_patch, load_data, data_dir, is_python_version_26_or_34, skip_if_predicate_true
+from tests.lib.tools import AgentTestCase, patch, open_patch, load_data, data_dir
 
 actual_get_proc_net_route = 'azurelinuxagent.common.osutil.default.DefaultOSUtil._get_proc_net_route'
 
@@ -637,7 +637,6 @@ Match host 192.168.1.2\n\
         print("WRITING TO {0}".format(waagent_sudoers))
         self.assertEqual(1, count)
 
-    @skip_if_predicate_true(is_python_version_26_or_34, "Disabled on Python 2.6 and 3.4, they run on containers where the OS commands needed by the test are not present.")
     def test_get_nic_state(self):
         state = osutil.DefaultOSUtil().get_nic_state()
         self.assertNotEqual(state, {})

--- a/tests/common/test_event.py
+++ b/tests/common/test_event.py
@@ -45,7 +45,7 @@ from azurelinuxagent.ga.collect_telemetry_events import _CollectAndEnqueueEvents
 from tests.lib import wire_protocol_data
 from tests.lib.mock_wire_protocol import mock_wire_protocol, MockHttpResponse
 from tests.lib.http_request_predicates import HttpRequestPredicates
-from tests.lib.tools import AgentTestCase, data_dir, load_data, patch, skip_if_predicate_true, is_python_version_26_or_34
+from tests.lib.tools import AgentTestCase, data_dir, load_data, patch, skip_if_predicate_true
 from tests.lib.event_logger_tools import EventLoggerTools
 
 
@@ -447,7 +447,6 @@ class TestEvent(HttpRequestPredicates, AgentTestCase):
         self.assertEqual(len(event_list), 1)
         self.assertEqual(TestEvent._get_event_message(event_list[0]), u'World\u05e2\u05d9\u05d5\u05ea \u05d0\u05d7\u05e8\u05d5\u05ea\u0906\u091c')
 
-    @skip_if_predicate_true(is_python_version_26_or_34, "Disabled on Python 2.6 and 3.4, they run on containers where the OS commands needed by the test are not present.")
     def test_collect_events_should_ignore_invalid_event_files(self):
         self._create_test_event_file("custom_script_1.tld")  # a valid event
         self._create_test_event_file("custom_script_utf-16.tld")

--- a/tests/ga/test_cgroupconfigurator.py
+++ b/tests/ga/test_cgroupconfigurator.py
@@ -37,7 +37,7 @@ from azurelinuxagent.common.utils import shellutil, fileutil
 from azurelinuxagent.ga.cpucontroller import CpuControllerV1
 from tests.lib.mock_environment import MockCommand
 from tests.lib.mock_cgroup_environment import mock_cgroup_v1_environment, UnitFilePaths, mock_cgroup_v2_environment
-from tests.lib.tools import AgentTestCase, patch, mock_sleep, data_dir, is_python_version_26_or_34, skip_if_predicate_true
+from tests.lib.tools import AgentTestCase, patch, mock_sleep, data_dir
 from tests.lib.miscellaneous_tools import format_processes, wait_for
 
 
@@ -539,7 +539,6 @@ class CGroupConfiguratorSystemdTestCase(AgentTestCase):
 
                         self.assertEqual(len(CGroupsTelemetry._tracked), 0, "No cgroups should have been created")
 
-    @skip_if_predicate_true(is_python_version_26_or_34, "Disabled on Python 2.6 and 3.4, they run on containers where the OS commands needed by the test are not present.")
     @patch('time.sleep', side_effect=lambda _: mock_sleep())
     def test_start_extension_command_should_capture_only_the_last_subprocess_output(self, _):
         with self._get_cgroup_configurator() as configurator:

--- a/tests/ga/test_cgroupconfigurator_sudo.py
+++ b/tests/ga/test_cgroupconfigurator_sudo.py
@@ -26,7 +26,7 @@ from azurelinuxagent.ga.cgroupstelemetry import CGroupsTelemetry
 from azurelinuxagent.common.exception import ExtensionError, ExtensionErrorCodes
 from azurelinuxagent.common.future import ustr
 from tests.lib.mock_cgroup_environment import mock_cgroup_v1_environment
-from tests.lib.tools import AgentTestCase, patch, mock_sleep, i_am_root, is_python_version_26_or_34, skip_if_predicate_true
+from tests.lib.tools import AgentTestCase, patch, mock_sleep, i_am_root
 
 
 class CGroupConfiguratorSystemdTestCaseSudo(AgentTestCase):
@@ -53,7 +53,6 @@ class CGroupConfiguratorSystemdTestCaseSudo(AgentTestCase):
                     configurator.initialize()
             yield configurator
 
-    @skip_if_predicate_true(is_python_version_26_or_34, "Disabled on Python 2.6 and 3.4 for now. Need to revisit to fix it")
     @patch('time.sleep', side_effect=lambda _: mock_sleep())
     def test_start_extension_command_should_not_use_fallback_option_if_extension_fails(self, *args):
         self.assertTrue(i_am_root(), "Test does not run when non-root")
@@ -90,7 +89,6 @@ class CGroupConfiguratorSystemdTestCaseSudo(AgentTestCase):
                     # wasn't truncated.
                     self.assertIn("Running scope as unit", ustr(context_manager.exception))
 
-    @skip_if_predicate_true(is_python_version_26_or_34, "Disabled on Python 2.6 and 3.4 for now. Need to revisit to fix it")
     @patch('time.sleep', side_effect=lambda _: mock_sleep())
     @patch("azurelinuxagent.ga.extensionprocessutil.TELEMETRY_MESSAGE_MAX_LEN", 5)
     def test_start_extension_command_should_not_use_fallback_option_if_extension_fails_with_long_output(self, *args):

--- a/tests/lib/tools.py
+++ b/tests/lib/tools.py
@@ -124,10 +124,6 @@ def is_python_version_34():
     return sys.version_info[0] == 3 and sys.version_info[1] == 4
 
 
-def is_python_version_26_or_34():
-    return is_python_version_26() or is_python_version_34()
-
-
 class AgentTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
Removing instances of skip_if_predicate_true(is_python_version_26_or_34...) since now the tests run on the actual VM.