### PR TITLE
Ext sequencing scenario should get utc timestamp for test case start

### DIFF
--- a/tests_e2e/test_suites/images.yml
+++ b/tests_e2e/test_suites/images.yml
@@ -174,10 +174,6 @@ images:
       locations:
          AzureChinaCloud: []
          AzureUSGovernment: []
-   oracle_95:
-      urn: "Oracle Oracle-Linux ol95-lvm-gen2 latest"
-      locations:
-         AzureChinaCloud: []
    rhel_610: "RedHat RHEL 6.10 latest"
    rhel_75:
       urn: "RedHat RHEL 7.5 latest"

--- a/tests_e2e/test_suites/images.yml
+++ b/tests_e2e/test_suites/images.yml
@@ -174,6 +174,10 @@ images:
       locations:
          AzureChinaCloud: []
          AzureUSGovernment: []
+   oracle_95:
+      urn: "Oracle Oracle-Linux ol95-lvm-gen2 latest"
+      locations:
+         AzureChinaCloud: []
    rhel_610: "RedHat RHEL 6.10 latest"
    rhel_75:
       urn: "RedHat RHEL 7.5 latest"

--- a/tests_e2e/tests/ext_sequencing/ext_sequencing.py
+++ b/tests_e2e/tests/ext_sequencing/ext_sequencing.py
@@ -186,7 +186,7 @@ class ExtSequencing(AgentVmssTest):
         }
 
         for case in self._test_cases:
-            test_case_start = random.choice(list(ssh_clients.values())).run_command("date '+%Y-%m-%d %T'").rstrip()
+            test_case_start = random.choice(list(ssh_clients.values())).run_command("date --utc '+%Y-%m-%d %T'").rstrip()
             if self._scenario_start == datetime_min_utc:
                 self._scenario_start = test_case_start
 


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
Some VM local times may not be set to UTC but agent logs are in UTC. The ext_sequencing scenario compares VM local time to agent log which was causing test failures for those VMs. 

This PR updates the ext_sequencing scenario to get UTC time instead of local VM time

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).