### PR TITLE
Explicitly set both settings and protected settings in calls to CSE

### DIFF
--- a/tests_e2e/tests/agent_bvt/extension_operations.py
+++ b/tests_e2e/tests/agent_bvt/extension_operations.py
@@ -55,6 +55,7 @@ class ExtensionOperationsBvt(AgentVmTest):
             log.info("Installing %s", custom_script_2_0)
             message = f"Hello {uuid.uuid4()}!"
             custom_script_2_0.enable(
+                settings={},
                 protected_settings={
                     'commandToExecute': f"echo \'{message}\'"
                 },
@@ -74,6 +75,7 @@ class ExtensionOperationsBvt(AgentVmTest):
 
         message = f"Hello {uuid.uuid4()}!"
         custom_script_2_1.enable(
+            settings={},
             protected_settings={
                 'commandToExecute': f"echo \'{message}\'"
             }

--- a/tests_e2e/tests/agent_not_provisioned/agent_not_provisioned.py
+++ b/tests_e2e/tests/agent_not_provisioned/agent_not_provisioned.py
@@ -79,7 +79,7 @@ class AgentNotProvisioned(AgentVmTest):
         log.info("Executing CustomScript; it should fail.")
         custom_script = VirtualMachineExtensionClient(self._context.vm, VmExtensionIds.CustomScript, resource_name="CustomScript")
         try:
-            custom_script.enable(settings={'commandToExecute': "date"}, force_update=True, timeout=20 * 60)
+            custom_script.enable(settings={'commandToExecute': "date"}, protected_settings={}, force_update=True, timeout=20 * 60)
             fail("CustomScript should have failed")
         except Exception as error:
             assert_that("OperationNotAllowed" in str(error)) \

--- a/tests_e2e/tests/agent_publish/agent_publish.py
+++ b/tests_e2e/tests/agent_publish/agent_publish.py
@@ -171,6 +171,7 @@ class AgentPublishTest(AgentVmTest):
         log.info("Installing %s", custom_script_2_1)
         message = f"Hello {uuid.uuid4()}!"
         custom_script_2_1.enable(
+            settings={},
             protected_settings={
                 'commandToExecute': f"echo \'{message}\'"
             },

--- a/tests_e2e/tests/ext_cgroups/install_extensions.py
+++ b/tests_e2e/tests/ext_cgroups/install_extensions.py
@@ -90,6 +90,7 @@ cp /proc/$$/cgroup /var/lib/waagent/tmp/custom_script_check
 
         log.info("Installing %s", custom_script_2_0)
         custom_script_2_0.enable(
+            settings={},
             protected_settings={
                 'commandToExecute': f"echo \'{script_contents}\' | bash"
             }

--- a/tests_e2e/tests/ext_policy/ext_policy.py
+++ b/tests_e2e/tests/ext_policy/ext_policy.py
@@ -70,9 +70,9 @@ class ExtPolicy(AgentVmTest):
         # For all other extensions, always set force_update to true.
         if not isinstance(extension_case.extension, VirtualMachineRunCommandClient):
             args["force_update"] = True
-        # Always send empty protected settings to CSE
-        if extension_case.extension.extension_id == VmExtensionIds.CustomScript:
-            args["protected_settings"] = {}
+            # Always send empty protected settings to CSE
+            if extension_case.extension.extension_id == VmExtensionIds.CustomScript:
+                args["protected_settings"] = {}
 
         # Add timeout only if specified, else use default
         if timeout is not None:

--- a/tests_e2e/tests/ext_policy/ext_policy.py
+++ b/tests_e2e/tests/ext_policy/ext_policy.py
@@ -64,12 +64,15 @@ class ExtPolicy(AgentVmTest):
     @staticmethod
     def __enable_extension(extension_case, timeout=None):
         """Helper to call 'enable' with appropriate parameters."""
-        args = {"settings": extension_case.settings, "protected_settings": {}}
+        args = {"settings": extension_case.settings}
 
         # VirtualMachineRunCommandClient (and VirtualMachineRunCommand) does not take force_update_tag as a parameter.
         # For all other extensions, always set force_update to true.
         if not isinstance(extension_case.extension, VirtualMachineRunCommandClient):
             args["force_update"] = True
+        # Always send empty protected settings to CSE
+        if extension_case.extension.extension_id == VmExtensionIds.CustomScript:
+            args["protected_settings"] = {}
 
         # Add timeout only if specified, else use default
         if timeout is not None:

--- a/tests_e2e/tests/ext_policy/ext_policy.py
+++ b/tests_e2e/tests/ext_policy/ext_policy.py
@@ -64,7 +64,7 @@ class ExtPolicy(AgentVmTest):
     @staticmethod
     def __enable_extension(extension_case, timeout=None):
         """Helper to call 'enable' with appropriate parameters."""
-        args = {"settings": extension_case.settings}
+        args = {"settings": extension_case.settings, "protected_settings": {}}
 
         # VirtualMachineRunCommandClient (and VirtualMachineRunCommand) does not take force_update_tag as a parameter.
         # For all other extensions, always set force_update to true.

--- a/tests_e2e/tests/ext_policy/policy_dependencies_cases.py
+++ b/tests_e2e/tests/ext_policy/policy_dependencies_cases.py
@@ -25,6 +25,7 @@ def __get_extension_template(extension_id: VmExtensionIdentifier, depends_on=Non
         template["properties"]["enableAutomaticUpgrade"] = True
     elif extension_id == VmExtensionIds.CustomScript:
         template["properties"]["settings"] = {"commandToExecute": "date"}
+        template["properties"]["protectedSettings"] = {}
     elif extension_id == VmExtensionIds.RunCommandHandler:
         # Each time, we generate a RunCommand template with different settings
         unique = str(uuid.uuid4())

--- a/tests_e2e/tests/ext_update/ext_update_failure.py
+++ b/tests_e2e/tests/ext_update/ext_update_failure.py
@@ -52,6 +52,7 @@ class ExtensionUpdateFailureTest(AgentVmTest):
             log.info("Installing %s", custom_script_2_0)
             message = f"Hello {uuid.uuid4()}!"
             custom_script_2_0.enable(
+                settings={},
                 protected_settings={
                     'commandToExecute': f"echo \'{message}\'"
                 },
@@ -74,6 +75,7 @@ class ExtensionUpdateFailureTest(AgentVmTest):
             message = f"Hello {uuid.uuid4()}!"
             try:
                 custom_script_2_1.enable(
+                    settings={},
                     protected_settings={
                         'commandToExecute': f"echo \'{message}\'"
                     }

--- a/tests_e2e/tests/extensions_disabled/extensions_disabled.py
+++ b/tests_e2e/tests/extensions_disabled/extensions_disabled.py
@@ -83,7 +83,7 @@ class ExtensionsDisabled(AgentVmTest):
                 .format(t.extension.__str__()))
 
             try:
-                t.extension.enable(settings=t.settings, force_update=True, timeout=6 * 60)
+                t.extension.enable(settings=t.settings, protected_settings={}, force_update=True, timeout=6 * 60)
                 fail("The agent should have reported an error processing the goal state")
             except Exception as error:
                 assert_that("VMExtensionProvisioningError" in str(error)) \

--- a/tests_e2e/tests/fips/fips.py
+++ b/tests_e2e/tests/fips/fips.py
@@ -61,6 +61,7 @@ class Fips(AgentVmTest):
         log.info("Installing %s", custom_script)
         message = f"Hello {uuid.uuid4()}!"
         custom_script.enable(
+            settings={},
             protected_settings={
                 'commandToExecute': f"echo \'{message}\'"
             }

--- a/tests_e2e/tests/hibernation/hibernation.py
+++ b/tests_e2e/tests/hibernation/hibernation.py
@@ -113,7 +113,7 @@ class Hibernation(AgentVmTest):
         log.info("Executing an extension with protected settings to verify it can use the new tenant certificate")
         custom_script = VirtualMachineExtensionClient(self._context.vm, VmExtensionIds.CustomScript, resource_name="CustomScript")
         message = str(uuid.uuid4())
-        custom_script.enable(protected_settings={'commandToExecute': f"echo \'{message}\'"}, force_update=True)
+        custom_script.enable(settings={}, protected_settings={'commandToExecute': f"echo \'{message}\'"}, force_update=True)
         custom_script.assert_instance_view(expected_message=message)
         log.info("")
 

--- a/tests_e2e/tests/lib/virtual_machine_extension_client.py
+++ b/tests_e2e/tests/lib/virtual_machine_extension_client.py
@@ -45,6 +45,10 @@ class VirtualMachineExtensionClient(AzureSdkClient):
         self._resource_name = resource_name or extension.type
         self._compute_client: ComputeManagementClient = AzureSdkClient.create_client(ComputeManagementClient, self._vm.cloud, self._vm.subscription)
 
+    @property
+    def extension_id(self) -> VmExtensionIdentifier:
+        return self._identifier
+
     def get_instance_view(self) -> VirtualMachineExtensionInstanceView:
         """
         Retrieves the instance view of the extension

--- a/tests_e2e/tests/multi_config_ext/multi_config_ext.py
+++ b/tests_e2e/tests/multi_config_ext/multi_config_ext.py
@@ -47,7 +47,7 @@ class MultiConfigExt(AgentVmTest):
         for resource_name, test_case in cases_to_enable.items():
             log.info("")
             log.info("Adding {0} to the test VM. guid={1}".format(resource_name, test_case.test_guid))
-            test_case.extension.enable(settings=test_case.get_settings(test_case.test_guid))
+            test_case.extension.enable(settings=test_case.get_settings(test_case.test_guid), protected_settings={})
             test_case.extension.assert_instance_view()
 
         log.info("")


### PR DESCRIPTION
Some tests use CSE with settings, and other with protected settings. When tests that differ on this run on the same VM, the extension fails because some parameters are in both sections in the VM model.

This PR sets both parameters explicitly, using an empty value on the parameter not used, in order to reset any pre-existing value in the VM model.