### PR TITLE
Update ext_signature_validation scenario region

### DIFF
--- a/tests_e2e/test_suites/ext_signature_validation.yml
+++ b/tests_e2e/test_suites/ext_signature_validation.yml
@@ -7,7 +7,7 @@ tests:
 images: "signature-validation-endorsed"
 # This test needs to run in a canary region until all extensions being tested are published with signature in all prod regions.
 # Extension signatures are currently only available in the public cloud, so we skip this test on other clouds.
-locations: "AzureCloud:centraluseuap"
+locations: "AzureCloud:eastus2euap"
 skip_on_clouds:
   - "AzureChinaCloud"
   - "AzureUSGovernment"

--- a/tests_e2e/tests/lib/agent_log.py
+++ b/tests_e2e/tests/lib/agent_log.py
@@ -286,16 +286,6 @@ class AgentLog(object):
                 'if': lambda r: r.thread == 'SendTelemetryHandler' and self._increment_counter("SendTelemetryHandler-telemetrydata-Status Code 410") < 2  # ignore unless there are 2 or more instances
             },
             #
-            # 2025-07-28T09:30:47.141626Z ERROR SendTelemetryHandler ExtHandler Event: name=WALinuxAgent, op=ReportEventErrors, message=DroppedEventsCount: 1
-            # Reasons (first 5 errors): [ProtocolError] [Wireserver Exception] [HttpError] [HTTP Failed] POST http://168.63.129.16/machine -- IOError timed out -- 3 attempts made: Traceback (most recent call last):
-            #
-            {
-                'message': r"(?s)\[ProtocolError\].*POST http://168.63.129.16/machine.*IOError timed out",
-                'if': lambda r: r.thread == 'SendTelemetryHandler' and self._increment_counter(
-                    "SendTelemetryHandler-telemetrydata-IOError timed out") < 2
-                # ignore unless there are 2 or more instances
-            },
-            #
             # Ignore these errors in flatcar:
             #
             #    1)  2023-03-16T14:30:33.091427Z ERROR Daemon Daemon Failed to mount resource disk [ResourceDiskError] unable to detect disk topology


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
the ext_signature_validation scenario needs to run in canary due to required updates in crp/vmsettings.

The scenario has been hitting CheckAgentLog failures due to IOError time out while sending telemetry events. We suspect this issue is due to instability issues in centraluseuap. This PR switches to eastus2euap and removes the ignore rule from agent_log.py so we can monitor the change

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).