### PR TITLE
Update RHEL versions in end-to-end tests

### DIFF
--- a/tests_e2e/test_suites/cgroup_v2_enabled.yml
+++ b/tests_e2e/test_suites/cgroup_v2_enabled.yml
@@ -10,7 +10,7 @@ tests:
 images:
   - "ubuntu_2204"
   - "ubuntu_2404"
-  - "rhel_90"
+  - "rhel_95"
   - "azure-linux_3"
 # The DCR test extension installs sample service, so this test suite uses it to test services cgroups but this is only published in southcentralus region in public cloud.
 locations: "AzureCloud:southcentralus"

--- a/tests_e2e/test_suites/images.yml
+++ b/tests_e2e/test_suites/images.yml
@@ -190,8 +190,8 @@ images:
          - "Standard_B2s"
    rhel_810: "RedHat RHEL 8_10 latest"
    rhel_95: "RedHat RHEL 9_5 latest"
-   rhel_90_arm64:
-      urn: "RedHat rhel-arm64 9_0-arm64 latest"
+   rhel_95_arm64:
+      urn: "RedHat rhel-arm64 9_5-arm64 latest"
       locations:
          AzureChinaCloud: []
          AzureUSGovernment: []

--- a/tests_e2e/test_suites/images.yml
+++ b/tests_e2e/test_suites/images.yml
@@ -17,15 +17,15 @@ image-sets:
       - "debian_10"
       - "debian_11"
       - "flatcar"
-      - "suse_12"
       - "mariner_2"
       - "azure-linux_3"
       - "azure-linux_3_fips"
-      - "suse_15"
       - "rhel_79"
-      - "rhel_82"
-      - "rhel_90"
+      - "rhel_810"
+      - "rhel_95"
       - "rocky_9"
+      - "suse_12"
+      - "suse_15"
       - "ubuntu_1604"
       - "ubuntu_1804"
       - "ubuntu_2004"
@@ -40,7 +40,7 @@ image-sets:
       - "flatcar_arm64"
       - "mariner_2_arm64"
       - "azure-linux_3_arm64"
-      - "rhel_90_arm64"
+      - "rhel_95_arm64"
       - "ubuntu_2204_arm64"
       - "ubuntu_2404_arm64"
 
@@ -66,10 +66,8 @@ image-sets:
       - "ubuntu_1804"
       - "ubuntu_2004"
       - "ubuntu_2204"
-      - "ubuntu_2204_minimal"
       - "ubuntu_2204_arm64"
       - "ubuntu_2404"
-      - "ubuntu_2404_minimal"
       - "ubuntu_2404_arm64"
 
 #
@@ -190,16 +188,13 @@ images:
       vm_sizes:
       # Previously one user reported agent hang on this VM size for redhat 7+ but not observed in rhel 8. So I'm using same vm size to test agent cgroups scenario for rhel 8 to make sure we don't see any issue in automation.
          - "Standard_B2s"
-   rhel_90:
-      urn: "RedHat RHEL 9_0 latest"
-      locations:
-         AzureChinaCloud: []
+   rhel_810: "RedHat RHEL 8_10 latest"
+   rhel_95: "RedHat RHEL 9_5 latest"
    rhel_90_arm64:
       urn: "RedHat rhel-arm64 9_0-arm64 latest"
       locations:
          AzureChinaCloud: []
          AzureUSGovernment: []
-   rhel_94: "RedHat RHEL 9_4 latest"
    rocky_9:
       urn: "resf rockylinux-x86_64 9-base latest"
       locations:
@@ -224,9 +219,4 @@ images:
       locations:
          AzureChinaCloud: []
          AzureUSGovernment: []
-   ubuntu_2404_minimal:
-      # TODO: Currently using the daily build, update to the release build once it is available
-      urn: "Canonical ubuntu-24_04-lts-daily minimal latest"
-      locations:
-         AzureChinaCloud: []
-         AzureUSGovernment: []
+   ubuntu_2404_minimal: "Canonical ubuntu-24_04-lts minimal latest"

--- a/tests_e2e/test_suites/images.yml
+++ b/tests_e2e/test_suites/images.yml
@@ -63,7 +63,7 @@ image-sets:
       - "azure-linux_3"
       - "centos_82"
       - "rhel_82"
-      - "rhel_90"
+      - "rhel_95"
       - "ubuntu_1604"
       - "ubuntu_1804"
       - "ubuntu_2004"

--- a/tests_e2e/tests/publish_hostname/publish_hostname.py
+++ b/tests_e2e/tests/publish_hostname/publish_hostname.py
@@ -123,8 +123,8 @@ class PublishHostname(AgentVmTest):
                 sleep(30)
 
     def run(self):
-        # TODO: Investigate why hostname is not being published on Ubuntu, alma, and rocky as expected
-        distros_with_known_publishing_issues = ["ubuntu", "alma", "rocky"]
+        # TODO: Investigate why hostname is not being published on these distros.
+        distros_with_known_publishing_issues = ["ubuntu", "alma", "rocky", "rhel_95"]
         distro = self._ssh_client.run_command("get_distro.py").lower()
         if any(d in distro for d in distros_with_known_publishing_issues):
             raise TestSkipped("Known issue with hostname publishing on this distro. Will skip test until we continue "


### PR DESCRIPTION
Update the RHEL versions in the end-to-end tests to use the latest minor version of each major version.

+minor cleanup of a couple of distros