### PR TITLE
Fix slow unit tests in TestExtensionPolicy

### DIFF
--- a/tests/ga/test_extension.py
+++ b/tests/ga/test_extension.py
@@ -3514,6 +3514,8 @@ class TestExtensionHandlerManifest(AgentTestCase):
 class TestExtensionPolicy(TestExtensionBase):
     def setUp(self):
         AgentTestCase.setUp(self)
+        self.mock_sleep = patch("time.sleep", lambda *_: mock_sleep(0.01))
+        self.mock_sleep.start()
         self.policy_path = os.path.join(self.tmp_dir, "waagent_policy.json")
 
         # Patch attributes to enable policy feature


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---
Some unit tests in TestExtensionPolicy (test_should_fail_uninstall_if_extension_disallowed and test_enable_should_succeed_if_extension_allowed) take > 5 seconds to run, due to time.sleep() calls. This PR mocks test.sleep() in TestExtensionPolicy to speed up the slow tests.

All policy tests now take < 1s: 

<img width="533" alt="image" src="https://github.com/user-attachments/assets/df4b6c3a-0f93-4676-a1b0-1426c6f96e04" />

### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).