### PR TITLE
Update retry logic for detecting hostname change

### DIFF
--- a/tests_e2e/tests/publish_hostname/publish_hostname.py
+++ b/tests_e2e/tests/publish_hostname/publish_hostname.py
@@ -153,9 +153,9 @@ class PublishHostname(AgentVmTest):
                 # Wait for the agent to detect the hostname change for up to 2 minutes if hostname monitoring is enabled
                 if monitors_hostname == "y" or monitors_hostname == "yes":
                     log.info("Agent hostname monitoring is enabled")
-                    timeout = datetime.datetime.now(UTC) + datetime.timedelta(minutes=2)
                     hostname_detected = ""
-                    while datetime.datetime.now(UTC) <= timeout:
+                    retries = 4
+                    while retries > 0:
                         try:
                             hostname_detected = self.retry_ssh_if_connection_reset("grep -n 'Detected hostname change:.*-> {0}' /var/log/waagent.log".format(hostname), use_sudo=True)
                             if hostname_detected:
@@ -165,7 +165,8 @@ class PublishHostname(AgentVmTest):
                             # Exit code 1 indicates grep did not find a match. Sleep if exit code is 1, otherwise raise.
                             if e.exit_code != 1:
                                 raise
-                        sleep(15)
+                        retries -= 1
+                        sleep(30)
 
                     if not hostname_detected:
                         fail("Agent did not detect hostname change: {0}".format(hostname))

--- a/tests_e2e/tests/publish_hostname/publish_hostname.py
+++ b/tests_e2e/tests/publish_hostname/publish_hostname.py
@@ -165,6 +165,7 @@ class PublishHostname(AgentVmTest):
                             # Exit code 1 indicates grep did not find a match. Sleep if exit code is 1, otherwise raise.
                             if e.exit_code != 1:
                                 raise
+                        log.info("Agent hasn't detected hostname change yet. Retrying after 30 seconds...")
                         retries -= 1
                         sleep(30)
 

--- a/tests_e2e/tests/publish_hostname/publish_hostname.py
+++ b/tests_e2e/tests/publish_hostname/publish_hostname.py
@@ -154,8 +154,7 @@ class PublishHostname(AgentVmTest):
                 if monitors_hostname == "y" or monitors_hostname == "yes":
                     log.info("Agent hostname monitoring is enabled")
                     hostname_detected = ""
-                    retries = 4
-                    while retries > 0:
+                    for _ in range(0, 4):
                         try:
                             hostname_detected = self.retry_ssh_if_connection_reset("grep -n 'Detected hostname change:.*-> {0}' /var/log/waagent.log".format(hostname), use_sudo=True)
                             if hostname_detected:
@@ -166,7 +165,6 @@ class PublishHostname(AgentVmTest):
                             if e.exit_code != 1:
                                 raise
                         log.info("Agent hasn't detected hostname change yet. Retrying after 30 seconds...")
-                        retries -= 1
                         sleep(30)
 
                     if not hostname_detected:


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
The publish_hostname scenario sometimes fails to find the 'Detected hostname change' log in the agent log on the test VM. 

In these cases, the VM logs show that the 'Detected hostname change' log is created during the existing 2 minute retry period.
For example, this is the test log for one of these failures:
```
2025-08-02T09:04:11Z.193 [INFO] Update hostname to hostname-monitor-0
2025-08-02T09:04:11Z.881 [INFO] Agent hostname monitoring is enabled
2025-08-02T09:06:19Z.688 [ERROR] ******** [Failed] PublishHostname: Fail: Agent did not detect hostname change: hostname-monitor-0!
```
And this is the agent log which shows the detection log within the 2 minute retry period:
`2025-08-02T09:04:37.317176Z INFO EnvHandler ExtHandler EnvMonitor: Detected hostname change: lisa-13-e121-n0 -> hostname-monitor-0`

I suspect this is happening because the grep command over ssh is taking longer than expected, and once it returns the test has reached its retry timeout so it doesn't retry the command.
This PR updates the logic to use 4 retries with a 30second sleep between each, instead of including the time it takes the command over ssh to return as a part of the timeout budget.



Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).