### PR TITLE
Support for FIPS 140-3

### DIFF
--- a/azurelinuxagent/common/event.py
+++ b/azurelinuxagent/common/event.py
@@ -93,6 +93,7 @@ class WALAEventOperation:
     FetchGoalState = "FetchGoalState"
     Firewall = "Firewall"
     GoalState = "GoalState"
+    GoalStateCertificates = "GoalStateCertificates"
     GoalStateUnsupportedFeatures = "GoalStateUnsupportedFeatures"
     HealthCheck = "HealthCheck"
     HealthObservation = "HealthObservation"
@@ -732,6 +733,25 @@ def error(op, fmt, *args):
     logger.error(fmt, *args)
     add_event(op=op, message=fmt.format(*args), is_success=False, log_event=False)
 
+
+class LogEvent(object):
+    """
+    Helper class that allows the use of info()/warn()/error() using a specific instance of a logger.
+    """
+    def __init__(self, logger_):
+        self._logger = logger_
+
+    def info(self, op, fmt, *args):
+        self._logger.info(fmt, *args)
+        add_event(op=op, message=fmt.format(*args), is_success=True)
+
+    def warn(self, op, fmt, *args):
+        self._logger.warn(fmt, *args)
+        add_event(op=op, message="[WARNING] " + fmt.format(*args), is_success=False, log_event=False)
+
+    def error(self, op, fmt, *args):
+        self._logger.error(fmt, *args)
+        add_event(op=op, message=fmt.format(*args), is_success=False, log_event=False)
 
 def add_log_event(level, message, forced=False, reporter=__event_logger__):
     """

--- a/azurelinuxagent/common/protocol/goal_state.py
+++ b/azurelinuxagent/common/protocol/goal_state.py
@@ -24,15 +24,14 @@ import json
 from azurelinuxagent.common import conf
 from azurelinuxagent.common import logger
 from azurelinuxagent.common.AgentGlobals import AgentGlobals
-from azurelinuxagent.common.datacontract import set_properties
-from azurelinuxagent.common.event import add_event, WALAEventOperation
+from azurelinuxagent.common.event import add_event, WALAEventOperation, LogEvent
 from azurelinuxagent.common.exception import ProtocolError, ResourceGoneError
 from azurelinuxagent.common.future import ustr
 from azurelinuxagent.common.protocol.extensions_goal_state_factory import ExtensionsGoalStateFactory
 from azurelinuxagent.common.protocol.extensions_goal_state import VmSettingsParseError, GoalStateSource
 from azurelinuxagent.common.protocol.hostplugin import VmSettingsNotSupported, VmSettingsSupportStopped
-from azurelinuxagent.common.protocol.restapi import Cert, CertList, RemoteAccessUser, RemoteAccessUsersList, ExtHandlerPackage, ExtHandlerPackageList
-from azurelinuxagent.common.utils import fileutil
+from azurelinuxagent.common.protocol.restapi import RemoteAccessUser, RemoteAccessUsersList, ExtHandlerPackage, ExtHandlerPackageList
+from azurelinuxagent.common.utils import fileutil, shellutil
 from azurelinuxagent.common.utils.archive import GoalStateHistory, SHARED_CONF_FILE_NAME
 from azurelinuxagent.common.utils.cryptutil import CryptUtil
 from azurelinuxagent.common.utils.textutil import parse_doc, findall, find, findtext, getattrib, gettext
@@ -41,6 +40,7 @@ from azurelinuxagent.common.utils.textutil import parse_doc, findall, find, find
 GOAL_STATE_URI = "http://{0}/machine/?comp=goalstate"
 CERTS_FILE_NAME = "Certificates.xml"
 P7M_FILE_NAME = "Certificates.p7m"
+PFX_FILE_NAME = "Certificates.pfx"
 PEM_FILE_NAME = "Certificates.pem"
 TRANSPORT_CERT_FILE_NAME = "TransportCert.pem"
 TRANSPORT_PRV_FILE_NAME = "TransportPrivate.pem"
@@ -282,16 +282,8 @@ class GoalState(object):
             self._check_and_download_missing_certs_on_disk()
 
     def _download_certificates(self, certs_uri):
-        xml_text = self._wire_client.fetch_config(certs_uri, self._wire_client.get_header_for_cert())
-        certs = Certificates(xml_text, self.logger)
-        # Log and save the certificates summary (i.e. the thumbprint but not the certificate itself) to the goal state history
-        for c in certs.summary:
-            message = "Downloaded certificate {0}".format(c)
-            self.logger.info(message)
-            add_event(op=WALAEventOperation.GoalState, message=message)
-        if len(certs.warnings) > 0:
-            self.logger.warn(certs.warnings)
-            add_event(op=WALAEventOperation.GoalState, message=certs.warnings)
+        certs = Certificates(self._wire_client, certs_uri, self.logger)
+        # Save the certificates summary (i.e. the thumbprints but not the certificates themselves) to the goal state history
         if self._save_to_history:
             self._history.save_certificates(json.dumps(certs.summary))
         return certs
@@ -511,31 +503,82 @@ class SharedConfig(object):
         self.xml_text = xml_text
 
 
-class Certificates(object):
-    def __init__(self, xml_text, my_logger):
-        self.cert_list = CertList()
-        self.summary = []  # debugging info
-        self.warnings = []
+class Certificates(LogEvent):
+    def __init__(self, wire_client, uri, logger_):
+        super(Certificates, self).__init__(logger_)
+        self.summary = []
+        self._crypt_util = CryptUtil(conf.get_openssl_cmd())
 
-        # Save the certificates
-        local_file = os.path.join(conf.get_lib_dir(), CERTS_FILE_NAME)
-        fileutil.write_file(local_file, xml_text)
+        try:
+            pfx_file = self._download_certificates_pfx(wire_client, uri)
+            if pfx_file is None:  # The response from the WireServer may not have any certificates
+                return
 
-        # Separate the certificates into individual files.
-        xml_doc = parse_doc(xml_text)
-        data = findtext(xml_doc, "Data")
-        if data is None:
-            return
+            try:
+                pem_file = self._convert_certificates_pfx_to_pem(pfx_file)
+            finally:
+                self._remove_file(pfx_file)
 
-        # if the certificates format is not Pkcs7BlobWithPfxContents do not parse it
-        certificate_format = findtext(xml_doc, "Format")
-        if certificate_format and certificate_format != "Pkcs7BlobWithPfxContents":
-            message = "The Format is not Pkcs7BlobWithPfxContents. Format is {0}".format(certificate_format)
-            my_logger.warn(message)
-            add_event(op=WALAEventOperation.GoalState, message=message)
-            return
+            self.summary = self._extract_certificate(pem_file)
 
-        cryptutil = CryptUtil(conf.get_openssl_cmd())
+            for c in self.summary:
+                self.info(WALAEventOperation.GoalStateCertificates, "Downloaded certificate {0}", c)
+
+        except Exception as e:
+            self.error(WALAEventOperation.GoalStateCertificates, "Error fetching the goal state certificates: {0}", ustr(e))
+
+    def _remove_file(self, file):
+        if os.path.exists(file):
+            try:
+                os.remove(file)
+            except Exception as e:
+                self.warn(WALAEventOperation.GoalStateCertificates, "Failed to remove {0}: {1}", file, ustr(e))
+
+    def _download_certificates_pfx(self, wire_client, uri):
+        """
+        Downloads the certificates from the WireServer and saves them to a pfx file.
+        Returns the full path of the pfx file, or None, if the WireServer response does not have a "Data" element
+        """
+        trans_prv_file = os.path.join(conf.get_lib_dir(), TRANSPORT_PRV_FILE_NAME)
+        trans_cert_file = os.path.join(conf.get_lib_dir(), TRANSPORT_CERT_FILE_NAME)
+        xml_file = os.path.join(conf.get_lib_dir(), CERTS_FILE_NAME)
+        pfx_file = os.path.join(conf.get_lib_dir(), PFX_FILE_NAME)
+
+        for cypher in ["AES128_CBC", "DES_EDE3_CBC"]:
+            headers = wire_client.get_headers_for_encrypted_request(cypher)
+
+            try:
+                xml_text = wire_client.fetch_config(uri, headers)
+            except Exception as e:
+                self.warn(WALAEventOperation.GoalStateCertificates, "Error in Certificates request [cypher: {0}]: {1}", cypher, ustr(e))
+                continue
+
+            fileutil.write_file(xml_file, xml_text)
+
+            xml_doc = parse_doc(xml_text)
+            data = findtext(xml_doc, "Data")
+            if data is None:
+                self.info(WALAEventOperation.GoalStateCertificates, "The Data element of the Certificates response is empty")
+                return None
+            certificate_format = findtext(xml_doc, "Format")
+            if certificate_format and certificate_format != "Pkcs7BlobWithPfxContents":
+                self.warn(WALAEventOperation.GoalStateCertificates, "The Certificates format is not Pkcs7BlobWithPfxContents; skipping. Format is {0}", certificate_format)
+                return None
+
+            p7m_file = Certificates._create_p7m_file(data)
+
+            try:
+                self._crypt_util.decrypt_certificates_p7m(p7m_file, trans_prv_file, trans_cert_file, pfx_file)
+            except shellutil.CommandError as e:
+                self.warn(WALAEventOperation.GoalState, "Error in transport decryption [cypher: {0}]: {1}", cypher, ustr(e))
+                continue
+
+            return pfx_file
+
+        raise Exception("Cannot download certificates using any of the supported cyphers")
+
+    @staticmethod
+    def _create_p7m_file(data):
         p7m_file = os.path.join(conf.get_lib_dir(), P7M_FILE_NAME)
         p7m = ("MIME-Version:1.0\n"  # pylint: disable=W1308
                "Content-Disposition: attachment; filename=\"{0}\"\n"
@@ -543,68 +586,74 @@ class Certificates(object):
                "Content-Transfer-Encoding: base64\n"
                "\n"
                "{2}").format(p7m_file, p7m_file, data)
-
         fileutil.write_file(p7m_file, p7m)
+        return p7m_file
 
-        trans_prv_file = os.path.join(conf.get_lib_dir(), TRANSPORT_PRV_FILE_NAME)
-        trans_cert_file = os.path.join(conf.get_lib_dir(), TRANSPORT_CERT_FILE_NAME)
+    def _convert_certificates_pfx_to_pem(self, pfx_file):
+        """
+        Convert the pfx file to pem file.
+        """
         pem_file = os.path.join(conf.get_lib_dir(), PEM_FILE_NAME)
-        # decrypt certificates
-        cryptutil.decrypt_p7m(p7m_file, trans_prv_file, trans_cert_file, pem_file)
 
+        for nomacver in [True, False]:
+            try:
+                self._crypt_util.convert_pfx_to_pem(pfx_file, nomacver, pem_file)
+                return pem_file
+            except shellutil.CommandError as e:
+                self._remove_file(pem_file)  # An error may leave an empty pem file, which can produce a failure on some versions of open SSL (e.g. 3.2.2) on the next invocation
+                self.warn(WALAEventOperation.GoalState, "Error converting PFX to PEM [-nomacver: {0}]: {1}", nomacver, ustr(e))
+                continue
+
+        raise Exception("Cannot convert PFX to PEM")
+
+    def _extract_certificate(self, pem_file):
+        """
+        Parse the certificates and private keys from the pem file and store them in the certificates directory.
+        """
         # The parsing process use public key to match prv and crt.
-        buf = []
-        prvs = {}
-        thumbprints = {}
+        private_keys = {}  # map of private keys indexed by public key
+        thumbprints = {}  # map of thumbprints indexed by public key
+        buffer = []  # buffer for reading lines belonging to a certificate or private key
         index = 0
-        v1_cert_list = []
 
-        # Ensure pem_file exists before read the certs data since decrypt_p7m may clear the pem_file wen decryption fails
-        if os.path.exists(pem_file):
-            with open(pem_file) as pem:
-                for line in pem.readlines():
-                    buf.append(line)
-                    if re.match(r'[-]+END.*KEY[-]+', line):
-                        tmp_file = Certificates._write_to_tmp_file(index, 'prv', buf)
-                        pub = cryptutil.get_pubkey_from_prv(tmp_file)
-                        prvs[pub] = tmp_file
-                        buf = []
-                        index += 1
-                    elif re.match(r'[-]+END.*CERTIFICATE[-]+', line):
-                        tmp_file = Certificates._write_to_tmp_file(index, 'crt', buf)
-                        pub = cryptutil.get_pubkey_from_crt(tmp_file)
-                        thumbprint = cryptutil.get_thumbprint_from_crt(tmp_file)
-                        thumbprints[pub] = thumbprint
-                        # Rename crt with thumbprint as the file name
-                        crt = "{0}.crt".format(thumbprint)
-                        v1_cert_list.append({
-                            "name": None,
-                            "thumbprint": thumbprint
-                        })
-                        os.rename(tmp_file, os.path.join(conf.get_lib_dir(), crt))
-                        buf = []
-                        index += 1
+        cryptutil = CryptUtil(conf.get_openssl_cmd())
+
+        with open(pem_file) as pem:
+            for line in pem.readlines():
+                buffer.append(line)
+                if re.match(r'[-]+END.*KEY[-]+', line):
+                    tmp_file = Certificates._write_to_tmp_file(index, 'prv', buffer)
+                    pub = cryptutil.get_pubkey_from_prv(tmp_file)
+                    private_keys[pub] = tmp_file
+                    buffer = []
+                    index += 1
+                elif re.match(r'[-]+END.*CERTIFICATE[-]+', line):
+                    tmp_file = Certificates._write_to_tmp_file(index, 'crt', buffer)
+                    pub = cryptutil.get_pubkey_from_crt(tmp_file)
+                    thumbprint = cryptutil.get_thumbprint_from_crt(tmp_file)
+                    thumbprints[pub] = thumbprint
+                    # Rename crt with thumbprint as the file name
+                    crt = "{0}.crt".format(thumbprint)
+                    os.rename(tmp_file, os.path.join(conf.get_lib_dir(), crt))
+                    buffer = []
+                    index += 1
 
         # Rename prv key with thumbprint as the file name
-        for pubkey in prvs:
+        for pubkey in private_keys:
             thumbprint = thumbprints[pubkey]
             if thumbprint:
-                tmp_file = prvs[pubkey]
+                tmp_file = private_keys[pubkey]
                 prv = "{0}.prv".format(thumbprint)
                 os.rename(tmp_file, os.path.join(conf.get_lib_dir(), prv))
             else:
-                # Since private key has *no* matching certificate,
-                # it will not be named correctly
-                self.warnings.append("Found NO matching cert/thumbprint for private key!")
+                # Since private key has *no* matching certificate, it will not be named correctly
+                self.warn(WALAEventOperation.GoalState, "Found a private key with no matching cert/thumbprint!")
 
+        certificates = []
         for pubkey, thumbprint in thumbprints.items():
-            has_private_key = pubkey in prvs
-            self.summary.append({"thumbprint": thumbprint, "hasPrivateKey": has_private_key})
-
-        for v1_cert in v1_cert_list:
-            cert = Cert()
-            set_properties("certs", cert, v1_cert)
-            self.cert_list.certificates.append(cert)
+            has_private_key = pubkey in private_keys
+            certificates.append({"thumbprint": thumbprint, "hasPrivateKey": has_private_key})
+        return certificates
 
     @staticmethod
     def _write_to_tmp_file(index, suffix, buf):
@@ -614,9 +663,7 @@ class Certificates(object):
 
 class EmptyCertificates:
     def __init__(self):
-        self.cert_list = CertList()
-        self.summary = []  # debugging info
-        self.warnings = []
+        self.summary = []
 
 class RemoteAccess(object):
     """

--- a/azurelinuxagent/common/protocol/restapi.py
+++ b/azurelinuxagent/common/protocol/restapi.py
@@ -43,30 +43,6 @@ class VMInfo(DataContract):
         self.tenantName = tenantName
 
 
-class CertificateData(DataContract):
-    def __init__(self, certificateData=None):
-        self.certificateData = certificateData
-
-
-class Cert(DataContract):
-    def __init__(self,
-                 name=None,
-                 thumbprint=None,
-                 certificateDataUri=None,
-                 storeName=None,
-                 storeLocation=None):
-        self.name = name
-        self.thumbprint = thumbprint
-        self.certificateDataUri = certificateDataUri
-        self.storeLocation = storeLocation
-        self.storeName = storeName
-
-
-class CertList(DataContract):
-    def __init__(self):
-        self.certificates = DataContractList(Cert)
-
-
 class VMAgentFamily(object):
     def __init__(self, name):
         self.name = name

--- a/azurelinuxagent/common/utils/cryptutil.py
+++ b/azurelinuxagent/common/utils/cryptutil.py
@@ -97,7 +97,7 @@ class CryptUtil(object):
                 os.umask(umask)
 
     def convert_pfx_to_pem(self, pfx_file, nomacver, pem_file):
-        command = [self.openssl_cmd, "pkcs12", "-nodes", "-password", "pass:", "-nomacver", "-in", pfx_file, "-out", pem_file]
+        command = [self.openssl_cmd, "pkcs12", "-nodes", "-password", "pass:", "-in", pfx_file, "-out", pem_file]
         if nomacver:
             command.append("-nomacver")
 

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -85,6 +85,7 @@ READONLY_FILE_GLOBS = [
     "*.p7m",
     "*.pem",
     "*.prv",
+    "Certificates.xml",
     "ovf-env.xml"
 ]
 

--- a/tests/common/protocol/test_goal_state.py
+++ b/tests/common/protocol/test_goal_state.py
@@ -6,6 +6,7 @@ import datetime
 import glob
 import os
 import re
+import subprocess
 import shutil
 import time
 
@@ -495,6 +496,51 @@ class GoalStateTestCase(AgentTestCase, HttpRequestPredicates):
             self.assertEqual(0, len(goal_state.certs.summary), "Certificates should be empty")
             self.assertEqual(2, http_get_handler.certificate_requests, "There should have been exactly 2 requests for the goal state certificates")  # 1 for the initial request, 1 for the retry with an older cypher
 
+    def test_goal_state_should_try_legacy_cypher_and_then_fail_when_no_cyphers_are_supported(self):
+        cyphers = []
+        def http_get_handler(url, *_, **kwargs):
+            if HttpRequestPredicates.is_certificates_request(url):
+                cypher = kwargs["headers"].get("x-ms-cipher-name")
+                if cypher is None:
+                    raise Exception("x-ms-cipher-name header is missing from the Certificates request")
+                cyphers.append(cypher)
+                return MockHttpResponse(status=400, body="unsupported cypher: {0}".format(cypher).encode('utf-8'))
+            return None
+
+        with mock_wire_protocol(wire_protocol_data.DATA_FILE) as protocol:
+            with patch("azurelinuxagent.common.event.LogEvent.error") as log_error_patch:
+                protocol.set_http_handlers(http_get_handler=http_get_handler)
+                goal_state = GoalState(protocol.client)
+
+        log_error_args, _ = log_error_patch.call_args
+
+        self.assertEqual(cyphers, ["AES128_CBC", "DES_EDE3_CBC"], "There should have been 2 requests for the goal state certificates (AES128_CBC and DES_EDE3_CBC)")
+        self.assertEqual(log_error_args[0], "GoalStateCertificates", "An error fetching the goal state Certificates should have been reported")
+        self.assertEqual(0, len(goal_state.certs.summary), "Certificates should be empty")
+
+    def test_goal_state_should_try_without_and_with_mac_verification_then_fail_when_the_pfx_cannot_be_converted(self):
+        original_popen = subprocess.Popen
+        openssl = conf.get_openssl_cmd()
+        nomacver = []
+
+        def mock_fail_popen(command, *args, **kwargs):
+            if len(command) > 2 and command[0] == openssl and command[1] == "pkcs12":
+                nomacver.append("-nomacver" in command)
+                # force an error on the openssl to simulate the conversion failure
+                command[1] = "fake_openssl_command"
+            return original_popen(command, *args, **kwargs)
+
+
+        with mock_wire_protocol(wire_protocol_data.DATA_FILE) as protocol:
+            with patch("azurelinuxagent.common.event.LogEvent.error") as log_error_patch:
+                with patch("azurelinuxagent.ga.cgroupapi.subprocess.Popen", mock_fail_popen):
+                    goal_state = GoalState(protocol.client)
+
+        log_error_args, _ = log_error_patch.call_args
+
+        self.assertEqual(nomacver, [True, False], "There should have been 2 attempts to parse the PFX (with and without -nomacver)")
+        self.assertEqual(log_error_args[0], "GoalStateCertificates", "An error fetching the goal state Certificates should have been reported")
+        self.assertEqual(0, len(goal_state.certs.summary), "Certificates should be empty")
 
     def test_it_should_raise_when_goal_state_properties_not_initialized(self):
         with GoalStateTestCase._create_protocol_ws_and_hgap_in_sync() as protocol:

--- a/tests/common/protocol/test_goal_state.py
+++ b/tests/common/protocol/test_goal_state.py
@@ -492,8 +492,8 @@ class GoalStateTestCase(AgentTestCase, HttpRequestPredicates):
 
             goal_state = GoalState(protocol.client)
 
-            self.assertEqual(0, len(goal_state.certs.summary), "Cert list should be empty")
-            self.assertEqual(1, http_get_handler.certificate_requests, "There should have been exactly 1 requests for the goal state certificates")
+            self.assertEqual(0, len(goal_state.certs.summary), "Certificates should be empty")
+            self.assertEqual(2, http_get_handler.certificate_requests, "There should have been exactly 2 requests for the goal state certificates")  # 1 for the initial request, 1 for the retry with an older cypher
 
 
     def test_it_should_raise_when_goal_state_properties_not_initialized(self):

--- a/tests/common/protocol/test_wire.py
+++ b/tests/common/protocol/test_wire.py
@@ -497,12 +497,6 @@ class TestWireProtocol(AgentTestCase, HttpRequestPredicates):
             client.report_event(self._get_telemetry_events_generator(event_list), flush=True)
             self.assertEqual(mock_http_request.call_count, 3)
 
-    def test_get_header_for_cert_should_use_triple_des(self, *_):
-        with mock_wire_protocol(wire_protocol_data.DATA_FILE) as protocol:
-            headers = protocol.client.get_header_for_cert()
-            self.assertIn("x-ms-cipher-name", headers)
-            self.assertEqual(headers["x-ms-cipher-name"], "DES_EDE3_CBC", "Unexpected x-ms-cipher-name")
-
     def test_get_header_for_remote_access_should_use_aes128(self, *_):
         with mock_wire_protocol(wire_protocol_data.DATA_FILE) as protocol:
             headers = protocol.client.get_header_for_remote_access()
@@ -1096,7 +1090,7 @@ class UpdateGoalStateTestCase(HttpRequestPredicates, AgentTestCase):
                 self.assertEqual(protocol.client.get_hosting_env().deployment_name, new_hosting_env_deployment_name)
                 self.assertEqual(protocol.client.get_shared_conf().xml_text, new_shared_conf)
                 self.assertEqual(sequence_number, new_sequence_number)
-                self.assertEqual(len(protocol.client.get_certs().cert_list.certificates), 0)
+                self.assertEqual(len(protocol.client.get_certs().summary), 0)
 
                 self.assertEqual(protocol.client.get_host_plugin().container_id, new_container_id)
                 self.assertEqual(protocol.client.get_host_plugin().role_config_name, new_role_config_name)

--- a/tests/ga/test_update.py
+++ b/tests/ga/test_update.py
@@ -2059,7 +2059,7 @@ class TryUpdateGoalStateTestCase(HttpRequestPredicates, AgentTestCase):
             # Double check the certificates are correct
             goal_state = protocol.get_goal_state()
 
-            thumbprints = [c.thumbprint for c in goal_state.certs.cert_list.certificates]
+            thumbprints = [c["thumbprint"] for c in goal_state.certs.summary]
 
             for extension in goal_state.extensions_goal_state.extensions:
                 for settings in extension.settings:


### PR DESCRIPTION
When fetching certificates from WireServer, the Agent uses DES_EDE3_CBC. The PFX it receives has a MAC computed using PKCS12KDF. Both are deprecated on FIPS 140-3. 

This PR switches to AES128_CBC for communication with the WireServer (a subsequent PR will change it to AES256_CBC) and skips MAC verification when it is not needed.

The changes also include some minor cleanup to remove data structures that are not used.

Fixes #2600