### PR TITLE
Update SUSE versions on end-to-end tests

### DIFF
--- a/tests_e2e/test_suites/images.yml
+++ b/tests_e2e/test_suites/images.yml
@@ -219,8 +219,8 @@ images:
       locations:
          AzureChinaCloud: []
          AzureUSGovernment: []
-   suse_12: "SUSE sles-12-sp5-basic gen1 latest"
-   suse_15: "SUSE sles-15-sp2-basic gen2 latest"
+   suse_12: "SUSE sles-12-sp5 gen1 latest"
+   suse_15: "SUSE sles-15-sp6-basic gen2 latest"
    ubuntu_1604: "Canonical UbuntuServer 16.04-LTS latest"
    ubuntu_1804: "Canonical UbuntuServer 18.04-LTS latest"
    ubuntu_2004: "Canonical 0001-com-ubuntu-server-focal 20_04-lts latest"


### PR DESCRIPTION
The sles-12-sp5-basic image is no longer available; moving to the plain sles-12-sp5.

Also, updating sles 15 to the latest service pack.