### PR TITLE
report update errorcode for extension update failures

### DIFF
--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -875,7 +875,9 @@ class ExtHandlersHandler(object):
                 msg = "%s; ContinueOnUpdate: %s" % (ustr(e), continue_on_update_failure)
                 old_ext_handler_i.report_event(message=msg, is_success=False)
                 if not continue_on_update_failure:
-                    raise ExtensionUpdateError(msg)
+                    # We need to populate correct error code here
+                    # Without this, the superclass defaults to code -1, which may not accurately represent the error.
+                    raise ExtensionUpdateError(msg, code=ExtensionErrorCodes.PluginUpdateProcessingFailed)
 
                 exit_code = e.code
                 if isinstance(e, ExtensionOperationError):

--- a/tests/ga/test_extension.py
+++ b/tests/ga/test_extension.py
@@ -1880,7 +1880,7 @@ class TestExtension_Deprecated(TestExtensionBase):
             # for the new version is not called and the new version handler's status is reported as not ready.
             self.assertEqual(1, patch_get_disable_command.call_count)
             self.assertEqual(0, patch_get_enable_command.call_count)
-            self._assert_handler_status(protocol.report_vm_status, "NotReady", expected_ext_count=0, version="1.0.1")
+            self._assert_handler_status(protocol.report_vm_status, "NotReady", expected_ext_count=0, version="1.0.1", expected_code=ExtensionErrorCodes.PluginUpdateProcessingFailed)
 
     @patch('azurelinuxagent.ga.exthandlers.HandlerManifest.get_disable_command')
     def test_extension_upgrade_failure_when_prev_version_disable_fails_and_recovers_on_next_incarnation(self, patch_get_disable_command,
@@ -1987,7 +1987,7 @@ class TestExtension_Deprecated(TestExtensionBase):
         exthandlers_handler.report_ext_handlers_status()
 
         self.assertEqual(1, patch_get_update_command.call_count)
-        self._assert_handler_status(protocol.report_vm_status, "NotReady", expected_ext_count=1, version="1.0.1")
+        self._assert_handler_status(protocol.report_vm_status, "NotReady", expected_ext_count=1, version="1.0.1", expected_code=ExtensionErrorCodes.PluginUpdateProcessingFailed)
 
     @patch('azurelinuxagent.ga.exthandlers.HandlerManifest.get_disable_command')
     def test_extension_upgrade_should_pass_when_continue_on_update_failure_is_true_and_prev_version_disable_fails(
@@ -2046,7 +2046,7 @@ class TestExtension_Deprecated(TestExtensionBase):
                              "The first call would raise an exception")
 
         # Assert test scenario
-        self._assert_handler_status(protocol.report_vm_status, "NotReady", expected_ext_count=0, version="1.0.1")
+        self._assert_handler_status(protocol.report_vm_status, "NotReady", expected_ext_count=0, version="1.0.1", expected_code=ExtensionErrorCodes.PluginUpdateProcessingFailed)
 
     @patch('azurelinuxagent.ga.exthandlers.HandlerManifest.get_uninstall_command')
     def test_extension_upgrade_should_fail_when_continue_on_update_failure_is_false_and_prev_version_uninstall_fails(
@@ -2065,7 +2065,7 @@ class TestExtension_Deprecated(TestExtensionBase):
                              "The second call would raise an exception")
 
         # Assert test scenario
-        self._assert_handler_status(protocol.report_vm_status, "NotReady", expected_ext_count=0, version="1.0.1")
+        self._assert_handler_status(protocol.report_vm_status, "NotReady", expected_ext_count=0, version="1.0.1", expected_code=ExtensionErrorCodes.PluginUpdateProcessingFailed)
 
     @patch('azurelinuxagent.ga.exthandlers.HandlerManifest.get_disable_command')
     def test_extension_upgrade_should_fail_when_continue_on_update_failure_is_true_and_old_disable_and_new_enable_fails(
@@ -2086,7 +2086,7 @@ class TestExtension_Deprecated(TestExtensionBase):
                 self.assertEqual(1, patch_get_enable.call_count)
 
         # Assert test scenario
-        self._assert_handler_status(protocol.report_vm_status, "NotReady", expected_ext_count=1, version="1.0.1")
+        self._assert_handler_status(protocol.report_vm_status, "NotReady", expected_ext_count=1, version="1.0.1", expected_code=ExtensionErrorCodes.PluginEnableProcessingFailed)
 
     @patch('azurelinuxagent.ga.exthandlers.HandlerManifest.is_continue_on_update_failure', return_value=True)
     def test_uninstall_rc_env_var_should_report_not_run_for_non_update_calls_to_exthandler_run(

--- a/tests_e2e/orchestrator/runbook.yml
+++ b/tests_e2e/orchestrator/runbook.yml
@@ -58,6 +58,7 @@ variable:
       - cgroup_v2_enabled
       - log_collector
       - ext_signature_validation
+      - ext_update
 
   #
   # Additional arguments pass to the test suites

--- a/tests_e2e/test_suites/ext_update.yml
+++ b/tests_e2e/test_suites/ext_update.yml
@@ -5,4 +5,3 @@ name: "ExtensionUpdate"
 tests:
   - "ext_update/ext_update_failure.py"
 images: "random(endorsed)"
-owns_vm: true

--- a/tests_e2e/test_suites/ext_update.yml
+++ b/tests_e2e/test_suites/ext_update.yml
@@ -1,0 +1,8 @@
+#
+#    This test verifies that the agent reports correct status and code when operation fails during the ext update.
+#
+name: "ExtensionUpdate"
+tests:
+  - "ext_update/ext_update_failure.py"
+images: "random(endorsed)"
+owns_vm: true

--- a/tests_e2e/tests/ext_update/ext_update_failure.py
+++ b/tests_e2e/tests/ext_update/ext_update_failure.py
@@ -114,7 +114,7 @@ class ExtensionUpdateFailureTest(AgentVmTest):
                 'message': r"name=Microsoft.Azure.Extensions.CustomScript, op=Disable, message=\[ExtensionOperationError\] .*disablefailed"
             },
 
-            # In some distros, the scope not being found is not an error, so we consider as systemd error
+            # In some distros, scope not included in the error, so we consider as systemd error
             # 2025-07-21T22:07:23.541880Z INFO ExtHandler ExtHandler [CGW] Disabling resource usage monitoring. Reason: Failed to start Microsoft.Azure.Extensions.CustomScript-2.0.7 using systemd-run, will try invoking the extension directly. Error: [SystemdRunError] Systemd process exited with code 1 and output [stdout]
             # [stderr]
             # Failed to find executable /var/lib/waagent/Microsoft.Azure.Extensions.CustomScript-2.0.7/disablefailed: No such file or directory

--- a/tests_e2e/tests/ext_update/ext_update_failure.py
+++ b/tests_e2e/tests/ext_update/ext_update_failure.py
@@ -95,6 +95,7 @@ class ExtensionUpdateFailureTest(AgentVmTest):
             if ext_name in extension_names_on_vm:
                 self._ssh_client.run_command(f"ext_update-modify_handler_manifest.py --extension-name '{ext_name}' --reset", use_sudo=True)
                 ext.delete()
+                log.info("Removed extension %s", ext_name)
 
     def get_ignore_error_rules(self) -> List[Dict[str, Any]]:
         ignore_rules = [

--- a/tests_e2e/tests/ext_update/ext_update_failure.py
+++ b/tests_e2e/tests/ext_update/ext_update_failure.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+
+# Microsoft Azure Linux Agent
+#
+# Copyright 2018 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import uuid
+from typing import List, Dict, Any
+
+from assertpy import fail, assert_that
+
+from tests_e2e.tests.lib.agent_test import AgentVmTest
+from tests_e2e.tests.lib.logging import log
+from tests_e2e.tests.lib.ssh_client import SshClient
+from tests_e2e.tests.lib.virtual_machine_extension_client import VirtualMachineExtensionClient
+from tests_e2e.tests.lib.vm_extension_identifier import VmExtensionIds, VmExtensionIdentifier
+
+
+class ExtensionUpdateFailureTest(AgentVmTest):
+    """
+    This test verifies that the agent reports correct status and code when extension operation fails during the ext update.
+    """
+
+    def run(self):
+        ssh_client: SshClient = self._context.create_ssh_client()
+        is_arm64: bool = ssh_client.get_architecture() == "aarch64"
+
+        custom_script_2_0 = VirtualMachineExtensionClient(
+            self._context.vm,
+            VmExtensionIds.CustomScript,
+            resource_name="CustomScript")
+
+        if is_arm64:
+            log.info("Will skip the update scenario, since currently there is only 1 version of CSE on ARM64")
+            return
+        else:
+            log.info("Installing %s", custom_script_2_0)
+            message = f"Hello {uuid.uuid4()}!"
+            custom_script_2_0.enable(
+                protected_settings={
+                    'commandToExecute': f"echo \'{message}\'"
+                },
+                auto_upgrade_minor_version=False
+            )
+            custom_script_2_0.assert_instance_view(expected_version="2.0", expected_message=message)
+
+        log.info("Modifying existing handler commands (disable operation) in HandlerManifest.json to fail the disable operation during update")
+
+        output = ssh_client.run_command(f"ext_update-modify_handler_manifest.py --extension-name '{custom_script_2_0._identifier}' --cmd-name disableCommand --cmd-value 'disablefailed'", use_sudo=True)
+        log.info("Modified handlerManifest.json:\n%s", output)
+
+        custom_script_2_1 = VirtualMachineExtensionClient(
+            self._context.vm,
+            VmExtensionIdentifier(VmExtensionIds.CustomScript.publisher, VmExtensionIds.CustomScript.type, "2.1"),
+            resource_name="CustomScript")
+
+        log.info("Updating %s", custom_script_2_0)
+
+        message = f"Hello {uuid.uuid4()}!"
+        try:
+            custom_script_2_1.enable(
+                protected_settings={
+                    'commandToExecute': f"echo \'{message}\'"
+                }
+            )
+            fail("The agent should have reported an error processing the extension update")
+        except Exception as error:
+            assert_that(str(error)).described_as(f"Expected VMExtensionHandlerNonTransientError/ExtensionUpdateError for {custom_script_2_1._identifier}, but actual error was: {error}").contains("VMExtensionHandlerNonTransientError").contains(f"{custom_script_2_1._identifier}").contains("ExtensionUpdateError")
+            log.info("Goal state processing for %s failed as expected", custom_script_2_1._identifier)
+
+    def get_ignore_error_rules(self) -> List[Dict[str, Any]]:
+        ignore_rules = [
+            # 		2025-07-09T18:06:42.560709Z ERROR ExtHandler ExtHandler Event: name=Microsoft.Azure.Extensions.CustomScript, op=Disable, message=[ExtensionOperationError] Non-zero exit code: 2, /var/lib/waagent/Microsoft.Azure.Extensions.CustomScript-2.0.7/bin/custom-script-shim disablefailed
+            # 		[stdout]
+            # 		+ /var/lib/waagent/Microsoft.Azure.Extensions.CustomScript-2.0.7/bin/custom-script-extension disablefailed
+            # 		Usage: /var/lib/waagent/Microsoft.Azure.Extensions.CustomScript-2.0.7/bin/custom-script-extension disable|install|uninstall|enable|update
+            # 		v2.0.7 git:1f9c51c-clean build:2019-06-17T20:53:51Z go1.10.4
+            # 		Incorrect command: "disablefailed"
+            #
+            #
+            # 		[stderr]
+            # 		Running scope as unit: disable_3dc6fbcb-df81-49a4-8251-3a47d9ea686e.scope
+            # 		; ContinueOnUpdate: False, duration=0
+            {
+                'message': r"name=Microsoft.Azure.Extensions.CustomScript, op=Disable, message=\[ExtensionOperationError\] .*disablefailed"
+            }
+        ]
+        return ignore_rules
+
+if __name__ == "__main__":
+    ExtensionUpdateFailureTest.run_from_command_line()

--- a/tests_e2e/tests/ext_update/ext_update_failure.py
+++ b/tests_e2e/tests/ext_update/ext_update_failure.py
@@ -24,7 +24,6 @@ from assertpy import fail, assert_that
 
 from tests_e2e.tests.lib.agent_test import AgentVmTest
 from tests_e2e.tests.lib.logging import log
-from tests_e2e.tests.lib.ssh_client import SshClient
 from tests_e2e.tests.lib.virtual_machine_extension_client import VirtualMachineExtensionClient
 from tests_e2e.tests.lib.vm_extension_identifier import VmExtensionIds, VmExtensionIdentifier
 

--- a/tests_e2e/tests/scripts/ext_update-modify_handler_manifest.py
+++ b/tests_e2e/tests/scripts/ext_update-modify_handler_manifest.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env pypy3
+
+# Microsoft Azure Linux Agent
+#
+# Copyright 2018 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# The script updates the handlerManifest.json file for a given extension.
+#
+#
+
+import argparse
+import glob
+import json
+import sys
+
+from tests_e2e.tests.lib.logging import log
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--extension-name', dest='extension_name', required=True)
+    parser.add_argument('--cmd-name', dest='cmd_name', choices=['enableCommand', 'disableCommand', 'updateCommand', 'installCommand', 'uninstallCommand'])
+    parser.add_argument('--cmd-value', dest='cmd_value', required=True)
+
+    args, _ = parser.parse_known_args()
+    extension_name = args.extension_name
+    cmd_name = args.cmd_name
+    cmd_value = args.cmd_value
+
+    # Check for the handlerManifest   file
+    log.info("Checking that handlerManifest file exists.")
+    manifest_file_pattern = "/var/lib/waagent/*{0}*/HandlerManifest.json".format(extension_name)
+    matched_files = glob.glob(manifest_file_pattern)
+    if matched_files is None or len(matched_files) == 0:
+        log.info("No handlerManifest.json file found for extension '{0}'".format(extension_name))
+        sys.exit(1)
+
+
+    manifest_file = matched_files[0]
+    log.info("HandlerManifest file found for extension '{0}': {1}".format(extension_name, manifest_file))
+
+    # Update the handlerManifest file
+    log.info("Updating handlerManifest file for extension '{0}' for cmd '{1}' and value '{2}'".format(extension_name, cmd_name, cmd_value))
+    # Sample handlerManifest.json structure:
+    # [
+    #   {
+    #     "version": 1.0,
+    #     "handlerManifest": {
+    #       "installCommand": "bin/custom-script-shim install",
+    #       "uninstallCommand": "bin/custom-script-shim uninstall",
+    #       "updateCommand": "bin/custom-script-shim update",
+    #       "enableCommand": "bin/custom-script-shim enable",
+    #       "disableCommand": "bin/custom-script-shim disable",
+    #       "rebootAfterInstall": false,
+    #       "reportHeartbeat": false,
+    #       "updateMode": "UpdateWithInstall"
+    #     },
+    #     "signingInfo": {
+    #       "type": "CustomScript",
+    #       "publisher": "Microsoft.Azure.Extensions",
+    #       "version": "2.1.13"
+    #     }
+    #   }
+    # ]
+
+    with open(manifest_file, 'r') as file:
+        data = json.load(file)
+
+    commands = data[0]['handlerManifest']
+    if cmd_name in commands:
+        commands[cmd_name] = cmd_value
+    else:
+        log.info("Command '{0}' not found in handlerManifest for extension '{1}'".format(cmd_name, extension_name))
+        sys.exit(1)
+
+    with open(manifest_file, 'w') as file:
+        json.dump(data, file, indent=4)
+
+    log.info("Updated the handlerManifest file for extension '{0}'".format(extension_name))
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests_e2e/tests/scripts/ext_update-modify_handler_manifest.py
+++ b/tests_e2e/tests/scripts/ext_update-modify_handler_manifest.py
@@ -79,13 +79,13 @@ def main():
 
     commands = data[0]['handlerManifest']
 
-    for property in properties:
+    for prop in properties:
         # Split the property into cmd_name and cmd_value
-        if '=' not in property:
-            log.info("Property '{0}' is not in the format 'cmd_name=cmd_value'".format(property))
+        if '=' not in prop:
+            log.info("Property '{0}' is not in the format 'cmd_name=cmd_value'".format(prop))
             sys.exit(1)
 
-        cmd_name, cmd_value = property.split('=', 1)
+        cmd_name, cmd_value = prop.split('=', 1)
         log.info("Updating command '{0}' with value '{1}'".format(cmd_name, cmd_value))
 
         # Update the handlerManifest file


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Today we don't populate the terminal(update) error code when ext update fails, as a result CRP waits for 90mins timeout.  The PR fixing that and report the update errorcode.
Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).