### PR TITLE
Evaluate distro remotely [no_outbound_connections test suite]

### DIFF
--- a/tests_e2e/orchestrator/lib/agent_test_suite.py
+++ b/tests_e2e/orchestrator/lib/agent_test_suite.py
@@ -731,14 +731,14 @@ class AgentTestSuite(LisaTestSuite):
                         log.info("\t%s", r)
                     log.info("")
 
-                except:  # pylint: disable=bare-except
+                except Exception as e:
                     suite_success = False
                     self._report_test_result(
                         suite_full_name,
                         suite_name,
                         TestStatus.FAILED,
                         suite_start_time,
-                        message=f"Unhandled exception while executing test suite {suite_name}.",
+                        message=f"Unhandled exception while executing test suite {suite_name}: {e}",
                         add_exception_stack_trace=True)
                 finally:
                     if not suite_success:

--- a/tests_e2e/tests/lib/ssh_client.py
+++ b/tests_e2e/tests/lib/ssh_client.py
@@ -65,6 +65,9 @@ class SshClient(object):
     def get_architecture(self):
         return self.run_command("uname -m").rstrip()
 
+    def get_distro(self):
+        return self.run_command("get_distro.py").rstrip()
+
     def copy_to_node(self, local_path: Path, remote_path: Path, recursive: bool = False, attempts: int = ATTEMPTS, attempt_delay: int = ATTEMPT_DELAY) -> None:
         """
         File copy to a remote node


### PR DESCRIPTION
The lambdas for AgentVmTest.get_ignore_error_rules() are evaluated locally, and the rule for this test needs to be evaluated remotely.