### PR TITLE
ubuntu_2404_arm64 is not available in nat clouds

### DIFF
--- a/tests_e2e/test_suites/agent_removal.yml
+++ b/tests_e2e/test_suites/agent_removal.yml
@@ -27,7 +27,6 @@ tests:
   - "agent_removal/agent_removal.py"
 images:
   - "ubuntu_2404"
-  - "ubuntu_2404_arm64"
 locations:
   - "AzureCloud:centraluseuap"
   - "AzureCloud:eastus2euap"


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
ARM64 images are not available in national clouds, which is causing the agent_test_loader to fail validating the agent_removal test suite when running the scenario in Fairfax/Mooncake clouds. 
This PR removes ubuntu_2404_arm64 from the test suite locations. This scenario needs to be ran manually, so it can be ran twice for public cloud (once for image=ubuntu_2404, once again for image=ubuntu_2404_arm64)

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).