### PR TITLE
Use Ubuntu 24 for the Unit Tests workflow

### DIFF
--- a/.github/workflows/ci_pr.yml
+++ b/.github/workflows/ci_pr.yml
@@ -19,10 +19,10 @@ jobs:
           # Some of the Python versions we test are not supported by the setup-python Github Action. For those versions, we use a
           # pre-built virtual environment.
           #
-#          - python-version: "2.6"
-#            use_virtual_environment: true
-#          - python-version: "2.7"
-#            use_virtual_environment: true
+          - python-version: "2.6"
+            use_virtual_environment: true
+          - python-version: "2.7"
+            use_virtual_environment: true
           - python-version: "3.4"
             use_virtual_environment: true
           - python-version: "3.5"
@@ -31,11 +31,11 @@ jobs:
             use_virtual_environment: true
           - python-version: "3.7"
             use_virtual_environment: true
-#          - python-version: "3.8"
+          - python-version: "3.8"
           - python-version: "3.9"
             additional-nose-opts: "--with-coverage --cover-erase --cover-inclusive --cover-branches --cover-package=azurelinuxagent"
-#          - python-version: "3.10"
-#          - python-version: "3.11"
+          - python-version: "3.10"
+          - python-version: "3.11"
 
     steps:
     - name: Checkout WALinuxAgent

--- a/.github/workflows/ci_pr.yml
+++ b/.github/workflows/ci_pr.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   execute-tests:
     name: "Python ${{ matrix.python-version }} Unit Tests"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -19,23 +19,21 @@ jobs:
           # Some of the Python versions we test are not supported by the setup-python Github Action. For those versions, we use a
           # pre-built virtual environment.
           #
-          - python-version: "2.6"
-            use_virtual_environment: true
-          - python-version: "2.7"
-            use_virtual_environment: true
+#          - python-version: "2.6"
+#            use_virtual_environment: true
+#          - python-version: "2.7"
+#            use_virtual_environment: true
           - python-version: "3.4"
             use_virtual_environment: true
           - python-version: "3.5"
-            # workaround found in https://github.com/actions/setup-python/issues/866
-            # for issue "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:728)" on Python 3.5
-            pip_trusted_host: "pypi.python.org pypi.org files.pythonhosted.org"
-          - python-version: "3.6"
-          - python-version: "3.7"
-          - python-version: "3.8"
+            use_virtual_environment: true
+#          - python-version: "3.6"
+#          - python-version: "3.7"
+#          - python-version: "3.8"
           - python-version: "3.9"
             additional-nose-opts: "--with-coverage --cover-erase --cover-inclusive --cover-branches --cover-package=azurelinuxagent"
-          - python-version: "3.10"
-          - python-version: "3.11"
+#          - python-version: "3.10"
+#          - python-version: "3.11"
 
     steps:
     - name: Checkout WALinuxAgent
@@ -49,8 +47,6 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-      env:
-        PIP_TRUSTED_HOST: ${{ matrix.pip_trusted_host }}
 
     - name: Install dependencies
       if: (!matrix.use_virtual_environment)
@@ -70,9 +66,9 @@ jobs:
         curl -sSf --retry 5 -o /tmp/python-${{ matrix.python-version }}.tar.bz2 https://dcrdata.blob.core.windows.net/python/python-${{ matrix.python-version }}.tar.bz2
         sudo tar xjf /tmp/python-${{ matrix.python-version }}.tar.bz2 --directory /
         #
-        # The virtual environments for 2.6 and 3.4 have dependencies on OpenSSL 1.0, which is not available beyond Ubuntu 16. We use this script to patch the environments.
+        # The virtual environments for 2.6, 3.4 and 3.5 have dependencies on OpenSSL 1.0/1.1, which is not available on Ubuntu 24. We use this script to patch the environments.
         #
-        if [[ "${{ matrix.python-version }}" =~ ^2\.6|3\.4$ ]]; then
+        if [[ "${{ matrix.python-version }}" =~ ^2\.6|3\.[45]$ ]]; then
           sudo ./tests/python_eol/patch_python_venv.sh "${{ matrix.python-version }}"
         fi
 
@@ -82,25 +78,46 @@ jobs:
     - name: Execute Unit Tests
       run: |
         if [[ "${{ matrix.python-version }}" =~ ^3\.[1-9][0-9]+$ ]]; then
+          #
+          # Use pytest
+          #
           ./ci/pytest.sh
         else
-          if [[ "${{ matrix.use_virtual_environment}}" == "true"  ]]; then
-            export NOSEOPTS="--verbose ${{ matrix.additional-nose-opts }}"   # the pytest version on the venvs does not support the --with-timer option. 
-            source /home/waagent/virtualenv/python${{ matrix.python-version }}/bin/activate
+          #
+          # Use nosetests
+          #
+          if [[ "${{ matrix.python-version }}" =~ ^2\.[67]|3\.4$ ]]; then # the pytest version on these venvs does not support the --with-timer option
+            export NOSEOPTS="--verbose ${{ matrix.additional-nose-opts }}"
           else
             export NOSEOPTS="--verbose --with-timer ${{ matrix.additional-nose-opts }}"
           fi
+
+          #
+          # If using a venv, activate it.
+          #
+          if [[ "${{ matrix.use_virtual_environment}}" == "true"  ]]; then
+              source /home/waagent/virtualenv/python${{ matrix.python-version }}/bin/activate
+            fi
+          fi
+        
           ./ci/nosetests.sh
         fi
 
     #
     # Execute pylint even when the tests fail (but only if the dependencies were installed successfully)
     #
-    # The virtual environments do not include pylint, so we skip those Python versions.
+    # The virtual environments for 2.6, 2.7, and 3.4 do not include pylint, so we skip those Python versions.
     #
     - name: Run pylint
-      if: (!matrix.use_virtual_environment && (success() || (failure() && steps.install-dependencies.outcome == 'success')))
+      if: (!contains(fromJSON('["2.6", "2.7", "3.4"]'),  matrix.python-version) && (success() || (failure() && steps.install-dependencies.outcome == 'success')))
       run: |
+        #
+        # If using a venv, activate it.
+        #
+        if [[ "${{ matrix.use_virtual_environment}}" == "true"  ]]; then
+              source /home/waagent/virtualenv/python${{ matrix.python-version }}/bin/activate
+        fi
+
         #
         # List of files/directories to be checked by pylint.
         # The end-to-end tests run only on Python 3.9 and we lint them only on that version.

--- a/.github/workflows/ci_pr.yml
+++ b/.github/workflows/ci_pr.yml
@@ -96,8 +96,7 @@ jobs:
           # If using a venv, activate it.
           #
           if [[ "${{ matrix.use_virtual_environment}}" == "true"  ]]; then
-              source /home/waagent/virtualenv/python${{ matrix.python-version }}/bin/activate
-            fi
+            source /home/waagent/virtualenv/python${{ matrix.python-version }}/bin/activate
           fi
         
           ./ci/nosetests.sh

--- a/.github/workflows/ci_pr.yml
+++ b/.github/workflows/ci_pr.yml
@@ -29,7 +29,8 @@ jobs:
             use_virtual_environment: true
           - python-version: "3.6"
             use_virtual_environment: true
-#          - python-version: "3.7"
+          - python-version: "3.7"
+            use_virtual_environment: true
 #          - python-version: "3.8"
           - python-version: "3.9"
             additional-nose-opts: "--with-coverage --cover-erase --cover-inclusive --cover-branches --cover-package=azurelinuxagent"
@@ -67,9 +68,9 @@ jobs:
         curl -sSf --retry 5 -o /tmp/python-${{ matrix.python-version }}.tar.bz2 https://dcrdata.blob.core.windows.net/python/python-${{ matrix.python-version }}.tar.bz2
         sudo tar xjf /tmp/python-${{ matrix.python-version }}.tar.bz2 --directory /
         #
-        # The virtual environments for 2.6 and 3.4-3.6 have dependencies on OpenSSL 1.0/1.1, which is not available on Ubuntu 24. We use this script to patch the environments.
+        # The virtual environments have dependencies on old versions of OpenSSL (e.g 1.0/1.1) which are not available on Ubuntu 24. We use this script to patch the environments.
         #
-        if [[ "${{ matrix.python-version }}" =~ ^2\.6|3\.[456]$ ]]; then
+        if [[ "${{ matrix.use_virtual_environment}}" == "true" ]]; then
           sudo ./tests/python_eol/patch_python_venv.sh "${{ matrix.python-version }}"
         fi
 
@@ -87,7 +88,7 @@ jobs:
           #
           # Use nosetests
           #
-          if [[ "${{ matrix.python-version }}" =~ ^2\.[67]|3\.[456]$ ]]; then # the pytest version on these venvs does not support the --with-timer option
+          if [[ "${{ matrix.use_virtual_environment}}" == "true" ]]; then # the pytest version on the venvs does not support the --with-timer option
             export NOSEOPTS="--verbose ${{ matrix.additional-nose-opts }}"
           else
             export NOSEOPTS="--verbose --with-timer ${{ matrix.additional-nose-opts }}"

--- a/.github/workflows/ci_pr.yml
+++ b/.github/workflows/ci_pr.yml
@@ -27,7 +27,8 @@ jobs:
             use_virtual_environment: true
           - python-version: "3.5"
             use_virtual_environment: true
-#          - python-version: "3.6"
+          - python-version: "3.6"
+            use_virtual_environment: true
 #          - python-version: "3.7"
 #          - python-version: "3.8"
           - python-version: "3.9"
@@ -66,9 +67,9 @@ jobs:
         curl -sSf --retry 5 -o /tmp/python-${{ matrix.python-version }}.tar.bz2 https://dcrdata.blob.core.windows.net/python/python-${{ matrix.python-version }}.tar.bz2
         sudo tar xjf /tmp/python-${{ matrix.python-version }}.tar.bz2 --directory /
         #
-        # The virtual environments for 2.6, 3.4 and 3.5 have dependencies on OpenSSL 1.0/1.1, which is not available on Ubuntu 24. We use this script to patch the environments.
+        # The virtual environments for 2.6 and 3.4-3.6 have dependencies on OpenSSL 1.0/1.1, which is not available on Ubuntu 24. We use this script to patch the environments.
         #
-        if [[ "${{ matrix.python-version }}" =~ ^2\.6|3\.[45]$ ]]; then
+        if [[ "${{ matrix.python-version }}" =~ ^2\.6|3\.[456]$ ]]; then
           sudo ./tests/python_eol/patch_python_venv.sh "${{ matrix.python-version }}"
         fi
 
@@ -86,7 +87,7 @@ jobs:
           #
           # Use nosetests
           #
-          if [[ "${{ matrix.python-version }}" =~ ^2\.[67]|3\.4$ ]]; then # the pytest version on these venvs does not support the --with-timer option
+          if [[ "${{ matrix.python-version }}" =~ ^2\.[67]|3\.[456]$ ]]; then # the pytest version on these venvs does not support the --with-timer option
             export NOSEOPTS="--verbose ${{ matrix.additional-nose-opts }}"
           else
             export NOSEOPTS="--verbose --with-timer ${{ matrix.additional-nose-opts }}"

--- a/tests/ga/test_cgroupconfigurator_sudo.py
+++ b/tests/ga/test_cgroupconfigurator_sudo.py
@@ -87,7 +87,7 @@ class CGroupConfiguratorSystemdTestCaseSudo(AgentTestCase):
                     self.assertIn("Non-zero exit code", ustr(context_manager.exception))
                     # The scope name should appear in the process output since systemd-run was invoked and stderr
                     # wasn't truncated.
-                    self.assertIn("Running scope as unit", ustr(context_manager.exception))
+                    self.assertRegex(ustr(context_manager.exception), r"Running (scope )?as unit")
 
     @patch('time.sleep', side_effect=lambda _: mock_sleep())
     @patch("azurelinuxagent.ga.extensionprocessutil.TELEMETRY_MESSAGE_MAX_LEN", 5)

--- a/tests/python_eol/patch_python_venv.sh
+++ b/tests/python_eol/patch_python_venv.sh
@@ -27,7 +27,6 @@ PYTHON_VERSION=$1
 
 if [[ "${PYTHON_VERSION}" =~ ^2\.[0-9]$ ]]; then
   # Patch httplib.py on Python 2
-  httplib="$(find /opt -wholename '*/lib/python${PYTHON_VERSION}/http/client.py')"
   cat >> /opt/python/${PYTHON_VERSION}/lib/python${PYTHON_VERSION}/httplib.py << ...
 
 # Added by WALinuxAgent dev team to work around the lack of OpenSSL 1.0 shared libraries

--- a/tests/python_eol/patch_python_venv.sh
+++ b/tests/python_eol/patch_python_venv.sh
@@ -18,8 +18,8 @@
 #
 set -euo pipefail
 
-if [[ "$#" -ne 1 || ! "$1" =~ ^2\.6|2\.7|3\.[45]$ ]]; then
-  echo "Usage: patch_python_venv.sh 2.6|2.7|3.4|3.5"
+if [[ "$#" -ne 1 || ! "$1" =~ ^2\.6|2\.7|3\.[456]$ ]]; then
+  echo "Usage: patch_python_venv.sh 2.6|2.7|3.4|3.5|3.6"
   exit 1
 fi
 

--- a/tests/python_eol/patch_python_venv.sh
+++ b/tests/python_eol/patch_python_venv.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 #
-# The python 2.6, 2.7, and 3.4 virtual environments have hard dependencies on some of the shared libraries in Open SSL 1.0 (e.g libssl.so.1.0.0), which is not available beyond Ubuntu 16.
-# Modules like hashlib and ssl will fail to import on more recent versions of Ubuntu. The Agent uses classes HTTPSConnection and HTTPS, which depend on the ssl module. Those classes
-# are added conditionally on the import of ssl on httplib.py and http/client.py with code similar to:
+# The pre-built Python virtual environments have hard dependencies on some of the shared libraries in Open SSL 1.0/1.1 (e.g libssl.so.1.0.0), which are not available on current Ubuntu versions.
+# Modules like hashlib and ssl will fail to import. The Agent uses classes HTTPSConnection and HTTPS, which depend on the ssl module. Those classes are added conditionally on the
+# import of ssl on httplib.py and http/client.py with code similar to:
 #
 #     try:
 #        import ssl
@@ -18,14 +18,16 @@
 #
 set -euo pipefail
 
-if [[ "$#" -ne 1 || ! "$1" =~ ^2\.6|2\.7|3\.4$ ]]; then
-  echo "Usage: patch_python_venv.sh 2.6|2.7|3.4"
+if [[ "$#" -ne 1 || ! "$1" =~ ^2\.6|2\.7|3\.[45]$ ]]; then
+  echo "Usage: patch_python_venv.sh 2.6|2.7|3.4|3.5"
   exit 1
 fi
 
 PYTHON_VERSION=$1
 
-if [[ "${PYTHON_VERSION}" =~ ^2\.6|2\.7$ ]]; then
+if [[ "${PYTHON_VERSION}" =~ ^2\.[0-9]$ ]]; then
+  # Patch httplib.py on Python 2
+  httplib="$(find /opt -wholename '*/lib/python${PYTHON_VERSION}/http/client.py')"
   cat >> /opt/python/${PYTHON_VERSION}/lib/python${PYTHON_VERSION}/httplib.py << ...
 
 # Added by WALinuxAgent dev team to work around the lack of OpenSSL 1.0 shared libraries
@@ -50,8 +52,10 @@ def FakeSocket (sock, sslobj):
     raise NotImplementedError()
 ...
 
-elif [[ "${PYTHON_VERSION}" == "3.4" ]]; then
-  cat >> /opt/python/3.4.8/lib/python3.4/http/client.py << ...
+elif [[ "${PYTHON_VERSION}" =~ ^3\.[0-9]$ ]]; then
+  # Patch http/client.py on Python 3
+  path='*/lib/python'${PYTHON_VERSION}'/http/client.py'
+  cat >> "$(find /opt -wholename $path)" << ...
 
 # Added by WALinuxAgent dev team to work around the lack of OpenSSL 1.0 shared libraries
 class HTTPSConnection(HTTPConnection):

--- a/tests/python_eol/patch_python_venv.sh
+++ b/tests/python_eol/patch_python_venv.sh
@@ -18,8 +18,8 @@
 #
 set -euo pipefail
 
-if [[ "$#" -ne 1 || ! "$1" =~ ^2\.6|2\.7|3\.[456]$ ]]; then
-  echo "Usage: patch_python_venv.sh 2.6|2.7|3.4|3.5|3.6"
+if [[ "$#" -ne 1 ]]; then
+  echo "Usage: patch_python_venv.sh <python_version(major.minor, e.g. 2.6)>"
   exit 1
 fi
 


### PR DESCRIPTION
3.5, 3.6 and 3.7 are not supported on Ubuntu 24, so now we use pre-built venvs for those versions.