### PR TITLE
Enable manual runs of the FIPS test on AzureUSGovernment cloud

### DIFF
--- a/tests_e2e/test_suites/fips.yml
+++ b/tests_e2e/test_suites/fips.yml
@@ -12,16 +12,17 @@ name: "FIPS"
 tests:
   - source: "fips/fips.py"
 images:
-  - "ubuntu_pro_2204" # Enabling FIPS on Ubuntu requires the "pro" client to be enabled; it is pre-enabled on these "pro" images.
-  - "ubuntu_pro_fips_2204" # FIPS is pre-enabled on these "fips" images.
+#  - "ubuntu_pro_2204" # Enabling FIPS on Ubuntu requires the "pro" client to be enabled; it is pre-enabled on these "pro" images.
+#  - "ubuntu_pro_fips_2204" # FIPS is pre-enabled on these "fips" images.
   - "rhel_95"
 
-# Support for FIPS 140-3 is currently deployed only to the Canary regions
-locations: "AzureCloud:eastus2euap"
+# Support for FIPS 140-3 is currently deployed only to a few regions
+locations:
+  - "AzureCloud:eastus2euap"
+  - "AzureUSGovernment:usdodcentral"
 
 skip_on_clouds:
   - "AzureChinaCloud"
-  - "AzureUSGovernment"
 
 # The test VM could be shared with other test suites, but we want to ensure there is a mix of FIPS and non-FIPS environments in the test run,
 # so we take ownership of the VM for this test suite.

--- a/tests_e2e/test_suites/fips.yml
+++ b/tests_e2e/test_suites/fips.yml
@@ -12,17 +12,24 @@ name: "FIPS"
 tests:
   - source: "fips/fips.py"
 images:
-#  - "ubuntu_pro_2204" # Enabling FIPS on Ubuntu requires the "pro" client to be enabled; it is pre-enabled on these "pro" images.
-#  - "ubuntu_pro_fips_2204" # FIPS is pre-enabled on these "fips" images.
+  - "ubuntu_pro_2204" # Enabling FIPS on Ubuntu requires the "pro" client to be enabled; it is pre-enabled on these "pro" images.
+  - "ubuntu_pro_fips_2204" # FIPS is pre-enabled on these "fips" images.
   - "rhel_95"
 
-# Support for FIPS 140-3 is currently deployed only to a few regions
+#
+# Support for FIPS 140-3 is currently deployed only to a few regions.
+#
+# The Ubuntu images are not available on AzureChinaCloud and AzureUSGovernment, so they are skipped. The RHEL image is available on those
+# clouds and FIPS 140-3 is already enabled on AzureUSGovernment:usdodcentral. Allowing the test to run on AzureUSGovernment using RHEL
+# requires changes in the test infrastructure, so it is disabled for now.
+#
 locations:
   - "AzureCloud:eastus2euap"
-  - "AzureUSGovernment:usdodcentral"
+  # - "AzureUSGovernment:usdodcentral"
 
 skip_on_clouds:
   - "AzureChinaCloud"
+  - "AzureUSGovernment"
 
 # The test VM could be shared with other test suites, but we want to ensure there is a mix of FIPS and non-FIPS environments in the test run,
 # so we take ownership of the VM for this test suite.

--- a/tests_e2e/test_suites/images.yml
+++ b/tests_e2e/test_suites/images.yml
@@ -294,8 +294,16 @@ images:
    ubuntu_1804: "Canonical UbuntuServer 18.04-LTS latest"
    ubuntu_2004: "Canonical 0001-com-ubuntu-server-focal 20_04-lts latest"
    ubuntu_2204: "Canonical 0001-com-ubuntu-server-jammy 22_04-lts latest"
-   ubuntu_pro_2204: "Canonical 0001-com-ubuntu-pro-microsoft pro-22_04 latest"
-   ubuntu_pro_fips_2204: "Canonical 0001-com-ubuntu-pro-microsoft pro-fips-22_04 latest"
+   ubuntu_pro_2204:
+      urn: "Canonical 0001-com-ubuntu-pro-microsoft pro-22_04 latest"
+      locations:
+         AzureUSGovernment: []
+         AzureChinaCloud: []
+   ubuntu_pro_fips_2204:
+      urn: "Canonical 0001-com-ubuntu-pro-microsoft pro-fips-22_04 latest"
+      locations:
+         AzureUSGovernment: []
+         AzureChinaCloud: []
    ubuntu_2204_arm64:
       urn: "Canonical 0001-com-ubuntu-server-jammy 22_04-lts-arm64 latest"
       vm_sizes:

--- a/tests_e2e/test_suites/keyvault_certificates.yml
+++ b/tests_e2e/test_suites/keyvault_certificates.yml
@@ -12,4 +12,11 @@ tests:
 images:
   - "endorsed"
   - "endorsed-arm64"
+  -
+# The KeyVault and test VM need to be in the same region. The KeyVaults used by this test are in these regions.
+locations:
+  - "AzureCloud:westus2"
+  - "AzureUSGovernment:usgovarizona"
+  - "AzureChinaCloud:chinanorth2"
+
 owns_vm: true

--- a/tests_e2e/test_suites/keyvault_certificates.yml
+++ b/tests_e2e/test_suites/keyvault_certificates.yml
@@ -12,7 +12,7 @@ tests:
 images:
   - "endorsed"
   - "endorsed-arm64"
-  -
+
 # The KeyVault and test VM need to be in the same region. The KeyVaults used by this test are in these regions.
 locations:
   - "AzureCloud:westus2"

--- a/tests_e2e/tests/fips/fips.py
+++ b/tests_e2e/tests/fips/fips.py
@@ -185,15 +185,28 @@ class Fips(AgentVmTest):
 
         if random.choice([1, 2]) == 1:
             log.info("Adding a keyvault certificate to the osProfile to force a new PFX...")
+
+            certificates_by_cloud = {
+                'AzureCloud': {
+                    'source_vault': f"/subscriptions/{self._context.vm.subscription}/resourceGroups/waagent-tests/providers/Microsoft.KeyVault/vaults/waagenttests-canary",
+                    'certificate_url': 'https://waagenttests-canary.vault.azure.net/secrets/rsa/85d92c80443e44058cb034b2008e1e75'
+                },
+                'AzureUSGovernment': {
+                    'source_vault': f"/subscriptions/{self._context.vm.subscription}/resourceGroups/waagent-tests/providers/Microsoft.KeyVault/vaults/waagenttst-usdodcentral",
+                    'certificate_url': 'https://waagenttst-usdodcentral.vault.usgovcloudapi.net/secrets/rsa/2ba415fd15b148bc970c666ae9e1bff6'
+                },
+            }
+            certificate = certificates_by_cloud[self._context.vm.cloud]
+
             self._context.vm.update({
                 "properties": {
                     "osProfile": {
                         "secrets": [
                             {
                                 "sourceVault": {
-                                    "id": f"/subscriptions/{self._context.vm.subscription}/resourceGroups/waagent-tests/providers/Microsoft.KeyVault/vaults/waagenttests-canary"
+                                    "id": certificate["source_vault"],
                                 },
-                                "vaultCertificates": [{"certificateUrl": "https://waagenttests-canary.vault.azure.net/secrets/rsa/85d92c80443e44058cb034b2008e1e75"}]
+                                "vaultCertificates": [{"certificateUrl": certificate["certificate_url"]}],
                             }
                         ],
                     }


### PR DESCRIPTION
Fully enabling the FIPS test on AzureUSGovernment requires changes to the e2e test infrastructure. Those changes will come in a separate PR. For now, this PR allows running the test doing small changes in fips.yml