### PR TITLE
Add sleep test

### DIFF
--- a/tests_e2e/test_suites/pass.yml
+++ b/tests_e2e/test_suites/pass.yml
@@ -2,4 +2,4 @@ name: "Pass"
 tests:
   - "samples/pass_test.py"
   - "samples/pass_remote_test.py"
-images: "ubuntu_2004"
+images: "ubuntu_2204"

--- a/tests_e2e/test_suites/sleep.yml
+++ b/tests_e2e/test_suites/sleep.yml
@@ -1,0 +1,4 @@
+name: "Sleep"
+tests:
+  - "samples/sleep_test.py"
+images: "ubuntu_2204"

--- a/tests_e2e/tests/samples/sleep_test.py
+++ b/tests_e2e/tests/samples/sleep_test.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+
+# Microsoft Azure Linux Agent
+#
+# Copyright 2018 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import time
+
+from tests_e2e.tests.lib.agent_test import AgentVmTest
+from tests_e2e.tests.lib.logging import log
+
+
+class SleepTest(AgentVmTest):
+    """
+    A trivial test that passes.
+    """
+    def run(self):
+        log.info("Sleeping for 2 hours")
+        time.sleep(2 * 60 * 60)
+        log.info("* PASSED *")
+
+
+if __name__ == "__main__":
+    PassTest.run_from_command_line()


### PR DESCRIPTION
This sample test can be used to hold the orchestrator and test machines alive for a relatively long period of time.

The period to sleep should probably be a test parameter, but that can be added as needed.