### PR TITLE
fixing timing issue in fips tests

### DIFF
--- a/tests_e2e/tests/fips/fips.py
+++ b/tests_e2e/tests/fips/fips.py
@@ -208,6 +208,8 @@ class Fips(AgentVmTest):
                 # state. The reason is that, even if it cannot decrypt the response from the WireServer, 2.7.0.6 assumes that Certificates.pem always exists; if it does not, it goes
                 # into an infinite retry loop. To prevent this, before deallocating and reallocating, ensure that there is a Certificates.pem file, even if it is empty.
                 #
+                output = self._ssh_client.run_command('agent-service stop', use_sudo=True)
+                log.info(output)
                 pem_file = '/var/lib/waagent/Certificates.pem'
                 log.info("Ensuring that %s exists...", pem_file)
                 self._ssh_client.run_command(f"touch {pem_file}", use_sudo=True)


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
The test creates dummy certificate.pem as a workaround in rhel9.5 daemon issue but agent may delete it if agent is fetching the certs and failed to decrypt it.

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).