### PR TITLE
Ubuntu Ubuntu Pro FIPS images to FIPS tests

### DIFF
--- a/tests_e2e/test_suites/fips.yml
+++ b/tests_e2e/test_suites/fips.yml
@@ -13,6 +13,7 @@ tests:
   - source: "fips/fips.py"
 images:
   - "ubuntu_pro_2204" # Enabling FIPS on Ubuntu requires the "pro" client to be enabled; it is pre-enabled on these "pro" images.
+  - "ubuntu_pro_fips_2204" # FIPS is pre-enabled on these "fips" images.
   - "rhel_95"
 
 # Support for FIPS 140-3 is currently deployed only to the Canary regions

--- a/tests_e2e/test_suites/images.yml
+++ b/tests_e2e/test_suites/images.yml
@@ -267,6 +267,7 @@ images:
    ubuntu_2004: "Canonical 0001-com-ubuntu-server-focal 20_04-lts latest"
    ubuntu_2204: "Canonical 0001-com-ubuntu-server-jammy 22_04-lts latest"
    ubuntu_pro_2204: "Canonical 0001-com-ubuntu-pro-microsoft pro-22_04 latest"
+   ubuntu_pro_fips_2204: "Canonical 0001-com-ubuntu-pro-microsoft pro-fips-22_04 latest"
    ubuntu_2204_arm64:
       urn: "Canonical 0001-com-ubuntu-server-jammy 22_04-lts-arm64 latest"
       locations:


### PR DESCRIPTION
Adding the FIPS Ubuntu image to the tests for FIPS. FIPS is pre-enabled on those images and this can be useful to expose issues in the agent that is pre-installed on the image.