### PR TITLE
Support for Python 3.12

### DIFF
--- a/.github/workflows/ci_pr.yml
+++ b/.github/workflows/ci_pr.yml
@@ -36,6 +36,7 @@ jobs:
             additional-nose-opts: "--with-coverage --cover-erase --cover-inclusive --cover-branches --cover-package=azurelinuxagent"
           - python-version: "3.10"
           - python-version: "3.11"
+          - python-version: "3.12"
 
     steps:
     - name: Checkout WALinuxAgent
@@ -122,13 +123,13 @@ jobs:
         # * 'contextmanager-generator-missing-cleanup' are false positives if yield is used inside an if-else block for contextmanager generator functions.
         #   (https://pylint.readthedocs.io/en/latest/user_guide/messages/warning/contextmanager-generator-missing-cleanup.html).
         #   This is not implemented on versions (3.0-3.7) Bad option value 'contextmanager-generator-missing-cleanup' (bad-option-value)
-        # * 3.9-3.11 will produce "too-many-positional-arguments" for several methods that are having more than 5 args, so we suppress that warning.
+        # * >= 3.9 will produce "too-many-positional-arguments" for several methods that are having more than 5 args, so we suppress that warning.
         #  (R0917: Too many positional arguments (8/5) (too-many-positional-arguments))
         PYLINT_OPTIONS="--rcfile=ci/pylintrc --jobs=0"
         if [[ "${{ matrix.python-version }}" == "3.9" ]]; then
           PYLINT_OPTIONS="$PYLINT_OPTIONS --disable=no-member,too-many-positional-arguments --ignore=main.py"
         fi
-        if [[ "${{ matrix.python-version }}" =~ ^3\.(10|11)$ ]]; then
+        if [[ "${{ matrix.python-version }}" =~ ^3\.(10|11|12)$ ]]; then
           PYLINT_OPTIONS="$PYLINT_OPTIONS --disable=too-many-positional-arguments"
         fi
         if [[ "${{ matrix.python-version }}" =~ ^3\.[0-7]$ ]]; then

--- a/azurelinuxagent/common/errorstate.py
+++ b/azurelinuxagent/common/errorstate.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from azurelinuxagent.common.future import UTC
 
 ERROR_STATE_DELTA_DEFAULT = timedelta(minutes=15)
 ERROR_STATE_DELTA_INSTALL = timedelta(minutes=5)
@@ -14,7 +15,7 @@ class ErrorState(object):
 
     def incr(self):
         if self.count == 0:
-            self.timestamp = datetime.utcnow()
+            self.timestamp = datetime.now(UTC)
 
         self.count += 1
 
@@ -26,7 +27,7 @@ class ErrorState(object):
         if self.timestamp is None:
             return False
 
-        delta = datetime.utcnow() - self.timestamp
+        delta = datetime.now(UTC) - self.timestamp
         if delta >= self.min_timedelta:
             return True
 
@@ -37,7 +38,7 @@ class ErrorState(object):
         if self.timestamp is None:
             return 'unknown'
 
-        delta = round((datetime.utcnow() - self.timestamp).seconds / 60.0, 2)
+        delta = round((datetime.now(UTC) - self.timestamp).seconds / 60.0, 2)
         if delta < 60:
             return '{0} min'.format(delta)
 

--- a/azurelinuxagent/common/event.py
+++ b/azurelinuxagent/common/event.py
@@ -30,12 +30,12 @@ import azurelinuxagent.common.conf as conf
 import azurelinuxagent.common.logger as logger
 from azurelinuxagent.common.AgentGlobals import AgentGlobals
 from azurelinuxagent.common.exception import EventError, OSUtilError
-from azurelinuxagent.common.future import ustr
+from azurelinuxagent.common.future import ustr, UTC
 from azurelinuxagent.common.datacontract import get_properties, set_properties
 from azurelinuxagent.common.osutil import get_osutil
 from azurelinuxagent.common.telemetryevent import TelemetryEventParam, TelemetryEvent, CommonTelemetryEventSchema, \
     GuestAgentGenericLogsSchema, GuestAgentExtensionEventsSchema, GuestAgentPerfCounterEventsSchema
-from azurelinuxagent.common.utils import fileutil, textutil
+from azurelinuxagent.common.utils import fileutil, textutil, timeutil
 from azurelinuxagent.common.utils.textutil import parse_doc, findall, find, getattrib, str_to_encoded_ustr
 from azurelinuxagent.common.version import CURRENT_VERSION, CURRENT_AGENT, AGENT_NAME, DISTRO_NAME, DISTRO_VERSION, DISTRO_CODE_NAME, AGENT_EXECUTION_MODE
 from azurelinuxagent.common.protocol.imds import get_imds_client
@@ -484,7 +484,7 @@ class EventLogger(object):
 
     def is_period_elapsed(self, delta, h):
         return h not in self.periodic_events or \
-            (self.periodic_events[h] + delta) <= datetime.now()
+            (self.periodic_events[h] + delta) <= datetime.now(UTC)
 
     def add_periodic(self, delta, name, op=WALAEventOperation.Unknown, is_success=True, duration=0,
                      version=str(CURRENT_VERSION), message="", log_event=True, force=False):
@@ -493,7 +493,7 @@ class EventLogger(object):
         if force or self.is_period_elapsed(delta, h):
             self.add_event(name, op=op, is_success=is_success, duration=duration,
                            version=version, message=message, log_event=log_event)
-            self.periodic_events[h] = datetime.now()
+            self.periodic_events[h] = datetime.now(UTC)
 
     def add_event(self, name, op=WALAEventOperation.Unknown, is_success=True, duration=0, version=str(CURRENT_VERSION),
                   message="", log_event=True, flush=False):
@@ -511,7 +511,7 @@ class EventLogger(object):
         event.parameters.append(TelemetryEventParam(GuestAgentExtensionEventsSchema.OperationSuccess, bool(is_success)))
         event.parameters.append(TelemetryEventParam(GuestAgentExtensionEventsSchema.Message, str_to_encoded_ustr(message)))
         event.parameters.append(TelemetryEventParam(GuestAgentExtensionEventsSchema.Duration, int(duration)))
-        self.add_common_event_parameters(event, datetime.utcnow())
+        self.add_common_event_parameters(event, datetime.now(UTC))
 
         self.report_or_save_event(event, flush)
 
@@ -520,9 +520,9 @@ class EventLogger(object):
         event.parameters.append(TelemetryEventParam(GuestAgentGenericLogsSchema.EventName, WALAEventOperation.Log))
         event.parameters.append(TelemetryEventParam(GuestAgentGenericLogsSchema.CapabilityUsed, logger.LogLevel.STRINGS[level]))
         event.parameters.append(TelemetryEventParam(GuestAgentGenericLogsSchema.Context1, str_to_encoded_ustr(self._clean_up_message(message))))
-        event.parameters.append(TelemetryEventParam(GuestAgentGenericLogsSchema.Context2, datetime.utcnow().strftime(logger.Logger.LogTimeFormatInUTC)))
+        event.parameters.append(TelemetryEventParam(GuestAgentGenericLogsSchema.Context2, timeutil.create_utc_timestamp(datetime.now(UTC))))
         event.parameters.append(TelemetryEventParam(GuestAgentGenericLogsSchema.Context3, ''))
-        self.add_common_event_parameters(event, datetime.utcnow())
+        self.add_common_event_parameters(event, datetime.now(UTC))
 
         self.report_or_save_event(event)
 
@@ -545,7 +545,7 @@ class EventLogger(object):
         event.parameters.append(TelemetryEventParam(GuestAgentPerfCounterEventsSchema.Counter, str_to_encoded_ustr(counter)))
         event.parameters.append(TelemetryEventParam(GuestAgentPerfCounterEventsSchema.Instance, str_to_encoded_ustr(instance)))
         event.parameters.append(TelemetryEventParam(GuestAgentPerfCounterEventsSchema.Value, float(value)))
-        self.add_common_event_parameters(event, datetime.utcnow())
+        self.add_common_event_parameters(event, datetime.now(UTC))
 
         self.report_or_save_event(event)
 
@@ -615,7 +615,7 @@ class EventLogger(object):
         """
         common_params = [TelemetryEventParam(CommonTelemetryEventSchema.GAVersion, CURRENT_AGENT),
                          TelemetryEventParam(CommonTelemetryEventSchema.ContainerId, AgentGlobals.get_container_id()),
-                         TelemetryEventParam(CommonTelemetryEventSchema.OpcodeName, event_timestamp.strftime(logger.Logger.LogTimeFormatInUTC)),
+                         TelemetryEventParam(CommonTelemetryEventSchema.OpcodeName, timeutil.create_utc_timestamp(event_timestamp)),
                          TelemetryEventParam(CommonTelemetryEventSchema.EventTid, threading.current_thread().ident),
                          TelemetryEventParam(CommonTelemetryEventSchema.EventPid, os.getpid()),
                          TelemetryEventParam(CommonTelemetryEventSchema.TaskName, threading.current_thread().name)]
@@ -637,7 +637,7 @@ def get_event_logger():
 
 
 def elapsed_milliseconds(utc_start):
-    now = datetime.utcnow()
+    now = datetime.now(UTC)
     if now < utc_start:
         return 0
 

--- a/azurelinuxagent/common/future.py
+++ b/azurelinuxagent/common/future.py
@@ -71,12 +71,16 @@ else:
 
 
 #
-# datetime.utcnow triggers a DeprecationWarning on 3.12 and will be removed in a future version; to work around this,
-# use datetime.UTC, which was introduced on Python 3.11.
+# datetime.utcnow triggers a DeprecationWarning on 3.12 and will be removed in a future version.
+#
+# To work around this, we use timezone.utc on 3.5-3.10 (it was introduced on 3.2, but currently we test from 3.5), and
+# datetime.UTC (introduced on Python 3.11) for >= 3.11.
 #
 if sys.version_info[0] > 3 or sys.version_info[0] == 3 and sys.version_info[1] >= 11:
     # E1101: Module 'datetime' has no 'UTC' member (no-member)
     UTC = datetime.UTC  # pylint: disable=E1101
+elif sys.version_info[0] == 3 and sys.version_info[1] >= 5:
+    UTC = datetime.timezone.utc
 else:
     from datetime import tzinfo, timedelta
 

--- a/azurelinuxagent/common/future.py
+++ b/azurelinuxagent/common/future.py
@@ -74,7 +74,7 @@ else:
 # datetime.utcnow triggers a DeprecationWarning on 3.12 and will be removed in a future version; to work around this,
 # use datetime.UTC, which was introduced on Python 3.11.
 #
-if sys.version_info[0] == 3 and sys.version_info[1] >= 11:
+if sys.version_info[0] > 3 or sys.version_info[0] == 3 and sys.version_info[1] >= 11:
     # E1101: Module 'datetime' has no 'UTC' member (no-member)
     UTC = datetime.UTC  # pylint: disable=E1101
 else:

--- a/azurelinuxagent/common/logger.py
+++ b/azurelinuxagent/common/logger.py
@@ -21,7 +21,8 @@ import sys
 from datetime import datetime, timedelta
 from threading import current_thread
 
-from azurelinuxagent.common.future import ustr
+from azurelinuxagent.common.future import ustr, UTC
+from azurelinuxagent.common.utils import timeutil
 
 EVERY_DAY = timedelta(days=1)
 EVERY_HALF_DAY = timedelta(hours=12)
@@ -36,10 +37,6 @@ class Logger(object):
     """
     Logger class
     """
-
-    # This format is based on ISO-8601, Z represents UTC (Zero offset)
-    LogTimeFormatInUTC = u'%Y-%m-%dT%H:%M:%S.%fZ'
-
     def __init__(self, logger=None, prefix=None):
         self.appenders = []
         self.logger = self if logger is None else logger
@@ -55,13 +52,13 @@ class Logger(object):
 
     def _is_period_elapsed(self, delta, h):
         return h not in self.logger.periodic_messages or \
-            (self.logger.periodic_messages[h] + delta) <= datetime.now()
+            (self.logger.periodic_messages[h] + delta) <= datetime.now(UTC)
 
     def _periodic(self, delta, log_level_op, msg_format, *args):
         h = hash(msg_format)
         if self._is_period_elapsed(delta, h):
             log_level_op(msg_format, *args)
-            self.logger.periodic_messages[h] = datetime.now()
+            self.logger.periodic_messages[h] = datetime.now(UTC)
 
     def periodic_info(self, delta, msg_format, *args):
         self._periodic(delta, self.info, msg_format, *args)
@@ -135,7 +132,7 @@ class Logger(object):
             msg = msg_format.format(*args)
         else:
             msg = msg_format
-        time = datetime.utcnow().strftime(Logger.LogTimeFormatInUTC)
+        time = timeutil.create_utc_timestamp(datetime.now(UTC))
         level_str = LogLevel.STRINGS[level]
         thread_name = current_thread().name
         if self.prefix is not None:

--- a/azurelinuxagent/common/osutil/default.py
+++ b/azurelinuxagent/common/osutil/default.py
@@ -46,7 +46,10 @@ if sys.version_info[0] == 3 and sys.version_info[1] >= 13 or sys.version_info[0]
         def crypt(password, salt):
             raise OSUtilError("Please install the legacycrypt Python module to use this feature.")
 else:
-    from crypt import crypt  # pylint: disable=deprecated-module
+    import warnings
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=DeprecationWarning)
+        from crypt import crypt  # pylint: disable=deprecated-module
 
 from azurelinuxagent.common import conf
 from azurelinuxagent.common import logger
@@ -54,7 +57,7 @@ from azurelinuxagent.common.utils import fileutil
 from azurelinuxagent.common.utils import shellutil
 from azurelinuxagent.common.utils import textutil
 
-from azurelinuxagent.common.future import ustr, array_to_bytes
+from azurelinuxagent.common.future import ustr, array_to_bytes, UTC
 from azurelinuxagent.common.utils.cryptutil import CryptUtil
 from azurelinuxagent.common.utils.networkutil import RouteEntry, NetworkInterfaceCard
 from azurelinuxagent.common.utils.shellutil import CommandError
@@ -847,8 +850,8 @@ class DefaultOSUtil(object):
                         else:
                             try:
                                 expire_string = line.split(" ", 4)[-1].strip(";")
-                                expire_date = datetime.datetime.strptime(expire_string, FORMAT_DATETIME)
-                                if expire_date > datetime.datetime.utcnow():
+                                expire_date = datetime.datetime.strptime(expire_string, FORMAT_DATETIME).replace(tzinfo=UTC)
+                                if expire_date > datetime.datetime.now(UTC):
                                     expired = False
                             except:  # pylint: disable=W0702
                                 logger.error("could not parse expiry token '{0}'".format(line))

--- a/azurelinuxagent/common/osutil/openbsd.py
+++ b/azurelinuxagent/common/osutil/openbsd.py
@@ -23,6 +23,7 @@ import time
 import glob
 import datetime
 
+from azurelinuxagent.common.future import UTC
 import azurelinuxagent.common.utils.fileutil as fileutil
 import azurelinuxagent.common.utils.shellutil as shellutil
 import azurelinuxagent.common.logger as logger
@@ -190,9 +191,8 @@ class OpenBSDOSUtil(DefaultOSUtil):
                             try:
                                 expire_string = line.split(
                                     " ", 4)[-1].strip(";")
-                                expire_date = datetime.datetime.strptime(
-                                    expire_string, FORMAT_DATETIME)
-                                if expire_date > datetime.datetime.utcnow():
+                                expire_date = datetime.datetime.strptime(expire_string, FORMAT_DATETIME).replace(tzinfo=UTC)
+                                if expire_date > datetime.datetime.now(UTC):
                                     expired = False
                             except ValueError:
                                 logger.error("could not parse expiry token "

--- a/azurelinuxagent/common/protocol/extensions_goal_state.py
+++ b/azurelinuxagent/common/protocol/extensions_goal_state.py
@@ -20,7 +20,8 @@ import datetime
 from azurelinuxagent.common import logger
 from azurelinuxagent.common.AgentGlobals import AgentGlobals
 from azurelinuxagent.common.exception import AgentError
-from azurelinuxagent.common.utils import textutil
+from azurelinuxagent.common.future import UTC, datetime_min_utc
+from azurelinuxagent.common.utils import textutil, timeutil
 
 
 class GoalStateChannel(object):
@@ -55,6 +56,8 @@ class ExtensionsGoalState(object):
     """
     def __init__(self):
         self._is_outdated = False
+
+    _MINIMUM_TIMESTAMP = datetime.datetime(1900, 1, 1, 0, 0, tzinfo=UTC)  # min value accepted by datetime.strftime()
 
     @property
     def id(self):
@@ -153,16 +156,15 @@ class ExtensionsGoalState(object):
         Takes 'ticks', a string indicating the number of ticks since midnight 0001-01-01 00:00:00, and
         returns a UTC timestamp  (every tick is 1/10000000 of a second).
         """
-        minimum = datetime.datetime(1900, 1, 1, 0, 0)  # min value accepted by datetime.strftime()
-        as_date_time = minimum
+        as_date_time = ExtensionsGoalState._MINIMUM_TIMESTAMP
         if ticks_string not in (None, ""):
             try:
-                as_date_time = datetime.datetime.min + datetime.timedelta(seconds=float(ticks_string) / 10 ** 7)
+                as_date_time = datetime_min_utc + datetime.timedelta(seconds=float(ticks_string) / 10 ** 7)
             except Exception as exception:
                 logger.verbose("Can't parse ticks: {0}", textutil.format_exception(exception))
-        as_date_time = max(as_date_time, minimum)
+        as_date_time = max(as_date_time, ExtensionsGoalState._MINIMUM_TIMESTAMP)
 
-        return as_date_time.strftime(logger.Logger.LogTimeFormatInUTC)
+        return timeutil.create_utc_timestamp(as_date_time)
 
     @staticmethod
     def _string_to_id(id_string):
@@ -203,7 +205,7 @@ class EmptyExtensionsGoalState(ExtensionsGoalState):
 
     @property
     def created_on_timestamp(self):
-        return datetime.datetime.min
+        return datetime_min_utc
 
     @property
     def channel(self):

--- a/azurelinuxagent/common/protocol/extensions_goal_state.py
+++ b/azurelinuxagent/common/protocol/extensions_goal_state.py
@@ -20,7 +20,7 @@ import datetime
 from azurelinuxagent.common import logger
 from azurelinuxagent.common.AgentGlobals import AgentGlobals
 from azurelinuxagent.common.exception import AgentError
-from azurelinuxagent.common.future import UTC, datetime_min_utc
+from azurelinuxagent.common.future import datetime_min_utc
 from azurelinuxagent.common.utils import textutil, timeutil
 
 
@@ -56,8 +56,6 @@ class ExtensionsGoalState(object):
     """
     def __init__(self):
         self._is_outdated = False
-
-    _MINIMUM_TIMESTAMP = datetime.datetime(1900, 1, 1, 0, 0, tzinfo=UTC)  # min value accepted by datetime.strftime()
 
     @property
     def id(self):
@@ -156,13 +154,14 @@ class ExtensionsGoalState(object):
         Takes 'ticks', a string indicating the number of ticks since midnight 0001-01-01 00:00:00, and
         returns a UTC timestamp  (every tick is 1/10000000 of a second).
         """
-        as_date_time = ExtensionsGoalState._MINIMUM_TIMESTAMP
+        as_date_time = None
         if ticks_string not in (None, ""):
             try:
                 as_date_time = datetime_min_utc + datetime.timedelta(seconds=float(ticks_string) / 10 ** 7)
             except Exception as exception:
-                logger.verbose("Can't parse ticks: {0}", textutil.format_exception(exception))
-        as_date_time = max(as_date_time, ExtensionsGoalState._MINIMUM_TIMESTAMP)
+                logger.info("Can't parse ticks: {0}", textutil.format_exception(exception))
+        if as_date_time is None:
+            as_date_time = datetime_min_utc
 
         return timeutil.create_utc_timestamp(as_date_time)
 

--- a/azurelinuxagent/common/protocol/extensions_goal_state_from_vm_settings.py
+++ b/azurelinuxagent/common/protocol/extensions_goal_state_from_vm_settings.py
@@ -21,7 +21,7 @@ import sys
 from azurelinuxagent.common import logger
 from azurelinuxagent.common.AgentGlobals import AgentGlobals
 from azurelinuxagent.common.event import WALAEventOperation, add_event
-from azurelinuxagent.common.future import ustr, urlparse
+from azurelinuxagent.common.future import ustr, urlparse, datetime_min_utc
 from azurelinuxagent.common.protocol.extensions_goal_state import ExtensionsGoalState, GoalStateChannel, VmSettingsParseError
 from azurelinuxagent.common.protocol.restapi import VMAgentFamily, Extension, ExtensionRequestedState, ExtensionSettings
 from azurelinuxagent.common.utils.flexible_version import FlexibleVersion
@@ -39,7 +39,7 @@ class ExtensionsGoalStateFromVmSettings(ExtensionsGoalState):
         self._schema_version = FlexibleVersion('0.0.0.0')
         self._activity_id = AgentGlobals.GUID_ZERO
         self._correlation_id = AgentGlobals.GUID_ZERO
-        self._created_on_timestamp = self._MINIMUM_TIMESTAMP
+        self._created_on_timestamp = datetime_min_utc
         self._source = None
         self._status_upload_blob = None
         self._status_upload_blob_type = None

--- a/azurelinuxagent/common/protocol/extensions_goal_state_from_vm_settings.py
+++ b/azurelinuxagent/common/protocol/extensions_goal_state_from_vm_settings.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 #
 # Requires Python 2.6+ and Openssl 1.0+
-import datetime
 import json
 import sys
 
@@ -29,8 +28,6 @@ from azurelinuxagent.common.utils.flexible_version import FlexibleVersion
 
 
 class ExtensionsGoalStateFromVmSettings(ExtensionsGoalState):
-    _MINIMUM_TIMESTAMP = datetime.datetime(1900, 1, 1, 0, 0)  # min value accepted by datetime.strftime()
-
     def __init__(self, etag, json_text, correlation_id):
         super(ExtensionsGoalStateFromVmSettings, self).__init__()
         self._id = "etag_{0}".format(etag)

--- a/azurelinuxagent/common/protocol/extensions_goal_state_from_vm_settings.py
+++ b/azurelinuxagent/common/protocol/extensions_goal_state_from_vm_settings.py
@@ -24,6 +24,7 @@ from azurelinuxagent.common.event import WALAEventOperation, add_event
 from azurelinuxagent.common.future import ustr, urlparse, datetime_min_utc
 from azurelinuxagent.common.protocol.extensions_goal_state import ExtensionsGoalState, GoalStateChannel, VmSettingsParseError
 from azurelinuxagent.common.protocol.restapi import VMAgentFamily, Extension, ExtensionRequestedState, ExtensionSettings
+from azurelinuxagent.common.utils import timeutil
 from azurelinuxagent.common.utils.flexible_version import FlexibleVersion
 
 
@@ -39,7 +40,7 @@ class ExtensionsGoalStateFromVmSettings(ExtensionsGoalState):
         self._schema_version = FlexibleVersion('0.0.0.0')
         self._activity_id = AgentGlobals.GUID_ZERO
         self._correlation_id = AgentGlobals.GUID_ZERO
-        self._created_on_timestamp = datetime_min_utc
+        self._created_on_timestamp = timeutil.create_utc_timestamp(datetime_min_utc)
         self._source = None
         self._status_upload_blob = None
         self._status_upload_blob_type = None

--- a/azurelinuxagent/common/protocol/goal_state.py
+++ b/azurelinuxagent/common/protocol/goal_state.py
@@ -26,7 +26,7 @@ from azurelinuxagent.common import logger
 from azurelinuxagent.common.AgentGlobals import AgentGlobals
 from azurelinuxagent.common.event import add_event, WALAEventOperation, LogEvent
 from azurelinuxagent.common.exception import ProtocolError, ResourceGoneError
-from azurelinuxagent.common.future import ustr
+from azurelinuxagent.common.future import ustr, UTC
 from azurelinuxagent.common.protocol.extensions_goal_state_factory import ExtensionsGoalStateFactory
 from azurelinuxagent.common.protocol.extensions_goal_state import VmSettingsParseError, GoalStateSource
 from azurelinuxagent.common.protocol.hostplugin import VmSettingsNotSupported, VmSettingsSupportStopped
@@ -206,7 +206,7 @@ class GoalState(object):
         #
         # Fetch the goal state from both the HGAP and the WireServer
         #
-        timestamp = datetime.datetime.utcnow()
+        timestamp = datetime.datetime.now(UTC)
 
         if force_update:
             message = "Refreshing goal state and vmSettings"
@@ -323,7 +323,7 @@ class GoalState(object):
         self.logger.info(msg)
         add_event(op=WALAEventOperation.VmSettings, message=msg)
         if self._save_to_history:
-            self._history = GoalStateHistory(datetime.datetime.utcnow(), incarnation)
+            self._history = GoalStateHistory(datetime.datetime.now(UTC), incarnation)
             self._history.save_goal_state(xml_text)
         self._extensions_goal_state = self._fetch_full_wire_server_goal_state(incarnation, xml_doc)
         if self._extensions_goal_state.created_on_timestamp < vm_settings_support_stopped_error.timestamp:
@@ -395,7 +395,7 @@ class GoalState(object):
             except VmSettingsParseError as exception:
                 # ensure we save the vmSettings if there were parsing errors, but save them only once per ETag
                 if not GoalStateHistory.tag_exists(exception.etag):
-                    GoalStateHistory(datetime.datetime.utcnow(), exception.etag).save_vm_settings(exception.vm_settings_text)
+                    GoalStateHistory(datetime.datetime.now(UTC), exception.etag).save_vm_settings(exception.vm_settings_text)
                 raise
 
         return vm_settings, vm_settings_updated

--- a/azurelinuxagent/common/protocol/hostplugin.py
+++ b/azurelinuxagent/common/protocol/hostplugin.py
@@ -28,7 +28,7 @@ from azurelinuxagent.common.errorstate import ErrorState, ERROR_STATE_HOST_PLUGI
 from azurelinuxagent.common.event import WALAEventOperation, add_event
 from azurelinuxagent.common.exception import HttpError, ProtocolError, ResourceGoneError
 from azurelinuxagent.common.utils.flexible_version import FlexibleVersion
-from azurelinuxagent.common.future import ustr, httpclient, UTC
+from azurelinuxagent.common.future import ustr, httpclient, UTC, datetime_min_utc
 from azurelinuxagent.common.protocol.healthservice import HealthService
 from azurelinuxagent.common.protocol.extensions_goal_state import VmSettingsParseError, GoalStateSource
 from azurelinuxagent.common.protocol.extensions_goal_state_factory import ExtensionsGoalStateFactory
@@ -451,7 +451,7 @@ class HostPluginProtocol(object):
         with HostPluginProtocol._fast_track_state_lock:
             state_file = HostPluginProtocol._get_fast_track_state_file()
             if not os.path.exists(state_file):
-                return timeutil.create_utc_timestamp(datetime.datetime.min)
+                return timeutil.create_utc_timestamp(datetime_min_utc)
 
             try:
                 with open(state_file, "r") as file_:

--- a/azurelinuxagent/common/protocol/hostplugin.py
+++ b/azurelinuxagent/common/protocol/hostplugin.py
@@ -28,7 +28,7 @@ from azurelinuxagent.common.errorstate import ErrorState, ERROR_STATE_HOST_PLUGI
 from azurelinuxagent.common.event import WALAEventOperation, add_event
 from azurelinuxagent.common.exception import HttpError, ProtocolError, ResourceGoneError
 from azurelinuxagent.common.utils.flexible_version import FlexibleVersion
-from azurelinuxagent.common.future import ustr, httpclient
+from azurelinuxagent.common.future import ustr, httpclient, UTC
 from azurelinuxagent.common.protocol.healthservice import HealthService
 from azurelinuxagent.common.protocol.extensions_goal_state import VmSettingsParseError, GoalStateSource
 from azurelinuxagent.common.protocol.extensions_goal_state_factory import ExtensionsGoalStateFactory
@@ -89,19 +89,15 @@ class HostPluginProtocol(object):
         self.status_last_timestamp = None
         self._version = FlexibleVersion("0.0.0.0")  # Version 0 means "unknown"
         self._supports_vm_settings = None   # Tri-state variable: None == Not Initialized, True == Supports, False == Does Not Support
-        self._supports_vm_settings_next_check = datetime.datetime.now()
+        self._supports_vm_settings_next_check = datetime.datetime.now(UTC)
         self._vm_settings_error_reporter = _VmSettingsErrorReporter()
         self._cached_vm_settings = None  # Cached value of the most recent vmSettings
 
         # restore the state of Fast Track
-        if not os.path.exists(self._get_fast_track_state_file()):
-            self._supports_vm_settings = False
-            self._supports_vm_settings_next_check = datetime.datetime.now()
-            self._fast_track_timestamp = timeutil.create_timestamp(datetime.datetime.min)
-        else:
-            self._supports_vm_settings = True
-            self._supports_vm_settings_next_check = datetime.datetime.now()
-            self._fast_track_timestamp = HostPluginProtocol.get_fast_track_timestamp()
+        self._supports_vm_settings = os.path.exists(self._get_fast_track_state_file())
+        self._fast_track_timestamp = HostPluginProtocol.get_fast_track_timestamp()
+
+        self._supports_vm_settings_next_check = datetime.datetime.now(UTC)
 
     @staticmethod
     def _extract_deployment_id(role_config_name):
@@ -215,7 +211,7 @@ class HostPluginProtocol(object):
                               self.fetch_error_state,
                               self.fetch_last_timestamp,
                               HostPluginProtocol.FETCH_REPORTING_PERIOD):
-            self.fetch_last_timestamp = datetime.datetime.utcnow()
+            self.fetch_last_timestamp = datetime.datetime.now(UTC)
             health_signal = self.fetch_error_state.is_triggered() is False
             self.health_service.report_host_plugin_extension_artifact(is_healthy=health_signal,
                                                                       source=source,
@@ -226,7 +222,7 @@ class HostPluginProtocol(object):
                               self.status_error_state,
                               self.status_last_timestamp,
                               HostPluginProtocol.STATUS_REPORTING_PERIOD):
-            self.status_last_timestamp = datetime.datetime.utcnow()
+            self.status_last_timestamp = datetime.datetime.now(UTC)
             health_signal = self.status_error_state.is_triggered() is False
             self.health_service.report_host_plugin_status(is_healthy=health_signal,
                                                           response=response)
@@ -251,9 +247,9 @@ class HostPluginProtocol(object):
             error_state.incr()
 
         if last_timestamp is None:
-            last_timestamp = datetime.datetime.utcnow() - period
+            last_timestamp = datetime.datetime.now(UTC) - period
 
-        return datetime.datetime.utcnow() >= (last_timestamp + period)
+        return datetime.datetime.now(UTC) >= (last_timestamp + period)
 
     def put_vm_log(self, content):
         """
@@ -449,20 +445,20 @@ class HostPluginProtocol(object):
     @staticmethod
     def get_fast_track_timestamp():
         """
-        Returns the timestamp of the most recent FastTrack goal state retrieved by fetch_vm_settings(), or None if the most recent
-        goal state was Fabric or fetch_vm_settings() has not been invoked.
+        Returns the timestamp of the most recent FastTrack goal state retrieved by fetch_vm_settings(), or a timestamp representing datetime.min if
+        the most recent goal state was Fabric or fetch_vm_settings() has not been invoked.
         """
         with HostPluginProtocol._fast_track_state_lock:
-            if not os.path.exists(HostPluginProtocol._get_fast_track_state_file()):
-                return timeutil.create_timestamp(datetime.datetime.min)
+            state_file = HostPluginProtocol._get_fast_track_state_file()
+            if not os.path.exists(state_file):
+                return timeutil.create_utc_timestamp(datetime.datetime.min)
 
             try:
-                with open(HostPluginProtocol._get_fast_track_state_file(), "r") as file_:
+                with open(state_file, "r") as file_:
                     return json.load(file_)["timestamp"]
             except Exception as e:
-                logger.warn("Can't retrieve the timestamp for the most recent Fast Track goal state ({0}), will assume the current time. Error: {1}",
-                        HostPluginProtocol._get_fast_track_state_file(), ustr(e))
-            return timeutil.create_timestamp(datetime.datetime.utcnow())
+                logger.warn("Can't retrieve the timestamp for the most recent Fast Track goal state ({0}), will assume the current time. Error: {1}", state_file, ustr(e))
+            return timeutil.create_utc_timestamp(datetime.datetime.now(UTC))
 
     def fetch_vm_settings(self, force_update=False):
         """
@@ -490,7 +486,7 @@ class HostPluginProtocol(object):
                     raise VmSettingsNotSupported()
             finally:
                 self._supports_vm_settings = False
-                self._supports_vm_settings_next_check = datetime.datetime.now() + datetime.timedelta(hours=6)  # check again in 6 hours
+                self._supports_vm_settings_next_check = datetime.datetime.now(UTC) + datetime.timedelta(hours=6)  # check again in 6 hours
 
         def format_message(msg):
             return "GET vmSettings [correlation ID: {0} eTag: {1}]: {2}".format(correlation_id, etag, msg)
@@ -498,7 +494,7 @@ class HostPluginProtocol(object):
         try:
             # Raise if VmSettings are not supported, but check again periodically since the HostGAPlugin could have been updated since the last check
             # Note that self._host_plugin_supports_vm_settings can be None, so we need to compare against False
-            if not self._supports_vm_settings and self._supports_vm_settings_next_check > datetime.datetime.now():
+            if not self._supports_vm_settings and self._supports_vm_settings_next_check > datetime.datetime.now(UTC):
                 # Raise VmSettingsNotSupported directly instead of using raise_not_supported() to avoid resetting the timestamp for the next check
                 raise VmSettingsNotSupported()
 
@@ -626,7 +622,7 @@ class _VmSettingsErrorReporter(object):
         self._request_failure_count = 0  # Total count of requests that could not be issued (does not include timeouts or requests that were actually issued and failed, for example, with 500 or 400 statuses)
         self._server_error_count = 0  # Count of server side errors (HTTP status in the 500s)
         self._timeout_count = 0  # Count of timeouts on vmSettings requests
-        self._next_period = datetime.datetime.now() + _VmSettingsErrorReporter._Period
+        self._next_period = datetime.datetime.now(UTC) + _VmSettingsErrorReporter._Period
 
     def report_request(self):
         self._request_count += 1
@@ -649,7 +645,7 @@ class _VmSettingsErrorReporter(object):
             self._timeout_count += 1
 
     def report_summary(self):
-        if datetime.datetime.now() >= self._next_period:
+        if datetime.datetime.now(UTC) >= self._next_period:
             summary = {
                 "requests":       self._request_count,
                 "errors":         self._error_count,

--- a/azurelinuxagent/common/protocol/hostplugin.py
+++ b/azurelinuxagent/common/protocol/hostplugin.py
@@ -97,8 +97,6 @@ class HostPluginProtocol(object):
         self._supports_vm_settings = os.path.exists(self._get_fast_track_state_file())
         self._fast_track_timestamp = HostPluginProtocol.get_fast_track_timestamp()
 
-        self._supports_vm_settings_next_check = datetime.datetime.now(UTC)
-
     @staticmethod
     def _extract_deployment_id(role_config_name):
         # Role config name consists of: <deployment id>.<incarnation>(...)

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -36,7 +36,7 @@ from azurelinuxagent.common.event import add_event, WALAEventOperation, report_e
     CollectOrReportEventDebugInfo, add_periodic
 from azurelinuxagent.common.exception import ProtocolNotFoundError, \
     ResourceGoneError, ExtensionDownloadError, InvalidContainerError, ProtocolError, HttpError, ExtensionErrorCodes
-from azurelinuxagent.common.future import httpclient, bytebuffer, ustr
+from azurelinuxagent.common.future import httpclient, bytebuffer, ustr, UTC
 from azurelinuxagent.common.protocol.goal_state import GoalState, TRANSPORT_CERT_FILE_NAME, TRANSPORT_PRV_FILE_NAME, GoalStateProperties
 from azurelinuxagent.common.protocol.hostplugin import HostPluginProtocol
 from azurelinuxagent.common.protocol.restapi import DataContract, ProvisionStatus, VMInfo, VMStatus
@@ -654,14 +654,14 @@ class WireClient(object):
         This method enforces a timeout (_DOWNLOAD_TIMEOUT) on the download and raises an exception if the limit is exceeded.
         """
         logger.info("Downloading {0}", download_type)
-        start_time = datetime.now()
+        start_time = datetime.now(UTC)
 
         uris_shuffled = uris
         random.shuffle(uris_shuffled)
         most_recent_error = "None"
 
         for index, uri in enumerate(uris_shuffled):
-            elapsed = datetime.now() - start_time
+            elapsed = datetime.now(UTC) - start_time
             if elapsed > _DOWNLOAD_TIMEOUT:
                 message = "Timeout downloading {0}. Elapsed: {1} URIs tried: {2}/{3}. Last error: {4}".format(download_type, elapsed, index, len(uris), ustr(most_recent_error))
                 raise ExtensionDownloadError(message, code=ExtensionErrorCodes.PluginManifestDownloadError)

--- a/azurelinuxagent/common/utils/archive.py
+++ b/azurelinuxagent/common/utils/archive.py
@@ -9,7 +9,7 @@ import zipfile
 
 from azurelinuxagent.common import conf
 from azurelinuxagent.common import logger
-from azurelinuxagent.common.utils import fileutil, timeutil
+from azurelinuxagent.common.utils import fileutil
 
 # pylint: disable=W0105
 
@@ -211,10 +211,17 @@ class StateArchiver(object):
 class GoalStateHistory(object):
     def __init__(self, time, tag):
         self._errors = False
-        timestamp = timeutil.create_history_timestamp(time)
+        timestamp = GoalStateHistory._create_timestamp(time)
         self._root = os.path.join(conf.get_lib_dir(), ARCHIVE_DIRECTORY_NAME, "{0}__{1}".format(timestamp, tag) if tag is not None else timestamp)
 
         GoalStateHistory._purge()
+
+    @staticmethod
+    def _create_timestamp(dt):
+        """
+        Returns a string with the given datetime formatted as a timestamp for the agent's history folder
+        """
+        return dt.strftime('%Y-%m-%dT%H-%M-%S')
 
     @staticmethod
     def tag_exists(tag):

--- a/azurelinuxagent/common/utils/timeutil.py
+++ b/azurelinuxagent/common/utils/timeutil.py
@@ -1,39 +1,13 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the Apache License.
-import datetime
+
+# This format is based on ISO-8601, with Z representing UTC (Zero offset)
+UTCTimestampFormat = u'%Y-%m-%dT%H:%M:%S.%fZ'
 
 
-def create_timestamp(dt=None):
+def create_utc_timestamp(dt):
     """
-    Returns a string with the given datetime in iso format. If no datetime is given as parameter, it
-    uses datetime.utcnow().
+    Returns a string with the given datetime formatted according to UTCTimestampFormat.
     """
-    if dt is None:
-        dt = datetime.datetime.utcnow()
-    return dt.isoformat()
-
-
-def create_history_timestamp(dt=None):
-    """
-    Returns a string with the given datetime formatted as a timestamp for the agent's history folder
-    """
-    if dt is None:
-        dt = datetime.datetime.utcnow()
-    return dt.strftime('%Y-%m-%dT%H-%M-%S')
-
-
-def datetime_to_ticks(dt):
-    """
-    Converts 'dt', a datetime, to the number of ticks (1 tick == 1/10000000 sec) since datetime.min (0001-01-01 00:00:00).
-
-    Note that the resolution of a datetime goes only to microseconds.
-    """
-    return int(10 ** 7 * total_seconds(dt - datetime.datetime.min))
-
-
-def total_seconds(dt):
-    """
-    Compute the total_seconds for timedelta 'td'. Used instead timedelta.total_seconds() because 2.6 does not implement total_seconds.
-    """
-    return ((24.0 * 60 * 60 * dt.days + dt.seconds) * 10 ** 6 + dt.microseconds) / 10 ** 6
+    return dt.strftime(UTCTimestampFormat)
 

--- a/azurelinuxagent/common/utils/timeutil.py
+++ b/azurelinuxagent/common/utils/timeutil.py
@@ -1,13 +1,20 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the Apache License.
 
-# This format is based on ISO-8601, with Z representing UTC (Zero offset)
-UTCTimestampFormat = u'%Y-%m-%dT%H:%M:%S.%fZ'
-
+import datetime
 
 def create_utc_timestamp(dt):
     """
-    Returns a string with the given datetime formatted according to UTCTimestampFormat.
+    Formats the given datetime, which must be timezone-aware and in UTC, as "YYYY-MM-DDTHH:MM:SS.ffffffZ".
+    This is basically ISO-8601, but using "Z" (Zero offset) to represent the timezone offset (instead of "+00:00").
+    The corresponding format for strftime/strptime is "%Y-%m-%dT%H:%M:%S.%fZ".
     """
-    return dt.strftime(UTCTimestampFormat)
+    if dt.tzinfo is None:
+        raise ValueError("The datetime must be timezone-aware")
+    if dt.utcoffset() != datetime.timedelta(0):
+        raise ValueError("The datetime must be in UTC")
+
+    # We use isoformat() instead of strftime() since the later is limited to years >= 1900 in Python < 3.2.  We remove the
+    # timezone information since we are using "Z" to represent UTC, and we force the microseconds to be 000000 when it is 0.
+    return dt.replace(tzinfo=None).isoformat() + (".000000Z" if dt.microsecond == 0 else "Z")
 

--- a/azurelinuxagent/ga/collect_logs.py
+++ b/azurelinuxagent/ga/collect_logs.py
@@ -27,7 +27,7 @@ import azurelinuxagent.common.conf as conf
 from azurelinuxagent.common import logger
 from azurelinuxagent.ga.cgroupcontroller import MetricsCounter
 from azurelinuxagent.common.event import elapsed_milliseconds, add_event, WALAEventOperation
-from azurelinuxagent.common.future import ustr
+from azurelinuxagent.common.future import ustr, UTC
 from azurelinuxagent.ga.interfaces import ThreadHandlerInterface
 from azurelinuxagent.ga.logcollector import COMPRESSED_ARCHIVE_PATH, GRACEFUL_KILL_ERRCODE
 from azurelinuxagent.ga.cgroupconfigurator import CGroupConfigurator, LOGCOLLECTOR_ANON_MEMORY_LIMIT_FOR_V1_AND_V2, LOGCOLLECTOR_CACHE_MEMORY_LIMIT_FOR_V1_AND_V2, LOGCOLLECTOR_MAX_THROTTLED_EVENTS_FOR_V2
@@ -191,7 +191,7 @@ class CollectLogsHandler(ThreadHandlerInterface):
         final_command = systemd_cmd + collect_logs_cmd
 
         def exec_command():
-            start_time = datetime.datetime.utcnow()
+            start_time = datetime.datetime.now(UTC)
             success = False
             msg = None
             try:

--- a/azurelinuxagent/ga/collect_telemetry_events.py
+++ b/azurelinuxagent/ga/collect_telemetry_events.py
@@ -31,7 +31,7 @@ from azurelinuxagent.common.event import EVENTS_DIRECTORY, TELEMETRY_LOG_EVENT_I
     TELEMETRY_LOG_PROVIDER_ID, add_event, WALAEventOperation, add_log_event, get_event_logger, \
     CollectOrReportEventDebugInfo, EVENT_FILE_REGEX, parse_event
 from azurelinuxagent.common.exception import InvalidExtensionEventError, ServiceStoppedError, EventError
-from azurelinuxagent.common.future import ustr, is_file_not_found_error
+from azurelinuxagent.common.future import ustr, is_file_not_found_error, UTC
 from azurelinuxagent.ga.interfaces import ThreadHandlerInterface
 from azurelinuxagent.common.telemetryevent import TelemetryEvent, TelemetryEventParam, \
     GuestAgentGenericLogsSchema, GuestAgentExtensionEventsSchema
@@ -283,7 +283,7 @@ class _ProcessExtensionEvents(PeriodicOperation):
     def _enqueue_events_and_get_count(self, handler_name, event_file_path, captured_events_count,
                                       dropped_events_with_error_count):
 
-        event_file_time = datetime.datetime.fromtimestamp(os.path.getmtime(event_file_path))
+        event_file_time = datetime.datetime.fromtimestamp(os.path.getmtime(event_file_path)).replace(tzinfo=UTC)
 
         events = self._read_event_file(event_file_path)
 
@@ -467,7 +467,7 @@ class _CollectAndEnqueueEvents(PeriodicOperation):
                     if is_legacy_event:
                         # We'll use the file creation time for the event's timestamp
                         event_file_creation_time_epoch = os.path.getmtime(event_file_path)
-                        event_file_creation_time = datetime.datetime.fromtimestamp(event_file_creation_time_epoch)
+                        event_file_creation_time = datetime.datetime.fromtimestamp(event_file_creation_time_epoch).replace(tzinfo=UTC)
 
                         if event.is_extension_event():
                             _CollectAndEnqueueEvents._trim_legacy_extension_event_parameters(event)

--- a/azurelinuxagent/ga/env.py
+++ b/azurelinuxagent/ga/env.py
@@ -27,6 +27,7 @@ import azurelinuxagent.common.logger as logger
 from azurelinuxagent.common.dhcp import get_dhcp_handler
 from azurelinuxagent.common import event
 from azurelinuxagent.common.event import WALAEventOperation, add_event
+from azurelinuxagent.common.future import UTC
 from azurelinuxagent.ga.firewall_manager import FirewallManager, FirewallStateError
 from azurelinuxagent.common.future import ustr
 from azurelinuxagent.ga.interfaces import ThreadHandlerInterface
@@ -105,7 +106,7 @@ class EnableFirewall(PeriodicOperation):
         self._wire_server_address = wire_server_address
         self._firewall_manager = None  # initialized on demand in the _operation method
         self._message_count = 0
-        self._report_after = datetime.datetime.now()
+        self._report_after = datetime.datetime.now(UTC)
 
     def _operation(self):
         try:
@@ -126,12 +127,12 @@ class EnableFirewall(PeriodicOperation):
 
     def _report(self, report_function, message, *args):
         # Report the first 3 messages, then stop reporting for 12 hours
-        if datetime.datetime.now() < self._report_after:
+        if datetime.datetime.now(UTC) < self._report_after:
             return
 
         self._message_count += 1
         if self._message_count > 3:
-            self._report_after = datetime.datetime.now() + datetime.timedelta(hours=12)
+            self._report_after = datetime.datetime.now(UTC) + datetime.timedelta(hours=12)
             self._message_count = 0
             return
 

--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -24,6 +24,7 @@ import os
 import re
 import shutil
 import stat
+import sys
 import tempfile
 import time
 import zipfile
@@ -47,7 +48,7 @@ from azurelinuxagent.common.event import add_event, elapsed_milliseconds, WALAEv
 from azurelinuxagent.common.exception import ExtensionDownloadError, ExtensionError, ExtensionErrorCodes, \
     ExtensionOperationError, ExtensionUpdateError, ProtocolError, ProtocolNotFoundError, ExtensionsGoalStateError, \
     GoalStateAggregateStatusCodes, MultiConfigExtensionEnableError
-from azurelinuxagent.common.future import ustr, is_file_not_found_error
+from azurelinuxagent.common.future import ustr, UTC, is_file_not_found_error
 from azurelinuxagent.common.protocol.extensions_goal_state import GoalStateSource
 from azurelinuxagent.common.protocol.restapi import ExtensionStatus, ExtensionSubStatus, Extension, ExtHandlerStatus, \
     VMStatus, GoalStateAggregateStatus, ExtensionState, ExtensionRequestedState, ExtensionSettings
@@ -330,7 +331,7 @@ class ExtHandlersHandler(object):
             if self._extensions_on_hold():
                 return
 
-            utc_start = datetime.datetime.utcnow()
+            utc_start = datetime.datetime.now(UTC)
             error = None
             message = "ProcessExtensionsGoalState started [{0} channel: {1} source: {2} activity: {3} correlation {4} created: {5}]".format(
                 egs.id, egs.channel, egs.source, egs.activity_id, egs.correlation_id, egs.created_on_timestamp)
@@ -497,7 +498,7 @@ class ExtHandlersHandler(object):
             logger.info("No extension handlers found, not processing anything.")
             return
 
-        wait_until = datetime.datetime.utcnow() + datetime.timedelta(minutes=_DEFAULT_EXT_TIMEOUT_MINUTES)
+        wait_until = datetime.datetime.now(UTC) + datetime.timedelta(minutes=_DEFAULT_EXT_TIMEOUT_MINUTES)
 
         all_extensions = self.__get_sorted_extensions_for_processing()
         # Since all_extensions are sorted based on sort_key, the last element would be the maximum based on the sort_key
@@ -629,7 +630,7 @@ class ExtHandlersHandler(object):
             ext_completed, status = False, None
 
             # Keep polling for the extension status until it succeeds or times out
-            while datetime.datetime.utcnow() <= wait_until:
+            while datetime.datetime.now(UTC) <= wait_until:
                 ext_completed, status = handler_i.is_ext_handling_complete(extension)
                 if ext_completed:
                     break
@@ -642,7 +643,7 @@ class ExtHandlersHandler(object):
 
         # In case of timeout or terminal error state, we log it and raise
         # Incase extension reported status at the last sec, we should prioritize reporting status over timeout
-        if not ext_completed and datetime.datetime.utcnow() > wait_until:
+        if not ext_completed and datetime.datetime.now(UTC) > wait_until:
             msg = "Dependent Extension {0} did not reach a terminal state within the allowed timeout. Last status was {1}".format(
                 extension_name, status)
             raise Exception(msg)
@@ -1368,7 +1369,7 @@ class ExtHandlerInstance(object):
         return True
 
     def download(self):
-        begin_utc = datetime.datetime.utcnow()
+        begin_utc = datetime.datetime.now(UTC)
         self.set_operation(WALAEventOperation.Download)
 
         if self.pkg is None or self.pkg.uris is None or len(self.pkg.uris) == 0:
@@ -1462,7 +1463,7 @@ class ExtHandlerInstance(object):
         # false, create a status file only if it does not already exist.
         _, status_path = self.get_status_file_path(extension)
         if status_path is not None and (overwrite or not os.path.exists(status_path)):
-            now = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+            now = datetime.datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
             status_contents = [
                 {
                     "version": 1.0,
@@ -1611,12 +1612,18 @@ class ExtHandlerInstance(object):
                 self.logger.info("Remove extension handler directory: {0}", base_dir)
 
                 # some extensions uninstall asynchronously so ignore error 2 while removing them
-                def on_rmtree_error(_, __, exc_info):
-                    _, exception, _ = exc_info
+                def on_rmtree_exception(_, __, exception):
                     if not isinstance(exception, OSError) or exception.errno != 2:  # [Errno 2] No such file or directory
                         raise exception
 
-                shutil.rmtree(base_dir, onerror=on_rmtree_error)
+                # On 3.12, 'onerror' has been deprecated in favor of 'onexc'
+                if sys.version_info[0] == 3 and sys.version_info[1] >= 12 or sys.version_info[0] > 3:
+                    kwargs = { 'onexc': on_rmtree_exception }
+                else:
+                    kwargs = { 'onerror': lambda function, path, exc_info: on_rmtree_exception(function, path, exc_info[1]) }
+
+                # E1123: Unexpected keyword argument 'onexc' in function call (unexpected-keyword-arg)
+                shutil.rmtree(base_dir, **kwargs)  # pylint: disable=unexpected-keyword-arg
 
             CGroupConfigurator.get_instance().stop_tracking_extension_cgroups(self.get_full_name())
             self.logger.info("Remove the extension slice: {0}".format(self.get_full_name()))
@@ -1968,7 +1975,7 @@ class ExtHandlerInstance(object):
 
     def launch_command(self, cmd, cmd_name=None, timeout=300, extension_error_code=ExtensionErrorCodes.PluginProcessingError,
                        env=None, extension=None):
-        begin_utc = datetime.datetime.utcnow()
+        begin_utc = datetime.datetime.now(UTC)
         self.logger.verbose("Launch command: [{0}]", cmd)
 
         base_dir = self.get_base_dir()

--- a/azurelinuxagent/ga/logcollector.py
+++ b/azurelinuxagent/ga/logcollector.py
@@ -28,7 +28,7 @@ from heapq import heappush, heappop
 
 from azurelinuxagent.common.conf import get_lib_dir, get_ext_log_dir, get_agent_log_file
 from azurelinuxagent.common.event import initialize_event_logger_vminfo_common_parameters_and_protocol, add_event, WALAEventOperation
-from azurelinuxagent.common.future import ustr
+from azurelinuxagent.common.future import ustr, UTC
 from azurelinuxagent.ga.logcollector_manifests import MANIFEST_NORMAL, MANIFEST_FULL
 
 # Please note: be careful when adding agent dependencies in this module.
@@ -354,7 +354,7 @@ class LogCollector(object):
             # Clear previous run's output and create base directories if they don't exist already.
             self._create_base_dirs()
             LogCollector._reset_file(OUTPUT_RESULTS_FILE_PATH)
-            start_time = datetime.utcnow()
+            start_time = datetime.now(UTC)
             _LOGGER.info("Starting log collection at %s", start_time.strftime("%Y-%m-%dT%H:%M:%SZ"))
             _LOGGER.info("Using log collection mode %s", "full" if self._is_full_mode else "normal")
 
@@ -393,10 +393,10 @@ class LogCollector(object):
                 compressed_archive_size = os.path.getsize(COMPRESSED_ARCHIVE_PATH)
                 _LOGGER.info("Successfully compressed files. Compressed archive size is %s b", compressed_archive_size)
 
-                end_time = datetime.utcnow()
+                end_time = datetime.now(UTC)
                 duration = end_time - start_time
                 elapsed_ms = int(((duration.days * 24 * 60 * 60 + duration.seconds) * 1000) + (duration.microseconds / 1000.0))
-                _LOGGER.info("Finishing log collection at %s", end_time.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"))
+                _LOGGER.info("Finishing log collection at %s", end_time.strftime("%Y-%m-%dT%H:%M:%SZ"))
                 _LOGGER.info("Elapsed time: %s ms", elapsed_ms)
 
                 compressed_archive.write(OUTPUT_RESULTS_FILE_PATH.encode("utf-8"), arcname="results.txt")

--- a/azurelinuxagent/ga/monitor.py
+++ b/azurelinuxagent/ga/monitor.py
@@ -27,7 +27,7 @@ from azurelinuxagent.ga.cgroupconfigurator import CGroupConfigurator
 from azurelinuxagent.ga.cgroupstelemetry import CGroupsTelemetry
 from azurelinuxagent.common.errorstate import ErrorState
 from azurelinuxagent.common.event import add_event, WALAEventOperation, report_metric
-from azurelinuxagent.common.future import ustr
+from azurelinuxagent.common.future import ustr, UTC
 from azurelinuxagent.ga.interfaces import ThreadHandlerInterface
 from azurelinuxagent.common.osutil import get_osutil
 from azurelinuxagent.common.protocol.healthservice import HealthService
@@ -59,9 +59,9 @@ class PollResourceUsage(PeriodicOperation):
 
         for metric in tracked_metrics:
             key = metric.category + metric.counter + metric.instance
-            if key not in self.__periodic_metrics or (self.__periodic_metrics[key] + metric.report_period) <= datetime.datetime.now():
+            if key not in self.__periodic_metrics or (self.__periodic_metrics[key] + metric.report_period) <= datetime.datetime.now(UTC):
                 report_metric(metric.category, metric.counter, metric.instance, metric.value, log_event=self.__log_metrics)
-                self.__periodic_metrics[key] = datetime.datetime.now()
+                self.__periodic_metrics[key] = datetime.datetime.now(UTC)
 
         CGroupConfigurator.get_instance().check_cgroups(tracked_metrics)
 

--- a/azurelinuxagent/ga/remoteaccess.py
+++ b/azurelinuxagent/ga/remoteaccess.py
@@ -24,7 +24,7 @@ from datetime import datetime, timedelta
 import azurelinuxagent.common.conf as conf
 import azurelinuxagent.common.logger as logger
 from azurelinuxagent.common.event import add_event, WALAEventOperation
-from azurelinuxagent.common.future import ustr
+from azurelinuxagent.common.future import ustr, UTC
 from azurelinuxagent.common.osutil import get_osutil
 from azurelinuxagent.common.utils import textutil
 from azurelinuxagent.common.utils.cryptutil import CryptUtil
@@ -80,8 +80,8 @@ class RemoteAccessHandler(object):
             for acc in self._remote_access.user_list.users:
                 try:
                     raw_expiration = acc.expiration
-                    account_expiration = datetime.strptime(raw_expiration, REMOTE_USR_EXPIRATION_FORMAT)
-                    now = datetime.utcnow()
+                    account_expiration = datetime.strptime(raw_expiration, REMOTE_USR_EXPIRATION_FORMAT).replace(tzinfo=UTC)
+                    now = datetime.now(UTC)
                     if acc.name not in existing_jit_users and now < account_expiration:
                         self._add_user(acc.name, acc.encrypted_password, account_expiration)
                     elif acc.name in existing_jit_users and now > account_expiration:

--- a/azurelinuxagent/ga/send_telemetry_events.py
+++ b/azurelinuxagent/ga/send_telemetry_events.py
@@ -23,7 +23,7 @@ import time
 from azurelinuxagent.common import logger
 from azurelinuxagent.common.event import add_event, WALAEventOperation
 from azurelinuxagent.common.exception import ServiceStoppedError
-from azurelinuxagent.common.future import ustr, Queue, Empty
+from azurelinuxagent.common.future import ustr, UTC, Queue, Empty
 from azurelinuxagent.ga.interfaces import ThreadHandlerInterface
 from azurelinuxagent.common.utils import textutil
 
@@ -141,14 +141,14 @@ class SendTelemetryEventsHandler(ThreadHandlerInterface):
 
     def _send_events_in_queue(self, first_event):
         # Process everything in Queue
-        start_time = datetime.datetime.utcnow()
+        start_time = datetime.datetime.now(UTC)
         while not self.stopped() and (self._queue.qsize() + 1) < self._MIN_EVENTS_TO_BATCH and (
-                start_time + self._MIN_BATCH_WAIT_TIME) > datetime.datetime.utcnow():
+                start_time + self._MIN_BATCH_WAIT_TIME) > datetime.datetime.now(UTC):
             # To promote batching, we either wait for atleast _MIN_EVENTS_TO_BATCH events or _MIN_BATCH_WAIT_TIME secs
             # before sending out the first request to wireserver.
             # If the thread is requested to stop midway, we skip batching and send whatever we have in the queue.
             logger.verbose("Waiting for events to batch. Total events so far: {0}, Time elapsed: {1} secs",
-                           self._queue.qsize()+1, (datetime.datetime.utcnow() - start_time).seconds)
+                           self._queue.qsize()+1, (datetime.datetime.now(UTC) - start_time).seconds)
             time.sleep(1)
         # Delete files after sending the data rather than deleting and sending
         self._protocol.report_event(self._get_events_in_queue(first_event))

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -40,7 +40,7 @@ from azurelinuxagent.common.event import add_event, initialize_event_logger_vmin
     WALAEventOperation, EVENTS_DIRECTORY
 from azurelinuxagent.common.exception import ExitException, AgentUpgradeExitException, AgentMemoryExceededException
 from azurelinuxagent.ga.firewall_manager import FirewallManager, FirewallStateError
-from azurelinuxagent.common.future import ustr
+from azurelinuxagent.common.future import ustr, UTC, datetime_min_utc
 from azurelinuxagent.common.osutil import get_osutil, systemd
 from azurelinuxagent.ga.persist_firewall_rules import PersistFirewallRulesHandler
 from azurelinuxagent.common.protocol.goal_state import GoalStateSource
@@ -147,7 +147,7 @@ class UpdateHandler(object):
 
         self._initial_attempt_check_memory_usage = True
         self._last_check_memory_usage_time = time.time()
-        self._check_memory_usage_last_error_report = datetime.min
+        self._check_memory_usage_last_error_report = datetime_min_utc
 
         self._cloud_init_completed = False  # Only used when Extensions.WaitForCloudInit is enabled; note that this variable is always reset on service start.
 
@@ -157,7 +157,7 @@ class UpdateHandler(object):
         # these members are used to avoid reporting errors too frequently
         self._heartbeat_update_goal_state_error_count = 0
         self._update_goal_state_error_count = 0
-        self._update_goal_state_next_error_report = datetime.min
+        self._update_goal_state_next_error_report = datetime_min_utc
         self._report_status_last_failed_goal_state = None
 
         # incarnation of the last goal state that has been fully processed
@@ -564,12 +564,12 @@ class UpdateHandler(object):
             self._heartbeat_update_goal_state_error_count += 1
             if self._update_goal_state_error_count <= max_errors_to_log:
                 # Report up to 'max_errors_to_log' immediately
-                self._update_goal_state_next_error_report = datetime.now()
+                self._update_goal_state_next_error_report = datetime.now(UTC)
                 event.error(WALAEventOperation.FetchGoalState, "Error fetching the goal state: {0}", textutil.format_exception(e))
             else:
                 # Report one single periodic error every 6 hours
-                if datetime.now() >= self._update_goal_state_next_error_report:
-                    self._update_goal_state_next_error_report = datetime.now() + timedelta(hours=6)
+                if datetime.now(UTC) >= self._update_goal_state_next_error_report:
+                    self._update_goal_state_next_error_report = datetime.now(UTC) + timedelta(hours=6)
                     event.error(WALAEventOperation.FetchGoalState, "Fetching the goal state is still failing: {0}", textutil.format_exception(e))
             return False
 
@@ -1054,9 +1054,9 @@ class UpdateHandler(object):
 
     def _send_heartbeat_telemetry(self, agent_update_handler):
         if self._last_telemetry_heartbeat is None:
-            self._last_telemetry_heartbeat = datetime.utcnow() - UpdateHandler.TELEMETRY_HEARTBEAT_PERIOD
+            self._last_telemetry_heartbeat = datetime.now(UTC) - UpdateHandler.TELEMETRY_HEARTBEAT_PERIOD
 
-        if datetime.utcnow() >= (self._last_telemetry_heartbeat + UpdateHandler.TELEMETRY_HEARTBEAT_PERIOD):
+        if datetime.now(UTC) >= (self._last_telemetry_heartbeat + UpdateHandler.TELEMETRY_HEARTBEAT_PERIOD):
             auto_update_enabled = 1 if conf.get_auto_update_to_latest_version() else 0
             update_mode = agent_update_handler.get_current_update_mode()
 
@@ -1073,7 +1073,7 @@ class UpdateHandler(object):
             # Update/Reset the counters
             self._heartbeat_counter += 1
             self._heartbeat_update_goal_state_error_count = 0
-            self._last_telemetry_heartbeat = datetime.utcnow()
+            self._last_telemetry_heartbeat = datetime.now(UTC)
 
     def _check_agent_memory_usage(self):
         """
@@ -1093,8 +1093,8 @@ class UpdateHandler(object):
             add_event(AGENT_NAME, op=WALAEventOperation.AgentMemory, is_success=True, message=msg)
             raise ExitException("Agent {0} is reached memory limit -- exiting".format(CURRENT_AGENT))
         except Exception as exception:
-            if self._check_memory_usage_last_error_report == datetime.min or (self._check_memory_usage_last_error_report + timedelta(hours=6)) > datetime.now():
-                self._check_memory_usage_last_error_report = datetime.now()
+            if self._check_memory_usage_last_error_report == datetime_min_utc or (self._check_memory_usage_last_error_report + timedelta(hours=6)) > datetime.now(UTC):
+                self._check_memory_usage_last_error_report = datetime.now(UTC)
                 msg = "Error checking the agent's memory usage: {0} --- [NOTE: Will not log the same error for the 6 hours]".format(ustr(exception))
                 logger.warn(msg)
                 add_event(AGENT_NAME, op=WALAEventOperation.AgentMemory, is_success=False, message=msg)

--- a/azurelinuxagent/pa/provision/cloudinit.py
+++ b/azurelinuxagent/pa/provision/cloudinit.py
@@ -26,11 +26,10 @@ from datetime import datetime
 import azurelinuxagent.common.conf as conf
 import azurelinuxagent.common.logger as logger
 import azurelinuxagent.common.utils.fileutil as fileutil
-import azurelinuxagent.common.utils.shellutil as shellutil  # pylint: disable=W0611
 
-from azurelinuxagent.common.event import elapsed_milliseconds, WALAEventOperation  # pylint: disable=W0611
+from azurelinuxagent.common.event import elapsed_milliseconds
 from azurelinuxagent.common.exception import ProvisionError, ProtocolError
-from azurelinuxagent.common.future import ustr
+from azurelinuxagent.common.future import ustr, UTC
 from azurelinuxagent.common.protocol.util import OVF_FILE_NAME
 from azurelinuxagent.common.protocol.ovfenv import OvfEnv
 from azurelinuxagent.pa.provision.default import ProvisionHandler
@@ -47,7 +46,7 @@ class CloudInitProvisionHandler(ProvisionHandler):
                 logger.info("Provisioning already completed, skipping.")
                 return
 
-            utc_start = datetime.utcnow()
+            utc_start = datetime.now(UTC)
             logger.info("Running CloudInit provisioning handler")
             self.wait_for_ovfenv()
             self.protocol_util.get_protocol()  # Trigger protocol detection

--- a/azurelinuxagent/pa/provision/default.py
+++ b/azurelinuxagent/pa/provision/default.py
@@ -31,7 +31,7 @@ import azurelinuxagent.common.logger as logger
 import azurelinuxagent.common.utils.shellutil as shellutil
 import azurelinuxagent.common.utils.fileutil as fileutil
 
-from azurelinuxagent.common.future import ustr
+from azurelinuxagent.common.future import ustr, UTC
 from azurelinuxagent.common.event import add_event, WALAEventOperation, \
     elapsed_milliseconds
 from azurelinuxagent.common.exception import ProvisionError, ProtocolError, \
@@ -62,7 +62,7 @@ class ProvisionHandler(object):
             return
 
         try:
-            utc_start = datetime.utcnow()
+            utc_start = datetime.now(UTC)
             thumbprint = None  # pylint: disable=W0612
 
             if self.check_provisioned_file():

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,6 +6,7 @@ distro; python_version >= '3.8'
 nose; python_version <= '3.9'
 nose-timer; python_version >= '2.7' and python_version <= '3.9'
 pytest; python_version >= '3.10'
+setuptools; python_version >= '3.12'
 
 # Pinning the wrapt requirement to 1.12.0 due to the bug - https://github.com/GrahamDumpleton/wrapt/issues/188
 wrapt==1.12.0; python_version > '2.6' and python_version < '3.6'

--- a/tests/common/protocol/test_extensions_goal_state_from_extensions_config.py
+++ b/tests/common/protocol/test_extensions_goal_state_from_extensions_config.py
@@ -21,14 +21,14 @@ class ExtensionsGoalStateFromExtensionsConfigTestCase(AgentTestCase):
             extensions_goal_state = protocol.get_goal_state().extensions_goal_state
             self.assertEqual(AgentGlobals.GUID_ZERO, extensions_goal_state.activity_id, "Incorrect activity Id")
             self.assertEqual(AgentGlobals.GUID_ZERO, extensions_goal_state.correlation_id, "Incorrect correlation Id")
-            self.assertEqual('1900-01-01T00:00:00.000000Z', extensions_goal_state.created_on_timestamp, "Incorrect GS Creation time")
+            self.assertEqual('0001-01-01T00:00:00.000000Z', extensions_goal_state.created_on_timestamp, "Incorrect GS Creation time")
 
     def test_it_should_use_default_values_when_in_vm_metadata_is_invalid(self):
         with mock_wire_protocol(wire_protocol_data.DATA_FILE_INVALID_VM_META_DATA) as protocol:
             extensions_goal_state = protocol.get_goal_state().extensions_goal_state
             self.assertEqual(AgentGlobals.GUID_ZERO, extensions_goal_state.activity_id, "Incorrect activity Id")
             self.assertEqual(AgentGlobals.GUID_ZERO, extensions_goal_state.correlation_id, "Incorrect correlation Id")
-            self.assertEqual('1900-01-01T00:00:00.000000Z', extensions_goal_state.created_on_timestamp, "Incorrect GS Creation time")
+            self.assertEqual('0001-01-01T00:00:00.000000Z', extensions_goal_state.created_on_timestamp, "Incorrect GS Creation time")
 
     def test_it_should_parse_missing_status_upload_blob_as_none(self):
         data_file = wire_protocol_data.DATA_FILE.copy()

--- a/tests/common/protocol/test_goal_state.py
+++ b/tests/common/protocol/test_goal_state.py
@@ -11,7 +11,7 @@ import shutil
 import time
 
 from azurelinuxagent.common import conf
-from azurelinuxagent.common.future import httpclient, urlparse
+from azurelinuxagent.common.future import httpclient, urlparse, UTC
 from azurelinuxagent.common.protocol.extensions_goal_state import GoalStateSource, GoalStateChannel
 from azurelinuxagent.common.protocol.extensions_goal_state_from_extensions_config import ExtensionsGoalStateFromExtensionsConfig
 from azurelinuxagent.common.protocol.extensions_goal_state_from_vm_settings import ExtensionsGoalStateFromVmSettings
@@ -284,7 +284,7 @@ class GoalStateTestCase(AgentTestCase, HttpRequestPredicates):
         data_file = wire_protocol_data.DATA_FILE_VM_SETTINGS.copy()
 
         with mock_wire_protocol(data_file) as protocol:
-            timestamp = datetime.datetime.utcnow()
+            timestamp = datetime.datetime.now(UTC)
             incarnation = '111'
             etag = '111111'
             protocol.mock_wire_data.set_incarnation(incarnation, timestamp=timestamp)
@@ -324,7 +324,7 @@ class GoalStateTestCase(AgentTestCase, HttpRequestPredicates):
             # Verify __init__()
             #
             expected_incarnation = '111'  # test setup initializes to this value
-            timestamp = datetime.datetime.utcnow() + datetime.timedelta(seconds=15)
+            timestamp = datetime.datetime.now(UTC) + datetime.timedelta(seconds=15)
             protocol.mock_wire_data.set_etag('22222', timestamp)
 
             goal_state = GoalState(protocol.client)
@@ -349,7 +349,7 @@ class GoalStateTestCase(AgentTestCase, HttpRequestPredicates):
             # Verify __init__()
             #
             expected_etag = '22222'
-            timestamp = datetime.datetime.utcnow() + datetime.timedelta(seconds=15)
+            timestamp = datetime.datetime.now(UTC) + datetime.timedelta(seconds=15)
             protocol.mock_wire_data.set_etag(expected_etag, timestamp)
 
             goal_state = GoalState(protocol.client)
@@ -372,7 +372,7 @@ class GoalStateTestCase(AgentTestCase, HttpRequestPredicates):
             goal_state = GoalState(protocol.client)
 
             # The most recent goal state is FastTrack
-            timestamp = datetime.datetime.utcnow() + datetime.timedelta(seconds=15)
+            timestamp = datetime.datetime.now(UTC) + datetime.timedelta(seconds=15)
             protocol.mock_wire_data.set_vm_settings_source(GoalStateSource.FastTrack)
             protocol.mock_wire_data.set_etag('222222', timestamp)
 
@@ -404,7 +404,7 @@ class GoalStateTestCase(AgentTestCase, HttpRequestPredicates):
             initial_timestamp = goal_state.extensions_goal_state.created_on_timestamp
 
             # Make the most recent goal state FastTrack
-            timestamp = datetime.datetime.utcnow() + datetime.timedelta(seconds=15)
+            timestamp = datetime.datetime.now(UTC) + datetime.timedelta(seconds=15)
             protocol.mock_wire_data.set_vm_settings_source(GoalStateSource.FastTrack)
             protocol.mock_wire_data.set_etag('444444', timestamp)
 

--- a/tests/common/test_errorstate.py
+++ b/tests/common/test_errorstate.py
@@ -2,6 +2,7 @@ import unittest
 from datetime import timedelta, datetime
 
 from azurelinuxagent.common.errorstate import ErrorState
+from azurelinuxagent.common.future import UTC
 from tests.lib.tools import Mock, patch
 
 
@@ -47,12 +48,12 @@ class TestErrorState(unittest.TestCase):
         test_subject = ErrorState(timedelta(minutes=15))
 
         for x in range(1, 10):
-            mock_time.utcnow = Mock(return_value=datetime.utcnow() + timedelta(minutes=x))
+            mock_time.now = Mock(return_value=datetime.now(UTC) + timedelta(minutes=x))
 
             test_subject.incr()
             self.assertFalse(test_subject.is_triggered())
 
-        mock_time.utcnow = Mock(return_value=datetime.utcnow() + timedelta(minutes=30))
+        mock_time.now = Mock(return_value=datetime.now(UTC) + timedelta(minutes=30))
         test_subject.incr()
         self.assertTrue(test_subject.is_triggered())
         self.assertEqual('29.0 min', test_subject.fail_time)
@@ -83,23 +84,23 @@ class TestErrorState(unittest.TestCase):
         test_subject.incr()
         self.assertEqual('0.0 min', test_subject.fail_time)
 
-        test_subject.timestamp = datetime.utcnow() - timedelta(seconds=60)
+        test_subject.timestamp = datetime.now(UTC) - timedelta(seconds=60)
         self.assertEqual('1.0 min', test_subject.fail_time)
 
-        test_subject.timestamp = datetime.utcnow() - timedelta(seconds=73)
+        test_subject.timestamp = datetime.now(UTC) - timedelta(seconds=73)
         self.assertEqual('1.22 min', test_subject.fail_time)
 
-        test_subject.timestamp = datetime.utcnow() - timedelta(seconds=120)
+        test_subject.timestamp = datetime.now(UTC) - timedelta(seconds=120)
         self.assertEqual('2.0 min', test_subject.fail_time)
 
-        test_subject.timestamp = datetime.utcnow() - timedelta(seconds=60 * 59)
+        test_subject.timestamp = datetime.now(UTC) - timedelta(seconds=60 * 59)
         self.assertEqual('59.0 min', test_subject.fail_time)
 
-        test_subject.timestamp = datetime.utcnow() - timedelta(seconds=60 * 60)
+        test_subject.timestamp = datetime.now(UTC) - timedelta(seconds=60 * 60)
         self.assertEqual('1.0 hr', test_subject.fail_time)
 
-        test_subject.timestamp = datetime.utcnow() - timedelta(seconds=60 * 95)
+        test_subject.timestamp = datetime.now(UTC) - timedelta(seconds=60 * 95)
         self.assertEqual('1.58 hr', test_subject.fail_time)
 
-        test_subject.timestamp = datetime.utcnow() - timedelta(seconds=60 * 60 * 3)
+        test_subject.timestamp = datetime.now(UTC) - timedelta(seconds=60 * 60 * 3)
         self.assertEqual('3.0 hr', test_subject.fail_time)

--- a/tests/common/test_event.py
+++ b/tests/common/test_event.py
@@ -672,7 +672,7 @@ class TestEvent(HttpRequestPredicates, AgentTestCase):
 
     @staticmethod
     def _get_file_creation_timestamp(file):  # pylint: disable=redefined-builtin
-        return  timeutil.create_utc_timestamp(datetime.fromtimestamp(os.path.getmtime(file)))
+        return  timeutil.create_utc_timestamp(datetime.fromtimestamp(os.path.getmtime(file)).replace(tzinfo=UTC))
 
     def test_collect_events_should_add_all_the_parameters_in_the_telemetry_schema_to_legacy_agent_events(self):
         # Agents <= 2.2.46 use *.tld as the extension for event files (newer agents use "*.waagent.tld") and they populate

--- a/tests/common/test_logger.py
+++ b/tests/common/test_logger.py
@@ -23,7 +23,7 @@ from azurelinuxagent.common.event import __event_logger__, add_log_event, MAX_NU
 
 from azurelinuxagent.common.future import UTC
 import azurelinuxagent.common.logger as logger
-from azurelinuxagent.common.utils import fileutil, timeutil
+from azurelinuxagent.common.utils import fileutil
 from tests.lib.tools import AgentTestCase, MagicMock, patch, skip_if_predicate_true
 
 _MSG_INFO = "This is our test info logging message {0} {1}"
@@ -172,6 +172,8 @@ class TestLogger(AgentTestCase):
         logger.periodic_verbose(logger.EVERY_DAY, _MSG_VERBOSE, *_DATA)
         mock_verbose.assert_called_once_with(_MSG_VERBOSE, *_DATA)
 
+    _UTCTimestampFormat = u"%Y-%m-%dT%H:%M:%S.%fZ"
+
     def test_logger_should_log_in_utc(self):
         file_name = "test.log"
         file_path = os.path.join(self.tmp_dir, file_name)
@@ -184,7 +186,7 @@ class TestLogger(AgentTestCase):
         with open(file_path, "r") as log_file:
             log = log_file.read()
             try:
-                time_in_file = datetime.strptime(log.split(logger.LogLevel.STRINGS[logger.LogLevel.INFO])[0].strip(), timeutil.UTCTimestampFormat).replace(tzinfo=UTC)
+                time_in_file = datetime.strptime(log.split(logger.LogLevel.STRINGS[logger.LogLevel.INFO])[0].strip(), self._UTCTimestampFormat).replace(tzinfo=UTC)
             except ValueError:
                 self.fail("Ensure timestamp follows ISO-8601 format + 'Z' for UTC")
 
@@ -208,7 +210,7 @@ class TestLogger(AgentTestCase):
         with open(file_path, "r") as log_file:
             log = log_file.read()
             try:
-                time_in_file = datetime.strptime(log.split(logger.LogLevel.STRINGS[logger.LogLevel.INFO])[0].strip(), timeutil.UTCTimestampFormat).replace(tzinfo=UTC)
+                time_in_file = datetime.strptime(log.split(logger.LogLevel.STRINGS[logger.LogLevel.INFO])[0].strip(), self._UTCTimestampFormat).replace(tzinfo=UTC)
             except ValueError:
                 self.fail("Ensure timestamp follows ISO-8601 format and has micro seconds in it")
 

--- a/tests/common/test_logger.py
+++ b/tests/common/test_logger.py
@@ -21,8 +21,9 @@ from datetime import datetime, timedelta
 
 from azurelinuxagent.common.event import __event_logger__, add_log_event, MAX_NUMBER_OF_EVENTS, EVENTS_DIRECTORY
 
+from azurelinuxagent.common.future import UTC
 import azurelinuxagent.common.logger as logger
-from azurelinuxagent.common.utils import fileutil
+from azurelinuxagent.common.utils import fileutil, timeutil
 from tests.lib.tools import AgentTestCase, MagicMock, patch, skip_if_predicate_true
 
 _MSG_INFO = "This is our test info logging message {0} {1}"
@@ -119,7 +120,7 @@ class TestLogger(AgentTestCase):
         logger.periodic_info(logger.EVERY_DAY, _MSG_INFO, *_DATA)
         self.assertEqual(1, mock_info.call_count)
 
-        logger.DEFAULT_LOGGER.periodic_messages[hash(_MSG_INFO)] = datetime.now() - \
+        logger.DEFAULT_LOGGER.periodic_messages[hash(_MSG_INFO)] = datetime.now(UTC) - \
                                                                    logger.EVERY_DAY - logger.EVERY_HOUR
         logger.periodic_info(logger.EVERY_DAY, _MSG_INFO, *_DATA)
         self.assertEqual(2, mock_info.call_count)
@@ -129,7 +130,7 @@ class TestLogger(AgentTestCase):
         logger.periodic_warn(logger.EVERY_DAY, _MSG_WARN, *_DATA)
         self.assertEqual(1, mock_warn.call_count)
 
-        logger.DEFAULT_LOGGER.periodic_messages[hash(_MSG_WARN)] = datetime.now() - \
+        logger.DEFAULT_LOGGER.periodic_messages[hash(_MSG_WARN)] = datetime.now(UTC) - \
                                                                    logger.EVERY_DAY - logger.EVERY_HOUR
         logger.periodic_warn(logger.EVERY_DAY, _MSG_WARN, *_DATA)
         self.assertEqual(2, mock_info.call_count)
@@ -139,7 +140,7 @@ class TestLogger(AgentTestCase):
         logger.periodic_error(logger.EVERY_DAY, _MSG_ERROR, *_DATA)
         self.assertEqual(1, mock_error.call_count)
 
-        logger.DEFAULT_LOGGER.periodic_messages[hash(_MSG_ERROR)] = datetime.now() - \
+        logger.DEFAULT_LOGGER.periodic_messages[hash(_MSG_ERROR)] = datetime.now(UTC) - \
                                                                     logger.EVERY_DAY - logger.EVERY_HOUR
         logger.periodic_error(logger.EVERY_DAY, _MSG_ERROR, *_DATA)
         self.assertEqual(2, mock_info.call_count)
@@ -149,7 +150,7 @@ class TestLogger(AgentTestCase):
         logger.periodic_verbose(logger.EVERY_DAY, _MSG_VERBOSE, *_DATA)
         self.assertEqual(1, mock_verbose.call_count)
 
-        logger.DEFAULT_LOGGER.periodic_messages[hash(_MSG_VERBOSE)] = datetime.now() - \
+        logger.DEFAULT_LOGGER.periodic_messages[hash(_MSG_VERBOSE)] = datetime.now(UTC) - \
                                                                       logger.EVERY_DAY - logger.EVERY_HOUR
         logger.periodic_verbose(logger.EVERY_DAY, _MSG_VERBOSE, *_DATA)
         self.assertEqual(2, mock_info.call_count)
@@ -177,14 +178,13 @@ class TestLogger(AgentTestCase):
         test_logger = logger.Logger()
         test_logger.add_appender(logger.AppenderType.FILE, logger.LogLevel.INFO, path=file_path)
 
-        before_write_utc = datetime.utcnow()
+        before_write_utc = datetime.now(UTC)
         test_logger.info("The time should be in UTC")
 
         with open(file_path, "r") as log_file:
             log = log_file.read()
             try:
-                time_in_file = datetime.strptime(log.split(logger.LogLevel.STRINGS[logger.LogLevel.INFO])[0].strip()
-                                                 , logger.Logger.LogTimeFormatInUTC)
+                time_in_file = datetime.strptime(log.split(logger.LogLevel.STRINGS[logger.LogLevel.INFO])[0].strip(), timeutil.UTCTimestampFormat).replace(tzinfo=UTC)
             except ValueError:
                 self.fail("Ensure timestamp follows ISO-8601 format + 'Z' for UTC")
 
@@ -200,16 +200,15 @@ class TestLogger(AgentTestCase):
         test_logger = logger.Logger()
         test_logger.add_appender(logger.AppenderType.FILE, logger.LogLevel.INFO, path=file_path)
 
-        ts_with_no_ms = datetime.utcnow().replace(microsecond=0)
-        mock_dt.utcnow = MagicMock(return_value=ts_with_no_ms)
+        ts_with_no_ms = datetime.now(UTC).replace(microsecond=0)
+        mock_dt.now = MagicMock(return_value=ts_with_no_ms)
 
         test_logger.info("The time should contain milli-seconds")
 
         with open(file_path, "r") as log_file:
             log = log_file.read()
             try:
-                time_in_file = datetime.strptime(log.split(logger.LogLevel.STRINGS[logger.LogLevel.INFO])[0].strip()
-                                                 , logger.Logger.LogTimeFormatInUTC)
+                time_in_file = datetime.strptime(log.split(logger.LogLevel.STRINGS[logger.LogLevel.INFO])[0].strip(), timeutil.UTCTimestampFormat).replace(tzinfo=UTC)
             except ValueError:
                 self.fail("Ensure timestamp follows ISO-8601 format and has micro seconds in it")
 

--- a/tests/ga/test_periodic_operation.py
+++ b/tests/ga/test_periodic_operation.py
@@ -16,6 +16,7 @@
 #
 import datetime
 import time
+from azurelinuxagent.common.future import UTC
 from azurelinuxagent.ga.monitor import PeriodicOperation
 from tests.lib.tools import AgentTestCase, patch, PropertyMock
 
@@ -27,7 +28,7 @@ class TestPeriodicOperation(AgentTestCase):
             self.run_time = None
 
         def _operation(self):
-            self.run_time = datetime.datetime.utcnow()
+            self.run_time = datetime.datetime.now(UTC)
 
     def test_it_should_take_a_timedelta_as_period(self):
         op = TestPeriodicOperation.SaveRunTimestamp(datetime.timedelta(hours=1))

--- a/tests/ga/test_remoteaccess_handler.py
+++ b/tests/ga/test_remoteaccess_handler.py
@@ -17,6 +17,7 @@
 from datetime import timedelta, datetime
 
 from mock import Mock, MagicMock
+from azurelinuxagent.common.future import UTC
 from azurelinuxagent.common.osutil.default import DefaultOSUtil
 from azurelinuxagent.common.protocol.goal_state import RemoteAccess
 from azurelinuxagent.common.protocol.util import ProtocolUtil
@@ -91,7 +92,7 @@ class TestRemoteAccessHandler(AgentTestCase):
             rah = RemoteAccessHandler(Mock())
             tstpassword = "]aPPEv}uNg1FPnl?"
             tstuser = "foobar"
-            expiration_date = datetime.utcnow() + timedelta(days=1)
+            expiration_date = datetime.now(UTC) + timedelta(days=1)
             pwd = tstpassword
             rah._add_user(tstuser, pwd, expiration_date)
             users = get_user_dictionary(rah._os_util.get_users())
@@ -107,7 +108,7 @@ class TestRemoteAccessHandler(AgentTestCase):
             rah = RemoteAccessHandler(Mock())
             tstpassword = "]aPPEv}uNg1FPnl?"
             tstuser = ""
-            expiration = datetime.utcnow() + timedelta(days=1)
+            expiration = datetime.now(UTC) + timedelta(days=1)
             pwd = tstpassword
             error = "test exception for bad username"
             self.assertRaisesRegex(Exception, error, rah._add_user, tstuser, pwd, expiration)
@@ -119,7 +120,7 @@ class TestRemoteAccessHandler(AgentTestCase):
             rah = RemoteAccessHandler(Mock())
             tstpassword = ""
             tstuser = "foobar"
-            expiration = datetime.utcnow() + timedelta(days=1)
+            expiration = datetime.now(UTC) + timedelta(days=1)
             pwd = tstpassword
             error = "test exception for bad password"
             self.assertRaisesRegex(Exception, error, rah._add_user, tstuser, pwd, expiration)
@@ -131,7 +132,7 @@ class TestRemoteAccessHandler(AgentTestCase):
             rah = RemoteAccessHandler(Mock())
             tstpassword = "]aPPEv}uNg1FPnl?"
             tstuser = "foobar"
-            expiration_date = datetime.utcnow() + timedelta(days=1)
+            expiration_date = datetime.now(UTC) + timedelta(days=1)
             pwd = tstpassword
             rah._add_user(tstuser, pwd, expiration_date)
             users = get_user_dictionary(rah._os_util.get_users())
@@ -142,7 +143,7 @@ class TestRemoteAccessHandler(AgentTestCase):
             # add the new duplicate user, ensure it's not created and does not overwrite the existing user.
             # this does not test the user add function as that's mocked, it tests processing skips the remaining
             # calls after the initial failure
-            new_user_expiration = datetime.utcnow() + timedelta(days=5)
+            new_user_expiration = datetime.now(UTC) + timedelta(days=5)
             self.assertRaises(Exception, rah._add_user, tstuser, pwd, new_user_expiration)
             # refresh users
             users = get_user_dictionary(rah._os_util.get_users())
@@ -158,7 +159,7 @@ class TestRemoteAccessHandler(AgentTestCase):
             rah = RemoteAccessHandler(Mock())
             tstpassword = "]aPPEv}uNg1FPnl?"
             tstuser = "foobar"
-            expiration_date = datetime.utcnow() + timedelta(days=1)
+            expiration_date = datetime.now(UTC) + timedelta(days=1)
             expected_expiration = (expiration_date + timedelta(days=1)).strftime("%Y-%m-%d")  # pylint: disable=unused-variable
             pwd = tstpassword
             rah._add_user(tstuser, pwd, expiration_date)
@@ -176,7 +177,7 @@ class TestRemoteAccessHandler(AgentTestCase):
             data_str = load_data('wire/remote_access_single_account.xml')
             remote_access = RemoteAccess(data_str)
             tstuser = remote_access.user_list.users[0].name
-            expiration_date = datetime.utcnow() + timedelta(days=1)
+            expiration_date = datetime.now(UTC) + timedelta(days=1)
             expiration = expiration_date.strftime("%a, %d %b %Y %H:%M:%S ") + "UTC"
             remote_access.user_list.users[0].expiration = expiration
             rah._remote_access = remote_access
@@ -193,7 +194,7 @@ class TestRemoteAccessHandler(AgentTestCase):
             rah = RemoteAccessHandler(Mock())
             data_str = load_data('wire/remote_access_single_account.xml')
             remote_access = RemoteAccess(data_str)
-            expiration = (datetime.utcnow() - timedelta(days=2)).strftime("%a, %d %b %Y %H:%M:%S ") + "UTC"
+            expiration = (datetime.now(UTC) - timedelta(days=2)).strftime("%a, %d %b %Y %H:%M:%S ") + "UTC"
             remote_access.user_list.users[0].expiration = expiration
             rah._remote_access = remote_access
             rah._handle_remote_access()
@@ -204,7 +205,7 @@ class TestRemoteAccessHandler(AgentTestCase):
         with patch("azurelinuxagent.ga.remoteaccess.get_osutil", return_value=MockOSUtil()):
             rah = RemoteAccessHandler(Mock())
             tstuser = "foobar"
-            expiration = datetime.utcnow() + timedelta(days=1)
+            expiration = datetime.now(UTC) + timedelta(days=1)
             pwd = "bad password"
             error = r"\[CryptError\] Error decoding secret\nInner error: Incorrect padding"
             self.assertRaisesRegex(Exception, error, rah._add_user, tstuser, pwd, expiration)
@@ -247,7 +248,7 @@ class TestRemoteAccessHandler(AgentTestCase):
             count = 0
             while count < 2:
                 user = remote_access.user_list.users[count].name
-                expiration_date = datetime.utcnow() + timedelta(days=count + 1)
+                expiration_date = datetime.now(UTC) + timedelta(days=count + 1)
                 expiration = expiration_date.strftime("%a, %d %b %Y %H:%M:%S ") + "UTC"
                 remote_access.user_list.users[count].expiration = expiration
                 testusers.append(user)
@@ -269,7 +270,7 @@ class TestRemoteAccessHandler(AgentTestCase):
             for user in remote_access.user_list.users:
                 count += 1
                 user.name = "tstuser{0}".format(count)
-                expiration_date = datetime.utcnow() + timedelta(days=count)
+                expiration_date = datetime.now(UTC) + timedelta(days=count)
                 user.expiration = expiration_date.strftime("%a, %d %b %Y %H:%M:%S ") + "UTC"
             rah._remote_access = remote_access
             rah._handle_remote_access()
@@ -286,7 +287,7 @@ class TestRemoteAccessHandler(AgentTestCase):
             for user in remote_access.user_list.users:
                 count += 1
                 user.name = "tstuser{0}".format(count)
-                expiration_date = datetime.utcnow() + timedelta(days=count)
+                expiration_date = datetime.now(UTC) + timedelta(days=count)
                 user.expiration = expiration_date.strftime("%a, %d %b %Y %H:%M:%S ") + "UTC"
             rah._remote_access = remote_access
             rah._handle_remote_access()
@@ -307,7 +308,7 @@ class TestRemoteAccessHandler(AgentTestCase):
                 user.name = "tstuser{0}".format(count)
                 if count == 2:
                     user.name = ""
-                expiration_date = datetime.utcnow() + timedelta(days=count)
+                expiration_date = datetime.now(UTC) + timedelta(days=count)
                 user.expiration = expiration_date.strftime("%a, %d %b %Y %H:%M:%S ") + "UTC"
             rah._remote_access = remote_access
             rah._handle_remote_access()
@@ -321,7 +322,7 @@ class TestRemoteAccessHandler(AgentTestCase):
             data_str = load_data('wire/remote_access_single_account.xml')
             remote_access = RemoteAccess(data_str)
             tstuser = remote_access.user_list.users[0].name
-            expiration_date = datetime.utcnow() + timedelta(days=1)
+            expiration_date = datetime.now(UTC) + timedelta(days=1)
             expiration = expiration_date.strftime("%a, %d %b %Y %H:%M:%S ") + "UTC"
             remote_access.user_list.users[0].expiration = expiration
             rah._remote_access = remote_access
@@ -348,7 +349,7 @@ class TestRemoteAccessHandler(AgentTestCase):
             rah = RemoteAccessHandler(Mock())
             tstpassword = "]aPPEv}uNg1FPnl?"
             tstuser = "foobar"
-            expiration_date = datetime.utcnow() + timedelta(days=1)
+            expiration_date = datetime.now(UTC) + timedelta(days=1)
             pwd = tstpassword
             rah._add_user(tstuser, pwd, expiration_date)
             users = get_user_dictionary(rah._os_util.get_users())
@@ -366,7 +367,7 @@ class TestRemoteAccessHandler(AgentTestCase):
             for user in remote_access.user_list.users:
                 count += 1
                 user.name = "tstuser{0}".format(count)
-                expiration_date = datetime.utcnow() + timedelta(days=count)
+                expiration_date = datetime.now(UTC) + timedelta(days=count)
                 user.expiration = expiration_date.strftime("%a, %d %b %Y %H:%M:%S ") + "UTC"
             rah._remote_access = remote_access
             rah._handle_remote_access()
@@ -390,7 +391,7 @@ class TestRemoteAccessHandler(AgentTestCase):
             for user in remote_access.user_list.users:
                 count += 1
                 user.name = "tstuser{0}".format(count)
-                expiration_date = datetime.utcnow() + timedelta(days=count)
+                expiration_date = datetime.now(UTC) + timedelta(days=count)
                 user.expiration = expiration_date.strftime("%a, %d %b %Y %H:%M:%S ") + "UTC"
             rah._remote_access = remote_access
             rah._handle_remote_access()
@@ -412,7 +413,7 @@ class TestRemoteAccessHandler(AgentTestCase):
             for user in remote_access.user_list.users:
                 count += 1
                 user.name = "tstuser{0}".format(count)
-                expiration_date = datetime.utcnow() + timedelta(days=count)
+                expiration_date = datetime.now(UTC) + timedelta(days=count)
                 user.expiration = expiration_date.strftime("%a, %d %b %Y %H:%M:%S ") + "UTC"
             rah._remote_access = remote_access
             rah._handle_remote_access()
@@ -447,7 +448,7 @@ class TestRemoteAccessHandler(AgentTestCase):
             for user in remote_access.user_list.users:
                 count += 1
                 user.name = "tstuser{0}".format(count)
-                expiration_date = datetime.utcnow() + timedelta(days=count)
+                expiration_date = datetime.now(UTC) + timedelta(days=count)
                 user.expiration = expiration_date.strftime("%a, %d %b %Y %H:%M:%S ") + "UTC"
             rah._remote_access = remote_access
             rah._handle_remote_access()

--- a/tests/ga/test_send_telemetry_events.py
+++ b/tests/ga/test_send_telemetry_events.py
@@ -26,17 +26,16 @@ from datetime import datetime, timedelta
 
 from mock import MagicMock, Mock, patch, PropertyMock
 
-from azurelinuxagent.common import logger
 from azurelinuxagent.common.datacontract import get_properties
 from azurelinuxagent.common.event import WALAEventOperation, EVENTS_DIRECTORY
 from azurelinuxagent.common.exception import HttpError, ServiceStoppedError
-from azurelinuxagent.common.future import ustr
+from azurelinuxagent.common.future import ustr, UTC
 from azurelinuxagent.common.osutil.factory import get_osutil
 from azurelinuxagent.common.protocol.util import ProtocolUtil
 from azurelinuxagent.common.protocol.wire import event_to_v1_encoded
 from azurelinuxagent.common.telemetryevent import TelemetryEvent, TelemetryEventParam, \
     GuestAgentExtensionEventsSchema
-from azurelinuxagent.common.utils import restutil, fileutil
+from azurelinuxagent.common.utils import restutil, fileutil, timeutil
 from azurelinuxagent.common.version import CURRENT_VERSION, DISTRO_NAME, DISTRO_VERSION, AGENT_VERSION, CURRENT_AGENT, \
     DISTRO_CODE_NAME
 from azurelinuxagent.ga.collect_telemetry_events import _CollectAndEnqueueEvents
@@ -69,7 +68,7 @@ class TestSendTelemetryEventsHandler(AgentTestCase, HttpRequestPredicates):
     def _create_send_telemetry_events_handler(self, timeout=0.5, start_thread=True, batching_queue_limit=1):
         def http_post_handler(url, body, **__):
             if self.is_telemetry_request(url):
-                send_telemetry_events_handler.event_calls.append((datetime.now(), body))
+                send_telemetry_events_handler.event_calls.append((datetime.now(UTC), body))
                 return MockHttpResponse(status=200)
             return None
 
@@ -140,7 +139,7 @@ class TestSendTelemetryEventsHandler(AgentTestCase, HttpRequestPredicates):
         events = [TelemetryEvent(eventId=ustr(uuid.uuid4())), TelemetryEvent(eventId=ustr(uuid.uuid4()))]
 
         with self._create_send_telemetry_events_handler() as telemetry_handler:
-            test_start_time = datetime.now()
+            test_start_time = datetime.now(UTC)
             for test_event in events:
                 telemetry_handler.enqueue_event(test_event)
 
@@ -186,11 +185,11 @@ class TestSendTelemetryEventsHandler(AgentTestCase, HttpRequestPredicates):
         with patch("time.sleep", lambda *_: orig_sleep(0.05)):
             with patch("azurelinuxagent.ga.send_telemetry_events.SendTelemetryEventsHandler._MIN_BATCH_WAIT_TIME", wait_time):
                 with self._create_send_telemetry_events_handler(batching_queue_limit=5) as telemetry_handler:
-                    test_start_time = datetime.now()
+                    test_start_time = datetime.now(UTC)
                     for test_event in events:
                         telemetry_handler.enqueue_event(test_event)
 
-                    while not telemetry_handler.event_calls and (test_start_time + timedelta(seconds=1)) > datetime.now():
+                    while not telemetry_handler.event_calls and (test_start_time + timedelta(seconds=1)) > datetime.now(UTC):
                         # Wait for event calls to be made, wait a max of 1 secs
                         orig_sleep(0.1)
 
@@ -331,7 +330,7 @@ class TestSendTelemetryEventsHandler(AgentTestCase, HttpRequestPredicates):
             self._create_extension_event(message="Message-Test")
 
             test_mtime = 1000  # epoch time, in ms
-            test_opcodename = datetime.fromtimestamp(test_mtime).strftime(logger.Logger.LogTimeFormatInUTC)
+            test_opcodename = timeutil.create_utc_timestamp(datetime.fromtimestamp(test_mtime))
             test_eventtid = 42
             test_eventpid = 24
             test_taskname = "TEST_TaskName"

--- a/tests/ga/test_send_telemetry_events.py
+++ b/tests/ga/test_send_telemetry_events.py
@@ -330,7 +330,7 @@ class TestSendTelemetryEventsHandler(AgentTestCase, HttpRequestPredicates):
             self._create_extension_event(message="Message-Test")
 
             test_mtime = 1000  # epoch time, in ms
-            test_opcodename = timeutil.create_utc_timestamp(datetime.fromtimestamp(test_mtime))
+            test_opcodename = timeutil.create_utc_timestamp(datetime.fromtimestamp(test_mtime).replace(tzinfo=UTC))
             test_eventtid = 42
             test_eventpid = 24
             test_taskname = "TEST_TaskName"

--- a/tests/ga/test_update.py
+++ b/tests/ga/test_update.py
@@ -27,7 +27,7 @@ from azurelinuxagent.common.logger import LogLevel
 from azurelinuxagent.common.event import EVENTS_DIRECTORY, WALAEventOperation
 from azurelinuxagent.common.exception import HttpError, \
     ExitException, AgentMemoryExceededException
-from azurelinuxagent.common.future import ustr, UTC, httpclient
+from azurelinuxagent.common.future import ustr, UTC, datetime_min_utc, httpclient
 from azurelinuxagent.common.protocol.hostplugin import HostPluginProtocol
 from azurelinuxagent.common.protocol.restapi import VMAgentFamily, \
     ExtHandlerPackage, ExtHandlerPackageList, Extension, VMStatus, ExtHandlerStatus, ExtensionStatus, \
@@ -2287,7 +2287,7 @@ class ProcessGoalStateTestCase(AgentTestCase):
     def test_it_should_clear_the_timestamp_for_the_most_recent_fast_track_goal_state(self):
         data_file = self._prepare_fast_track_goal_state()
 
-        if HostPluginProtocol.get_fast_track_timestamp() == timeutil.create_utc_timestamp(datetime.min):
+        if HostPluginProtocol.get_fast_track_timestamp() == timeutil.create_utc_timestamp(datetime_min_utc):
             raise Exception("The test setup did not save the Fast Track state")
 
         with patch("azurelinuxagent.common.conf.get_enable_fast_track", return_value=False):
@@ -2297,7 +2297,7 @@ class ProcessGoalStateTestCase(AgentTestCase):
                     with mock_update_handler(protocol) as update_handler:
                         update_handler.run()
 
-        self.assertEqual(HostPluginProtocol.get_fast_track_timestamp(), timeutil.create_utc_timestamp(datetime.min),
+        self.assertEqual(HostPluginProtocol.get_fast_track_timestamp(), timeutil.create_utc_timestamp(datetime_min_utc),
             "The Fast Track state was not cleared")
 
     def test_it_should_default_fast_track_timestamp_to_datetime_min(self):
@@ -2344,8 +2344,8 @@ class ProcessGoalStateTestCase(AgentTestCase):
                     check_for_errors()
 
             timestamp = protocol.client.get_host_plugin()._fast_track_timestamp
-            self.assertEqual(timestamp, timeutil.create_utc_timestamp(datetime.min),
-                "Expected fast track time stamp to be set to {0}, got {1}".format(datetime.min, timestamp))
+            self.assertEqual(timestamp, timeutil.create_utc_timestamp(datetime_min_utc),
+                "Expected fast track time stamp to be set to {0}, got {1}".format(datetime_min_utc, timestamp))
 
 class HeartbeatTestCase(AgentTestCase):
 

--- a/tests/ga/test_update.py
+++ b/tests/ga/test_update.py
@@ -27,7 +27,7 @@ from azurelinuxagent.common.logger import LogLevel
 from azurelinuxagent.common.event import EVENTS_DIRECTORY, WALAEventOperation
 from azurelinuxagent.common.exception import HttpError, \
     ExitException, AgentMemoryExceededException
-from azurelinuxagent.common.future import ustr, httpclient
+from azurelinuxagent.common.future import ustr, UTC, httpclient
 from azurelinuxagent.common.protocol.hostplugin import HostPluginProtocol
 from azurelinuxagent.common.protocol.restapi import VMAgentFamily, \
     ExtHandlerPackage, ExtHandlerPackageList, Extension, VMStatus, ExtHandlerStatus, ExtensionStatus, \
@@ -2133,7 +2133,7 @@ class TryUpdateGoalStateTestCase(HttpRequestPredicates, AgentTestCase):
             #
             with create_log_and_telemetry_mocks() as (log_messages, add_event):
                 for _ in range(5):
-                    update_handler._update_goal_state_next_error_report = datetime.now()  # force the reporting period to elapse
+                    update_handler._update_goal_state_next_error_report = datetime.now(UTC)  # force the reporting period to elapse
                     update_handler._try_update_goal_state(protocol)
 
                 e = errors()
@@ -2287,7 +2287,7 @@ class ProcessGoalStateTestCase(AgentTestCase):
     def test_it_should_clear_the_timestamp_for_the_most_recent_fast_track_goal_state(self):
         data_file = self._prepare_fast_track_goal_state()
 
-        if HostPluginProtocol.get_fast_track_timestamp() == timeutil.create_timestamp(datetime.min):
+        if HostPluginProtocol.get_fast_track_timestamp() == timeutil.create_utc_timestamp(datetime.min):
             raise Exception("The test setup did not save the Fast Track state")
 
         with patch("azurelinuxagent.common.conf.get_enable_fast_track", return_value=False):
@@ -2297,7 +2297,7 @@ class ProcessGoalStateTestCase(AgentTestCase):
                     with mock_update_handler(protocol) as update_handler:
                         update_handler.run()
 
-        self.assertEqual(HostPluginProtocol.get_fast_track_timestamp(), timeutil.create_timestamp(datetime.min),
+        self.assertEqual(HostPluginProtocol.get_fast_track_timestamp(), timeutil.create_utc_timestamp(datetime.min),
             "The Fast Track state was not cleared")
 
     def test_it_should_default_fast_track_timestamp_to_datetime_min(self):
@@ -2344,7 +2344,7 @@ class ProcessGoalStateTestCase(AgentTestCase):
                     check_for_errors()
 
             timestamp = protocol.client.get_host_plugin()._fast_track_timestamp
-            self.assertEqual(timestamp, timeutil.create_timestamp(datetime.min),
+            self.assertEqual(timestamp, timeutil.create_utc_timestamp(datetime.min),
                 "Expected fast track time stamp to be set to {0}, got {1}".format(datetime.min, timestamp))
 
 class HeartbeatTestCase(AgentTestCase):
@@ -2354,7 +2354,7 @@ class HeartbeatTestCase(AgentTestCase):
     def test_telemetry_heartbeat_creates_event(self, patch_add_event, patch_info, *_):
         update_handler = get_update_handler()
         agent_update_handler = Mock()
-        update_handler.last_telemetry_heartbeat = datetime.utcnow() - timedelta(hours=1)
+        update_handler.last_telemetry_heartbeat = datetime.now(UTC) - timedelta(hours=1)
         update_handler._send_heartbeat_telemetry(agent_update_handler)
         self.assertEqual(1, patch_add_event.call_count)
         self.assertTrue(any(call_args[0] == "[HEARTBEAT] Agent {0} is running as the goal state agent [DEBUG {1}]"

--- a/tests/lib/miscellaneous_tools.py
+++ b/tests/lib/miscellaneous_tools.py
@@ -26,7 +26,7 @@ import datetime
 import os
 import time
 
-from azurelinuxagent.common.future import ustr
+from azurelinuxagent.common.future import ustr, UTC
 
 
 def format_processes(pid_list):
@@ -54,8 +54,8 @@ def wait_for(predicate, timeout=10, frequency=0.01):
     def to_seconds(time_delta):
         return (time_delta.microseconds + (time_delta.seconds + time_delta.days * 24 * 3600) * 10 ** 6) / 10 ** 6
 
-    start_time = datetime.datetime.now()
-    while to_seconds(datetime.datetime.now() - start_time) < timeout:
+    start_time = datetime.datetime.now(UTC)
+    while to_seconds(datetime.datetime.now(UTC) - start_time) < timeout:
         if predicate():
             return True
         time.sleep(frequency)

--- a/tests/lib/wire_protocol_data.py
+++ b/tests/lib/wire_protocol_data.py
@@ -19,13 +19,12 @@ import datetime
 import json
 import re
 
-from azurelinuxagent.common.utils import timeutil
 from azurelinuxagent.common.utils.textutil import parse_doc, find, findall
 from tests.lib.http_request_predicates import HttpRequestPredicates
 from tests.lib.tools import load_bin_data, load_data, MagicMock, Mock
 from azurelinuxagent.common.protocol.imds import IMDS_ENDPOINT
 from azurelinuxagent.common.exception import HttpError, ResourceGoneError
-from azurelinuxagent.common.future import httpclient
+from azurelinuxagent.common.future import httpclient, UTC, datetime_min_utc
 from azurelinuxagent.common.utils.cryptutil import CryptUtil
 
 DATA_FILE = {
@@ -393,11 +392,11 @@ class WireProtocolData(object):
         This function is used to mock a new goal state, and it also updates the timestamp (extensionsLastModifiedTickCount) in vmSettings.
         """
         if timestamp is None:
-            timestamp = datetime.datetime.utcnow()
+            timestamp = datetime.datetime.now(UTC)
         self.etag = etag
         try:
             vm_settings = json.loads(self.vm_settings)
-            vm_settings["extensionsLastModifiedTickCount"] = timeutil.datetime_to_ticks(timestamp)
+            vm_settings["extensionsLastModifiedTickCount"] = self._datetime_to_ticks(timestamp)
             self.vm_settings = json.dumps(vm_settings)
         except ValueError:  # some test data include syntax errors; ignore those
             pass
@@ -418,8 +417,24 @@ class WireProtocolData(object):
         self.goal_state = WireProtocolData.replace_xml_element_value(self.goal_state, "Incarnation", str(incarnation))
         if self.ext_conf is not None:
             if timestamp is None:
-                timestamp = datetime.datetime.utcnow()
-            self.ext_conf = WireProtocolData.replace_xml_attribute_value(self.ext_conf, "InVMGoalStateMetaData", "createdOnTicks", timeutil.datetime_to_ticks(timestamp))
+                timestamp = datetime.datetime.now(UTC)
+            self.ext_conf = WireProtocolData.replace_xml_attribute_value(self.ext_conf, "InVMGoalStateMetaData", "createdOnTicks", self._datetime_to_ticks(timestamp))
+
+    @staticmethod
+    def _datetime_to_ticks(dt):
+        """
+        Converts 'dt', a datetime, to the number of ticks (1 tick == 1/10000000 sec) since datetime.min (0001-01-01 00:00:00).
+
+        Note that the resolution of a datetime goes only to microseconds.
+        """
+        return int(10 ** 7 * WireProtocolData._total_seconds(dt - datetime_min_utc))
+
+    @staticmethod
+    def _total_seconds(time_delta):
+        """
+        Compute the total_seconds for the given timedelta. Used instead timedelta.total_seconds() because 2.6 does not implement total_seconds.
+        """
+        return ((24.0 * 60 * 60 * time_delta.days + time_delta.seconds) * 10 ** 6 + time_delta.microseconds) / 10 ** 6
 
     def set_container_id(self, container_id):
         self.goal_state = WireProtocolData.replace_xml_element_value(self.goal_state, "ContainerId", container_id)

--- a/tests_e2e/GuestAgentDcrTestExtension/GuestAgentDcrTest.py
+++ b/tests_e2e/GuestAgentDcrTestExtension/GuestAgentDcrTest.py
@@ -4,11 +4,18 @@ from __future__ import print_function
 
 from Utils.WAAgentUtil import waagent
 import Utils.HandlerUtil as Util
+import datetime
 import sys
 import re
 import traceback
 import os
-import datetime
+
+if sys.version_info[0] == 3 and sys.version_info[1] >= 11:
+    def utc_now():
+        return datetime.datetime.now(datetime.UTC)
+else:
+    def utc_now():
+        return datetime.datetime.utcnow()
 
 ExtensionShortName = "GADcrTestExt"
 OperationFileName = "operations-{0}.log"
@@ -93,7 +100,7 @@ def parse_context(operation):
     op_log = os.path.join(hutil.get_log_dir(), OperationFileName.format(hutil.get_extension_version()))
     with open(op_log, 'a+') as oplog_handler:
         oplog_handler.write("Date:{0}; Operation:{1}; SeqNo:{2}\n"
-                            .format(datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+                            .format(utc_now().strftime("%Y-%m-%dT%H:%M:%SZ"),
                                     operation, hutil.get_seq_no()))
     return hutil
 

--- a/tests_e2e/orchestrator/lib/agent_test_suite_combinator.py
+++ b/tests_e2e/orchestrator/lib/agent_test_suite_combinator.py
@@ -1,12 +1,9 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
-import datetime
 import logging
 import random
 import re
-import traceback
 import urllib.parse
-import uuid
 
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Type
@@ -17,9 +14,8 @@ from dataclasses_json import dataclass_json  # pylint: disable=E0401
 # Disable those warnings, since 'lisa' is an external, non-standard, dependency
 #     E0401: Unable to import 'lisa' (import-error)
 #     etc
-from lisa import notifier, schema  # pylint: disable=E0401
+from lisa import schema  # pylint: disable=E0401
 from lisa.combinator import Combinator  # pylint: disable=E0401
-from lisa.messages import TestStatus, TestResultMessage  # pylint: disable=E0401
 from lisa.util import field_metadata  # pylint: disable=E0401
 
 from tests_e2e.orchestrator.lib.agent_test_loader import AgentTestLoader, VmImageInfo, TestSuiteInfo, CustomImage
@@ -573,38 +569,3 @@ class AgentTestSuitesCombinator(Combinator):
         # VHDs are given as URIs to storage; do some basic validation, not intending to be exhaustive.
         parsed = urllib.parse.urlparse(vhd)
         return parsed.scheme == 'https' and parsed.netloc != "" and parsed.path != ""
-
-    @staticmethod
-    def _report_test_result(
-            suite_name: str,
-            test_name: str,
-            status: TestStatus,
-            start_time: datetime.datetime,
-            message: str = "",
-            add_exception_stack_trace: bool = False
-    ) -> None:
-        """
-        Reports a test result to the junit notifier
-        """
-        # The junit notifier requires an initial RUNNING message in order to register the test in its internal cache.
-        msg: TestResultMessage = TestResultMessage()
-        msg.type = "AgentTestResultMessage"
-        msg.id_ = str(uuid.uuid4())
-        msg.status = TestStatus.RUNNING
-        msg.suite_full_name = suite_name
-        msg.suite_name = msg.suite_full_name
-        msg.full_name = test_name
-        msg.name = msg.full_name
-        msg.elapsed = 0
-
-        notifier.notify(msg)
-
-        # Now send the actual result. The notifier pipeline makes a deep copy of the message so it is OK to re-use the
-        # same object and just update a few fields. If using a different object, be sure that the "id_" is the same.
-        msg.status = status
-        msg.message = message
-        if add_exception_stack_trace:
-            msg.stacktrace = traceback.format_exc()
-        msg.elapsed = (datetime.datetime.now() - start_time).total_seconds()
-
-        notifier.notify(msg)

--- a/tests_e2e/tests/agent_ext_workflow/extension_workflow.py
+++ b/tests_e2e/tests/agent_ext_workflow/extension_workflow.py
@@ -174,7 +174,7 @@ class ExtensionWorkflow(AgentVmTest):
             log.info("*******Verifying the extension install scenario*******")
 
             # Record the time we start the test
-            start_time = self._ssh_client.run_command("date '+%Y-%m-%dT%TZ'").rstrip()
+            start_time = self._ssh_client.run_command("date --utc '+%Y-%m-%dT%TZ'").rstrip()
 
             # Create DcrTestExtension with version 1.1.5
             dcr_test_ext_id_1_1 = VmExtensionIdentifier(
@@ -223,7 +223,7 @@ class ExtensionWorkflow(AgentVmTest):
             log.info("*******Verifying the extension enable scenario*******")
 
             # Record the time we start the test
-            start_time = self._ssh_client.run_command("date '+%Y-%m-%dT%TZ'").rstrip()
+            start_time = self._ssh_client.run_command("date --utc '+%Y-%m-%dT%TZ'").rstrip()
 
             # Enable test extension on the VM
             dcr_ext.modify_ext_settings_and_enable()
@@ -280,7 +280,7 @@ class ExtensionWorkflow(AgentVmTest):
             log.info("*******Verifying the extension uninstall scenario*******")
 
             # Record the time we start the test
-            start_time = self._ssh_client.run_command("date '+%Y-%m-%dT%TZ'").rstrip()
+            start_time = self._ssh_client.run_command("date --utc '+%Y-%m-%dT%TZ'").rstrip()
 
             # Remove the test extension on the VM
             log.info("Delete %s from VM", dcr_test_ext_client)
@@ -320,7 +320,7 @@ class ExtensionWorkflow(AgentVmTest):
             dcr_ext.assert_instance_view()
 
             # Record the time we start the update with install scenario test
-            start_time = self._ssh_client.run_command("date '+%Y-%m-%dT%TZ'").rstrip()
+            start_time = self._ssh_client.run_command("date --utc '+%Y-%m-%dT%TZ'").rstrip()
 
             # Create DcrTestExtension with version 1.2
             dcr_test_ext_id_1_2 = VmExtensionIdentifier(
@@ -387,7 +387,7 @@ class ExtensionWorkflow(AgentVmTest):
             dcr_ext.assert_instance_view()
 
             # Record the time we start the update without scenario test
-            start_time = self._ssh_client.run_command("date '+%Y-%m-%dT%TZ'").rstrip()
+            start_time = self._ssh_client.run_command("date --utc '+%Y-%m-%dT%TZ'").rstrip()
 
             # Create DcrTestExtension with version 1.3
             dcr_test_ext_id_1_3 = VmExtensionIdentifier(

--- a/tests_e2e/tests/agent_publish/agent_publish.py
+++ b/tests_e2e/tests/agent_publish/agent_publish.py
@@ -18,6 +18,8 @@
 import uuid
 from datetime import datetime
 
+from azurelinuxagent.common.future import UTC
+
 from tests_e2e.tests.lib.agent_setup_helpers import wait_for_agent_to_complete_provisioning
 from tests_e2e.tests.lib.agent_test import AgentVmTest
 from tests_e2e.tests.lib.agent_test_context import AgentVmTestContext
@@ -75,7 +77,7 @@ class AgentPublishTest(AgentVmTest):
 
     def get_ignore_errors_before_timestamp(self) -> datetime:
         timestamp = self._ssh_client.run_command("agent_publish-get_agent_log_record_timestamp.py")
-        return datetime.strptime(timestamp.strip(), u'%Y-%m-%d %H:%M:%S.%f')
+        return datetime.strptime(timestamp.strip(), u'%Y-%m-%d %H:%M:%S.%f').replace(tzinfo=UTC)
 
     def _get_published_version(self):
         """

--- a/tests_e2e/tests/agent_status/agent_status.py
+++ b/tests_e2e/tests/agent_status/agent_status.py
@@ -28,6 +28,8 @@ from datetime import datetime, timedelta
 from time import sleep
 import json
 
+from azurelinuxagent.common.future import UTC
+
 from tests_e2e.tests.lib.agent_test import AgentVmTest
 from tests_e2e.tests.lib.agent_test_context import AgentVmTestContext
 from tests_e2e.tests.lib.logging import log
@@ -138,14 +140,14 @@ class AgentStatus(AgentVmTest):
         log.info("")
         log.info("*******Verifying the agent status updates 3 times*******")
 
-        timeout = datetime.now() + timedelta(minutes=6)
+        timeout = datetime.now(UTC) + timedelta(minutes=6)
         instance_view_exception = None
         status_updated = 0
         prev_status_timestamp = None
         prev_gs_processed_log = None
 
         # Retry validating agent status updates 2 times with timeout of 6 minutes
-        while datetime.now() <= timeout and status_updated < 2:
+        while datetime.now(UTC) <= timeout and status_updated < 2:
             instance_view = self._context.vm.get_instance_view()
             log.info("")
             log.info(

--- a/tests_e2e/tests/ext_policy/ext_policy.py
+++ b/tests_e2e/tests/ext_policy/ext_policy.py
@@ -144,7 +144,7 @@ class ExtPolicy(AgentVmTest):
             #   2. force a new goal state by enabling a different extension
             #   3. allow extension with policy and send another delete request (should succeed)
             log.info(f"Attempting to delete {extension_case.extension}, should fail due to policy.")
-            delete_start_time = self._ssh_client.run_command("date '+%Y-%m-%d %T'").rstrip()
+            delete_start_time = self._ssh_client.run_command("date --utc '+%Y-%m-%d %T'").rstrip()
             try:
                 # Wait long enough for CRP timeout (15 min) and confirm that a timeout error was thrown.
                 timeout = (20 * 60)

--- a/tests_e2e/tests/ext_sequencing/ext_sequencing.py
+++ b/tests_e2e/tests/ext_sequencing/ext_sequencing.py
@@ -32,6 +32,8 @@ from typing import List, Dict, Any
 from assertpy import fail
 from azure.mgmt.compute.models import VirtualMachineScaleSetVMExtensionsSummary
 
+from azurelinuxagent.common.future import UTC, datetime_min_utc
+
 from tests_e2e.tests.ext_sequencing.ext_seq_test_cases import add_one_dependent_ext_without_settings, add_two_extensions_with_dependencies, \
     remove_one_dependent_extension, remove_all_dependencies, add_one_dependent_extension, \
     add_single_dependencies, remove_all_dependent_extensions, add_failing_dependent_extension_with_one_dependency, add_failing_dependent_extension_with_two_dependencies
@@ -48,7 +50,7 @@ class ExtSequencing(AgentVmssTest):
 
     def __init__(self, context: AgentVmTestContext):
         super().__init__(context)
-        self._scenario_start = datetime.min
+        self._scenario_start = datetime_min_utc
 
     # Cases to test different dependency scenarios
     _test_cases = [
@@ -185,7 +187,7 @@ class ExtSequencing(AgentVmssTest):
 
         for case in self._test_cases:
             test_case_start = random.choice(list(ssh_clients.values())).run_command("date '+%Y-%m-%d %T'").rstrip()
-            if self._scenario_start == datetime.min:
+            if self._scenario_start == datetime_min_utc:
                 self._scenario_start = test_case_start
 
             # Assign unique guid to forceUpdateTag for each extension to make sure they're always unique to force CRP
@@ -285,9 +287,9 @@ class ExtSequencing(AgentVmssTest):
 
     def get_ignore_errors_before_timestamp(self) -> datetime:
         # Ignore errors in the agent log before the first test case starts
-        if self._scenario_start == datetime.min:
+        if self._scenario_start == datetime_min_utc:
             return self._scenario_start
-        return datetime.strptime(self._scenario_start, u'%Y-%m-%d %H:%M:%S')
+        return datetime.strptime(self._scenario_start, u'%Y-%m-%d %H:%M:%S').replace(tzinfo=UTC)
 
     def get_ignore_error_rules(self) -> List[Dict[str, Any]]:
         ignore_rules = [

--- a/tests_e2e/tests/extensions_disabled/extensions_disabled.py
+++ b/tests_e2e/tests/extensions_disabled/extensions_disabled.py
@@ -23,13 +23,14 @@
 #
 
 import datetime
-import pytz
 import uuid
 
 from assertpy import assert_that, fail
 from typing import List, Dict, Any
 
 from azure.mgmt.compute.models import VirtualMachineInstanceView
+
+from azurelinuxagent.common.future import UTC
 
 from tests_e2e.tests.lib.agent_test import AgentVmTest
 from tests_e2e.tests.lib.vm_extension_identifier import VmExtensionIds
@@ -52,7 +53,7 @@ class ExtensionsDisabled(AgentVmTest):
         log.info("Disabling extension processing on the test VM [%s]", self._context.vm.name)
         output = ssh_client.run_command("update-waagent-conf Extensions.Enabled=n", use_sudo=True)
         log.info("Disable completed:\n%s", output)
-        disabled_timestamp: datetime.datetime = datetime.datetime.utcnow() - datetime.timedelta(minutes=60)
+        disabled_timestamp: datetime.datetime = datetime.datetime.now(UTC) - datetime.timedelta(minutes=60)
 
         # Prepare test cases
         unique = str(uuid.uuid4())
@@ -116,7 +117,7 @@ class ExtensionsDisabled(AgentVmTest):
         # The time in the status is time zone aware and 'disabled_timestamp' is not; we need to make the latter time zone aware before comparing them
         assert_that(instance_view.vm_agent.statuses[0].time)\
             .described_as("The VM Agent should be have reported status even after extensions were disabled")\
-            .is_greater_than(pytz.utc.localize(disabled_timestamp))
+            .is_greater_than(disabled_timestamp)
         log.info("The VM Agent reported status after extensions were disabled, as expected.")
 
         #

--- a/tests_e2e/tests/keyvault_certificates/keyvault_certificates.py
+++ b/tests_e2e/tests/keyvault_certificates/keyvault_certificates.py
@@ -25,6 +25,8 @@ import time
 
 from assertpy import fail
 
+from azurelinuxagent.common.future import UTC
+
 from tests_e2e.tests.lib.agent_test import AgentVmTest
 from tests_e2e.tests.lib.logging import log
 from tests_e2e.tests.lib.shell import CommandError
@@ -87,7 +89,7 @@ class KeyvaultCertificates(AgentVmTest):
 
         # If the goal state includes only the certificates, but no extensions, the update/reapply operations may complete before the Agent has downloaded the certificates
         # so we retry for a few minutes to ensure the certificates are downloaded.
-        timed_out = datetime.datetime.utcnow() + datetime.timedelta(minutes=5)
+        timed_out = datetime.datetime.now(UTC) + datetime.timedelta(minutes=5)
         while True:
             try:
                 output = ssh_client.run_command(f"ls {expected_certificates}", use_sudo=True)
@@ -95,7 +97,7 @@ class KeyvaultCertificates(AgentVmTest):
                 break
             except CommandError as error:
                 if error.stdout == "":
-                    if datetime.datetime.utcnow() < timed_out:
+                    if datetime.datetime.now(UTC) < timed_out:
                         log.info("The certificates have not been downloaded yet, will retry after a short delay.")
                         time.sleep(30)
                         continue

--- a/tests_e2e/tests/lib/agent_log.py
+++ b/tests_e2e/tests/lib/agent_log.py
@@ -21,6 +21,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, AnyStr, Dict, Iterable, List, Match
 
+from azurelinuxagent.common.future import UTC, datetime_min_utc
 from azurelinuxagent.common.version import DISTRO_NAME, DISTRO_VERSION
 
 
@@ -71,11 +72,11 @@ class AgentLogRecord:
         ext_timestamp_regex_2 = r"\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}"
 
         if re.match(ext_timestamp_regex_1, self.when):
-            return datetime.strptime(self.when, u'%Y/%m/%d %H:%M:%S.%f')
+            return datetime.strptime(self.when, u'%Y/%m/%d %H:%M:%S.%f').replace(tzinfo=UTC)
         elif re.match(ext_timestamp_regex_2, self.when):
-            return datetime.strptime(self.when, u'%Y/%m/%d %H:%M:%S')
+            return datetime.strptime(self.when, u'%Y/%m/%d %H:%M:%S').replace(tzinfo=UTC)
         # Logs from agent follow this format: 2023-07-10T20:50:13.038599Z
-        return datetime.strptime(self.when, u'%Y-%m-%dT%H:%M:%S.%fZ')
+        return datetime.strptime(self.when, u'%Y-%m-%dT%H:%M:%S.%fZ').replace(tzinfo=UTC)
 
     def __str__(self):
         return self.text
@@ -458,7 +459,7 @@ class AgentLog(object):
 
         return errors
 
-    def agent_log_contains(self, data: str, after_timestamp: str = datetime.min):
+    def agent_log_contains(self, data: str, after_timestamp: datetime = datetime_min_utc):
         """
         This function looks for the specified test data string in the WALinuxAgent logs and returns if found or not.
         :param data: The string to look for in the agent logs

--- a/tests_e2e/tests/lib/agent_test.py
+++ b/tests_e2e/tests/lib/agent_test.py
@@ -25,6 +25,8 @@ from datetime import datetime
 from assertpy import fail
 from typing import Any, Dict, List
 
+from azurelinuxagent.common.future import datetime_min_utc
+
 from tests_e2e.tests.lib.agent_test_context import AgentTestContext, AgentVmTestContext, AgentVmssTestContext
 from tests_e2e.tests.lib.logging import log
 from tests_e2e.tests.lib.remote_test import FAIL_EXIT_CODE
@@ -66,7 +68,7 @@ class AgentTest(ABC):
 
     def get_ignore_errors_before_timestamp(self) -> datetime:
         # Ignore errors in the agent log before this timestamp
-        return datetime.min
+        return datetime_min_utc
 
     @classmethod
     def run_from_command_line(cls):

--- a/tests_e2e/tests/lib/cgroup_helpers.py
+++ b/tests_e2e/tests/lib/cgroup_helpers.py
@@ -1,9 +1,9 @@
-import datetime
 import os
 import re
 
 from assertpy import assert_that, fail
 
+from azurelinuxagent.common.future import datetime_min_utc
 from azurelinuxagent.common.osutil import systemd
 from azurelinuxagent.common.utils import shellutil, fileutil
 from azurelinuxagent.common.version import DISTRO_NAME, DISTRO_VERSION
@@ -154,7 +154,7 @@ def check_cgroup_disabled_due_to_systemd_error():
     """
     return check_log_message("Failed to start.+using systemd-run, will try invoking the extension directly.+[SystemdRunError].+Connection reset by peer")
 
-def check_log_message(message, after_timestamp=datetime.datetime.min):
+def check_log_message(message, after_timestamp=datetime_min_utc):
     """
     Check if the log message is present after the given timestamp(if provided) in the agent log
     """

--- a/tests_e2e/tests/publish_hostname/publish_hostname.py
+++ b/tests_e2e/tests/publish_hostname/publish_hostname.py
@@ -36,6 +36,7 @@ from tests_e2e.tests.lib.agent_test import AgentVmTest, TestSkipped
 from tests_e2e.tests.lib.agent_test_context import AgentVmTestContext
 from tests_e2e.tests.lib.logging import log
 
+from azurelinuxagent.common.future import UTC
 
 class PublishHostname(AgentVmTest):
     def __init__(self, context: AgentVmTestContext):
@@ -151,9 +152,9 @@ class PublishHostname(AgentVmTest):
                 # Wait for the agent to detect the hostname change for up to 2 minutes if hostname monitoring is enabled
                 if monitors_hostname == "y" or monitors_hostname == "yes":
                     log.info("Agent hostname monitoring is enabled")
-                    timeout = datetime.datetime.now() + datetime.timedelta(minutes=2)
+                    timeout = datetime.datetime.now(UTC) + datetime.timedelta(minutes=2)
                     hostname_detected = ""
-                    while datetime.datetime.now() <= timeout:
+                    while datetime.datetime.now(UTC) <= timeout:
                         try:
                             hostname_detected = self.retry_ssh_if_connection_reset("grep -n 'Detected hostname change:.*-> {0}' /var/log/waagent.log".format(hostname), use_sudo=True)
                             if hostname_detected:
@@ -171,9 +172,9 @@ class PublishHostname(AgentVmTest):
                     log.info("Agent hostname monitoring is disabled")
 
                 # Check that the expected hostname is published with 4 minute timeout
-                timeout = datetime.datetime.now() + datetime.timedelta(minutes=4)
+                timeout = datetime.datetime.now(UTC) + datetime.timedelta(minutes=4)
                 published_hostname = ""
-                while datetime.datetime.now() <= timeout:
+                while datetime.datetime.now(UTC) <= timeout:
                     try:
                         dns_info = self.retry_ssh_if_connection_reset(lookup_cmd)
                         actual_hostname = re.match(dns_regex, dns_info)

--- a/tests_e2e/tests/scripts/agent_cgroups_process_check-unknown_process_check.py
+++ b/tests_e2e/tests/scripts/agent_cgroups_process_check-unknown_process_check.py
@@ -23,6 +23,7 @@ import datetime
 
 from assertpy import fail
 
+from azurelinuxagent.common.future import UTC
 from azurelinuxagent.common.utils import shellutil
 from tests_e2e.tests.lib.cgroup_helpers import check_agent_quota_disabled, check_log_message, get_unit_cgroup_proc_path, AGENT_SERVICE_NAME
 from tests_e2e.tests.lib.logging import log
@@ -30,7 +31,7 @@ from tests_e2e.tests.lib.retry import retry_if_false
 
 
 def prepare_agent():
-    check_time = datetime.datetime.utcnow()
+    check_time = datetime.datetime.now(UTC)
     log.info("Executing script update-waagent-conf to enable agent cgroups config flag")
     result = shellutil.run_command(["update-waagent-conf", "Debug.CgroupCheckPeriod=20", "Debug.CgroupLogMetrics=y",
                                     "Debug.CgroupDisableOnProcessCheckFailure=y",

--- a/tests_e2e/tests/scripts/agent_cpu_quota-check_agent_cpu_quota.py
+++ b/tests_e2e/tests/scripts/agent_cpu_quota-check_agent_cpu_quota.py
@@ -24,6 +24,7 @@ import time
 
 from assertpy import fail
 
+from azurelinuxagent.common.future import UTC
 from azurelinuxagent.common.osutil import systemd
 from azurelinuxagent.common.utils import shellutil
 from tests_e2e.tests.lib.agent_log import AgentLog
@@ -133,8 +134,8 @@ def verify_agent_reported_metrics():
 
 def wait_for_log_message(message, timeout=datetime.timedelta(minutes=5)):
     log.info("Checking agent's log for message matching [%s]", message)
-    start_time = datetime.datetime.now()
-    while datetime.datetime.now() - start_time <= timeout:
+    start_time = datetime.datetime.now(UTC)
+    while datetime.datetime.now(UTC) - start_time <= timeout:
         for record in AgentLog().read():
             match = re.search(message, record.message, flags=re.DOTALL)
             if match is not None:
@@ -177,7 +178,7 @@ def cleanup_test_setup():
         os.remove(drop_in_file)
         shellutil.run_command(["systemctl", "daemon-reload"])
 
-    check_time = datetime.datetime.utcnow()
+    check_time = datetime.datetime.now(UTC)
     shellutil.run_command(["agent-service", "restart"])
 
     found: bool = retry_if_false(lambda: check_log_message(" Agent cgroups enabled: True", after_timestamp=check_time))

--- a/tests_e2e/tests/scripts/agent_ext_policy-verify_operation_disallowed.py
+++ b/tests_e2e/tests/scripts/agent_ext_policy-verify_operation_disallowed.py
@@ -23,6 +23,7 @@ import sys
 import re
 
 from datetime import datetime
+from azurelinuxagent.common.future import UTC, datetime_min_utc
 from pathlib import Path
 from tests_e2e.tests.lib.logging import log
 from tests_e2e.tests.lib.agent_log import AgentLog
@@ -42,9 +43,9 @@ def main():
     agent_log = AgentLog(Path('/var/log/waagent.log'))
 
     if args.after_timestamp is None:
-        after_datetime = datetime.min
+        after_datetime = datetime_min_utc
     else:
-        after_datetime = datetime.strptime(args.after_timestamp, '%Y-%m-%d %H:%M:%S')
+        after_datetime = datetime.strptime(args.after_timestamp, '%Y-%m-%d %H:%M:%S').replace(tzinfo=UTC)
 
     try:
         for record in agent_log.read():

--- a/tests_e2e/tests/scripts/agent_ext_policy-verify_operation_success.py
+++ b/tests_e2e/tests/scripts/agent_ext_policy-verify_operation_success.py
@@ -25,6 +25,8 @@ from datetime import datetime
 import time
 import re
 
+from azurelinuxagent.common.future import UTC, datetime_min_utc
+
 from tests_e2e.tests.lib.logging import log
 from tests_e2e.tests.lib.agent_log import AgentLog
 
@@ -91,9 +93,9 @@ def main():
     args = parser.parse_args()
 
     if args.after_timestamp is not None:
-        after_datetime = datetime.strptime(args.after_timestamp, '%Y-%m-%d %H:%M:%S')
+        after_datetime = datetime.strptime(args.after_timestamp, '%Y-%m-%d %H:%M:%S').replace(tzinfo=UTC)
     else:
-        after_datetime = datetime.min
+        after_datetime = datetime_min_utc
 
     status = __get_last_reported_status(after_datetime)
     if status is None:

--- a/tests_e2e/tests/scripts/agent_ext_workflow-assert_operation_sequence.py
+++ b/tests_e2e/tests/scripts/agent_ext_workflow-assert_operation_sequence.py
@@ -33,6 +33,7 @@ import sys
 import time
 from datetime import datetime
 from typing import Any, Dict, List
+from azurelinuxagent.common.future import UTC
 
 DELIMITER = ";"
 OPS_FILE_DIR = "/var/log/azure/Microsoft.Azure.TestExtensions.Edp.GuestAgentDcrTest/"
@@ -62,7 +63,7 @@ def parse_ops_log(ops_version: str, input_ops: List[str], start_time: str):
         content = ops_log.readlines()
         for op_log in content:
             data = op_log.split(DELIMITER)
-            date = datetime.strptime(data[0].split("Date:")[1], "%Y-%m-%dT%H:%M:%SZ")
+            date = datetime.strptime(data[0].split("Date:")[1], "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=UTC)
             op = data[1].split("Operation:")[1]
             seq_no = data[2].split("SeqNo:")[1].strip('\n')
 
@@ -87,7 +88,7 @@ def assert_ops_in_sequence(actual_ops: List[Dict[str, Any]], expected_ops: List[
         print("Operation sequence length doesn't match, exit code 2")
         exit_code = 2
 
-    last_date = datetime(70, 1, 1)
+    last_date = datetime(70, 1, 1, tzinfo=UTC)
     for idx, val in enumerate(actual_ops):
         if exit_code != 0:
             break
@@ -152,7 +153,7 @@ def main():
         # Print any unknown arguments passed to this script and fix them with low priority
         print("[Low Proiority][To-Fix] Found unknown args: %s" % ', '.join(unknown))
 
-    args.start_time = datetime.strptime(args.start_time, "%Y-%m-%dT%H:%M:%SZ")
+    args.start_time = datetime.strptime(args.start_time, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=UTC)
 
     exit_code = 999
     actual_ops = []

--- a/tests_e2e/tests/scripts/agent_ext_workflow-check_data_in_agent_log.py
+++ b/tests_e2e/tests/scripts/agent_ext_workflow-check_data_in_agent_log.py
@@ -23,6 +23,7 @@ import sys
 
 from datetime import datetime
 from pathlib import Path
+from azurelinuxagent.common.future import UTC
 from tests_e2e.tests.lib.agent_log import AgentLog
 
 
@@ -37,7 +38,7 @@ def main():
 
     try:
         if args.after_timestamp is not None:
-            after_datetime = datetime.strptime(args.after_timestamp, '%Y-%m-%d %H:%M:%S')
+            after_datetime = datetime.strptime(args.after_timestamp, '%Y-%m-%d %H:%M:%S').replace(tzinfo=UTC)
             found = AgentLog(Path('/var/log/waagent.log')).agent_log_contains(args.data, after_datetime)
         else:
             found = AgentLog(Path('/var/log/waagent.log')).agent_log_contains(args.data)

--- a/tests_e2e/tests/scripts/agent_publish-get_agent_log_record_timestamp.py
+++ b/tests_e2e/tests/scripts/agent_publish-get_agent_log_record_timestamp.py
@@ -18,8 +18,7 @@
 #
 
 import re
-from datetime import datetime
-
+from azurelinuxagent.common.future import datetime_min_utc
 from tests_e2e.tests.lib.agent_log import AgentLog
 
 # pylint: disable=W0105
@@ -70,7 +69,7 @@ def main():
                 if update_match:
                     return record.timestamp
 
-        return datetime.min
+        return datetime_min_utc
     except Exception as e:
         raise Exception("Error thrown when searching for update pattern in agent log to get record timestamp: {0}".format(str(e)))
 

--- a/tests_e2e/tests/scripts/ext_sequencing-get_ext_enable_time.py
+++ b/tests_e2e/tests/scripts/ext_sequencing-get_ext_enable_time.py
@@ -23,6 +23,7 @@ import argparse
 import re
 import sys
 from datetime import datetime
+from azurelinuxagent.common.future import UTC
 
 from tests_e2e.tests.lib.agent_log import AgentLog
 
@@ -37,7 +38,7 @@ def main():
     args, _ = parser.parse_known_args()
 
     # Only search the agent log after the provided timestamp: args.after_time
-    after_time = datetime.strptime(args.after_time, u'%Y-%m-%d %H:%M:%S')
+    after_time = datetime.strptime(args.after_time, u'%Y-%m-%d %H:%M:%S').replace(tzinfo=UTC)
     # Agent logs for extension enable: 2024-02-09T09:29:08.943529Z INFO ExtHandler [Microsoft.Azure.Extensions.CustomScript-2.1.10] Enable extension: [bin/custom-script-shim enable]
     enable_log_regex = r"\[{0}-[.\d]+\] Enable extension: .*".format(args.ext)
 

--- a/tests_e2e/tests/scripts/ext_telemetry_pipeline-add_extension_events.py
+++ b/tests_e2e/tests/scripts/ext_telemetry_pipeline-add_extension_events.py
@@ -31,6 +31,8 @@ from datetime import datetime, timedelta
 from random import choice
 from typing import List
 
+from azurelinuxagent.common.future import UTC
+
 from tests_e2e.tests.lib.agent_log import AgentLog
 from tests_e2e.tests.lib.logging import log
 
@@ -123,7 +125,7 @@ def add_extension_events(extensions: List[str], bad_event_count=0, no_of_events_
         for _ in range(no_of_events_per_extension):
             event = sample_ext_event.copy()
             event["OperationId"] = new_opr_id
-            event["TimeStamp"] = datetime.utcnow().strftime(u'%Y-%m-%dT%H:%M:%S.%fZ')
+            event["TimeStamp"] = datetime.now(UTC).strftime(u'%Y-%m-%dT%H:%M:%S.%fZ')
             event["Message"] = choice(sample_messages)
 
             if bad_count != 0:
@@ -148,11 +150,11 @@ def add_extension_events(extensions: List[str], bad_event_count=0, no_of_events_
 
 def wait_for_extension_events_dir_empty(extensions: List[str]):
     # By ensuring events dir to be empty, we verify that the telemetry events collector has completed its run
-    start_time = datetime.now()
+    start_time = datetime.now(UTC)
     timeout = timedelta(minutes=2)
     ext_event_dirs = [os.path.join("/var/log/azure/", ext, "events") for ext in extensions]
 
-    while (start_time + timeout) >= datetime.now():
+    while (start_time + timeout) >= datetime.now(UTC):
         log.info("")
         log.info("Waiting for extension event directories to be empty...")
         all_dir_empty = True


### PR DESCRIPTION
- Added Python 3.12 to the Unit Tests runs
- Removed use of the deprecated onerror argument to shutil.rmtree (https://docs.python.org/3.12/library/shutil.html#shutil.rmtree)
- Removed use the deprecated method datetime.utc_now (https://docs.python.org/3.12/library/datetime.html#datetime.datetime.utcnow)
- As part of the above item, I made all datetime instances time-zone aware.

Fixes #3215 