### PR TITLE
Pick latest version based on new and legay autoupdates flag

### DIFF
--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -199,7 +199,10 @@ class UpdateHandler(object):
         if self.signal_handler is None:
             self.signal_handler = signal.signal(signal.SIGTERM, self.forward_signal)
 
-        latest_agent = None if not conf.get_autoupdate_enabled() else self.get_latest_agent_greater_than_daemon(
+        # If new flag explicitly set, agent will use latest agent downloaded and will not fall back to installed agent. See the new flag definition in conf.py
+        use_latest_agent = conf.is_present("AutoUpdate.UpdateToLatestVersion") or conf.get_autoupdate_enabled()
+
+        latest_agent = None if not use_latest_agent else self.get_latest_agent_greater_than_daemon(
             daemon_version=CURRENT_VERSION)
         if latest_agent is None:
             logger.info(u"Installed Agent {0} is the most current agent", CURRENT_AGENT)

--- a/tests_e2e/orchestrator/scripts/remove-waagent-conf
+++ b/tests_e2e/orchestrator/scripts/remove-waagent-conf
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# Microsoft Azure Linux Agent
+#
+# Copyright 2018 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# Removes the specified setting((allows multiple) from waagent.conf and restarts the Agent.
+#
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: remove-waagent-conf [setting]"
+    exit 1
+fi
+
+PYTHON=$(get-agent-python)
+waagent_conf=$($PYTHON -c 'from azurelinuxagent.common.osutil import get_osutil; print(get_osutil().agent_conf_file_path)')
+for setting in "$@"; do
+    echo "Removing setting:$setting in $waagent_conf"
+    sed -i -E "/^$setting=/d" "$waagent_conf"
+done
+agent-service restart

--- a/tests_e2e/test_suites/initial_agent_update.yml
+++ b/tests_e2e/test_suites/initial_agent_update.yml
@@ -8,6 +8,7 @@
 name: "InitialAgentUpdate"
 tests:
   - "initial_agent_update/initial_agent_update.py"
+  - "initial_agent_update/latest_agent_version.py"
 install_test_agent: false
 images: "gallery/initial-agent-update/1.0.0"
 locations: "AzureCloud:eastus2euap"

--- a/tests_e2e/tests/initial_agent_update/latest_agent_version.py
+++ b/tests_e2e/tests/initial_agent_update/latest_agent_version.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+
+# Microsoft Azure Linux Agent
+#
+# Copyright 2018 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from tests_e2e.tests.lib.agent_test import AgentVmTest
+from tests_e2e.tests.lib.agent_test_context import AgentVmTestContext
+from tests_e2e.tests.lib.agent_update_helpers import verify_current_agent_version
+from tests_e2e.tests.lib.logging import log
+
+
+class LatestAgentVersion(AgentVmTest):
+    """
+    This test verifies that the agent picks up the latest version based on the AutoUpdate.UpdateToLatestVersion flag.
+    """
+
+    def __init__(self, context: AgentVmTestContext):
+        super().__init__(context)
+        self._ssh_client = self._context.create_ssh_client()
+        self._test_version = "2.8.9.9"
+
+    def run(self):
+
+        log.info("Testing daemon picks latest version based on AutoUpdate flag")
+        log.info("Updating AutoUpdate.UpdateToLatestVersion=y and AutoUpdate.Enabled=n")
+
+        setup_script = (
+            "agent-service stop && "
+            "rm -rfv /var/lib/waagent/WALinuxAgent-* && "
+            "update-waagent-conf AutoUpdate.UpdateToLatestVersion=y AutoUpdate.Enabled=n Debug.EnableGAVersioning=n Debug.SelfUpdateHotfixFrequency=90 Debug.SelfUpdateRegularFrequency=90 Autoupdate.Frequency=30")
+
+        output: str = self._ssh_client.run_command(f"sh -c '{setup_script}'", use_sudo=True)
+        log.info("Updated: %s", output)
+
+        latest_version: str = self._ssh_client.run_command("agent_update-get_latest_version_from_manifest.py --family_type Prod",
+                                                           use_sudo=True).rstrip()
+        log.info("Verifying agent updated to latest version: %s from custom image test version: %s", latest_version, self._test_version)
+
+        verify_current_agent_version(self._ssh_client, latest_version)
+
+        log.info("Testing daemon picks installed version based on AutoUpdate flag")
+        log.info("Removing AutoUpdate.UpdateToLatestVersion")
+
+        output = self._ssh_client.run_command("remove-waagent-conf AutoUpdate.UpdateToLatestVersion", use_sudo=True)
+        log.info("Removed: %s", output)
+
+        log.info("Verifying agent reverted to daemon version: %s", self._test_version)
+        verify_current_agent_version(self._ssh_client, self._test_version)
+
+
+if __name__ == "__main__":
+    LatestAgentVersion.run_from_command_line()


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
The issue is when a user explicitly sets AutoUpdate.UpdateToLatestVersion=y and AutoUpdate.Enabled=n. In this case, the extension handler downloads the latest agent based on the new flag. However, the daemon code responsible for starting the agent doesn't consider the new flag, it still relies on the legacy logic using AutoUpdate.Enabled to determine whether to use the latest or the currently installed version. As a result, even after downloading the new version, the daemon ends up starting the installed version.

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).