### PR TITLE
Add fix for ExtPolicyWithDependencies e2e test

### DIFF
--- a/tests_e2e/tests/scripts/agent_ext_policy-verify_operation_success.py
+++ b/tests_e2e/tests/scripts/agent_ext_policy-verify_operation_success.py
@@ -43,7 +43,7 @@ def __get_last_reported_status(after_timestamp):
     # after that timestamp, and raise error if not found after 2 tries.
     agent_log = AgentLog(Path('/var/log/waagent.log'))
 
-    retries = 2
+    retries = 5
     for attempt in range(retries):
         phrase = "All extensions in the goal state have reached a terminal state"
         latest_status = None
@@ -63,7 +63,7 @@ def __get_last_reported_status(after_timestamp):
             return latest_status
 
         log.info("Unable to find handler status in agent log on attempt {0}. Retrying...".format(attempt + 1))
-        time.sleep(30)
+        time.sleep(60)
 
     return None
 

--- a/tests_e2e/tests/scripts/agent_ext_policy-verify_operation_success.py
+++ b/tests_e2e/tests/scripts/agent_ext_policy-verify_operation_success.py
@@ -43,7 +43,7 @@ def __get_last_reported_status(after_timestamp):
     # after that timestamp, and raise error if not found after 2 tries.
     agent_log = AgentLog(Path('/var/log/waagent.log'))
 
-    retries = 5
+    retries = 10
     for attempt in range(retries):
         phrase = "All extensions in the goal state have reached a terminal state"
         latest_status = None
@@ -63,7 +63,7 @@ def __get_last_reported_status(after_timestamp):
             return latest_status
 
         log.info("Unable to find handler status in agent log on attempt {0}. Retrying...".format(attempt + 1))
-        time.sleep(60)
+        time.sleep(30)
 
     return None
 


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

We're seeing ExtPolicyWithDependencies e2e tests fail in the following case: no-config extension (with dependencies) is blocked by policy and fails to be enabled, and then is allowed again. Re-enable is expected to succeed. There is a known issue where CRP will pick up a stale status for extensions without settings. The test works around this by ignoring the CRP result and instead checking the last handler status reported in the agent log to confirm success. 

However, in the most recent failure, the status check occurred before the extension completed processing, leading to a false failure. To reduce the chance of this happening again, this change increases the retry frequency and wait period in the log-checking script. 


### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).