### PR TITLE
Remove the reference to conf in the supported variable assignment for GAVersioningGovernance

### DIFF
--- a/azurelinuxagent/common/agent_supported_feature.py
+++ b/azurelinuxagent/common/agent_supported_feature.py
@@ -85,7 +85,7 @@ class _GAVersioningGovernanceFeature(AgentSupportedFeature):
 
     __NAME = SupportedFeatureNames.GAVersioningGovernance
     __VERSION = "1.0"
-    __SUPPORTED = conf.get_auto_update_to_latest_version() and conf.get_enable_ga_versioning()
+    __SUPPORTED = True
 
     def __init__(self):
         super(_GAVersioningGovernanceFeature, self).__init__(name=self.__NAME,
@@ -96,7 +96,6 @@ class _GAVersioningGovernanceFeature(AgentSupportedFeature):
 # This is the list of features that Agent supports and we advertise to CRP
 __CRP_ADVERTISED_FEATURES = {
     SupportedFeatureNames.MultiConfig: _MultiConfigFeature(),
-    SupportedFeatureNames.GAVersioningGovernance: _GAVersioningGovernanceFeature()
 }
 
 
@@ -127,7 +126,13 @@ def get_agent_supported_features_list_for_crp():
             }
     """
 
-    return dict((name, feature) for name, feature in __CRP_ADVERTISED_FEATURES.items() if feature.is_supported)
+    supported_features = dict((name, feature) for name, feature in __CRP_ADVERTISED_FEATURES.items() if feature.is_supported)
+    ga_versioning_feature = _GAVersioningGovernanceFeature()
+    # For GA Versioning Governance feature, we need to check auto updates and GA versioning is enabled.
+    # If disabled, we need to inform that feature is not supported by not sending feature in the supported list to CRP
+    if ga_versioning_feature.is_supported and conf.get_auto_update_to_latest_version() and conf.get_enable_ga_versioning():
+        supported_features[SupportedFeatureNames.GAVersioningGovernance] = ga_versioning_feature
+    return supported_features
 
 
 def get_agent_supported_features_list_for_extensions():

--- a/tests/common/protocol/test_wire.py
+++ b/tests/common/protocol/test_wire.py
@@ -24,8 +24,7 @@ import time
 import unittest
 import uuid
 
-from azurelinuxagent.common.agent_supported_feature import SupportedFeatureNames, get_supported_feature_by_name, \
-    get_agent_supported_features_list_for_crp
+from azurelinuxagent.common.agent_supported_feature import get_agent_supported_features_list_for_crp, _MultiConfigFeature, _GAVersioningGovernanceFeature
 from azurelinuxagent.common.event import WALAEventOperation
 from azurelinuxagent.common.exception import ResourceGoneError, ProtocolError, \
     ExtensionDownloadError, HttpError
@@ -369,7 +368,7 @@ class TestWireProtocol(AgentTestCase, HttpRequestPredicates):
 
                     self.assertIsNotNone(protocol.aggregate_status, "Aggregate status should not be None")
                     self.assertIn("supportedFeatures", protocol.aggregate_status, "supported features not reported")
-                    multi_config_feature = get_supported_feature_by_name(SupportedFeatureNames.MultiConfig)
+                    multi_config_feature = _MultiConfigFeature()
                     found = False
                     for feature in protocol.aggregate_status['supportedFeatures']:
                         if feature['Key'] == multi_config_feature.name and feature['Value'] == multi_config_feature.version:
@@ -377,7 +376,7 @@ class TestWireProtocol(AgentTestCase, HttpRequestPredicates):
                             break
                     self.assertTrue(found, "Multi-config name should be present in supportedFeatures")
 
-                    ga_versioning_feature = get_supported_feature_by_name(SupportedFeatureNames.GAVersioningGovernance)
+                    ga_versioning_feature = _GAVersioningGovernanceFeature()
                     found = False
                     for feature in protocol.aggregate_status['supportedFeatures']:
                         if feature['Key'] == ga_versioning_feature.name and feature['Value'] == ga_versioning_feature.version:
@@ -402,7 +401,7 @@ class TestWireProtocol(AgentTestCase, HttpRequestPredicates):
                         return
 
                     # If there are other features available, confirm MultiConfig and GA versioning was not reported
-                    multi_config_feature = get_supported_feature_by_name(SupportedFeatureNames.MultiConfig)
+                    multi_config_feature = _MultiConfigFeature()
                     found = False
                     for feature in protocol.aggregate_status['supportedFeatures']:
                         if feature['Key'] == multi_config_feature.name and feature['Value'] == multi_config_feature.version:
@@ -410,7 +409,7 @@ class TestWireProtocol(AgentTestCase, HttpRequestPredicates):
                             break
                     self.assertFalse(found, "Multi-config name should not be present in supportedFeatures")
 
-                    ga_versioning_feature = get_supported_feature_by_name(SupportedFeatureNames.GAVersioningGovernance)
+                    ga_versioning_feature = _GAVersioningGovernanceFeature()
                     found = False
                     for feature in protocol.aggregate_status['supportedFeatures']:
                         if feature['Key'] == ga_versioning_feature.name and feature['Value'] == ga_versioning_feature.version:

--- a/tests/common/test_agent_supported_feature.py
+++ b/tests/common/test_agent_supported_feature.py
@@ -63,9 +63,9 @@ class TestAgentSupportedFeature(AgentTestCase):
             self.assertNotIn(SupportedFeatureNames.GAVersioningGovernance, get_agent_supported_features_list_for_crp(),
                              "GAVersioningGovernance should not be fetched in crp_supported_features as not supported")
 
-        self.assertEqual(SupportedFeatureNames.GAVersioningGovernance,
-                         get_supported_feature_by_name(SupportedFeatureNames.GAVersioningGovernance).name,
-                         "Invalid/Wrong feature returned")
+        with patch("azurelinuxagent.common.conf.get_auto_update_to_latest_version", return_value=False):
+            self.assertNotIn(SupportedFeatureNames.GAVersioningGovernance, get_agent_supported_features_list_for_crp(),
+                             "GAVersioningGovernance should not be fetched in crp_supported_features as not supported")
 
         # Raise error if feature name not found
         with self.assertRaises(NotImplementedError):

--- a/tests_e2e/tests/lib/retry.py
+++ b/tests_e2e/tests/lib/retry.py
@@ -80,6 +80,27 @@ def retry_if_false(operation: Callable[[], bool], attempts: int = 5, delay: int 
     return success
 
 
+def retry_if_true(operation: Callable[[], bool], attempts: int = 5, delay: int = 30) -> bool:
+    """
+    This method attempts the given operation retrying a few times if expected value is false but its true
+    (after a short delay)
+    Note: Method used for operations which are return True or False
+    """
+    success: bool = True
+    while attempts > 0 and success:
+        attempts -= 1
+        try:
+            success = operation()
+        except Exception as e:
+            log.warning("Error in operation: %s", e)
+            if attempts == 0:
+                raise
+        if success and attempts != 0:
+            log.info("Current operation failed, retrying in %s secs.", delay)
+            time.sleep(delay)
+    return success
+
+
 # R1710: Either all return statements in a function should return an expression, or none of them should. (inconsistent-return-statements)
 def retry(operation: Callable[[], Any], attempts: int = 5, delay: int = 30) -> Any:  # pylint: disable=inconsistent-return-statements
     """

--- a/tests_e2e/tests/scripts/agent_update-verify_versioning_supported_feature.py
+++ b/tests_e2e/tests/scripts/agent_update-verify_versioning_supported_feature.py
@@ -18,12 +18,13 @@
 #
 # Verify if the agent reported supportedfeature VersioningGovernance flag to CRP via status file
 #
+import argparse
 import glob
 import json
 
 from tests_e2e.tests.lib.logging import log
 from tests_e2e.tests.lib.remote_test import run_remote_test
-from tests_e2e.tests.lib.retry import retry_if_false
+from tests_e2e.tests.lib.retry import retry_if_false, retry_if_true
 
 
 def check_agent_supports_versioning() -> bool:
@@ -41,11 +42,20 @@ def check_agent_supports_versioning() -> bool:
 
 
 def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-s', '--supported', required=True)
+    args = parser.parse_args()
+
     log.info("checking agent status file for VersioningGovernance supported feature flag")
-    found: bool = retry_if_false(check_agent_supports_versioning)
-    if not found:
-        raise Exception("Agent failed to report supported feature flag. So, skipping agent update validations "
-                        "since CRP will not send RSM requested version in GS if feature flag not found in status")
+    if args.supported == "True":
+        found: bool = retry_if_false(check_agent_supports_versioning)
+        if not found:
+            raise Exception("Agent failed to report supported feature flag. So, skipping agent update validations "
+                            "since CRP will not send RSM requested version in GS if feature flag not found in status")
+    else:
+        found: bool = retry_if_true(check_agent_supports_versioning)
+        if found:
+            raise Exception("Agent should not report supported feature flag while agent updates disabled in the vm.")
 
 
 run_remote_test(main)


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
Fixing the issue agent_supported_feature module is using conf before it is initialized if they are imported before load_conf_from_file() is invoked, we get default values from conf instead of actual value from the file.

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).