### PR TITLE
Change redhat waagent-network-setup.service path to /etc

### DIFF
--- a/azurelinuxagent/common/osutil/redhat.py
+++ b/azurelinuxagent/common/osutil/redhat.py
@@ -101,7 +101,7 @@ class RedhatOSUtil(Redhat6xOSUtil):
 
     @staticmethod
     def get_systemd_unit_file_install_path():
-        return "/usr/lib/systemd/system"
+        return "/etc/systemd/system"
 
     def set_hostname(self, hostname):
         """


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Issue #3391

In image mode, the /usr path is readonly. WALA intends to write a /usr/lib/systemd/system/waagent-network-setup.service file to setup the persistent firewall rules, which is not permitted in image mode. So we change the service file path to /etc/systemd/system/waagent-network-setup.service to resolve this issue.

---

### PR information
- [x] Ensure development PR is based on the `develop` branch.
- [x] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).