### PR TITLE
Remove references to conf that may be uninitialized

### DIFF
--- a/azurelinuxagent/common/event.py
+++ b/azurelinuxagent/common/event.py
@@ -26,7 +26,6 @@ import time
 import traceback
 from datetime import datetime
 
-import azurelinuxagent.common.conf as conf
 import azurelinuxagent.common.logger as logger
 from azurelinuxagent.common.AgentGlobals import AgentGlobals
 from azurelinuxagent.common.exception import EventError, OSUtilError
@@ -176,7 +175,7 @@ class EventStatus(object):
             return True
         return self._status[event] is True
 
-    def initialize(self, status_dir=conf.get_lib_dir()):
+    def initialize(self, status_dir):
         self._path = os.path.join(status_dir, EventStatus.EVENT_STATUS_FILE)
         self._load()
 

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -125,7 +125,6 @@ def get_update_handler():
 
 class UpdateHandler(object):
     TELEMETRY_HEARTBEAT_PERIOD = timedelta(minutes=30)
-    CHECK_MEMORY_USAGE_PERIOD = timedelta(seconds=conf.get_cgroup_check_period())
 
     def __init__(self):
         self.osutil = get_osutil()


### PR DESCRIPTION
These 2 modules may use conf before it is initialized if they are imported before load_conf_from_file() is invoked.