### PR TITLE
Set protected settings only for Custom Script

### DIFF
--- a/tests_e2e/tests/multi_config_ext/multi_config_ext.py
+++ b/tests_e2e/tests/multi_config_ext/multi_config_ext.py
@@ -47,7 +47,10 @@ class MultiConfigExt(AgentVmTest):
         for resource_name, test_case in cases_to_enable.items():
             log.info("")
             log.info("Adding {0} to the test VM. guid={1}".format(resource_name, test_case.test_guid))
-            test_case.extension.enable(settings=test_case.get_settings(test_case.test_guid), protected_settings={})
+            kwargs = {"settings": test_case.get_settings(test_case.test_guid)}
+            if isinstance(test_case.extension, VirtualMachineExtensionClient) and test_case.extension.extension_id == VmExtensionIds.CustomScript:
+                kwargs["protected_settings"] = {}
+            test_case.extension.enable(**kwargs)
             test_case.extension.assert_instance_view()
 
         log.info("")


### PR DESCRIPTION
#3427 was meant to set protected settings only on invocations to Custom Script, but ended up doing it for RunCommand as well on this test.

Adding a check to prevent that.