### PR TITLE
Fix unit test failures when run on containers

### DIFF
--- a/azurelinuxagent/common/osutil/default.py
+++ b/azurelinuxagent/common/osutil/default.py
@@ -82,7 +82,7 @@ IOCTL_SIOCGIFFLAGS = 0x8913
 IOCTL_SIOCGIFHWADDR = 0x8927
 IFNAMSIZ = 16
 
-IP_COMMAND_OUTPUT = re.compile(r'^\d+:\s+(\w+):\s+(.*)$')
+IP_COMMAND_OUTPUT = re.compile(r'^\d+:\s+([\w@]+):\s+(.*)$')
 
 STORAGE_DEVICE_PATH = '/sys/bus/vmbus/devices/'
 GEN2_DEVICE_ID = 'f8b3781a-1e82-4818-a1c3-63d806ec15bb'

--- a/tests/ga/test_cgroupconfigurator.py
+++ b/tests/ga/test_cgroupconfigurator.py
@@ -542,39 +542,37 @@ class CGroupConfiguratorSystemdTestCase(AgentTestCase):
     @patch('time.sleep', side_effect=lambda _: mock_sleep())
     def test_start_extension_command_should_capture_only_the_last_subprocess_output(self, _):
         with self._get_cgroup_configurator() as configurator:
-            pass  # release the mocks used to create the test CGroupConfigurator so that they do not conflict the mock Popen below
+            original_popen = subprocess.Popen
 
-        original_popen = subprocess.Popen
+            def mock_popen(command, *args, **kwargs):
+                # Inject a syntax error to the call
 
-        def mock_popen(command, *args, **kwargs):
-            # Inject a syntax error to the call
-            
-            # Popen can accept both strings and lists, handle both here.
-            if isinstance(command, str):
-                command = command.replace('systemd-run', 'systemd-run syntax_error')
-            elif isinstance(command, list) and command[0] == 'systemd-run':
-                command = ['systemd-run', 'syntax_error'] + command[1:]
+                # Popen can accept both strings and lists, handle both here.
+                if isinstance(command, str) and command.startswith('systemd-run'):
+                    command = 'systemd-run syntax_error'
+                elif isinstance(command, list) and command[0] == 'systemd-run':
+                    command = ['systemd-run', 'syntax_error']
 
-            return original_popen(command, *args, **kwargs)
+                return original_popen(command, *args, **kwargs)
 
-        expected_output = "[stdout]\n{0}\n\n\n[stderr]\n"
+            expected_output = "[stdout]\n{0}\n\n\n[stderr]\n"
 
-        with tempfile.TemporaryFile(dir=self.tmp_dir, mode="w+b") as stdout:
-            with tempfile.TemporaryFile(dir=self.tmp_dir, mode="w+b") as stderr:
-                with patch("azurelinuxagent.ga.cgroupapi.subprocess.Popen", side_effect=mock_popen):
-                    # We expect this call to fail because of the syntax error
-                    process_output = configurator.start_extension_command(
-                        extension_name="Microsoft.Compute.TestExtension-1.2.3",
-                        command="echo 'very specific test message'",
-                        cmd_name="test",
-                        timeout=300,
-                        shell=True,
-                        cwd=self.tmp_dir,
-                        env={}.update(os.environ),
-                        stdout=stdout,
-                        stderr=stderr)
+            with tempfile.TemporaryFile(dir=self.tmp_dir, mode="w+b") as stdout:
+                with tempfile.TemporaryFile(dir=self.tmp_dir, mode="w+b") as stderr:
+                    with patch("azurelinuxagent.ga.cgroupapi.subprocess.Popen", side_effect=mock_popen):
+                        # We expect this call to fail because of the syntax errors
+                        process_output = configurator.start_extension_command(
+                            extension_name="Microsoft.Compute.TestExtension-1.2.3",
+                            command="echo 'very specific test message'",
+                            cmd_name="test",
+                            timeout=300,
+                            shell=True,
+                            cwd=self.tmp_dir,
+                            env={}.update(os.environ),
+                            stdout=stdout,
+                            stderr=stderr)
 
-                    self.assertEqual(expected_output.format("very specific test message"), process_output)
+                        self.assertEqual(expected_output.format("very specific test message"), process_output)
 
     def test_it_should_set_extension_services_cpu_memory_quota(self):
         service_list = [

--- a/tests/ga/test_cgroupconfigurator.py
+++ b/tests/ga/test_cgroupconfigurator.py
@@ -560,7 +560,7 @@ class CGroupConfiguratorSystemdTestCase(AgentTestCase):
             with tempfile.TemporaryFile(dir=self.tmp_dir, mode="w+b") as stdout:
                 with tempfile.TemporaryFile(dir=self.tmp_dir, mode="w+b") as stderr:
                     with patch("azurelinuxagent.ga.cgroupapi.subprocess.Popen", side_effect=mock_popen):
-                        # We expect this call to fail because of the syntax errors
+                        # We expect this call to fail because of the syntax error
                         process_output = configurator.start_extension_command(
                             extension_name="Microsoft.Compute.TestExtension-1.2.3",
                             command="echo 'very specific test message'",

--- a/tests/python_eol/Dockerfile
+++ b/tests/python_eol/Dockerfile
@@ -31,7 +31,7 @@ RUN <<..
     # Install the Python venv
     #
     apt-get update
-    apt-get -y install curl bzip2 sudo
+    apt-get -y install curl bzip2 sudo iproute2
     groupadd waagent
     useradd --shell /bin/bash --create-home -g waagent waagent
     curl -sSf --retry 5 -o /tmp/python-${PYTHON_VERSION}.tar.bz2 https://dcrdata.blob.core.windows.net/python/python-${PYTHON_VERSION}.tar.bz2

--- a/tests/python_eol/patch_python_venv.sh
+++ b/tests/python_eol/patch_python_venv.sh
@@ -26,12 +26,7 @@ fi
 PYTHON_VERSION=$1
 
 if [[ "${PYTHON_VERSION}" =~ ^2\.6|2\.7$ ]]; then
-  if [[ "${PYTHON_VERSION}" == "2.6" ]]; then
-    file_to_patch="/opt/python/2.6.9/lib/python2.6/httplib.py"
-  else
-    file_to_patch="/opt/python/2.7.16/lib/python2.7/httplib.py"
-  fi
-  cat >> "$file_to_patch" << ...
+  cat >> /opt/python/${PYTHON_VERSION}/lib/python${PYTHON_VERSION}/httplib.py << ...
 
 # Added by WALinuxAgent dev team to work around the lack of OpenSSL 1.0 shared libraries
 class HTTPSConnection(HTTPConnection):


### PR DESCRIPTION
TestOSUtil.test_get_nic_state and CGroupConfiguratorSystemdTestCase.test_start_extension_command_should_capture_only_the_last_subprocess_output were failing when run on our container images. This PR fixes them.