### PR TITLE
Require Hyper-V to start waagent service

### DIFF
--- a/init/arch/waagent.service
+++ b/init/arch/waagent.service
@@ -5,6 +5,7 @@ After=network-online.target
 
 ConditionFileIsExecutable=/usr/bin/waagent
 ConditionPathExists=/etc/waagent.conf
+ConditionVirtualization=microsoft
 
 [Service]
 Type=simple

--- a/init/clearlinux/waagent.service
+++ b/init/clearlinux/waagent.service
@@ -5,6 +5,7 @@ After=network-online.target
 
 ConditionFileIsExecutable=/usr/bin/waagent
 ConditionPathExists=/usr/share/defaults/waagent/waagent.conf
+ConditionVirtualization=microsoft
 
 [Service]
 Type=simple

--- a/init/mariner/waagent.service
+++ b/init/mariner/waagent.service
@@ -5,6 +5,7 @@ After=systemd-networkd-wait-online.service cloud-init.service
 
 ConditionFileIsExecutable=/usr/bin/waagent
 ConditionPathExists=/etc/waagent.conf
+ConditionVirtualization=microsoft
 
 [Service]
 Type=simple

--- a/init/photonos/waagent.service
+++ b/init/photonos/waagent.service
@@ -5,6 +5,7 @@ After=systemd-networkd-wait-online.service cloud-init.service
 
 ConditionFileIsExecutable=/usr/bin/waagent
 ConditionPathExists=/etc/waagent.conf
+ConditionVirtualization=microsoft
 
 [Service]
 Type=simple

--- a/init/redhat/py2/waagent.service
+++ b/init/redhat/py2/waagent.service
@@ -5,6 +5,7 @@ After=network-online.target
 
 ConditionFileIsExecutable=/usr/sbin/waagent
 ConditionPathExists=/etc/waagent.conf
+ConditionVirtualization=microsoft
 
 [Service]
 Type=simple

--- a/init/redhat/waagent.service
+++ b/init/redhat/waagent.service
@@ -5,6 +5,7 @@ After=network-online.target
 
 ConditionFileIsExecutable=/usr/sbin/waagent
 ConditionPathExists=/etc/waagent.conf
+ConditionVirtualization=microsoft
 
 [Service]
 Type=simple

--- a/init/sles/waagent.service
+++ b/init/sles/waagent.service
@@ -5,6 +5,7 @@ After=network-online.target
 
 ConditionFileIsExecutable=/usr/sbin/waagent
 ConditionPathExists=/etc/waagent.conf
+ConditionVirtualization=microsoft
 
 [Service]
 Type=simple

--- a/init/waagent.service
+++ b/init/waagent.service
@@ -5,6 +5,7 @@ After=network-online.target
 
 ConditionFileIsExecutable=/usr/sbin/waagent
 ConditionPathExists=/etc/waagent.conf
+ConditionVirtualization=microsoft
 
 [Service]
 Type=simple


### PR DESCRIPTION

<!-- DO NOT DELETE THIS TEMPLATE -->

## Description  

 WALinuxAgent is Azure specific and Azure runs on Hyper-V. Add  

   ConditionVirtualization=microsoft
 
to service files to avoid starting WALA in other environments. In particular, this avoids polluting the console when the  
 same image is used both for Azure and some other env (e.g. local QEMU).

### PR information
- [ X ] Ensure development PR is based on the `develop` branch.
- [ X ] The title of the PR is clear and informative.
- [ X ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ - ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ - ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ X ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).