### PR TITLE
FreeBSDOSUtil: Set the agent config file path for FreeBSD

### DIFF
--- a/azurelinuxagent/common/osutil/freebsd.py
+++ b/azurelinuxagent/common/osutil/freebsd.py
@@ -32,6 +32,7 @@ class FreeBSDOSUtil(DefaultOSUtil):
 
     def __init__(self):
         super(FreeBSDOSUtil, self).__init__()
+        self.agent_conf_file_path = '/usr/local/etc/waagent.conf'
         self._scsi_disks_timeout_set = False
         self.jit_enabled = True
 


### PR DESCRIPTION
Sponsored by:	The FreeBSD Foundation

<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Issue # N/A

Provide correct agent config file path for FreeBSD to avoid falling back to the default path.

---

### PR information
- [x] Ensure development PR is based on the `develop` branch.
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [x] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).