### PR TITLE
Use systemctl instead of service to manager services in new RHEL versions

### DIFF
--- a/azurelinuxagent/common/osutil/redhat.py
+++ b/azurelinuxagent/common/osutil/redhat.py
@@ -245,6 +245,18 @@ class RedhatOSModernUtil(RedhatOSUtil):
     def __init__(self):  # pylint: disable=W0235
         super(RedhatOSModernUtil, self).__init__()
 
+    def restart_ssh_service(self):
+        return shellutil.run("systemctl condrestart sshd", chk_err=False)
+
+    def stop_agent_service(self):
+        return shellutil.run("systemctl stop {0}".format(self.service_name), chk_err=False)
+
+    def start_agent_service(self):
+        return shellutil.run("systemctl start {0}".format(self.service_name), chk_err=False)
+
+    def restart_network_manager(self):
+        shellutil.run("systemctl restart NetworkManager")
+
     def restart_if(self, ifname, retries=3, wait=5):
         """
         Restart an interface by bouncing the link. systemd-networkd observes
@@ -270,5 +282,5 @@ class RedhatOSModernUtil(RedhatOSUtil):
         # RedhatOSUtil was updated to conditionally run NetworkManager restart in response to a race condition between
         # NetworkManager restart and the agent restarting the network interface during publish_hostname. Keeping the
         # NetworkManager restart in RedhatOSModernUtil because the issue was not reproduced on these versions.
-        shellutil.run("service NetworkManager restart")
+        self.restart_network_manager()
         DefaultOSUtil.publish_hostname(self, hostname)


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Issue #3402
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->
In the RHEL bootc base image there's no initscripts-service package installed, so that there's no "service" command by default. This causes many service control commands cannot be executed inside WALA.
From RHEL-7 on, the systemctl command replaces service and chkconfig. So we'd like to drop all the 'service' command and use systemctl instead.

---

### PR information
- [x] Ensure development PR is based on the `develop` branch.
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).