### PR TITLE
Disable rsm downgrade

### DIFF
--- a/azurelinuxagent/common/conf.py
+++ b/azurelinuxagent/common/conf.py
@@ -707,3 +707,11 @@ def get_log_collector_initial_delay(conf=__conf__):
     NOTE: This option is experimental and may be removed in later versions of the Agent.
     """
     return conf.get_int("Debug.LogCollectorInitialDelay", 5 * 60)
+
+def get_disable_rsm_downgrade(conf=__conf__):
+    """
+    If True, the agent will not downgrade to a lower version when a lower version is requested in the goal state.
+
+    Todo: Flag will be removed once we have a fix for rsm downgrade scenario.
+    """
+    return conf.get_switch("Debug.DisableRsmDowngrade", True)

--- a/azurelinuxagent/common/conf.py
+++ b/azurelinuxagent/common/conf.py
@@ -708,10 +708,10 @@ def get_log_collector_initial_delay(conf=__conf__):
     """
     return conf.get_int("Debug.LogCollectorInitialDelay", 5 * 60)
 
-def get_disable_rsm_downgrade(conf=__conf__):
+def get_enable_rsm_downgrade(conf=__conf__):
     """
-    If True, the agent will not downgrade to a lower version when a lower version is requested in the goal state.
+    If False, the agent will not downgrade to a lower version when a lower version is requested in the goal state.
 
     Todo: Flag will be removed once we have a fix for rsm downgrade scenario.
     """
-    return conf.get_switch("Debug.DisableRsmDowngrade", True)
+    return conf.get_switch("Debug.EnableRsmDowngrade", False)

--- a/azurelinuxagent/ga/rsm_version_updater.py
+++ b/azurelinuxagent/ga/rsm_version_updater.py
@@ -92,7 +92,7 @@ class RSMVersionUpdater(GAVersionUpdater):
         Todo: Downgrade flow has issues, not allowing it until we have a fix
         """
 
-        if not agent_family.is_version_from_rsm or self._version < self._daemon_version or self._version == CURRENT_VERSION or (self._version < CURRENT_VERSION and conf.get_disable_rsm_downgrade()):
+        if not agent_family.is_version_from_rsm or self._version < self._daemon_version or self._version == CURRENT_VERSION or (self._version < CURRENT_VERSION and not conf.get_enable_rsm_downgrade()):
             return False
 
         return True

--- a/azurelinuxagent/ga/rsm_version_updater.py
+++ b/azurelinuxagent/ga/rsm_version_updater.py
@@ -88,9 +88,11 @@ class RSMVersionUpdater(GAVersionUpdater):
         """
         Once version retrieved from goal state, we check if we allowed to update for that version
         allow update If new version not same as current version, not below than daemon version and if version is from rsm request
+
+        Todo: Downgrade flow has issues, not allowing it until we have a fix
         """
 
-        if not agent_family.is_version_from_rsm or self._version < self._daemon_version or self._version == CURRENT_VERSION:
+        if not agent_family.is_version_from_rsm or self._version < self._daemon_version or self._version == CURRENT_VERSION or (self._version < CURRENT_VERSION and conf.get_disable_rsm_downgrade()):
             return False
 
         return True

--- a/tests/data/wire/ext_conf_version_missing_in_manifest.xml
+++ b/tests/data/wire/ext_conf_version_missing_in_manifest.xml
@@ -3,7 +3,7 @@
         <GAFamilies>
             <GAFamily>
                 <Name>Prod</Name>
-                <Version>5.2.1.0</Version>
+                <Version>9.9.9.999</Version>
                 <IsVersionFromRSM>True</IsVersionFromRSM>
                 <IsVMEnabledForRSMUpgrades>True</IsVMEnabledForRSMUpgrades>
                 <Uris>
@@ -12,7 +12,7 @@
             </GAFamily>
             <GAFamily>
                 <Name>Test</Name>
-                <Version>5.2.1.0</Version>
+                <Version>9.9.9.999</Version>
                 <IsVersionFromRSM>True</IsVersionFromRSM>
                 <IsVMEnabledForRSMUpgrades>True</IsVMEnabledForRSMUpgrades>
                 <Uris>

--- a/tests/ga/test_agent_update_handler.py
+++ b/tests/ga/test_agent_update_handler.py
@@ -277,7 +277,7 @@ class TestAgentUpdate(UpdateTestCase):
             self._assert_agent_directories_exist_and_others_dont_exist(versions=["9.9.9.10", str(CURRENT_VERSION)])
             self._assert_agent_exit_process_telemetry_emitted(ustr(context.exception.reason))
 
-    def test_it_should_downgrade_agent_if_rsm_version_is_available_less_than_current_version(self):
+    def test_it_should_not_allow_rsm_downgrade_if_rsm_version_is_available_less_than_current_version(self):
         data_file = DATA_FILE.copy()
         data_file["ext_conf"] = "wire/ext_conf_rsm_version.xml"
 
@@ -287,22 +287,40 @@ class TestAgentUpdate(UpdateTestCase):
 
         downgraded_version = "2.5.0"
 
-        with self._get_agent_update_handler(test_data=data_file) as (agent_update_handler, mock_telemetry):
+        with self._get_agent_update_handler(test_data=data_file) as (agent_update_handler, _):
             agent_update_handler._protocol.mock_wire_data.set_version_in_agent_family(downgraded_version)
             agent_update_handler._protocol.mock_wire_data.set_incarnation(2)
             agent_update_handler._protocol.client.update_goal_state()
-            with self.assertRaises(AgentUpgradeExitException) as context:
-                agent_update_handler.run(agent_update_handler._protocol.get_goal_state(), True)
-            self._assert_agent_rsm_version_in_goal_state(mock_telemetry, inc=2, version=downgraded_version)
-            self._assert_agent_directories_exist_and_others_dont_exist(
-                versions=[downgraded_version, str(CURRENT_VERSION)])
-            self._assert_agent_exit_process_telemetry_emitted(ustr(context.exception.reason))
+            agent_update_handler.run(agent_update_handler._protocol.get_goal_state(), True)
+            self.assertFalse(os.path.exists(self.agent_dir(downgraded_version)),"New agent directory should not be found")
+
+    # Todo: Uncomment this test case once the issue with rsm downgrade scenario fixed
+    # def test_it_should_downgrade_agent_if_rsm_version_is_available_less_than_current_version(self):
+    #     data_file = DATA_FILE.copy()
+    #     data_file["ext_conf"] = "wire/ext_conf_rsm_version.xml"
+    #
+    #     # Set the test environment by adding 20 random agents to the agent directory
+    #     self.prepare_agents()
+    #     self.assertEqual(20, self.agent_count(), "Agent directories not set properly")
+    #
+    #     downgraded_version = "2.5.0"
+    #
+    #     with self._get_agent_update_handler(test_data=data_file) as (agent_update_handler, mock_telemetry):
+    #         agent_update_handler._protocol.mock_wire_data.set_version_in_agent_family(downgraded_version)
+    #         agent_update_handler._protocol.mock_wire_data.set_incarnation(2)
+    #         agent_update_handler._protocol.client.update_goal_state()
+    #         with self.assertRaises(AgentUpgradeExitException) as context:
+    #             agent_update_handler.run(agent_update_handler._protocol.get_goal_state(), True)
+    #         self._assert_agent_rsm_version_in_goal_state(mock_telemetry, inc=2, version=downgraded_version)
+    #         self._assert_agent_directories_exist_and_others_dont_exist(
+    #             versions=[downgraded_version, str(CURRENT_VERSION)])
+    #         self._assert_agent_exit_process_telemetry_emitted(ustr(context.exception.reason))
 
     def test_it_should_not_do_rsm_update_if_gs_not_updated_in_next_attempt(self):
         self.prepare_agents(count=1)
         data_file = DATA_FILE.copy()
         data_file["ext_conf"] = "wire/ext_conf_rsm_version.xml"
-        version = "5.2.0.1"
+        version = "9.9.9.999"
         with self._get_agent_update_handler(test_data=data_file, autoupdate_frequency=10) as (agent_update_handler, mock_telemetry):
             agent_update_handler._protocol.mock_wire_data.set_version_in_agent_family(version)
             agent_update_handler._protocol.mock_wire_data.set_incarnation(2)
@@ -370,7 +388,7 @@ class TestAgentUpdate(UpdateTestCase):
         self.prepare_agents()
         self.assertEqual(20, self.agent_count(), "Agent directories not set properly")
 
-        version = "5.2.0.4"
+        version = "9.9.9.999"
 
         with self._get_agent_update_handler(test_data=data_file) as (agent_update_handler, mock_telemetry):
             agent_update_handler._protocol.mock_wire_data.set_version_in_agent_family(version)

--- a/tests/ga/test_update.py
+++ b/tests/ga/test_update.py
@@ -1752,31 +1752,31 @@ class TestAgentUpgrade(UpdateTestCase):
             self.__assert_exit_code_successful(update_handler)
             self.__assert_upgrade_telemetry_emitted(mock_telemetry, version="9.9.9.10")
 
-    # Todo: Uncomment this test case once the issue with rsm downgrade scenario fixed
-    # def test_it_should_mark_current_agent_as_bad_version_on_downgrade(self):
-    #     # Create Agent directory for current agent
-    #     self.prepare_agents(count=1)
-    #     self.assertTrue(os.path.exists(self.agent_dir(CURRENT_VERSION)))
-    #     self.assertFalse(next(agent for agent in self.agents() if agent.version == CURRENT_VERSION).is_blacklisted,
-    #                      "The current agent should not be blacklisted")
-    #     downgraded_version = "2.5.0"
-    #
-    #     data_file = wire_protocol_data.DATA_FILE.copy()
-    #     data_file["ext_conf"] = "wire/ext_conf_rsm_version.xml"
-    #     with self.__get_update_handler(test_data=data_file) as (update_handler, mock_telemetry):
-    #         update_handler._protocol.mock_wire_data.set_version_in_agent_family(downgraded_version)
-    #         update_handler._protocol.mock_wire_data.set_incarnation(2)
-    #         update_handler.run(debug=True)
-    #
-    #         self.__assert_exit_code_successful(update_handler)
-    #         self.__assert_upgrade_telemetry_emitted(mock_telemetry, upgrade=False,
-    #                                                                       version=downgraded_version)
-    #         current_agent = next(agent for agent in self.agents() if agent.version == CURRENT_VERSION)
-    #         self.assertTrue(current_agent.is_blacklisted, "The current agent should be blacklisted")
-    #         self.assertEqual(current_agent.error.reason, "Marking the agent {0} as bad version since a downgrade was requested in the GoalState, "
-    #                                                      "suggesting that we really don't want to execute any extensions using this version".format(CURRENT_VERSION),
-    #                          "Invalid reason specified for blacklisting agent")
-    #         self.__assert_agent_directories_exist_and_others_dont_exist(versions=[downgraded_version, str(CURRENT_VERSION)])
+    @skip_if_predicate_true(lambda: True, "Enable this test when rsm downgrade scenario fixed")
+    def test_it_should_mark_current_agent_as_bad_version_on_downgrade(self):
+        # Create Agent directory for current agent
+        self.prepare_agents(count=1)
+        self.assertTrue(os.path.exists(self.agent_dir(CURRENT_VERSION)))
+        self.assertFalse(next(agent for agent in self.agents() if agent.version == CURRENT_VERSION).is_blacklisted,
+                         "The current agent should not be blacklisted")
+        downgraded_version = "2.5.0"
+
+        data_file = wire_protocol_data.DATA_FILE.copy()
+        data_file["ext_conf"] = "wire/ext_conf_rsm_version.xml"
+        with self.__get_update_handler(test_data=data_file) as (update_handler, mock_telemetry):
+            update_handler._protocol.mock_wire_data.set_version_in_agent_family(downgraded_version)
+            update_handler._protocol.mock_wire_data.set_incarnation(2)
+            update_handler.run(debug=True)
+
+            self.__assert_exit_code_successful(update_handler)
+            self.__assert_upgrade_telemetry_emitted(mock_telemetry, upgrade=False,
+                                                                          version=downgraded_version)
+            current_agent = next(agent for agent in self.agents() if agent.version == CURRENT_VERSION)
+            self.assertTrue(current_agent.is_blacklisted, "The current agent should be blacklisted")
+            self.assertEqual(current_agent.error.reason, "Marking the agent {0} as bad version since a downgrade was requested in the GoalState, "
+                                                         "suggesting that we really don't want to execute any extensions using this version".format(CURRENT_VERSION),
+                             "Invalid reason specified for blacklisting agent")
+            self.__assert_agent_directories_exist_and_others_dont_exist(versions=[downgraded_version, str(CURRENT_VERSION)])
 
     def test_it_should_do_self_update_if_vm_opt_out_rsm_upgrades_later(self):
         no_of_iterations = 100

--- a/tests_e2e/tests/agent_publish/rollback.py
+++ b/tests_e2e/tests/agent_publish/rollback.py
@@ -46,7 +46,7 @@ class Rollback(AgentVmTest):
         self._check_rsm_gs(rollback_version)
 
         output: str = self._ssh_client.run_command(
-            "update-waagent-conf Debug.EnableGAVersioning=y Debug.DisableRsmDowngrade=n", use_sudo=True)
+            "update-waagent-conf Debug.EnableGAVersioning=y Debug.EnableRsmDowngrade=y", use_sudo=True)
         log.info('Successfully enabled rsm updates \n %s', output)
 
         verify_current_agent_version(self._ssh_client, rollback_version)

--- a/tests_e2e/tests/agent_publish/rollback.py
+++ b/tests_e2e/tests/agent_publish/rollback.py
@@ -46,7 +46,7 @@ class Rollback(AgentVmTest):
         self._check_rsm_gs(rollback_version)
 
         output: str = self._ssh_client.run_command(
-            "update-waagent-conf Debug.EnableGAVersioning=y", use_sudo=True)
+            "update-waagent-conf Debug.EnableGAVersioning=y Debug.DisableRsmDowngrade=n", use_sudo=True)
         log.info('Successfully enabled rsm updates \n %s', output)
 
         verify_current_agent_version(self._ssh_client, rollback_version)

--- a/tests_e2e/tests/agent_update/rsm_update.py
+++ b/tests_e2e/tests/agent_update/rsm_update.py
@@ -138,7 +138,7 @@ class RsmUpdateBvt(AgentVmTest):
         log.info(
             'Executing update-waagent-conf remote script to update agent update config flags to allow and download test versions')
         output: str = self._ssh_client.run_command(
-                              "update-waagent-conf AutoUpdate.UpdateToLatestVersion=y Debug.EnableGAVersioning=y AutoUpdate.GAFamily=Test", use_sudo=True)
+                              "update-waagent-conf AutoUpdate.UpdateToLatestVersion=y Debug.EnableGAVersioning=y Debug.DisableRsmDowngrade=n AutoUpdate.GAFamily=Test", use_sudo=True)
         log.info('Successfully updated agent update config \n %s', output)
 
     def _verify_guest_agent_update(self, requested_version: str) -> None:

--- a/tests_e2e/tests/agent_update/rsm_update.py
+++ b/tests_e2e/tests/agent_update/rsm_update.py
@@ -138,7 +138,7 @@ class RsmUpdateBvt(AgentVmTest):
         log.info(
             'Executing update-waagent-conf remote script to update agent update config flags to allow and download test versions')
         output: str = self._ssh_client.run_command(
-                              "update-waagent-conf AutoUpdate.UpdateToLatestVersion=y Debug.EnableGAVersioning=y Debug.DisableRsmDowngrade=n AutoUpdate.GAFamily=Test", use_sudo=True)
+                              "update-waagent-conf AutoUpdate.UpdateToLatestVersion=y Debug.EnableGAVersioning=y Debug.EnableRsmDowngrade=y AutoUpdate.GAFamily=Test", use_sudo=True)
         log.info('Successfully updated agent update config \n %s', output)
 
     def _verify_guest_agent_update(self, requested_version: str) -> None:


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
The scenarios like reimage, service heal causing unintended agent downgrades for rsm vms, which requires fixes in multiple components (From RSM to Agent). Disabling the downgrade path in next release, re enable it once components are fixed and validated.


Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).