### PR TITLE
Add test for goal state after hibernate-resume

### DIFF
--- a/tests_e2e/orchestrator/lib/agent_test_suite.py
+++ b/tests_e2e/orchestrator/lib/agent_test_suite.py
@@ -39,8 +39,7 @@ from lisa import (  # pylint: disable=E0401
 )
 from lisa.environment import EnvironmentStatus  # pylint: disable=E0401
 from lisa.messages import TestStatus, TestResultMessage  # pylint: disable=E0401
-from lisa.node import LocalNode  # pylint: disable=E0401
-# from lisa.node import Nodes  # pylint: disable=E0401
+from lisa.node import LocalNode, Nodes  # pylint: disable=E0401
 from lisa.util.constants import RUN_ID  # pylint: disable=E0401
 from lisa.sut_orchestrator.azure.common import get_node_context  # pylint: disable=E0401
 from lisa.sut_orchestrator.azure.platform_ import AzurePlatform  # pylint: disable=E0401
@@ -134,7 +133,7 @@ class AgentTestSuite(LisaTestSuite):
         self._runbook_name: str  # name of the runbook execution, used as prefix on ARM resources created by the AgentTestSuite
 
         self._lisa_log: Logger  # Main log for the LISA run
-        # self._lisa_nodes: Nodes  # List of test nodes maintained by LISA
+        self._lisa_nodes: Nodes  # List of test nodes maintained by LISA
 
         self._lisa_environment_name: str  # Name assigned by LISA to the test environment, useful for correlation with LISA logs
         self._environment_name: str  # Name assigned by the AgentTestSuiteCombinator to the test environment
@@ -196,7 +195,7 @@ class AgentTestSuite(LisaTestSuite):
         self._runbook_name = variables["name"]
 
         self._lisa_log = lisa_log
-        # self._lisa_nodes = environment.nodes
+        self._lisa_nodes = environment.nodes
 
         self._lisa_environment_name = environment.name
         self._environment_name = variables["c_env_name"]
@@ -387,13 +386,24 @@ class AgentTestSuite(LisaTestSuite):
         finally:
             self._setup_lock.release()
 
+    def _refresh_lisa_nodes(self, test_context: AgentVmTestContext) -> None:
+        """
+        Tests can change the IP address of the test VM, and LISA does SSH connections during test cleanup, so we refresh the IP address of the LISA node
+        with the current value from the test context.
+        """
+        for n in self._lisa_nodes.list():
+            if (n.is_remote):
+                n.set_connection_info(
+                    use_public_address=True,
+                    public_address=test_context.ip_address,
+                    port=n.connection_info["port"],
+                    username=n.connection_info["username"],
+                    private_key_file=n.connection_info["private_key_file"])
+
     def _clean_up(self, success: bool) -> None:
         """
         Cleans up any items created by the test suite run.
         """
-        # for n in self._lisa_nodes:
-        #     n.close()
-        #
         if self._delete_scale_set:
             if self._keep_environment == KeepEnvironment.Always:
                 log.info("Won't delete the scale set %s, per the test suite configuration.", self._vmss_name)
@@ -588,6 +598,8 @@ class AgentTestSuite(LisaTestSuite):
                     finally:
                         if self._collect_logs == CollectLogs.Always or self._collect_logs == CollectLogs.Failed and not test_suite_success:
                             self._collect_logs_from_test_nodes(test_context)
+                        if isinstance(test_context, AgentVmTestContext):  # Scale sets are not managed by LISA, so do this only for VM tests.
+                            self._refresh_lisa_nodes(test_context)
 
                 except Exception as e:   # pylint: disable=bare-except
                     # Report the error and raise an exception to let LISA know that the test errored out.

--- a/tests_e2e/orchestrator/lib/agent_test_suite.py
+++ b/tests_e2e/orchestrator/lib/agent_test_suite.py
@@ -39,7 +39,8 @@ from lisa import (  # pylint: disable=E0401
 )
 from lisa.environment import EnvironmentStatus  # pylint: disable=E0401
 from lisa.messages import TestStatus, TestResultMessage  # pylint: disable=E0401
-from lisa.node import LocalNode, Nodes  # pylint: disable=E0401
+from lisa.node import LocalNode  # pylint: disable=E0401
+# from lisa.node import Nodes  # pylint: disable=E0401
 from lisa.util.constants import RUN_ID  # pylint: disable=E0401
 from lisa.sut_orchestrator.azure.common import get_node_context  # pylint: disable=E0401
 from lisa.sut_orchestrator.azure.platform_ import AzurePlatform  # pylint: disable=E0401
@@ -133,7 +134,7 @@ class AgentTestSuite(LisaTestSuite):
         self._runbook_name: str  # name of the runbook execution, used as prefix on ARM resources created by the AgentTestSuite
 
         self._lisa_log: Logger  # Main log for the LISA run
-        self._lisa_nodes: Nodes  # List of test nodes maintained by LISA
+        # self._lisa_nodes: Nodes  # List of test nodes maintained by LISA
 
         self._lisa_environment_name: str  # Name assigned by LISA to the test environment, useful for correlation with LISA logs
         self._environment_name: str  # Name assigned by the AgentTestSuiteCombinator to the test environment
@@ -195,7 +196,7 @@ class AgentTestSuite(LisaTestSuite):
         self._runbook_name = variables["name"]
 
         self._lisa_log = lisa_log
-        self._lisa_nodes = environment.nodes
+        # self._lisa_nodes = environment.nodes
 
         self._lisa_environment_name = environment.name
         self._environment_name = variables["c_env_name"]
@@ -390,9 +391,9 @@ class AgentTestSuite(LisaTestSuite):
         """
         Cleans up any items created by the test suite run.
         """
-        for n in self._lisa_nodes:
-            n.close()
-
+        # for n in self._lisa_nodes:
+        #     n.close()
+        #
         if self._delete_scale_set:
             if self._keep_environment == KeepEnvironment.Always:
                 log.info("Won't delete the scale set %s, per the test suite configuration.", self._vmss_name)

--- a/tests_e2e/orchestrator/lib/agent_test_suite.py
+++ b/tests_e2e/orchestrator/lib/agent_test_suite.py
@@ -388,8 +388,8 @@ class AgentTestSuite(LisaTestSuite):
 
     def _refresh_lisa_nodes(self, test_context: AgentVmTestContext) -> None:
         """
-        Tests can change the IP address of the test VM, and LISA does SSH connections during test cleanup, so we refresh the IP address of the LISA node
-        with the current value from the test context.
+        Tests can change the IP address of the test VM. We refresh the IP address of the LISA node before we return control from our test, since LISA performs SSH operations on the test
+        nodes before completing the test run.
         """
         for n in self._lisa_nodes.list():
             if (n.is_remote):

--- a/tests_e2e/orchestrator/lib/agent_test_suite.py
+++ b/tests_e2e/orchestrator/lib/agent_test_suite.py
@@ -39,7 +39,7 @@ from lisa import (  # pylint: disable=E0401
 )
 from lisa.environment import EnvironmentStatus  # pylint: disable=E0401
 from lisa.messages import TestStatus, TestResultMessage  # pylint: disable=E0401
-from lisa.node import LocalNode  # pylint: disable=E0401
+from lisa.node import LocalNode, Nodes  # pylint: disable=E0401
 from lisa.util.constants import RUN_ID  # pylint: disable=E0401
 from lisa.sut_orchestrator.azure.common import get_node_context  # pylint: disable=E0401
 from lisa.sut_orchestrator.azure.platform_ import AzurePlatform  # pylint: disable=E0401
@@ -114,18 +114,6 @@ class TestFailedException(Exception):
         super().__init__(msg)
 
 
-class _TestNode(object):
-    """
-    Name and IP address of a test VM
-    """
-    def __init__(self, name: str, ip_address: str):
-        self.name = name
-        self.ip_address = ip_address
-
-    def __str__(self):
-        return f"{self.name}:{self.ip_address}"
-
-
 @TestSuiteMetadata(area="waagent", category="", description="")
 class AgentTestSuite(LisaTestSuite):
     """
@@ -145,6 +133,7 @@ class AgentTestSuite(LisaTestSuite):
         self._runbook_name: str  # name of the runbook execution, used as prefix on ARM resources created by the AgentTestSuite
 
         self._lisa_log: Logger  # Main log for the LISA run
+        self._lisa_nodes: Nodes  # List of test nodes maintained by LISA
 
         self._lisa_environment_name: str  # Name assigned by LISA to the test environment, useful for correlation with LISA logs
         self._environment_name: str  # Name assigned by the AgentTestSuiteCombinator to the test environment
@@ -177,8 +166,6 @@ class AgentTestSuite(LisaTestSuite):
         self._vm_ip_address: str
         self._vmss_name: str
 
-        self._test_nodes: List[_TestNode]  # VMs or scale set instances the tests will run on
-
         # Whether to create and delete a scale set.
         self._create_scale_set: bool
         self._delete_scale_set: bool
@@ -208,6 +195,7 @@ class AgentTestSuite(LisaTestSuite):
         self._runbook_name = variables["name"]
 
         self._lisa_log = lisa_log
+        self._lisa_nodes = environment.nodes
 
         self._lisa_environment_name = environment.name
         self._environment_name = variables["c_env_name"]
@@ -270,7 +258,6 @@ class AgentTestSuite(LisaTestSuite):
             finally:
                 AgentTestSuite._rg_count_lock.release()
             self._vmss_name = f"{self._resource_group_name}-n0"
-            self._test_nodes = []  # we'll fill this up when the scale set is created
             self._create_scale_set = True
             self._delete_scale_set = False  # we set it to True once we create the scale set
         else:
@@ -281,16 +268,13 @@ class AgentTestSuite(LisaTestSuite):
                 self._resource_group_name = node_context.resource_group_name
                 self._vm_name = node_context.vm_name
                 self._vm_ip_address = environment.nodes[0].connection_info['address']
-                self._test_nodes = [_TestNode(self._vm_name, self._vm_ip_address)]
             else:  # An existing VM/VMSS was passed as argument to the runbook
                 self._resource_group_name = variables["resource_group_name"]
                 if variables["vm_name"] != "":
                     self._vm_name = variables["vm_name"]
                     self._vm_ip_address = environment.nodes[0].connection_info['address']
-                    self._test_nodes = [_TestNode(self._vm_name, self._vm_ip_address)]
                 else:
                     self._vmss_name = variables["vmss_name"]
-                    self._test_nodes = [_TestNode(node.name, node.connection_info['address']) for node in environment.nodes.list()]
 
     @staticmethod
     def _get_log_path(variables: Dict[str, Any], lisa_log_path: str) -> Path:
@@ -406,6 +390,9 @@ class AgentTestSuite(LisaTestSuite):
         """
         Cleans up any items created by the test suite run.
         """
+        for n in self._lisa_nodes:
+            n.close()
+
         if self._delete_scale_set:
             if self._keep_environment == KeepEnvironment.Always:
                 log.info("Won't delete the scale set %s, per the test suite configuration.", self._vmss_name)
@@ -417,7 +404,7 @@ class AgentTestSuite(LisaTestSuite):
                 except Exception as error:  # pylint: disable=broad-except
                     log.warning("Error deleting resource group %s: %s", self._resource_group_name, error)
 
-    def _setup_test_nodes(self) -> None:
+    def _setup_test_nodes(self, test_context: AgentTestContext) -> None:
         """
         Prepares the test nodes for execution of the test suite (installs tools and the test agent, etc)
         """
@@ -426,7 +413,7 @@ class AgentTestSuite(LisaTestSuite):
         log.info("")
         log.info("************************************ [Test Nodes Setup] ************************************")
         log.info("")
-        for node in self._test_nodes:
+        for node in test_context.get_test_nodes():
             self._lisa_log.info(f"Setting up test node {node}")
             log.info("Test Node: %s", node.name)
             log.info("IP Address: %s", node.ip_address)
@@ -510,11 +497,13 @@ class AgentTestSuite(LisaTestSuite):
                 log.info("SSH is not ready [%s], will retry after a short delay.", error)
                 time.sleep(15)
 
-    def _collect_logs_from_test_nodes(self) -> None:
+    def _collect_logs_from_test_nodes(self, test_context: AgentTestContext) -> None:
         """
         Collects the test logs from the test nodes and copies them to the local machine
         """
-        for node in self._test_nodes:
+        test_nodes = test_context.get_test_nodes()
+
+        for node in test_nodes:
             node_name = node.name
             ssh_client = SshClient(ip_address=node.ip_address, username=self._user, identity_file=Path(self._identity_file))
             try:
@@ -526,7 +515,7 @@ class AgentTestSuite(LisaTestSuite):
 
                 # Copy the tarball to the local logs directory
                 tgz_name = self._environment_name
-                if len(self._test_nodes) > 1:
+                if len(test_nodes) > 1:
                     # Append instance of scale set to the end of tarball name
                     tgz_name += '_' + node_name.split('_')[-1]
                 remote_path = "/tmp/waagent-logs.tgz"
@@ -575,12 +564,12 @@ class AgentTestSuite(LisaTestSuite):
                     if not self._skip_setup:
                         self._setup_test_run()
 
-                    try:
-                        test_context = self._create_test_context()
+                    test_context = self._create_test_context()
 
+                    try:
                         if not self._skip_setup:
                             try:
-                                self._setup_test_nodes()
+                                self._setup_test_nodes(test_context)
                             except:
                                 test_suite_success = False
                                 raise
@@ -597,7 +586,7 @@ class AgentTestSuite(LisaTestSuite):
 
                     finally:
                         if self._collect_logs == CollectLogs.Always or self._collect_logs == CollectLogs.Failed and not test_suite_success:
-                            self._collect_logs_from_test_nodes()
+                            self._collect_logs_from_test_nodes(test_context)
 
                 except Exception as e:   # pylint: disable=bare-except
                     # Report the error and raise an exception to let LISA know that the test errored out.
@@ -663,56 +652,31 @@ class AgentTestSuite(LisaTestSuite):
                             summary.append(f"[Passed]  {test.name}")
                             log.info("******** [Passed] %s", test.name)
                             self._lisa_log.info("[Passed] %s", test_full_name)
-                            self._report_test_result(
-                                suite_full_name,
-                                test.name,
-                                TestStatus.PASSED,
-                                test_start_time)
+                            self._report_test_result(suite_full_name, test.name, TestStatus.PASSED, test_start_time)
                         except TestSkipped as e:
                             summary.append(f"[Skipped] {test.name}")
                             log.info("******** [Skipped] %s: %s", test.name, e)
                             self._lisa_log.info("******** [Skipped] %s", test_full_name)
-                            self._report_test_result(
-                                suite_full_name,
-                                test.name,
-                                TestStatus.SKIPPED,
-                                test_start_time,
-                                message=str(e))
+                            self._report_test_result(suite_full_name, test.name, TestStatus.SKIPPED, test_start_time, message=str(e))
                         except AssertionError as e:
                             test_success = False
                             summary.append(f"[Failed]  {test.name}")
                             log.error("******** [Failed] %s: %s", test.name, e)
                             self._lisa_log.error("******** [Failed] %s", test_full_name)
-                            self._report_test_result(
-                                suite_full_name,
-                                test.name,
-                                TestStatus.FAILED,
-                                test_start_time,
-                                message=str(e))
+                            self._report_test_result(suite_full_name, test.name, TestStatus.FAILED, test_start_time, message=str(e))
                         except RemoteTestError as e:
                             test_success = False
                             summary.append(f"[Failed]  {test.name}")
                             message = f"UNEXPECTED ERROR IN [{e.command}] {e.stderr}\n{e.stdout}"
                             log.error("******** [Failed] %s: %s", test.name, message)
                             self._lisa_log.error("******** [Failed] %s", test_full_name)
-                            self._report_test_result(
-                                suite_full_name,
-                                test.name,
-                                TestStatus.FAILED,
-                                test_start_time,
-                                message=str(message))
+                            self._report_test_result(suite_full_name, test.name, TestStatus.FAILED, test_start_time, message=str(message))
                         except:  # pylint: disable=bare-except
                             test_success = False
                             summary.append(f"[Error]   {test.name}")
                             log.exception("UNEXPECTED ERROR IN %s", test.name)
                             self._lisa_log.exception("UNEXPECTED ERROR IN %s", test_full_name)
-                            self._report_test_result(
-                                suite_full_name,
-                                test.name,
-                                TestStatus.FAILED,
-                                test_start_time,
-                                message="Unexpected error.",
-                                add_exception_stack_trace=True)
+                            self._report_test_result(suite_full_name, test.name, TestStatus.FAILED, test_start_time, message="Unexpected error.", add_exception_stack_trace=True)
 
                         log.info("")
 
@@ -739,34 +703,30 @@ class AgentTestSuite(LisaTestSuite):
 
                 except Exception as e:
                     suite_success = False
-                    self._report_test_result(
-                        suite_full_name,
-                        suite_name,
-                        TestStatus.FAILED,
-                        suite_start_time,
-                        message=f"Unhandled exception while executing test suite {suite_name}: {e}",
-                        add_exception_stack_trace=True)
+                    self._report_test_result(suite_full_name, suite_name, TestStatus.FAILED, suite_start_time, message=f"Unhandled exception while executing test suite {suite_name}: {e}", add_exception_stack_trace=True)
                 finally:
                     if not suite_success:
                         self._mark_log_as_failed()
 
                 next_check_log_start_time = datetime.datetime.now(UTC)
-                suite_success = suite_success and self._check_agent_log_on_test_nodes(ignore_error_rules, check_log_start_time_override if check_log_start_time_override != datetime_max_utc else check_log_start_time)
+                start_time = check_log_start_time_override if check_log_start_time_override != datetime_max_utc else check_log_start_time
+                suite_success = suite_success and self._check_agent_log_on_test_nodes(test_context, ignore_error_rules, start_time)
 
                 return suite_success, next_check_log_start_time
 
-    def _check_agent_log_on_test_nodes(self, ignore_error_rules: List[Dict[str, Any]], check_log_start_time: datetime.datetime) -> bool:
+    def _check_agent_log_on_test_nodes(self, test_context: AgentTestContext, ignore_error_rules: List[Dict[str, Any]], check_log_start_time: datetime.datetime) -> bool:
         """
         Checks the agent log on the test nodes for errors; returns true on success (no errors in the logs)
         """
         success: bool = True
+        test_nodes = test_context.get_test_nodes()
 
-        for node in self._test_nodes:
+        for node in test_nodes:
             node_name = node.name
             ssh_client = SshClient(ip_address=node.ip_address, username=self._user, identity_file=Path(self._identity_file))
 
             test_result_name = self._environment_name
-            if len(self._test_nodes) > 1:
+            if len(test_nodes) > 1:
                 # If there are multiple test nodes, as in a scale set, append the name of the node to the name of the result
                 test_result_name += '_' + node_name.split('_')[-1]
 
@@ -846,10 +806,6 @@ class AgentTestSuite(LisaTestSuite):
                 subscription=self._subscription_id,
                 resource_group=self._resource_group_name,
                 name=self._vmss_name)
-
-            # If we created the scale set, fill up the test nodes
-            if self._create_scale_set:
-                self._test_nodes = [_TestNode(name=i.instance_name, ip_address=i.ip_address) for i in scale_set.get_instances_ip_address()]
 
             vmss_test_context = AgentVmssTestContext(
                 working_directory=self._working_directory,

--- a/tests_e2e/orchestrator/runbook.yml
+++ b/tests_e2e/orchestrator/runbook.yml
@@ -50,6 +50,7 @@ variable:
       - ext_sequencing
       - ext_telemetry_pipeline
       - fips
+      - hibernation
       - keyvault_certificates
       - multi_config_ext
       - no_outbound_connections

--- a/tests_e2e/orchestrator/scripts/check-agent-log.py
+++ b/tests_e2e/orchestrator/scripts/check-agent-log.py
@@ -31,7 +31,7 @@ try:
     parser.set_defaults(json=False)
     args = parser.parse_args()
 
-    error_list = AgentLog(Path(args.path)).get_errors()
+    error_list = AgentLog(path=Path(args.path)).get_errors()
 
     if args.json:
         print(json.dumps(error_list, default=lambda o: o.__dict__))

--- a/tests_e2e/test_suites/hibernation.yml
+++ b/tests_e2e/test_suites/hibernation.yml
@@ -1,0 +1,10 @@
+name: "Hibernation"
+tests:
+  - source: "hibernation/hibernation.py"
+
+#
+# Hibernation is supported only in a few distros, we chose the most recent version of the 2 most used distros.
+#
+images:
+  - "ubuntu_2204"
+  - "rhel_95"

--- a/tests_e2e/test_suites/hibernation.yml
+++ b/tests_e2e/test_suites/hibernation.yml
@@ -3,8 +3,7 @@ tests:
   - source: "hibernation/hibernation.py"
 
 #
-# Hibernation is supported only in a few distros, we chose the most recent version of the 2 most used distros.
+# Hibernation is supported only in a few distros, using Ubuntu 22 for now.
 #
 images:
   - "ubuntu_2204"
-  - "rhel_95"

--- a/tests_e2e/test_suites/hibernation.yml
+++ b/tests_e2e/test_suites/hibernation.yml
@@ -3,8 +3,7 @@ tests:
   - source: "hibernation/hibernation.py"
 
 #
-# Hibernation is supported only in a few distros. For now we use Ubuntu 22 and Debian 11 only, since the Hibernation extension fails in current RHEL versions.
+# Hibernation is supported only in a few distros. For now we use Ubuntu 22, since the Hibernation extension fails in current RHEL versions and resume is unstable on Debian 11.
 #
 images:
   - "ubuntu_2204"
-  - "debian_11"

--- a/tests_e2e/test_suites/hibernation.yml
+++ b/tests_e2e/test_suites/hibernation.yml
@@ -3,7 +3,8 @@ tests:
   - source: "hibernation/hibernation.py"
 
 #
-# Hibernation is supported only in a few distros. For now we use Ubuntu 22 only, since the Hibernation extension fails in current RHEL versions.
+# Hibernation is supported only in a few distros. For now we use Ubuntu 22 and Debian 11 only, since the Hibernation extension fails in current RHEL versions.
 #
 images:
   - "ubuntu_2204"
+  - "debian_11"

--- a/tests_e2e/test_suites/hibernation.yml
+++ b/tests_e2e/test_suites/hibernation.yml
@@ -3,7 +3,7 @@ tests:
   - source: "hibernation/hibernation.py"
 
 #
-# Hibernation is supported only in a few distros, using Ubuntu 22 for now.
+# Hibernation is supported only in a few distros. For now we use Ubuntu 22 only, since the Hibernation extension fails in current RHEL versions.
 #
 images:
   - "ubuntu_2204"

--- a/tests_e2e/tests/hibernation/hibernation.py
+++ b/tests_e2e/tests/hibernation/hibernation.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+
+# Microsoft Azure Linux Agent
+#
+# Copyright 2018 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import json
+import uuid
+
+from assertpy import fail
+
+from tests_e2e.tests.lib.agent_test import AgentVmTest
+from tests_e2e.tests.lib.agent_test_context import AgentVmTestContext
+from tests_e2e.tests.lib.logging import log
+from tests_e2e.tests.lib.ssh_client import SshClient
+from tests_e2e.tests.lib.virtual_machine_client import VirtualMachine
+from tests_e2e.tests.lib.virtual_machine_extension_client import VirtualMachineExtensionClient
+from tests_e2e.tests.lib.vm_extension_identifier import VmExtensionIds
+
+
+class Hibernation(AgentVmTest):
+    """
+    A hibernate/resume cycle is a special case in that resume produces a new Fabric goal state with incarnation 1. Since the VM is re-allocated,
+    that goal state will include a new tenant encryption certificate. If the incarnation was also 1 before hibernation, the Agent won't detect
+    this new goal state and subsequent Fast Track goal states would fail because they require the new certificate.
+
+    The Agent has logic to detect this scenario and fetch the required certificates; this test verifies that logic.
+
+    See https://learn.microsoft.com/en-us/azure/virtual-machines/linux/hibernate-resume-linux for details on hibernation
+    """
+    def __init__(self, context: AgentVmTestContext):
+        super().__init__(context)
+        self._ssh_client: SshClient = self._context.create_ssh_client()
+
+    def run(self):
+        #
+        # Ensure hibernation is enabled
+        #
+        self._enable_hibernation()
+
+        #
+        # Check that the current incarnation is 1; if that is not the case, do a hibernate-resume cycle to reset the incarnation to 1
+        #
+        log.info("Retrieving current incarnation...")
+        incarnation = self._ssh_client.run_command("get_goal_state.py --properties incarnation", use_sudo=True).rstrip()
+        if incarnation != "1":
+            self._do_hibernate_resume_cycle()
+            incarnation = self._ssh_client.run_command("get_goal_state.py --properties incarnation", use_sudo=True).rstrip()
+            if incarnation != "1":
+                raise Exception(f"The incarnation was not reset to 1 after a hibernate-resume cycle. Incarnation is {incarnation}")
+        log.info("The current incarnation is 1")
+
+        #
+        # Do a hibernate-resume cycle; this will generate a new tenant certificate but, since the incarnation has not changed,
+        # the Agent will not download it yet.
+        #
+        log.info("Retrieving tenant certificate before hibernation...")
+        pre_hibernation_tenant_certificate = self._get_tenant_certificate()
+        log.info("Tenant certificate: %s", pre_hibernation_tenant_certificate)
+
+        log.info("Triggering a hibernate-resume cycle to test the tenant certificate...")
+        self._do_hibernate_resume_cycle()
+
+        log.info("Retrieving current incarnation...")
+        incarnation = self._ssh_client.run_command("get_goal_state.py --properties incarnation", use_sudo=True).rstrip()
+        if incarnation != "1":
+            raise Exception(f"Unexpected behavior: The incarnation is not 1 after a hibernate-resume cycle. Incarnation is {incarnation}")
+        log.info("The current incarnation is 1")
+
+        log.info("Checking tenant certificate after resume...")
+        post_hibernation_tenant_certificate = self._get_tenant_certificate()
+        if post_hibernation_tenant_certificate == pre_hibernation_tenant_certificate:
+            raise Exception("Unexpected behavior: hibernate-resume did not create a new tenant certificate")
+        log.info("Tenant certificate: %s", post_hibernation_tenant_certificate)
+        log.info("Checking that the new tenant certificate has not been downloaded yet...")
+        downloaded = self._ssh_client.run_command(f"ls /var/lib/waagent/{post_hibernation_tenant_certificate}.* || true", use_sudo=True).rstrip()
+        if downloaded != "":
+            raise Exception(f"Unexpected behavior: The new tenant certificate was downloaded after resume: {downloaded}")
+        log.info("The new tenant certificate has not been downloaded yet.")
+
+        #
+        # Execute an extension with protected settings and verify that the new tenant certificate was downloaded.
+        #
+        log.info("Executing an extension with protected settings to verify it can use the new tenant certificate")
+        custom_script = VirtualMachineExtensionClient(self._context.vm, VmExtensionIds.CustomScript, resource_name="CustomScript")
+        message = str(uuid.uuid4())
+        custom_script.enable(protected_settings={'commandToExecute': f"echo \'{message}\'"}, force_update=True)
+        custom_script.assert_instance_view(expected_message=message)
+
+        log.info("Checking that the new tenant certificate was downloaded...")
+        downloaded = self._ssh_client.run_command("find /var/lib/waagent -name '*.crt'", use_sudo=True)
+        if f"/var/lib/waagent/{post_hibernation_tenant_certificate}.crt" not in downloaded:
+            fail(f"The new tenant certificate ({post_hibernation_tenant_certificate}) was not downloaded:\n{downloaded}")
+        log.info("The new tenant certificate was downloaded.")
+
+    def _get_tenant_certificate(self) -> str:
+        certificates = json.loads(self._ssh_client.run_command("get_goal_state.py --certificates --json", use_sudo=True))
+        candidates = [c["thumbprint"] for c in certificates if c["hasPrivateKey"]]
+        if len(candidates) != 1:
+            raise Exception(f"Could not find the tenant certificate. Current certificates: {certificates}")
+        return candidates[0]
+
+    def _enable_hibernation(self) -> None:
+        #
+        # The test may be running on an existing machine where hibernation has already been set as an additional capability, so we check that before setting it.
+        #
+        log.info("Enabling hibernation on %s", self._context.vm)
+        model: VirtualMachine = self._context.vm.get_model(include_instance_view=True)
+        if model.additional_capabilities is not None and model.additional_capabilities.hibernation_enabled:
+            log.info("Hibernation is already an additional capability of %s", self._context.vm)
+        else:
+            #
+            # To enable hibernation, the machine must be deallocated, then the hibernationEnabled property must be set, and, lastly, the machine must be reallocated
+            #
+            log.info("Deallocating %s in order to enable hibernation", self._context.vm)
+            self._context.vm.deallocate()
+            log.info("Adding hibernation as an additional capability to %s", self._context.vm)
+            self._context.vm.update(
+                {
+                    "additionalCapabilities": {
+                        "hibernationEnabled": True
+                    }
+                }
+            )
+            log.info("Reallocating %s after enabling hibernation", self._context.vm)
+            self._context.vm.start()
+
+        #
+        # The test may be running on an existing machine where the Hibernate extension has already been installed, so we check that before installing it.
+        #
+        if model.instance_view.extensions is not None and any(e for e in model.instance_view.extensions if e.type == "Microsoft.CPlat.Core.LinuxHibernateExtension"):
+            log.info("The Hibernation extension is already installed")
+        else:
+            log.info("Installing the Hibernation extension")
+            hibernate = VirtualMachineExtensionClient(self._context.vm, VmExtensionIds.Hibernate, resource_name="Hibernate")
+            hibernate.enable(auto_upgrade_minor_version=True)
+
+    def _do_hibernate_resume_cycle(self) -> None:
+        log.info("Hibernating %s...", self._context.vm)
+        self._context.vm.deallocate(hibernate=True)
+        log.info("Resuming %s...", self._context.vm)
+        self._context.vm.start()
+
+
+if __name__ == "__main__":
+    Hibernation.run_from_command_line()
+

--- a/tests_e2e/tests/hibernation/hibernation.py
+++ b/tests_e2e/tests/hibernation/hibernation.py
@@ -87,11 +87,6 @@ class Hibernation(AgentVmTest):
         if post_hibernation_tenant_certificate == pre_hibernation_tenant_certificate:
             raise Exception("Unexpected behavior: hibernate-resume did not create a new tenant certificate")
         log.info("Tenant certificate: %s", post_hibernation_tenant_certificate)
-        log.info("Checking that the new tenant certificate has not been downloaded yet...")
-        downloaded = self._ssh_client.run_command(f"ls /var/lib/waagent/{post_hibernation_tenant_certificate}.* || true", use_sudo=True).rstrip()
-        if downloaded != "":
-            raise Exception(f"Unexpected behavior: The new tenant certificate was downloaded after resume: {downloaded}")
-        log.info("The new tenant certificate has not been downloaded yet.")
 
         #
         # Execute an extension with protected settings and verify that the new tenant certificate was downloaded.

--- a/tests_e2e/tests/hibernation/hibernation.py
+++ b/tests_e2e/tests/hibernation/hibernation.py
@@ -160,11 +160,11 @@ class Hibernation(AgentVmTest):
 
     def _refresh_ip_address(self) -> None:
         """
-        Updates the test contect and the SSH client to reflect the current IP address of the test VM.
+        Updates the test context and the SSH client to reflect the current IP address of the test VM.
         The IP address of a VM can change as the result of a deallocate/allocate cycle.
         """
         log.info("Refreshing IP address of %s...", self._context.vm)
-        self._context.refresh_ip_address()
+        self._context.refresh_ip_addresses()
         self._ssh_client = self._context.create_ssh_client()
         log.info("IP address: %s", self._context.ip_address)
 

--- a/tests_e2e/tests/lib/agent_log.py
+++ b/tests_e2e/tests/lib/agent_log.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
+import io
 import os
 import re
 
@@ -85,9 +85,17 @@ class AgentLogRecord:
 class AgentLog(object):
     """
     Provides facilities to parse and/or extract errors from the agent's log.
+
+    The contents of the log can be specified by a file ('path' parameter) or a string ('contents' parameter). If no arguments are
+    specified, the contents are read from /var/log/waagent.log.
     """
-    def __init__(self, path: Path = Path('/var/log/waagent.log')):
-        self._path: Path = path
+    def __init__(self, path: Path = None, contents: str = None):
+        if path is not None and contents is not None:
+            raise ValueError("path and contents are mutually exclusive")
+        if path is None and contents is None:
+            path = Path('/var/log/waagent.log')
+
+        self._open_log = path.open if path is not None else lambda: io.StringIO(contents)
         self._counter_table: Dict[str, int] = {}
 
     def get_errors(self) -> List[AgentLogRecord]:
@@ -537,9 +545,6 @@ class AgentLog(object):
                  ... do something...
 
         """
-        if not self._path.exists():
-            raise IOError('{0} does not exist'.format(self._path))
-
         def match_record():
             for regex in [self._NEWER_AGENT_RECORD, self._2_2_46_AGENT_RECORD, self._OLDER_AGENT_RECORD, self._OLDEST_AGENT_RECORD]:
                 m = regex.match(line)
@@ -555,11 +560,12 @@ class AgentLog(object):
                 record.message = record.message + "\n" + extra_lines.rstrip()
             return record
 
-        with self._path.open() as file_:
+        log = self._open_log()
+        try:
             record = None
             extra_lines = ""
 
-            line = file_.readline()
+            line = log.readline()
             while line != "":  # while not EOF
                 match = match_record()
                 if match is not None:
@@ -569,7 +575,9 @@ class AgentLog(object):
                     extra_lines = ""
                 else:
                     extra_lines = extra_lines + line
-                line = file_.readline()
+                line = log.readline()
 
             if record is not None:
                 yield complete_record()
+        finally:
+            log.close()

--- a/tests_e2e/tests/lib/agent_test_context.py
+++ b/tests_e2e/tests/lib/agent_test_context.py
@@ -17,12 +17,25 @@
 import argparse
 import os
 
-from abc import ABC
+from abc import ABC, abstractmethod
 from pathlib import Path
+from typing import List
 
 from tests_e2e.tests.lib.virtual_machine_client import VirtualMachineClient
 from tests_e2e.tests.lib.virtual_machine_scale_set_client import VirtualMachineScaleSetClient
 from tests_e2e.tests.lib.ssh_client import SshClient
+
+
+class TestNode(object):
+    """
+    Name and IP address of a test VM
+    """
+    def __init__(self, name: str, ip_address: str):
+        self.name = name
+        self.ip_address = ip_address
+
+    def __str__(self):
+        return f"{self.name}:{self.ip_address}"
 
 
 class AgentTestContext(ABC):
@@ -36,6 +49,18 @@ class AgentTestContext(ABC):
         self.username: str = username
         self.identity_file: Path = identity_file
         self.ssh_port: int = ssh_port
+
+    @abstractmethod
+    def get_test_nodes(self) -> List[TestNode]:
+        """
+        Returns the list of nodes the test is executed on
+        """
+
+    @abstractmethod
+    def refresh_ip_addresses(self) -> None:
+        """
+        Updates the list of test nodes with their current IP addresses
+        """
 
     @staticmethod
     def _create_argument_parser() -> argparse.ArgumentParser:
@@ -66,6 +91,18 @@ class AgentVmTestContext(AgentTestContext):
         self.vm: VirtualMachineClient = vm
         self.ip_address: str = ip_address
 
+    def get_test_nodes(self) -> List[TestNode]:
+        """
+        Returns the list of nodes the test is executed on
+        """
+        return [TestNode(name=self.vm.name, ip_address=self.ip_address)]
+
+    def refresh_ip_addresses(self) -> None:
+        """
+        Updates self.ip_address to reflect the current IP address of the VM.
+        """
+        self.ip_address = self.vm.get_ip_address()
+
     def create_ssh_client(self) -> SshClient:
         """
         Convenience method to create an SSH client using the connection info from the context.
@@ -75,12 +112,6 @@ class AgentVmTestContext(AgentTestContext):
             username=self.username,
             identity_file=self.identity_file,
             port=self.ssh_port)
-
-    def refresh_ip_address(self) -> None:
-        """
-        Updates self.ip_address to reflect the current IP address of the VM.
-        """
-        self.ip_address = self.vm.get_ip_address()
 
     @staticmethod
     def from_args():
@@ -109,6 +140,21 @@ class AgentVmssTestContext(AgentTestContext):
     def __init__(self, working_directory: Path, vmss: VirtualMachineScaleSetClient, username: str, identity_file: Path, ssh_port: int = AgentTestContext.DEFAULT_SSH_PORT):
         super().__init__(working_directory, username, identity_file, ssh_port)
         self.vmss: VirtualMachineScaleSetClient = vmss
+        self._test_nodes = None  # fetched on demand
+
+    def get_test_nodes(self) -> List[TestNode]:
+        """
+        Returns the list of nodes the test is executed on
+        """
+        if self._test_nodes is None:
+            self.refresh_ip_addresses()
+        return self._test_nodes
+
+    def refresh_ip_addresses(self) -> None:
+        """
+        Updates self.ip_address to reflect the current IP address of the VM.
+        """
+        self._test_nodes = [TestNode(name=i.instance_name, ip_address=i.ip_address) for i in self.vmss.get_instances_ip_address()]
 
     @staticmethod
     def from_args():

--- a/tests_e2e/tests/lib/agent_test_context.py
+++ b/tests_e2e/tests/lib/agent_test_context.py
@@ -76,6 +76,12 @@ class AgentVmTestContext(AgentTestContext):
             identity_file=self.identity_file,
             port=self.ssh_port)
 
+    def refresh_ip_address(self) -> None:
+        """
+        Updates self.ip_address to reflect the current IP address of the VM.
+        """
+        self.ip_address = self.vm.get_ip_address()
+
     @staticmethod
     def from_args():
         """

--- a/tests_e2e/tests/lib/virtual_machine_client.py
+++ b/tests_e2e/tests/lib/virtual_machine_client.py
@@ -20,7 +20,6 @@
 #
 
 import datetime
-import json
 import time
 from typing import Any, Dict, List
 
@@ -79,15 +78,18 @@ class VirtualMachineClient(AzureSdkClient):
         private_ip = nic.ip_configurations[0].private_ip_address
         return private_ip
 
-    def get_model(self) -> VirtualMachine:
+    def get_model(self, include_instance_view: bool = False) -> VirtualMachine:
         """
         Retrieves the model of the virtual machine.
         """
         log.info("Retrieving VM model for %s", self)
-        return execute_with_retry(
-            lambda: self._compute_client.virtual_machines.get(
-                resource_group_name=self.resource_group,
-                vm_name=self.name))
+        kwargs = {
+            "resource_group_name": self.resource_group,
+            "vm_name":  self.name
+        }
+        if include_instance_view:
+            kwargs["expand"] = "instanceView"
+        return execute_with_retry(lambda: self._compute_client.virtual_machines.get(**kwargs))
 
     def get_instance_view(self) -> VirtualMachineInstanceView:
         """
@@ -183,32 +185,69 @@ class VirtualMachineClient(AzureSdkClient):
             return
 
         start = datetime.datetime.now(UTC)
+
+        self._wait_for_status("PowerState/running", boot_timeout)
+
+        # self._wait_for_power_state() works by checking the instance view, and we may capture a view from before the reboot actually happened, so we verify
+        # that the reboot actually happened by checking the system's uptime.
         while datetime.datetime.now(UTC) < start + boot_timeout:
-            log.info("Waiting for VM %s to boot", self)
-            time.sleep(15)  # Note that we always sleep at least 1 time, to give the reboot time to start
-            instance_view = self.get_instance_view()
-            power_state = [s.code for s in instance_view.statuses if "PowerState" in s.code]
-            if len(power_state) != 1:
-                raise Exception(f"Could not find PowerState in the instance view statuses:\n{json.dumps(instance_view.serialize(), indent=2)}")
-            log.info("VM's Power State: %s", power_state[0])
-            if power_state[0] == "PowerState/running":
-                # We may get an instance view captured before the reboot actually happened; verify
-                # that the reboot actually happened by checking the system's uptime.
-                log.info("Verifying VM's uptime to ensure the reboot has completed...")
-                try:
-                    uptime = ssh_client.run_command("cat /proc/uptime | sed 's/ .*//'", attempts=1).rstrip()  # The uptime is the first field in the file
-                    log.info("Uptime: %s", uptime)
-                    boot_time = datetime.datetime.now(UTC) - datetime.timedelta(seconds=float(uptime))
-                    if boot_time > before_restart:
-                        log.info("VM %s completed boot and is running. Boot time: %s", self, boot_time)
-                        return
-                    log.info("The VM has not rebooted yet. Restart time: %s. Boot time: %s", before_restart, boot_time)
-                except CommandError as e:
-                    if (e.exit_code == 255 and ("Connection refused" in str(e) or "Connection timed out" in str(e))) or "Unprivileged users are not permitted to log in yet" in str(e):
-                        log.info("VM %s is not yet accepting SSH connections", self)
-                    else:
-                        raise
+            log.info("Verifying VM's uptime to ensure the reboot has completed...")
+            try:
+                uptime = ssh_client.run_command("cat /proc/uptime | sed 's/ .*//'", attempts=1).rstrip()  # The uptime is the first field in the file
+                log.info("Uptime: %s", uptime)
+                boot_time = datetime.datetime.now(UTC) - datetime.timedelta(seconds=float(uptime))
+                if boot_time > before_restart:
+                    log.info("VM %s completed boot and is running. Boot time: %s", self, boot_time)
+                    return
+                log.info("The VM has not rebooted yet. Restart time: %s. Boot time: %s", before_restart, boot_time)
+            except CommandError as e:
+                if (e.exit_code == 255 and ("Connection refused" in str(e) or "Connection timed out" in str(e))) or "Unprivileged users are not permitted to log in yet" in str(e):
+                    log.info("VM %s is not yet accepting SSH connections", self)
+                else:
+                    raise
+            time.sleep(10)
+
         raise Exception(f"VM {self} did not boot after {boot_timeout}")
+
+    def start(self, start_timeout: datetime.timedelta = datetime.timedelta(minutes=5), timeout: int = AzureSdkClient._DEFAULT_TIMEOUT) -> None:
+        """
+        Starts (allocates) the virtual machine.
+        """
+        self._execute_async_operation(
+            lambda: self._compute_client.virtual_machines.begin_start(
+                resource_group_name=self.resource_group,
+                vm_name=self.name),
+            operation_name=f"Start {self}",
+            timeout=timeout)
+        self._wait_for_status("PowerState/running", start_timeout)
+
+    def deallocate(self, hibernate: bool = False, deallocate_timeout: datetime.timedelta = datetime.timedelta(minutes=5), timeout: int = AzureSdkClient._DEFAULT_TIMEOUT) -> None:
+        """
+        Deallocates the virtual machine, optionally setting it up to hibernate.
+        """
+        log.info("Deallocating %s [hibernate=%s]...", self, hibernate)
+        self._execute_async_operation(
+            lambda: self._compute_client.virtual_machines.begin_deallocate(
+                resource_group_name=self.resource_group,
+                vm_name=self.name,
+                hibernate=hibernate),
+            operation_name=f"Deallocate {self} [hibernate={hibernate}]",
+            timeout=timeout)
+        self._wait_for_status('HibernationState/Hibernated' if hibernate else 'PowerState/deallocated', deallocate_timeout)
+
+    def _wait_for_status(self, status: str, timeout: datetime.timedelta = datetime.timedelta(minutes=5)) -> None:
+        start = datetime.datetime.now(UTC)
+
+        while datetime.datetime.now(UTC) < start + timeout:
+            log.info("Waiting for Status to reach %s", status)
+            instance_view = self.get_instance_view()
+            statuses = [s.code for s in instance_view.statuses]
+            log.info("Current status: %s", statuses)
+            if status in statuses:
+                return
+            time.sleep(10)
+
+        raise Exception(f"VM {self} did not reach {status} after {timeout}")
 
     def __str__(self):
         return f"{self.resource_group}:{self.name}"

--- a/tests_e2e/tests/lib/virtual_machine_client.py
+++ b/tests_e2e/tests/lib/virtual_machine_client.py
@@ -188,7 +188,7 @@ class VirtualMachineClient(AzureSdkClient):
 
         self._wait_for_status("PowerState/running", boot_timeout)
 
-        # self._wait_for_power_state() works by checking the instance view, and we may capture a view from before the reboot actually happened, so we verify
+        # self._wait_for_status() works by checking the instance view, and we may capture a view from before the reboot actually happened, so we verify
         # that the reboot actually happened by checking the system's uptime.
         while datetime.datetime.now(UTC) < start + boot_timeout:
             log.info("Verifying VM's uptime to ensure the reboot has completed...")

--- a/tests_e2e/tests/lib/vm_extension_identifier.py
+++ b/tests_e2e/tests/lib/vm_extension_identifier.py
@@ -59,14 +59,15 @@ class VmExtensionIds(object):
     Only the major version is specified, and the minor version is set to 0 (set autoUpgradeMinorVersion to True in the call to enable
     to use the latest version)
     """
+    AzureMonitorLinuxAgent: VmExtensionIdentifier = VmExtensionIdentifier(publisher='Microsoft.Azure.Monitor', ext_type='AzureMonitorLinuxAgent', version="1.5")
+    AzureSecurityLinuxAgent: VmExtensionIdentifier = VmExtensionIdentifier(publisher='Microsoft.Azure.Security.Monitoring', ext_type='AzureSecurityLinuxAgent', version="2.0")
     CustomScript: VmExtensionIdentifier = VmExtensionIdentifier(publisher='Microsoft.Azure.Extensions', ext_type='CustomScript', version="2.0")
+    GATestExtension: VmExtensionIdentifier = VmExtensionIdentifier(publisher='Microsoft.Azure.Extensions.Edp', ext_type='GATestExtGo', version="1.2")
+    GuestAgentDcrTestExtension: VmExtensionIdentifier = VmExtensionIdentifier(publisher='Microsoft.Azure.TestExtensions.Edp', ext_type='GuestAgentDcrTest', version='1.0')
+    GuestConfig: VmExtensionIdentifier = VmExtensionIdentifier(publisher='Microsoft.GuestConfiguration', ext_type='ConfigurationforLinux', version="1.0")
+    Hibernate: VmExtensionIdentifier = VmExtensionIdentifier(publisher='Microsoft.CPlat.Core', ext_type='LinuxHibernateExtension', version="1.0")
     # Older run command extension, still used by the Portal as of Dec 2022
     RunCommand: VmExtensionIdentifier = VmExtensionIdentifier(publisher='Microsoft.CPlat.Core', ext_type='RunCommandLinux', version="1.0")
     # New run command extension, with support for multi-config
     RunCommandHandler: VmExtensionIdentifier = VmExtensionIdentifier(publisher='Microsoft.CPlat.Core', ext_type='RunCommandHandlerLinux', version="1.0")
     VmAccess: VmExtensionIdentifier = VmExtensionIdentifier(publisher='Microsoft.OSTCExtensions', ext_type='VMAccessForLinux', version="1.0")
-    GuestAgentDcrTestExtension: VmExtensionIdentifier = VmExtensionIdentifier(publisher='Microsoft.Azure.TestExtensions.Edp', ext_type='GuestAgentDcrTest', version='1.0')
-    AzureMonitorLinuxAgent: VmExtensionIdentifier = VmExtensionIdentifier(publisher='Microsoft.Azure.Monitor', ext_type='AzureMonitorLinuxAgent', version="1.5")
-    GATestExtension: VmExtensionIdentifier = VmExtensionIdentifier(publisher='Microsoft.Azure.Extensions.Edp', ext_type='GATestExtGo', version="1.2")
-    GuestConfig: VmExtensionIdentifier = VmExtensionIdentifier(publisher='Microsoft.GuestConfiguration', ext_type='ConfigurationforLinux', version="1.0")
-    AzureSecurityLinuxAgent: VmExtensionIdentifier = VmExtensionIdentifier(publisher='Microsoft.Azure.Security.Monitoring', ext_type='AzureSecurityLinuxAgent', version="2.0")

--- a/tests_e2e/tests/scripts/agent_ext_policy-verify_operation_disallowed.py
+++ b/tests_e2e/tests/scripts/agent_ext_policy-verify_operation_disallowed.py
@@ -24,7 +24,6 @@ import re
 
 from datetime import datetime
 from azurelinuxagent.common.future import UTC, datetime_min_utc
-from pathlib import Path
 from tests_e2e.tests.lib.logging import log
 from tests_e2e.tests.lib.agent_log import AgentLog
 
@@ -40,7 +39,7 @@ def main():
     log.info("Verifying that agent log shows {0} failure due to policy".format(args.operation))
     pattern = (r".*Extension will not be processed: failed to {0} extension '{1}' because it is not specified as an allowed extension.*"
                .format(args.operation, re.escape(args.extension_name)))
-    agent_log = AgentLog(Path('/var/log/waagent.log'))
+    agent_log = AgentLog()
 
     if args.after_timestamp is None:
         after_datetime = datetime_min_utc

--- a/tests_e2e/tests/scripts/agent_ext_policy-verify_operation_success.py
+++ b/tests_e2e/tests/scripts/agent_ext_policy-verify_operation_success.py
@@ -20,7 +20,6 @@
 import argparse
 
 from assertpy import fail
-from pathlib import Path
 from datetime import datetime
 import time
 import re
@@ -41,7 +40,7 @@ from tests_e2e.tests.lib.agent_log import AgentLog
 def __get_last_reported_status(after_timestamp):
     # Get last reported status from the agent log file. If after_timestamp is specified, return only the status reported
     # after that timestamp, and raise error if not found after 2 tries.
-    agent_log = AgentLog(Path('/var/log/waagent.log'))
+    agent_log = AgentLog()
 
     retries = 10
     for attempt in range(retries):

--- a/tests_e2e/tests/scripts/agent_ext_workflow-validate_no_lag_between_agent_start_and_gs_processing.py
+++ b/tests_e2e/tests/scripts/agent_ext_workflow-validate_no_lag_between_agent_start_and_gs_processing.py
@@ -23,7 +23,6 @@ import re
 import sys
 import time
 
-from pathlib import Path
 from tests_e2e.tests.lib.agent_log import AgentLog
 
 
@@ -49,7 +48,7 @@ def main():
         verified_atleast_one_agent_started_log_line = False
         verified_atleast_one_gs_complete_log_line = False
 
-        agent_log = AgentLog(Path('/var/log/waagent.log'))
+        agent_log = AgentLog()
 
         try:
             for agent_record in agent_log.read():

--- a/tests_e2e/tests/scripts/check_data_in_agent_log.py
+++ b/tests_e2e/tests/scripts/check_data_in_agent_log.py
@@ -22,7 +22,6 @@ import argparse
 import sys
 
 from datetime import datetime
-from pathlib import Path
 from azurelinuxagent.common.future import UTC
 from tests_e2e.tests.lib.agent_log import AgentLog
 
@@ -39,9 +38,9 @@ def main():
     try:
         if args.after_timestamp is not None:
             after_datetime = datetime.strptime(args.after_timestamp, '%Y-%m-%dT%H:%M:%SZ').replace(tzinfo=UTC)
-            found = AgentLog(Path('/var/log/waagent.log')).agent_log_contains(args.data, after_datetime)
+            found = AgentLog().agent_log_contains(args.data, after_datetime)
         else:
-            found = AgentLog(Path('/var/log/waagent.log')).agent_log_contains(args.data)
+            found = AgentLog().agent_log_contains(args.data)
         if found:
             print("Found data: {0} in agent log".format(args.data))
         else:

--- a/tests_e2e/tests/scripts/ext_signature_validation-check_signature_validated.py
+++ b/tests_e2e/tests/scripts/ext_signature_validation-check_signature_validated.py
@@ -24,7 +24,6 @@ import re
 
 from datetime import datetime
 from azurelinuxagent.common.future import UTC, datetime_min_utc
-from pathlib import Path
 from tests_e2e.tests.lib.logging import log
 from tests_e2e.tests.lib.agent_log import AgentLog
 
@@ -42,7 +41,7 @@ def main():
     log.info("Verifying that {0} package signature was validated.".format(args.extension_name))
     sig_pattern = (r".*Successfully validated signature for package '.*{0}.*'".format(re.escape(args.extension_name)))
     man_pattern = (r".*Successfully validated handler manifest 'signingInfo' for extension '.*{0}.*'".format(re.escape(args.extension_name)))
-    agent_log = AgentLog(Path('/var/log/waagent.log'))
+    agent_log = AgentLog()
 
     if args.after_timestamp is None:
         after_datetime = datetime_min_utc

--- a/tests_e2e/tests/scripts/get_goal_state.py
+++ b/tests_e2e/tests/scripts/get_goal_state.py
@@ -16,83 +16,247 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Displays a set of properties from an object in the goal state.
-#
-# Currently, it only supports the basic goal state, certificates, and the extensions goal state. Support for other objects
-# can be added as needed.
-#
-# If multiple properties are specified, the output is a JSON object with a member for each of the properties. If no
-# properties are specified, a default property is displayed:
-#
-#     * basic goal state - incarnation
-#     * certificates - summary
-#     * extensions goal state - id
-#
-# Examples:
-#       # get_goal_state.py
-#       1
-#
-#       # get_goal_state.py -p incarnation
-#       1
-#
-#       # get_goal_state.py --certificates
-#       [{'thumbprint': 'DF940808B0BB7823492E28E2E233860CDD317588', 'hasPrivateKey': False}, {'thumbprint': '0E3139B2153423AAE88433898A3A30255E24F5C4', 'hasPrivateKey': True}]
-#
-#       get_goal_state.py --extensions_goal_state --properties id source
-#       {"id": "incarnation_1", "source": "Fabric"}
+# Utility to fetch the goal state.
 #
 import argparse
-import json
-import os
+import os.path
+import re
+import subprocess
 import sys
+import tempfile
+import time
 
-from azurelinuxagent.common.conf import get_lib_dir
-from azurelinuxagent.common.protocol.util import ENDPOINT_FILE_NAME
-from azurelinuxagent.common.protocol.wire import WireProtocol, GoalState, GoalStateProperties
+from http import client
+from typing import Dict, List
+from urllib.parse import urlparse
+from xml.dom import minidom
+
+
+def _get(url: str, headers: Dict[str, str], tries: int, timeout: int, delay: int) -> str:
+    """
+    Issues an HTTP GET request using the given 'url'; returns the response.
+    """
+    p = urlparse(url)
+    relative_uri = p.path
+    if p.fragment:
+        relative_uri = f"{relative_uri}#{p.fragment}"
+    if p.query:
+        relative_uri = f"{relative_uri}?{p.query}"
+
+    for i in range(tries):
+        try:
+            connection = client.HTTPConnection(p.hostname, p.port, timeout=timeout)
+            try:
+                connection.request("GET", url=relative_uri, headers=headers)
+                response = connection.getresponse()
+                content = response.read().decode("utf-8")
+                if response.status != 200:
+                    raise Exception(f"{response.reason} - {content}")
+                return content
+            finally:
+                connection.close()
+        except Exception as exception:
+            print(f"GET {url} failed: {exception}", file=sys.stderr)
+        if i < tries - 1:
+            print(f"Retrying in {delay} seconds...", file=sys.stderr)
+            time.sleep(delay)
+    raise Exception(f"GET {url} failed after {tries} tries")
+
+
+def _get_goal_state(endpoint: str, tries: int, timeout: int, delay: int) -> str:
+    """
+    Issues an HTTP GET request to retrieve the goal state.
+    """
+    return _get(url=f"http://{endpoint}:80/machine/?comp=goalstate", headers=_get_wireserver_request_headers(request_encryption=False, key_location=None), tries=tries, timeout=timeout, delay=delay)
+
+
+def _get_wireserver_request_headers(request_encryption: bool, key_location) -> Dict[str, str]:
+    """
+    Returns the headers needed for requests to the WireServer endpoint. If 'request_encryption' is True, adds the Transport certificate to the headers.
+    """
+    headers = {
+        "x-ms-agent-name": "WALinuxAgent",
+        "x-ms-version": "2012-11-30"
+    }
+    if request_encryption:
+        key = ""
+        with open(os.path.join(key_location, "TransportCert.pem"), mode="rt") as f:
+            for line in f:
+                if not line.startswith("----"):
+                    key += line.rstrip()
+        headers.update({
+            "x-ms-cipher-name": "AES128_CBC",
+            "x-ms-guest-agent-public-x509-cert": key
+        })
+    return headers
+
+
+def _get_elements_by_tag_name(xml: str, tag: str) -> List[str]:
+    """
+    Retrieves a list of all the elements matching the given tag in the given XML.
+    """
+    root = minidom.parseString(xml)
+    elements = root.getElementsByTagName(tag)
+    if len(elements) == 0:
+        raise Exception(f"Can't find {tag}")
+    return list(map(lambda e: e.childNodes[0].data if len(e.childNodes) == 1 and e.childNodes[0].nodeType == minidom.Node.TEXT_NODE else e.toxml(), elements))
+
+
+def _run_command(command: str, command_input: str) -> str:
+    """
+    Executes a command and returns the stdout.
+    """
+    return subprocess.Popen(
+        command,
+        shell=True,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE
+    ).communicate(input=command_input.encode())[0].decode()
+
+
+def _extract_certificates(data: str, key_location: str, output_location: str) -> None:
+    """
+    Extracts the certificates from the WireServer response and writes them to *.crt and *.prv files in the given 'output_location'. The 'key_location'
+    specifies the path to the Transport certificate.
+    """
+    #
+    # Decrypt the data returned by the WireServer (which is a PFX package) and convert it into a PEM package.
+    #
+    pem_data = _run_command(
+        f'openssl cms -decrypt -inkey {os.path.join(key_location, "TransportPrivate.pem")} -recip {os.path.join(key_location, "TransportCert.pem")} | openssl pkcs12 -nodes -password pass: -nomacver',
+        command_input=f'MIME-Version:1.0\nContent-Disposition: attachment\nContent-Type: application/x-pkcs7-mime\nContent-Transfer-Encoding: base64\n\n{data}'
+    )
+
+    #
+    # Split the PEM data into individual keys and certificates
+    #
+    pem_data_lines = pem_data.splitlines()
+    keys, certificates = [], []
+    start, end = 0, 0
+    while end < len(pem_data_lines):
+        if re.match(r'[-]+END.*KEY[-]+', pem_data_lines[end]):
+            keys.append((start, end))
+            start = end + 1
+        elif re.match(r'[-]+END.*CERTIFICATE[-]+', pem_data_lines[end]):
+            certificates.append((start, end))
+            start = end + 1
+        end += 1
+
+    #
+    # Write each certificates to a *.crt file using the corresponding thumbprint as name; keep a map of thumbprints indexed by public key in
+    # order to associate each private key with its corresponding thumbprint.
+    #
+    thumbprints_by_public_key = {}  # map of thumbprints indexed by the corresponding public key
+
+    for c in certificates:
+        certificate_data = "\n".join(pem_data_lines[c[0] : c[1] + 1]) + "\n"
+        thumbprint = _run_command('openssl x509 -fingerprint -noout', command_input=certificate_data)
+        thumbprint = thumbprint.rstrip().split('=')[1].replace(':', '').upper()  # the fingerprint looks like 'SHA1 Fingerprint=DF:94:08:08:B0:BB:78:23:49:2E:28:E2:E2:33:86:0C:DD:31:75:88'
+        public_key = _run_command('openssl x509 -pubkey -noout', command_input=certificate_data)
+        thumbprints_by_public_key[public_key] = thumbprint
+        certificate_path = os.path.join(output_location, f'{thumbprint}.crt')
+        with open(certificate_path, "wt") as f:
+            f.write(certificate_data)
+        print(certificate_path)
+
+    #
+    # Write each private key to a *.prv file using the corresponding thumbprint as name.
+    #
+    for k in keys:
+        key_data = "\n".join(pem_data_lines[k[0] : k[1] + 1])
+        public_key = _run_command('openssl rsa -pubout', command_input=key_data)
+        thumbprint = thumbprints_by_public_key.get(public_key)
+        if thumbprint is None:
+            print("WARNING: Skipping private key with no associated certificate", file=sys.stderr)
+            continue
+        key_path = os.path.join(output_location, f'{thumbprint}.prv')
+        with open(key_path, "wt") as f:
+            f.write(key_data)
+        print(key_path)
 
 
 def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument('-j', '--json', action='store_true', help='Force JSON output')
-    parser.add_argument('-p', '--properties', nargs='*', help='Display the value of the given property')
-    parser.add_mutually_exclusive_group()
-    parser.add_argument('-c', '--certificates', action='store_true', help='Display the certificate thumbprints')
-    parser.add_argument('-e', '--extensions_goal_state', action='store_true', help='Display the Extensions Goal State')
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description='Display the current goal state.',
+        epilog="""
+Displays the main goal state object.
+
+Use the --certificates, --extensions, '--hosting-environment, --remote-access, and --shared option to display the corresponding sub-object. 
+Use the --tag option to display only the XML elements matching that tag.
+
+Examples:
+
+    * get_goal_state.py
+    * get_goal_state.py --tag Incarnation
+    * get_goal_state.py --extensions
+    * get_goal_state.py --certificates --expand /tmp    
+""")
+    parser.add_argument('--delay', required=False, default=6, type=int, help="Delay in seconds between retries of WireServer requests.")
+    parser.add_argument('--endpoint', required=False, default="168.63.129.16", help="IP address for the WireServer endpoint.")
+    parser.add_argument('--expand', nargs="?", const="", required=False, help="When used with --certificates, expands the WireServer response into *.crt and *.prv PEM files. If a value is given, files are created under that path, otherwise a temporary directory is used.")
+    parser.add_argument('--tag', required=False, default=None, help="Outputs only the XML elements that match the tag.")
+    parser.add_argument('--tries', required=False, default=3, type=int, help="Number of times to attempt WireServer requests.")
+    parser.add_argument('--timeout', required=False, default=10, type=int, help="Timeout in seconds for WireServer requests.")
+    parser.add_argument('--waagent', required=False, default="/var/lib/waagent", help="Location of the Transport certificate for WireServer requests.")
+    group = parser.add_mutually_exclusive_group(required=False)
+    group.add_argument('--certificates', action='store_true', help='Fetch the Certificates for the goal state')
+    group.add_argument('--extensions', action='store_true', help='Fetch the ExtensionsConfig for the goal state')
+    group.add_argument('--hosting-environment', action='store_true', help='Fetch the HostingEnvironmentConfig for the goal state')
+    group.add_argument('--remote-access', action='store_true', help='Fetch the RemoteAccessInfo for the goal state')
+    group.add_argument('--shared', action='store_true', help='Fetch the SharedConfig for the goal state')
+
     args = parser.parse_args()
 
+    if args.expand is not None:
+        if not args.certificates:
+            raise Exception("The --expand option can only be used with --certificates")
+        if args.tag:
+            raise Exception("--expand and --tag are mutually exclusive")
+
+    goal_state = _get_goal_state(endpoint=args.endpoint, tries=args.tries, timeout=args.timeout, delay=args.delay)
+
+    url, headers = None, None
     if args.certificates:
-        data = _get_goal_state(GoalStateProperties.Certificates).certs
-        default_property = "summary"
-    elif args.extensions_goal_state:
-        data = _get_goal_state(GoalStateProperties.ExtensionsGoalState).extensions_goal_state
-        default_property = "id"
+        url = _get_elements_by_tag_name(goal_state, 'Certificates')[0]
+        headers = _get_wireserver_request_headers(request_encryption=True, key_location=args.waagent)
+    elif args.extensions:
+        url = _get_elements_by_tag_name(goal_state, 'ExtensionsConfig')[0]
+    elif args.hosting_environment:
+        url = _get_elements_by_tag_name(goal_state, 'HostingEnvironmentConfig')[0]
+    elif args.remote_access:
+        url = _get_elements_by_tag_name(goal_state, 'RemoteAccessInfo')[0]
+        headers = _get_wireserver_request_headers(request_encryption=True, key_location=args.waagent)
+    elif args.shared:
+        url = _get_elements_by_tag_name(goal_state, 'SharedConfig')[0]
+
+    if url is None:
+        xml_document = goal_state
     else:
-        data = _get_goal_state()
-        default_property = "incarnation"
+        if headers is None:
+            headers = _get_wireserver_request_headers(request_encryption=False, key_location=None)
+        xml_document = _get(url, headers=headers, tries=args.tries, timeout=args.timeout, delay=args.delay)
 
-    properties = args.properties if args.properties is not None else [default_property]
+    if args.certificates and args.expand is not None:
+        output_location = args.expand if args.expand != '' else tempfile.mkdtemp()
+        _extract_certificates(_get_elements_by_tag_name(xml_document, 'Data')[0], key_location=args.waagent, output_location=output_location)
+        return
 
-    if len(properties) == 1:
-        value = data.__getattribute__(properties[0])
-        if args.json:
-            print(json.dumps(value, indent=4))
+    if args.tag is None:
+        print(xml_document)
+    else:
+        elements = _get_elements_by_tag_name(xml_document, args.tag)
+        if len(elements) == 1:
+            print(elements[0])
         else:
-            print(value)
-    else:
-        output = {}
-        for p in properties:
-            output[p] = data.__getattribute__(p)
-        print(json.dumps(output, indent=4))
-
-
-def _get_goal_state(goal_state_properties: GoalStateProperties = 0x0):
-    with (open(os.path.join(get_lib_dir(), ENDPOINT_FILE_NAME), "r")) as endpoint_file:
-        endpoint = endpoint_file.read().rstrip()
-
-    protocol = WireProtocol(endpoint)
-    return GoalState(protocol.client, goal_state_properties=goal_state_properties, save_to_history=False, silent=True)
+            print(elements)
 
 
 if __name__ == "__main__":
-    main()
-sys.exit(0)
+    try:
+        main()
+    except Exception as exception:
+        print(exception, file=sys.stderr)
+        sys.exit(1)
+    sys.exit(0)

--- a/tests_e2e/tests/scripts/get_goal_state.py
+++ b/tests_e2e/tests/scripts/get_goal_state.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env pypy3
+
+# Microsoft Azure Linux Agent
+#
+# Copyright 2018 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Displays a set of properties from an object in the goal state.
+#
+# Currently, it only supports the basic goal state, certificates, and the extensions goal state. Support for other objects
+# can be added as needed.
+#
+# If multiple properties are specified, the output is a JSON object with a member for each of the properties. If no
+# properties are specified, a default property is displayed:
+#
+#     * basic goal state - incarnation
+#     * certificates - summary
+#     * extensions goal state - id
+#
+# Examples:
+#       # get_goal_state.py
+#       1
+#
+#       # get_goal_state.py -p incarnation
+#       1
+#
+#       # get_goal_state.py --certificates
+#       [{'thumbprint': 'DF940808B0BB7823492E28E2E233860CDD317588', 'hasPrivateKey': False}, {'thumbprint': '0E3139B2153423AAE88433898A3A30255E24F5C4', 'hasPrivateKey': True}]
+#
+#       get_goal_state.py --extensions_goal_state --properties id source
+#       {"id": "incarnation_1", "source": "Fabric"}
+#
+import argparse
+import json
+import os
+import sys
+
+from azurelinuxagent.common.conf import get_lib_dir
+from azurelinuxagent.common.protocol.util import ENDPOINT_FILE_NAME
+from azurelinuxagent.common.protocol.wire import WireProtocol, GoalState, GoalStateProperties
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-j', '--json', action='store_true', help='Force JSON output')
+    parser.add_argument('-p', '--properties', nargs='*', help='Display the value of the given property')
+    parser.add_mutually_exclusive_group()
+    parser.add_argument('-c', '--certificates', action='store_true', help='Display the certificate thumbprints')
+    parser.add_argument('-e', '--extensions_goal_state', action='store_true', help='Display the Extensions Goal State')
+    args = parser.parse_args()
+
+    if args.certificates:
+        data = _get_goal_state(GoalStateProperties.Certificates).certs
+        default_property = "summary"
+    elif args.extensions_goal_state:
+        data = _get_goal_state(GoalStateProperties.ExtensionsGoalState).extensions_goal_state
+        default_property = "id"
+    else:
+        data = _get_goal_state()
+        default_property = "incarnation"
+
+    properties = args.properties if args.properties is not None else [default_property]
+
+    if len(properties) == 1:
+        value = data.__getattribute__(properties[0])
+        if args.json:
+            print(json.dumps(value, indent=4))
+        else:
+            print(value)
+    else:
+        output = {}
+        for p in properties:
+            output[p] = data.__getattribute__(p)
+        print(json.dumps(output, indent=4))
+
+
+def _get_goal_state(goal_state_properties: GoalStateProperties = 0x0):
+    with (open(os.path.join(get_lib_dir(), ENDPOINT_FILE_NAME), "r")) as endpoint_file:
+        endpoint = endpoint_file.read().rstrip()
+
+    protocol = WireProtocol(endpoint)
+    return GoalState(protocol.client, goal_state_properties=goal_state_properties, save_to_history=False, silent=True)
+
+
+if __name__ == "__main__":
+    main()
+sys.exit(0)

--- a/tests_e2e/tests/scripts/http_get.py
+++ b/tests_e2e/tests/scripts/http_get.py
@@ -55,7 +55,7 @@ def main():
                 response = connection.getresponse()
                 content = response.read().decode("utf-8")
                 if response.status != 200:
-                    raise Exception(f"{response.reason}", content)
+                    raise Exception(f"{response.reason} - {content}")
                 print(content)
                 break
             finally:


### PR DESCRIPTION
Adding test to verify that the certificates in the goal state are refreshed after a hibernate-resume cycle.

Hibernate-resume can change the IP address of the VM, and the Agent was maintaining a static list of test nodes and their IP addresses. I changed that to get that information from the AgentTestContext, and added methods in the context to refresh the address.

At this point, only this test changes the IP address, and I decided to make the test's responsibility to keep the AgentTestContext up to date. If we need to this functionality for other tests, we can switch that responsibility to the AgentTestSuite and, for example, refresh the context after executing each test.