### PR TITLE
Add skipped tests to test results

### DIFF
--- a/tests_e2e/orchestrator/lib/agent_test_result.py
+++ b/tests_e2e/orchestrator/lib/agent_test_result.py
@@ -1,0 +1,65 @@
+# Microsoft Azure Linux Agent
+#
+# Copyright 2018 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import datetime
+import traceback
+import uuid
+
+# Disable those warnings, since 'lisa' is an external, non-standard, dependency
+#     E0401: Unable to import 'lisa' (import-error)
+#     etc
+from lisa import (  # pylint: disable=E0401
+    notifier
+)
+from lisa.messages import TestStatus, TestResultMessage  # pylint: disable=E0401
+from azurelinuxagent.common.future import UTC
+
+
+class AgentTestResult:
+    @staticmethod
+    def report(
+            suite_name: str,
+            test_name: str,
+            status: TestStatus,
+            start_time: datetime.datetime,
+            message: str = "",
+            add_exception_stack_trace: bool = False
+    ) -> None:
+        """
+        Reports a test result to the junit notifier
+        """
+        # The junit notifier requires an initial RUNNING message in order to register the test in its internal cache.
+        msg: TestResultMessage = TestResultMessage()
+        msg.type = "AgentTestResultMessage"
+        msg.id_ = str(uuid.uuid4())
+        msg.status = TestStatus.RUNNING
+        msg.suite_full_name = suite_name
+        msg.suite_name = msg.suite_full_name
+        msg.full_name = test_name
+        msg.name = msg.full_name
+        msg.elapsed = 0
+
+        notifier.notify(msg)
+
+        # Now send the actual result. The notifier pipeline makes a deep copy of the message so it is OK to re-use the
+        # same object and just update a few fields. If using a different object, be sure that the "id_" is the same.
+        msg.status = status
+        msg.message = message
+        if add_exception_stack_trace:
+            msg.stacktrace = traceback.format_exc()
+        msg.elapsed = (datetime.datetime.now(UTC) - start_time).total_seconds()
+
+        notifier.notify(msg)

--- a/tests_e2e/orchestrator/lib/agent_test_suite_combinator.py
+++ b/tests_e2e/orchestrator/lib/agent_test_suite_combinator.py
@@ -1,12 +1,15 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
+import datetime
 import logging
 import random
 import re
 import urllib.parse
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Type
+from typing import Any, Dict, List, Optional, Tuple, Type
+
+from azurelinuxagent.common.future import UTC
 
 # E0401: Unable to import 'dataclasses_json' (import-error)
 from dataclasses_json import dataclass_json  # pylint: disable=E0401
@@ -16,9 +19,11 @@ from dataclasses_json import dataclass_json  # pylint: disable=E0401
 #     etc
 from lisa import schema  # pylint: disable=E0401
 from lisa.combinator import Combinator  # pylint: disable=E0401
+from lisa.messages import TestStatus  # pylint: disable=E0401
 from lisa.util import field_metadata  # pylint: disable=E0401
 
 from tests_e2e.orchestrator.lib.agent_test_loader import AgentTestLoader, VmImageInfo, TestSuiteInfo, CustomImage
+from tests_e2e.orchestrator.lib.agent_test_result import AgentTestResult
 from tests_e2e.tests.lib.logging import set_thread_name
 from tests_e2e.tests.lib.virtual_machine_client import VirtualMachineClient
 from tests_e2e.tests.lib.virtual_machine_scale_set_client import VirtualMachineScaleSetClient
@@ -150,7 +155,7 @@ class AgentTestSuitesCombinator(Combinator):
         runbook_images = self._get_runbook_images(loader)
 
         skip_test_suites: List[str] = []
-        skip_test_suites_images: List[str] = []
+        skip_test_suites_images: List[Tuple[str, str]] = []
         for test_suite_info in loader.test_suites:
             if self.runbook.cloud in test_suite_info.skip_on_clouds:
                 skip_test_suites.append(test_suite_info.name)
@@ -162,8 +167,7 @@ class AgentTestSuitesCombinator(Combinator):
 
             skip_images_info: List[VmImageInfo] = self._get_test_suite_skip_images(test_suite_info, loader)
             if len(skip_images_info) > 0:
-                skip_test_suite_image = f"{test_suite_info.name}: {','.join([i.urn for i in skip_images_info])}"
-                skip_test_suites_images.append(skip_test_suite_image)
+                skip_test_suites_images.append((test_suite_info.name, ', '.join([i.urn for i in skip_images_info])))
 
             for image in images_info:
                 if image in skip_images_info:
@@ -253,6 +257,17 @@ class AgentTestSuitesCombinator(Combinator):
 
         environments.extend(shared_environments.values())
 
+        if len(skip_test_suites) > 0:
+            self._log.info("Skipping test suites %s", skip_test_suites)
+            for skipped in skip_test_suites:
+                AgentTestResult.report(skipped, skipped, TestStatus.SKIPPED, datetime.datetime.now(UTC), message=f"Skipping test suite {skipped}")
+
+        if len(skip_test_suites_images) > 0:
+            self._log.info("Skipping test suits run on images \n %s", '\n'.join([f"\t{suite}: {images}" for suite, images in skip_test_suites_images]))
+            for skipped in skip_test_suites_images:
+                suite, images = skipped
+                AgentTestResult.report(suite, suite, TestStatus.SKIPPED, datetime.datetime.now(UTC), message=f"Skipping test suite {suite} on images {images}")
+
         if len(environments) == 0:
             raise Exception("No VM images were found to execute the test suites.")
 
@@ -261,12 +276,6 @@ class AgentTestSuitesCombinator(Combinator):
         summary = [f"{e['c_env_name']}: [{format_suites(e['c_test_suites'])}]" for e in environments]
         summary.sort()
         self._log.info("Executing tests on %d environments\n\n%s\n", len(environments), '\n'.join([f"\t{s}" for s in summary]))
-
-        if len(skip_test_suites) > 0:
-            self._log.info("Skipping test suites %s", skip_test_suites)
-
-        if len(skip_test_suites_images) > 0:
-            self._log.info("Skipping test suits run on images \n %s", '\n'.join([f"\t{skip}" for skip in skip_test_suites_images]))
 
         return environments
 


### PR DESCRIPTION
When we skip a test due to restrictions on clouds or images, we log an INFO message, but it is hard to keep track of all the skipped tests.

This PR adds those tests as SKIPPED test results, and they will show up on the test run results.