### PR TITLE
Skip publish hostname test on RHEL 8.10

### DIFF
--- a/tests_e2e/tests/publish_hostname/publish_hostname.py
+++ b/tests_e2e/tests/publish_hostname/publish_hostname.py
@@ -124,7 +124,7 @@ class PublishHostname(AgentVmTest):
 
     def run(self):
         # TODO: Investigate why hostname is not being published on these distros.
-        distros_with_known_publishing_issues = ["ubuntu", "alma", "rocky", "rhel_95"]
+        distros_with_known_publishing_issues = ["ubuntu", "alma", "rocky", "redhat_810", "rhel_95"]
         distro = self._ssh_client.run_command("get_distro.py").lower()
         if any(d in distro for d in distros_with_known_publishing_issues):
             raise TestSkipped("Known issue with hostname publishing on this distro. Will skip test until we continue "


### PR DESCRIPTION
Publish hostname has not been tested on RHEL 8.10 and fails intermittently. 