### PR TITLE
Add Python 2 unicode strings to regex check [CheckAgentLog]

### DIFF
--- a/tests_e2e/tests/lib/agent_log.py
+++ b/tests_e2e/tests/lib/agent_log.py
@@ -398,7 +398,7 @@ class AgentLog(object):
                 'message': r"(?s)name=Microsoft.GuestConfiguration.ConfigurationforLinux.*op=Install.*Non-zero exit code: (1.*Text file busy|51.*Unexpected Linux distribution|126.*Exec format error)",
             },
             {
-                'message': r"A new goal state was received, but not all the extensions in the previous goal state have completed.*'Microsoft.GuestConfiguration.ConfigurationforLinux',\s+'transitioning'",
+                'message': r"A new goal state was received, but not all the extensions in the previous goal state have completed.*'Microsoft.GuestConfiguration.ConfigurationforLinux',\s+u?'transitioning'",
             },
             #
             # Below systemd errors are transient and will not block extension execution


### PR DESCRIPTION
Unicode strings in Python 2 are prefixed by 'u'. Added to regular expression matching error message.