### PR TITLE
Passing BadVersion in rsm downgrade request in e2e test

### DIFF
--- a/tests_e2e/tests/lib/agent_update_helpers.py
+++ b/tests_e2e/tests/lib/agent_update_helpers.py
@@ -90,6 +90,9 @@ def request_rsm_update(requested_version: str, vm: VirtualMachineClient, arch_ty
 
     if is_downgrade:
         data.update({"isEmergencyRollbackRequest": True})
+        # CRP updated the downgrade API request and expecting BadVersion. Adding dummy BadVersion to pass the downgrade request.
+        # TODO: When CRP fully implements the downgrade fix, the agent needs to update accordingly.
+        data.update({"BadVersion": "0.0.0.0"})
 
     log.info("Attempting rsm upgrade post request to endpoint: {0} with data: {1}".format(url, data))
     response = requests.post(url, data=json.dumps(data), headers=headers, timeout=300)


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

CRP changed the API request for a downgrade, and we need to pass the bad version as a workaround to fix rsm update e2e test failures.

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).