### PR TITLE
Add conf option to use hardcoded wireserver ip instead of dhcp req

### DIFF
--- a/README.md
+++ b/README.md
@@ -653,6 +653,15 @@ _Default: customscript,runcommand_
 
 The list of extensions which will be excluded from cgroups limits. This should be comma separated. 
 
+#### __Protocol.EndpointDiscovery__
+
+_Type: String_  
+_Default: dhcp_
+
+Determines how the agent will discover the protocol endpoint. Agent will use DHCP by default to discover 
+the wire server endpoint, but if this setting is 'hardcoded' the agent will use the known wireserver ip. 
+Possible options are "dhcp" (default) or "hardcoded".
+
 ### Telemetry
 
 WALinuxAgent collects usage data and sends it to Microsoft to help improve our products and services. The data collected is used to track service health and

--- a/azurelinuxagent/common/conf.py
+++ b/azurelinuxagent/common/conf.py
@@ -171,7 +171,8 @@ __STRING_OPTIONS__ = {
     "ResourceDisk.MountOptions": None,
     "ResourceDisk.Filesystem": "ext3",
     "AutoUpdate.GAFamily": "Prod",
-    "Policy.PolicyFilePath": "/etc/waagent_policy.json"
+    "Policy.PolicyFilePath": "/etc/waagent_policy.json",
+    "Protocol.EndpointDiscovery": "dhcp"
 }
 
 
@@ -547,6 +548,19 @@ def get_auto_update_to_latest_version(conf=__conf__):
     return conf.get_switch("AutoUpdate.UpdateToLatestVersion", default)
 
 
+def get_protocol_endpoint_discovery(conf=__conf__):
+    return conf.get("Protocol.EndpointDiscovery", "dhcp")
+
+
+def get_dhcp_discovery_enabled(conf=__conf__):
+    """
+    Determines how the agent will discover the protocol endpoint.
+    If set to 'dhcp', the agent will use DHCP to get the protocol endpoint.
+    Otherwise, the agent will use the hardcoded wireserver endpoint.
+    """
+    return get_protocol_endpoint_discovery(conf) == "dhcp"
+
+
 def get_cgroup_check_period(conf=__conf__):
     """
     How often to perform checks on cgroups (are the processes in the cgroups as expected,
@@ -618,6 +632,7 @@ def get_enable_agent_memory_usage_check(conf=__conf__):
     NOTE: This option is experimental and may be removed in later versions of the Agent.
     """
     return conf.get_switch("Debug.EnableAgentMemoryUsageCheck", False)
+
 
 def get_enable_fast_track(conf=__conf__):
     """

--- a/azurelinuxagent/common/dhcp.py
+++ b/azurelinuxagent/common/dhcp.py
@@ -20,6 +20,7 @@ import socket
 import time
 
 import azurelinuxagent.common.logger as logger
+from azurelinuxagent.common import conf
 from azurelinuxagent.common.exception import DhcpError
 from azurelinuxagent.common.osutil import get_osutil
 from azurelinuxagent.common.utils.restutil import KNOWN_WIRESERVER_IP
@@ -151,9 +152,15 @@ class DhcpHandler(object):
         """
         Check if DHCP is available
         """
-        dhcp_available =  self.osutil.is_dhcp_available()
-        if not dhcp_available:
-            logger.info("send_dhcp_req: DHCP not available")
+        dhcp_available = self.osutil.is_dhcp_available()
+        # If user has DHCP disabled for their VM then the dhcp request will fail. The user can configure the agent to
+        # use the hardcoded wire server ip instead.
+        use_dhcp = conf.get_dhcp_discovery_enabled()
+        if not dhcp_available or not use_dhcp:
+            if not dhcp_available:
+                logger.info("send_dhcp_req: DHCP not available")
+            if not use_dhcp:
+                logger.info("send_dhcp_req: DHCP usage for endpoint discovery is disabled (Protocol.EndpointDiscovery={0}). Will use hardcoded wireserver endpoint.".format(conf.get_protocol_endpoint_discovery()))
             self.endpoint = KNOWN_WIRESERVER_IP
             return
 

--- a/azurelinuxagent/common/event.py
+++ b/azurelinuxagent/common/event.py
@@ -117,6 +117,7 @@ class WALAEventOperation:
     ProvisionAfterExtensions = "ProvisionAfterExtensions"
     PluginSettingsVersionMismatch = "PluginSettingsVersionMismatch"
     InvalidExtensionConfig = "InvalidExtensionConfig"
+    ProtocolEndpoint = "ProtocolEndpoint"
     Provision = "Provision"
     ProvisionGuestAgent = "ProvisionGuestAgent"
     RemoteAccessHandling = "RemoteAccessHandling"

--- a/azurelinuxagent/common/protocol/util.py
+++ b/azurelinuxagent/common/protocol/util.py
@@ -204,7 +204,10 @@ class ProtocolUtil(SingletonPerThread):
                     ''' 
                     # pylint: enable=W0105
                     dhcp_available = self.osutil.is_dhcp_available()
-                    if dhcp_available:
+                    # If user has DHCP disabled for their VM then the agent may enter a loop of failed dhcp requests.
+                    # The user can configure the agent to use the hardcoded wire server ip instead.
+                    use_dhcp = conf.get_dhcp_discovery_enabled()
+                    if dhcp_available and use_dhcp:
                         logger.info("WireServer endpoint is not found. Rerun dhcp handler")
                         try:
                             self.dhcp_handler.run()
@@ -212,7 +215,10 @@ class ProtocolUtil(SingletonPerThread):
                             raise ProtocolError(ustr(e))
                         endpoint = self.dhcp_handler.endpoint
                     else:
-                        logger.info("_detect_protocol: DHCP not available")
+                        if not dhcp_available:
+                            logger.info("_detect_protocol: DHCP not available")
+                        if not use_dhcp:
+                            logger.info("_detect_protocol: DHCP usage for endpoint discovery is disabled (Protocol.EndpointDiscovery={0}). Will use hardcoded wireserver endpoint.".format(conf.get_protocol_endpoint_discovery()))
                         endpoint = self.get_wireserver_endpoint()
 
                 try:

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -44,7 +44,7 @@ from azurelinuxagent.common.telemetryevent import GuestAgentExtensionEventsSchem
 from azurelinuxagent.common.utils import fileutil, restutil
 from azurelinuxagent.common.utils.cryptutil import CryptUtil
 from azurelinuxagent.common.utils.restutil import TELEMETRY_THROTTLE_DELAY_IN_SECONDS, \
-    TELEMETRY_FLUSH_THROTTLE_DELAY_IN_SECONDS, TELEMETRY_DATA
+    TELEMETRY_FLUSH_THROTTLE_DELAY_IN_SECONDS, TELEMETRY_DATA, KNOWN_WIRESERVER_IP
 from azurelinuxagent.common.utils.textutil import parse_doc, findall, find, \
     findtext, gettext, remove_bom, get_bytes_from_pem, parse_json
 from azurelinuxagent.common.version import AGENT_NAME, CURRENT_VERSION
@@ -76,6 +76,13 @@ class WireProtocol(DataContract):
 
     def detect(self, init_goal_state=True, save_to_history=False):
         self.client.check_wire_protocol_version()
+
+        # Send telemetry if protocol endpoint is not the known WireServer endpoint.
+        endpoint = self.get_endpoint()
+        if endpoint is not None and endpoint != KNOWN_WIRESERVER_IP:
+            message = 'Protocol endpoint is not known wireserver ip: {0}'.format(endpoint)
+            logger.info(message)
+            add_event(op=WALAEventOperation.ProtocolEndpoint, message=message)
 
         trans_prv_file = os.path.join(conf.get_lib_dir(),
                                       TRANSPORT_PRV_FILE_NAME)

--- a/tests/common/dhcp/test_dhcp.py
+++ b/tests/common/dhcp/test_dhcp.py
@@ -18,6 +18,7 @@
 import mock
 import azurelinuxagent.common.dhcp as dhcp
 import azurelinuxagent.common.osutil.default as osutil
+from azurelinuxagent.common.utils.restutil import KNOWN_WIRESERVER_IP
 from tests.lib.tools import AgentTestCase, open_patch, patch
 
 
@@ -90,7 +91,7 @@ class TestDHCP(AgentTestCase):
         handler = dhcp.get_dhcp_handler()
         handler.osutil = osutil.DefaultOSUtil()
 
-        open_file_mock = mock.mock_open(read_data=TestDHCP.DEFAULT_ROUTING_TABLE) 
+        open_file_mock = mock.mock_open(read_data=TestDHCP.DEFAULT_ROUTING_TABLE)
 
         with patch('os.path.exists', return_value=False):
             with patch.object(osutil.DefaultOSUtil, 'get_dhcp_lease_endpoint')\
@@ -125,3 +126,43 @@ class TestDHCP(AgentTestCase):
                     
                     self.assertTrue(patch_dhcp_cache.call_count == 1)
                     self.assertTrue(patch_dhcp_send.call_count == 1)
+
+    def test_dhcp_send_req_dhcp_unavailable(self):
+        handler = dhcp.get_dhcp_handler()
+        handler.skip_cache = True   # Force test to skip cache and get to send_dhcp_req
+        handler.osutil = osutil.DefaultOSUtil()
+
+        # Mock routing table so that it doesn't have wireserver route
+        with patch("os.path.exists", return_value=True):
+            open_file_mock = mock.mock_open(read_data=TestDHCP.DEFAULT_ROUTING_TABLE)
+            with patch(open_patch(), open_file_mock):
+                # Mock osutil so dhcp is not available
+                with patch('azurelinuxagent.common.osutil.default.DefaultOSUtil.is_dhcp_available', return_value=False):
+                    with patch.object(dhcp.DhcpHandler, '_send_dhcp_req') as patch_dhcp_send:
+                        handler.run()
+
+                        # Assert that endpoint is set to known wireserver ip
+                        self.assertEqual(handler.endpoint, KNOWN_WIRESERVER_IP)
+
+                        # Assert that the dhcp request did not get sent, because dhcp is not available
+                        self.assertTrue(patch_dhcp_send.call_count == 0)
+
+    def test_dhcp_send_req_dhcp_discovery_disabled(self):
+        handler = dhcp.get_dhcp_handler()
+        handler.skip_cache = True  # Force test to skip cache and get to send_dhcp_req
+        handler.osutil = osutil.DefaultOSUtil()
+
+        # Mock routing table so that it doesn't have wireserver route
+        with patch("os.path.exists", return_value=True):
+            open_file_mock = mock.mock_open(read_data=TestDHCP.DEFAULT_ROUTING_TABLE)
+            with patch(open_patch(), open_file_mock):
+                # Mock osutil so dhcp is not available
+                with patch('azurelinuxagent.common.conf.get_dhcp_discovery_enabled', return_value=False):
+                    with patch.object(dhcp.DhcpHandler, '_send_dhcp_req') as patch_dhcp_send:
+                        handler.run()
+
+                        # Assert that endpoint is set to known wireserver ip
+                        self.assertEqual(handler.endpoint, KNOWN_WIRESERVER_IP)
+
+                        # Assert that the dhcp request did not get sent, because dhcp discovery is disabled
+                        self.assertTrue(patch_dhcp_send.call_count == 0)

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -87,6 +87,7 @@ OS.SudoersDir = /etc/sudoers.d
 OS.UpdateRdmaDriver = False
 Pid.File = /var/run/waagent.pid
 Policy.PolicyFilePath = /etc/waagent_policy.json
+Protocol.EndpointDiscovery = dhcp
 Provisioning.Agent = auto
 Provisioning.AllowResetSysUser = False
 Provisioning.DecodeCustomData = False


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
Add a configuration option for users who disable dhcp to skip protocol endpoint discovery via dhcp request. 
Send telemetry if protocol endpoint does not match known wireserver ip.

Issue #2781
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).