### PR TITLE
Suppress wireserver failures in the test

### DIFF
--- a/tests_e2e/tests/lib/agent_log.py
+++ b/tests_e2e/tests/lib/agent_log.py
@@ -194,7 +194,7 @@ class AgentLog(object):
             # This can be ignored, if the issue persist the log would include other errors as well.
             {
                 'message': r"\[ProtocolError\] GET vmSettings.*\[403: Forbidden\].*AccessDenied",
-                'if': lambda r: r.level == "ERROR"
+                'if': lambda r: r.level == "ERROR" and self._increment_counter("ProtocolError-vmSettings-403") < 6 # ignore unless there are 6 or more instances
             },
             #
             # 2022-02-09T04:50:37.384810Z ERROR ExtHandler ExtHandler Error fetching the goal state: [ProtocolError] GET vmSettings [correlation ID: 2bed9b62-188e-4668-b1a8-87c35cfa4927 eTag: 7031887032544600793]: [Internal error in HostGAPlugin] [HTTP Failed] [502: Bad Gateway] b'{  "errorCode": "VMArtifactsProfileBlobContentNotFound",  "message": "VM artifacts profile blob has no content in it.",  "details": ""}'
@@ -239,7 +239,7 @@ class AgentLog(object):
             #
             {
                 'message': r"\[HttpError\] \[HTTP Failed\] GET http://168.63.129.16/machine/ -- IOError (\[Errno 104\] Connection reset by peer|timed out)",
-                'if': lambda r: r.level in ("WARNING", "ERROR")
+                'if': lambda r: r.level in ("WARNING", "ERROR") and self._increment_counter("ProtocolError-Goalstate-IOError") < 6  # ignore unless there are 6 or more instances
             },
             #
             # 2022-03-08T03:03:23.036161Z WARNING ExtHandler ExtHandler Fetch failed from [http://168.63.129.16:32526/extensionArtifact]: [HTTP Failed] [400: Bad Request] b''
@@ -275,7 +275,7 @@ class AgentLog(object):
             #
             {
                 'message': r"SendHostPluginHeartbeat:.*GET http:\/\/168.63.129.16\/machine.*timed out",
-                'if': lambda r: r.level == "WARNING"
+                'if': lambda r: r.level == "WARNING" and self._increment_counter("SendHostPluginHeartbeat-Goalstate-timedout") < 6  # ignore unless there are 6 or more instances
             },
             # 2022-09-30T03:09:25.013398Z WARNING MonitorHandler ExtHandler Error in SendHostPluginHeartbeat: [ResourceGoneError] [HTTP Failed] [410: Gone]
             #


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
Suppressing the following errors in E2E tests until a certain error count, since they can be transient

1.  VMSettings 403: Forbidden
2.  GET wireserver timedout
3.  Wireserver timedout while SendHostPluginHeartbeat
4.  SendTelemetryHandler telemetrydata timedout

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).