### PR TITLE
Fix ExtPolicy e2e test failures

### DIFF
--- a/tests_e2e/test_suites/ext_policy.yml
+++ b/tests_e2e/test_suites/ext_policy.yml
@@ -7,4 +7,7 @@ tests:
 images: "endorsed"
 # This test is executed in southcentralus as a workaround for recurring fabric "ServiceUnavailableFault" issues observed in westus2.
 locations: "AzureCloud:southcentralus"
+# TODO: This test is currently failing on usgov cloud due to an issue with the GuestConfig extension. Re-enable once the extension fix has been rolled out.
+skip_on_clouds:
+  - "AzureUSGovernment"
 owns_vm: false

--- a/tests_e2e/tests/ext_policy/ext_policy.py
+++ b/tests_e2e/tests/ext_policy/ext_policy.py
@@ -243,7 +243,9 @@ class ExtPolicy(AgentVmTest):
             # does not support the distro, skip this workaround and the test case (5).
             distro = self._ssh_client.run_command("get_distro.py").rstrip()
             if VmExtensionIds.GuestConfig.supports_distro(distro):
-                if "AzurePolicyforLinux" not in extension_names_on_vm:
+                # Refresh the list of installed extensions and check if GuestConfig is already present
+                extension_types_on_vm = {ext.type_properties_type for ext in self._context.vm.get_extensions().value}
+                if "ConfigurationforLinux" not in extension_types_on_vm:
                     log.info("")
                     log.info("Installing GuestConfig extension.")
                     guest_config = VirtualMachineExtensionClient(self._context.vm, VmExtensionIds.GuestConfig)

--- a/tests_e2e/tests/lib/agent_log.py
+++ b/tests_e2e/tests/lib/agent_log.py
@@ -70,11 +70,18 @@ class AgentLogRecord:
         ext_timestamp_regex_1 = r"\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}[.\d]+"
         # 2023/07/10 20:50:13
         ext_timestamp_regex_2 = r"\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}"
+        # 2023/07/10 20:50:1
+        ext_timestamp_regex_3 = r"\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{1}(?!\d)"
 
         if re.match(ext_timestamp_regex_1, self.when):
             return datetime.strptime(self.when, u'%Y/%m/%d %H:%M:%S.%f').replace(tzinfo=UTC)
         elif re.match(ext_timestamp_regex_2, self.when):
             return datetime.strptime(self.when, u'%Y/%m/%d %H:%M:%S').replace(tzinfo=UTC)
+        elif re.match(ext_timestamp_regex_3, self.when):
+            # Pad the 1-digit second to 2-digits (e.g, 00:1 -> 00:01)
+            padded_time = self.when[:-1] + '0' + self.when[-1]
+            return datetime.strptime(padded_time, u'%Y/%m/%d %H:%M:%S').replace(tzinfo=UTC)
+
         # Logs from agent follow this format: 2023-07-10T20:50:13.038599Z
         return datetime.strptime(self.when, u'%Y-%m-%dT%H:%M:%S.%fZ').replace(tzinfo=UTC)
 

--- a/tests_e2e/tests/scripts/agent_ext_policy-verify_operation_disallowed.py
+++ b/tests_e2e/tests/scripts/agent_ext_policy-verify_operation_disallowed.py
@@ -54,7 +54,7 @@ def main():
                     sys.exit(0)
 
     except Exception as e:
-        log.info("Error thrown when searching for test data in agent log: {0}".format(str(e)))
+        log.info("Error thrown when searching for test data in agent log: {0}".format(str(e)), exc_info=True)
 
     log.info("Did not find expected error in agent log. Expected to find pattern: {0}".format(pattern))
     sys.exit(1)


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

This PR makes the following changes:
- temporarily disables ExtPolicy tests on government cloud until the GuestConfig extension fix is deployed to the cloud.
- update timestamp parsing logic in agent_log.py to handle non-standard timestamp format
- check if GuestConfig is already present immediately before trying to install it as part of the policy tests

### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).