### PR TITLE
Enable FIPS test on AzureUSGovernment cloud

### DIFF
--- a/tests_e2e/orchestrator/lib/agent_test_loader.py
+++ b/tests_e2e/orchestrator/lib/agent_test_loader.py
@@ -176,16 +176,27 @@ class AgentTestLoader(object):
                 if image not in self.images:
                     raise Exception(f"Invalid image reference in test suite {suite.name}: Can't find {image} in images.yml or image from a shared gallery")
 
-            # If the suite specifies a cloud and it's location<cloud:location>, validate that location string is start with <cloud:> and then validate that the images it uses are available in that location
+            valid_clouds = ["AzureCloud", "AzureChinaCloud", "AzureUSGovernment"]
+
+            def split_on_cloud(value):
+                split = value.split(":")
+                if len(split) == 2:
+                    if split[0] not in valid_clouds:
+                        raise Exception(f"{value} does not contain a valid cloud: {split[0]}")
+                    return split
+                if len(split) == 1:
+                    return "", split[0]
+                raise Exception(f"{value} is not a valid value in the test configuration")
+
+            # If the test suite specifies any locations, validate that the images it uses are available in those locations
             for suite_location in suite.locations:
-                if suite_location.startswith(self.__cloud + ":"):
-                    suite_location = suite_location.split(":")[1]
-                else:
+                cloud, suite_location = split_on_cloud(suite_location)
+                if self.__cloud != cloud:
                     continue
                 for suite_image in suite.images:
                     suite_image = _parse_image(suite_image)
-                    # skip validation if suite image from gallery image
-                    if CustomImage._is_image_from_gallery(suite_image):
+                    # skip validation if suite image is a gallery image or is in 'skip_images'
+                    if CustomImage._is_image_from_gallery(suite_image) or f"{self.__cloud}:{suite_image}" in suite.skip_on_images:
                         continue
                     for image in self.images[suite_image]:
                         # If the image has a location restriction, validate that it is available on the location the suite must run on
@@ -196,11 +207,12 @@ class AgentTestLoader(object):
 
             # if the suite specifies skip clouds, validate that cloud used in our tests
             for suite_skip_cloud in suite.skip_on_clouds:
-                if suite_skip_cloud not in ["AzureCloud", "AzureChinaCloud", "AzureUSGovernment"]:
+                if suite_skip_cloud not in valid_clouds:
                     raise Exception(f"Invalid cloud {suite_skip_cloud} for in {suite.name}")
 
-            # if the suite specifies skip images, validate that images used in our tests
+            # if the suite specifies skip_on_images, validate that the images are valid
             for suite_skip_image in suite.skip_on_images:
+                _, suite_skip_image = split_on_cloud(suite_skip_image)
                 if suite_skip_image not in self.images:
                     raise Exception(f"Invalid image reference in test suite {suite.name}: Can't find {suite_skip_image} in images.yml")
 

--- a/tests_e2e/orchestrator/lib/agent_test_loader.py
+++ b/tests_e2e/orchestrator/lib/agent_test_loader.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Type
 
 import tests_e2e
+from tests_e2e.tests.lib.azure_clouds import AZURE_CLOUDS
 from tests_e2e.tests.lib.agent_test import AgentTest, AgentVmTest, AgentVmssTest
 
 
@@ -166,8 +167,6 @@ class AgentTestLoader(object):
                 return match.group('image_set')
             return image
 
-        valid_clouds = ["AzureCloud", "AzureChinaCloud", "AzureUSGovernment"]
-
         for suite in self.test_suites:
             # Validate that the images the suite must run on are in images.yml
             for image in suite.images:
@@ -181,7 +180,7 @@ class AgentTestLoader(object):
             def split_on_cloud(value):
                 split = value.split(":")
                 if len(split) == 2:
-                    if split[0] not in valid_clouds:
+                    if split[0] not in AZURE_CLOUDS:
                         raise Exception(f"{value} does not contain a valid cloud: {split[0]}")
                     return split
                 if len(split) == 1:
@@ -191,12 +190,12 @@ class AgentTestLoader(object):
             # If the test suite specifies any locations, validate that the images it uses are available in those locations
             for suite_location in suite.locations:
                 cloud, suite_location = split_on_cloud(suite_location)
-                if self.__cloud != cloud:
+                if cloud != "" and cloud != self.__cloud:
                     continue
                 for suite_image in suite.images:
                     suite_image = _parse_image(suite_image)
                     # skip validation if suite image is a gallery image or is in 'skip_images'
-                    if CustomImage._is_image_from_gallery(suite_image) or f"{self.__cloud}:{suite_image}" in suite.skip_on_images:
+                    if CustomImage._is_image_from_gallery(suite_image) or suite_image in suite.skip_on_images or f"{self.__cloud}:{suite_image}" in suite.skip_on_images:
                         continue
                     for image in self.images[suite_image]:
                         # If the image has a location restriction, validate that it is available on the location the suite must run on
@@ -207,7 +206,7 @@ class AgentTestLoader(object):
 
             # if the suite specifies skip clouds, validate that cloud used in our tests
             for suite_skip_cloud in suite.skip_on_clouds:
-                if suite_skip_cloud not in valid_clouds:
+                if suite_skip_cloud not in AZURE_CLOUDS:
                     raise Exception(f"Invalid cloud {suite_skip_cloud} for in {suite.name}")
 
             # if the suite specifies skip_on_images, validate that the images are valid

--- a/tests_e2e/orchestrator/lib/agent_test_loader.py
+++ b/tests_e2e/orchestrator/lib/agent_test_loader.py
@@ -166,6 +166,8 @@ class AgentTestLoader(object):
                 return match.group('image_set')
             return image
 
+        valid_clouds = ["AzureCloud", "AzureChinaCloud", "AzureUSGovernment"]
+
         for suite in self.test_suites:
             # Validate that the images the suite must run on are in images.yml
             for image in suite.images:
@@ -175,8 +177,6 @@ class AgentTestLoader(object):
                     continue
                 if image not in self.images:
                     raise Exception(f"Invalid image reference in test suite {suite.name}: Can't find {image} in images.yml or image from a shared gallery")
-
-            valid_clouds = ["AzureCloud", "AzureChinaCloud", "AzureUSGovernment"]
 
             def split_on_cloud(value):
                 split = value.split(":")

--- a/tests_e2e/orchestrator/lib/agent_test_suite_combinator.py
+++ b/tests_e2e/orchestrator/lib/agent_test_suite_combinator.py
@@ -509,7 +509,7 @@ class AgentTestSuitesCombinator(Combinator):
             split = image.split(':')
             if len(split) == 2:
                 cloud, image = split
-            if self.runbook.cloud != cloud:
+            if cloud != "" and cloud != self.runbook.cloud:
                 continue
             image_list = loader.images[image]
             for i in image_list:

--- a/tests_e2e/test_suites/fips.yml
+++ b/tests_e2e/test_suites/fips.yml
@@ -19,10 +19,6 @@ images:
 #
 # Support for FIPS 140-3 is currently deployed only to a few regions.
 #
-# The Ubuntu images are not available on AzureChinaCloud and AzureUSGovernment, so they are skipped. The RHEL image is available on those
-# clouds and FIPS 140-3 is already enabled on AzureUSGovernment:usdodcentral. Allowing the test to run on AzureUSGovernment using RHEL
-# requires changes in the test infrastructure, so it is disabled for now.
-#
 locations:
   - "AzureCloud:eastus2euap"
   - "AzureUSGovernment:usdodcentral"

--- a/tests_e2e/test_suites/fips.yml
+++ b/tests_e2e/test_suites/fips.yml
@@ -17,21 +17,25 @@ images:
   - "rhel_95"
 
 #
-# Support for FIPS 140-3 is currently deployed only to a few regions.
+# Support for FIPS 140-3 is currently deployed only to a few regions on AzureCloud, and deployment has not started on AzureChinaCloud.
 #
 locations:
   - "AzureCloud:eastus2euap"
-  - "AzureUSGovernment:usdodcentral"
 
 skip_on_clouds:
   - "AzureChinaCloud"
 
+#
+# The Ubuntu images required by the test are not available on AzureUSGovernment
+#
 skip_on_images:
   - "AzureUSGovernment:ubuntu_pro_2204"
   - "AzureUSGovernment:ubuntu_pro_fips_2204"
 
+#
 # The test VM could be shared with other test suites, but we want to ensure there is a mix of FIPS and non-FIPS environments in the test run,
 # so we take ownership of the VM for this test suite.
+#
 owns_vm: true
 
 

--- a/tests_e2e/test_suites/fips.yml
+++ b/tests_e2e/test_suites/fips.yml
@@ -25,11 +25,14 @@ images:
 #
 locations:
   - "AzureCloud:eastus2euap"
-  # - "AzureUSGovernment:usdodcentral"
+  - "AzureUSGovernment:usdodcentral"
 
 skip_on_clouds:
   - "AzureChinaCloud"
-  - "AzureUSGovernment"
+
+skip_on_images:
+  - "AzureUSGovernment:ubuntu_pro_2204"
+  - "AzureUSGovernment:ubuntu_pro_fips_2204"
 
 # The test VM could be shared with other test suites, but we want to ensure there is a mix of FIPS and non-FIPS environments in the test run,
 # so we take ownership of the VM for this test suite.


### PR DESCRIPTION
Added the cloud as a prefix to skip_on_images in the test suite configuration. This allowed me to skip the Ubuntu images not available in the gov cloud, and enable the FIPS test on that cloud.