### PR TITLE
Use default resource name for VirtualMachineExtensionClient (#3468)

### DIFF
--- a/tests_e2e/tests/agent_bvt/extension_operations.py
+++ b/tests_e2e/tests/agent_bvt/extension_operations.py
@@ -46,8 +46,7 @@ class ExtensionOperationsBvt(AgentVmTest):
 
         custom_script_2_0 = VirtualMachineExtensionClient(
             self._context.vm,
-            VmExtensionIds.CustomScript,
-            resource_name="CustomScript")
+            VmExtensionIds.CustomScript)
 
         if is_arm64:
             log.info("Will skip the update scenario, since currently there is only 1 version of CSE on ARM64")
@@ -65,8 +64,7 @@ class ExtensionOperationsBvt(AgentVmTest):
 
         custom_script_2_1 = VirtualMachineExtensionClient(
             self._context.vm,
-            VmExtensionIdentifier(VmExtensionIds.CustomScript.publisher, VmExtensionIds.CustomScript.type, "2.1"),
-            resource_name="CustomScript")
+            VmExtensionIdentifier(VmExtensionIds.CustomScript.publisher, VmExtensionIds.CustomScript.type, "2.1"))
 
         if is_arm64:
             log.info("Installing %s", custom_script_2_1)

--- a/tests_e2e/tests/agent_bvt/run_command.py
+++ b/tests_e2e/tests/agent_bvt/run_command.py
@@ -49,7 +49,7 @@ class RunCommandBvt(AgentVmTest):
 
         test_cases = [
             RunCommandBvt.TestCase(
-                VirtualMachineExtensionClient(self._context.vm, VmExtensionIds.RunCommand, resource_name="RunCommand"),
+                VirtualMachineExtensionClient(self._context.vm, VmExtensionIds.RunCommand),
                 lambda s: {
                     "script": base64.standard_b64encode(bytearray(s, 'utf-8')).decode('utf-8')
                 })
@@ -60,7 +60,7 @@ class RunCommandBvt(AgentVmTest):
         else:
             test_cases.append(
                 RunCommandBvt.TestCase(
-                    VirtualMachineExtensionClient(self._context.vm, VmExtensionIds.RunCommandHandler, resource_name="RunCommandHandler"),
+                    VirtualMachineExtensionClient(self._context.vm, VmExtensionIds.RunCommandHandler),
                     lambda s: {
                         "source": {
                             "script": s

--- a/tests_e2e/tests/agent_bvt/vm_access.py
+++ b/tests_e2e/tests/agent_bvt/vm_access.py
@@ -58,7 +58,7 @@ class VmAccessBvt(AgentVmTest):
             public_key = f.read()
 
         # Invoke the extension
-        vm_access = VirtualMachineExtensionClient(self._context.vm, VmExtensionIds.VmAccess, resource_name="VmAccess")
+        vm_access = VirtualMachineExtensionClient(self._context.vm, VmExtensionIds.VmAccess)
         vm_access.enable(
             protected_settings={
                 'username': username,

--- a/tests_e2e/tests/agent_cgroups/agent_cgroups_process_check.py
+++ b/tests_e2e/tests/agent_cgroups/agent_cgroups_process_check.py
@@ -53,8 +53,7 @@ class AgentCgroupsProcessCheck(AgentVmTest):
 
     def _install_ama_extension(self):
         ama_extension = VirtualMachineExtensionClient(
-            self._context.vm, VmExtensionIds.AzureMonitorLinuxAgent,
-            resource_name="AMAAgent")
+            self._context.vm, VmExtensionIds.AzureMonitorLinuxAgent)
         log.info("Installing %s", ama_extension)
         ama_extension.enable()
         ama_extension.assert_instance_view()

--- a/tests_e2e/tests/agent_ext_workflow/extension_workflow.py
+++ b/tests_e2e/tests/agent_ext_workflow/extension_workflow.py
@@ -184,8 +184,7 @@ class ExtensionWorkflow(AgentVmTest):
             )
             dcr_test_ext_client = VirtualMachineExtensionClient(
                 self._context.vm,
-                dcr_test_ext_id_1_1,
-                resource_name="GuestAgentDcrTestExt"
+                dcr_test_ext_id_1_1
             )
             dcr_ext = ExtensionWorkflow.GuestAgentDcrTestExtension(
                 extension=dcr_test_ext_client,
@@ -330,8 +329,7 @@ class ExtensionWorkflow(AgentVmTest):
             )
             dcr_test_ext_client_1_2 = VirtualMachineExtensionClient(
                 self._context.vm,
-                dcr_test_ext_id_1_2,
-                resource_name="GuestAgentDcrTestExt"
+                dcr_test_ext_id_1_2
             )
 
             # Update extension object & version to new version
@@ -396,8 +394,7 @@ class ExtensionWorkflow(AgentVmTest):
                 "1.3")
             dcr_test_ext_client_1_3 = VirtualMachineExtensionClient(
                 self._context.vm,
-                dcr_test_ext_id_1_3,
-                resource_name="GuestAgentDcrTestExt"
+                dcr_test_ext_id_1_3
             )
 
             # Update extension object & version to new version

--- a/tests_e2e/tests/agent_not_provisioned/agent_not_provisioned.py
+++ b/tests_e2e/tests/agent_not_provisioned/agent_not_provisioned.py
@@ -77,7 +77,7 @@ class AgentNotProvisioned(AgentVmTest):
         #
         log.info("Verifying that extension processing is disabled.")
         log.info("Executing CustomScript; it should fail.")
-        custom_script = VirtualMachineExtensionClient(self._context.vm, VmExtensionIds.CustomScript, resource_name="CustomScript")
+        custom_script = VirtualMachineExtensionClient(self._context.vm, VmExtensionIds.CustomScript)
         try:
             custom_script.enable(settings={'commandToExecute': "date"}, protected_settings={}, force_update=True, timeout=20 * 60)
             fail("CustomScript should have failed")

--- a/tests_e2e/tests/agent_publish/agent_publish.py
+++ b/tests_e2e/tests/agent_publish/agent_publish.py
@@ -165,8 +165,7 @@ class AgentPublishTest(AgentVmTest):
     def _check_cse(self) -> None:
         custom_script_2_1 = VirtualMachineExtensionClient(
             self._context.vm,
-            VmExtensionIdentifier(VmExtensionIds.CustomScript.publisher, VmExtensionIds.CustomScript.type, "2.1"),
-            resource_name="CustomScript")
+            VmExtensionIdentifier(VmExtensionIds.CustomScript.publisher, VmExtensionIds.CustomScript.type, "2.1"))
 
         log.info("Installing %s", custom_script_2_1)
         message = f"Hello {uuid.uuid4()}!"

--- a/tests_e2e/tests/ext_cgroups/install_extensions.py
+++ b/tests_e2e/tests/ext_cgroups/install_extensions.py
@@ -45,8 +45,7 @@ class InstallExtensions:
 
     def _install_ama(self):
         ama_extension = VirtualMachineExtensionClient(
-            self._context.vm, VmExtensionIds.AzureMonitorLinuxAgent,
-            resource_name="AMAAgent")
+            self._context.vm, VmExtensionIds.AzureMonitorLinuxAgent)
         log.info("Installing %s", ama_extension)
         ama_extension.enable()
         ama_extension.assert_instance_view()
@@ -57,7 +56,7 @@ class InstallExtensions:
         with public_key_file.open() as f:
             public_key = f.read()
         # Invoke the extension
-        vm_access = VirtualMachineExtensionClient(self._context.vm, VmExtensionIds.VmAccess, resource_name="VmAccess")
+        vm_access = VirtualMachineExtensionClient(self._context.vm, VmExtensionIds.VmAccess)
         log.info("Installing %s", vm_access)
         vm_access.enable(
             protected_settings={
@@ -70,8 +69,7 @@ class InstallExtensions:
 
     def _install_gatest_extension(self):
         gatest_extension = VirtualMachineExtensionClient(
-            self._context.vm, VmExtensionIds.GATestExtension,
-            resource_name="GATestExt")
+            self._context.vm, VmExtensionIds.GATestExtension)
         log.info("Installing %s", gatest_extension)
         gatest_extension.enable()
         gatest_extension.assert_instance_view()
@@ -85,8 +83,7 @@ cp /proc/$$/cgroup /var/lib/waagent/tmp/custom_script_check
 """
         custom_script_2_0 = VirtualMachineExtensionClient(
             self._context.vm,
-            VmExtensionIds.CustomScript,
-            resource_name="CustomScript")
+            VmExtensionIds.CustomScript)
 
         log.info("Installing %s", custom_script_2_0)
         custom_script_2_0.enable(

--- a/tests_e2e/tests/ext_policy/ext_policy.py
+++ b/tests_e2e/tests/ext_policy/ext_policy.py
@@ -185,8 +185,7 @@ class ExtPolicy(AgentVmTest):
             # without settings have different status reporting logic, so we should test all cases.
             # CustomScript is a single-config extension.
             custom_script = ExtPolicy.TestCase(
-                VirtualMachineExtensionClient(self._context.vm, VmExtensionIds.CustomScript,
-                                              resource_name="CustomScript"),
+                VirtualMachineExtensionClient(self._context.vm, VmExtensionIds.CustomScript),
                 {'commandToExecute': f"echo '{str(uuid.uuid4())}'"}
             )
 
@@ -206,15 +205,13 @@ class ExtPolicy(AgentVmTest):
 
             # AzureMonitorLinuxAgent is a no-config extension (extension without settings).
             azure_monitor = ExtPolicy.TestCase(
-                VirtualMachineExtensionClient(self._context.vm, VmExtensionIds.AzureMonitorLinuxAgent,
-                                              resource_name="AzureMonitorLinuxAgent"),
+                VirtualMachineExtensionClient(self._context.vm, VmExtensionIds.AzureMonitorLinuxAgent),
                 None
             )
 
             # AzureSecurityLinuxAgent is an extension that reports heartbeat.
             azure_security = ExtPolicy.TestCase(
-                VirtualMachineExtensionClient(self._context.vm, VmExtensionIds.AzureSecurityLinuxAgent,
-                                              resource_name="AzureSecurityLinuxAgent"),
+                VirtualMachineExtensionClient(self._context.vm, VmExtensionIds.AzureSecurityLinuxAgent),
                 {}
             )
 

--- a/tests_e2e/tests/ext_signature_validation/ext_signature_validation.py
+++ b/tests_e2e/tests/ext_signature_validation/ext_signature_validation.py
@@ -135,21 +135,21 @@ class ExtSignatureValidation(AgentVmTest):
         cse_id_21 = VmExtensionIdentifier(publisher='Microsoft.Azure.Extensions', ext_type='CustomScript',
                                           version="2.1")
         custom_script_signed = ExtSignatureValidation._TestCase(
-            VirtualMachineExtensionClient(self._context.vm, cse_id_21, resource_name="CustomScript"),
+            VirtualMachineExtensionClient(self._context.vm, cse_id_21),
             {'commandToExecute': f"echo '{str(uuid.uuid4())}'"}
         )
 
         # CustomScript 2.0 is an unsigned, single-config extension.
         cse_id_20 = VmExtensionIdentifier(publisher='Microsoft.Azure.Extensions', ext_type='CustomScript', version="2.0")
         custom_script_unsigned = ExtSignatureValidation._TestCase(
-            VirtualMachineExtensionClient(self._context.vm, cse_id_20, resource_name="CustomScript"),
+            VirtualMachineExtensionClient(self._context.vm, cse_id_20),
             {'commandToExecute': f"echo '{str(uuid.uuid4())}'"}
         )
 
         # RunCommandHandler 1.3 is a signed, multi-config extension.
         rc_id_1_3 = VmExtensionIdentifier(publisher="Microsoft.CPlat.Core", ext_type="RunCommandHandlerLinux", version="1.3")
         run_command_signed = ExtSignatureValidation._TestCase(
-            VirtualMachineRunCommandClient(self._context.vm, rc_id_1_3, resource_name="RunCommandHandler"),
+            VirtualMachineRunCommandClient(self._context.vm, rc_id_1_3),
             {'source': f"echo '{str(uuid.uuid4())}'"}
         )
 
@@ -157,14 +157,14 @@ class ExtSignatureValidation(AgentVmTest):
         vmapp_id_1_0 = VmExtensionIdentifier(publisher='Microsoft.CPlat.Core', ext_type='VMApplicationManagerLinux',
                                             version='1.0')
         vm_app_signed = ExtSignatureValidation._TestCase(
-            VirtualMachineExtensionClient(self._context.vm, vmapp_id_1_0, resource_name="VMApplicationManagerLinux"),
+            VirtualMachineExtensionClient(self._context.vm, vmapp_id_1_0),
             None
         )
 
         # AzureMonitorLinuxAgent 1.33 is an unsigned, no-config extension.
         ama_id_1_33 = VmExtensionIdentifier(publisher='Microsoft.Azure.Monitor', ext_type='AzureMonitorLinuxAgent', version="1.33")
         azure_monitor_unsigned = ExtSignatureValidation._TestCase(
-            VirtualMachineExtensionClient(self._context.vm, ama_id_1_33, resource_name="AzureMonitorLinuxAgent"),
+            VirtualMachineExtensionClient(self._context.vm, ama_id_1_33),
             None
         )
 
@@ -173,13 +173,13 @@ class ExtSignatureValidation(AgentVmTest):
         # signed extensions in a single goal state.
         vmaccess_id_1_5 = VmExtensionIdentifier(publisher='Microsoft.OSTCExtensions.Edp', ext_type='VMAccessForLinux', version="1.5")
         vm_access_signed = ExtSignatureValidation._TestCase(
-            VirtualMachineExtensionClient(self._context.vm, vmaccess_id_1_5, resource_name="VMAccessForLinux"),
+            VirtualMachineExtensionClient(self._context.vm, vmaccess_id_1_5),
             settings = None,
             protected_settings={'username': 'testuser'}
         )
         ahl_id_2_0 = VmExtensionIdentifier(publisher='Microsoft.ManagedServices.Edp', ext_type='ApplicationHealthLinux', version="2.0")
         application_health_signed = ExtSignatureValidation._TestCase(
-            VirtualMachineExtensionClient(self._context.vm, ahl_id_2_0, resource_name="ApplicationHealthLinux"),
+            VirtualMachineExtensionClient(self._context.vm, ahl_id_2_0),
             None
         )
 

--- a/tests_e2e/tests/ext_telemetry_pipeline/ext_telemetry_pipeline.py
+++ b/tests_e2e/tests/ext_telemetry_pipeline/ext_telemetry_pipeline.py
@@ -55,7 +55,7 @@ class ExtTelemetryPipeline(AgentVmTest):
         # Add CSE to the test VM twice to ensure its events directory still exists after re-enabling
         log.info("")
         log.info("Add CSE to the test VM...")
-        cse = VirtualMachineExtensionClient(self._context.vm, VmExtensionIds.CustomScript, resource_name="CustomScript")
+        cse = VirtualMachineExtensionClient(self._context.vm, VmExtensionIds.CustomScript)
         cse.enable(settings={'commandToExecute': "echo 'enable'"}, protected_settings={})
         cse.assert_instance_view()
 

--- a/tests_e2e/tests/ext_update/ext_update_failure.py
+++ b/tests_e2e/tests/ext_update/ext_update_failure.py
@@ -40,8 +40,7 @@ class ExtensionUpdateFailureTest(AgentVmTest):
         custom_script = VmExtensionIds.CustomScript
         custom_script_2_0 = VirtualMachineExtensionClient(
             self._context.vm,
-            custom_script,
-            resource_name="CustomScript")
+            custom_script)
         extensions_to_cleanup = {
             custom_script: custom_script_2_0
         }
@@ -67,8 +66,7 @@ class ExtensionUpdateFailureTest(AgentVmTest):
 
             custom_script_2_1 = VirtualMachineExtensionClient(
                 self._context.vm,
-                VmExtensionIdentifier(VmExtensionIds.CustomScript.publisher, VmExtensionIds.CustomScript.type, "2.1"),
-                resource_name="CustomScript")
+                VmExtensionIdentifier(VmExtensionIds.CustomScript.publisher, VmExtensionIds.CustomScript.type, "2.1"))
 
             log.info("Updating %s", custom_script_2_0)
 

--- a/tests_e2e/tests/extensions_disabled/extensions_disabled.py
+++ b/tests_e2e/tests/extensions_disabled/extensions_disabled.py
@@ -60,13 +60,11 @@ class ExtensionsDisabled(AgentVmTest):
         test_file = f"waagent-test.{unique}"
         test_cases = [
             ExtensionsDisabled.TestCase(
-                VirtualMachineExtensionClient(self._context.vm, VmExtensionIds.CustomScript,
-                                              resource_name="CustomScript"),
+                VirtualMachineExtensionClient(self._context.vm, VmExtensionIds.CustomScript),
                 {'commandToExecute': f"echo '{unique}' > /tmp/{test_file}"}
             ),
             ExtensionsDisabled.TestCase(
-                VirtualMachineExtensionClient(self._context.vm, VmExtensionIds.RunCommandHandler,
-                                              resource_name="RunCommandHandler"),
+                VirtualMachineExtensionClient(self._context.vm, VmExtensionIds.RunCommandHandler),
                 {'source': {'script': f"echo '{unique}' > /tmp/{test_file}"}}
             )
         ]

--- a/tests_e2e/tests/fips/fips.py
+++ b/tests_e2e/tests/fips/fips.py
@@ -69,7 +69,7 @@ class Fips(AgentVmTest):
         #
         # Execute an extension with protected settings to ensure the tenant certificate can be decrypted under FIPS
         #
-        custom_script = VirtualMachineExtensionClient(self._context.vm, VmExtensionIds.CustomScript, resource_name="CustomScript")
+        custom_script = VirtualMachineExtensionClient(self._context.vm, VmExtensionIds.CustomScript)
         log.info("Executing %s using protected settings to verify they can be decrypted when FIPS 140-3 is enabled.", custom_script)
         message = f"Hello {uuid.uuid4()}!"
         custom_script.enable(

--- a/tests_e2e/tests/hibernation/hibernation.py
+++ b/tests_e2e/tests/hibernation/hibernation.py
@@ -111,7 +111,7 @@ class Hibernation(AgentVmTest):
         # Execute an extension with protected settings and verify that the new tenant certificate was downloaded.
         #
         log.info("Executing an extension with protected settings to verify it can use the new tenant certificate")
-        custom_script = VirtualMachineExtensionClient(self._context.vm, VmExtensionIds.CustomScript, resource_name="CustomScript")
+        custom_script = VirtualMachineExtensionClient(self._context.vm, VmExtensionIds.CustomScript)
         message = str(uuid.uuid4())
         custom_script.enable(settings={}, protected_settings={'commandToExecute': f"echo \'{message}\'"}, force_update=True)
         custom_script.assert_instance_view(expected_message=message)
@@ -184,7 +184,7 @@ class Hibernation(AgentVmTest):
             log.info("The Hibernation extension is already installed")
         else:
             log.info("Installing the Hibernation extension")
-            hibernate = VirtualMachineExtensionClient(self._context.vm, VmExtensionIds.Hibernate, resource_name="Hibernate")
+            hibernate = VirtualMachineExtensionClient(self._context.vm, VmExtensionIds.Hibernate)
             hibernate.enable(auto_upgrade_minor_version=True)
 
     def _do_hibernate_resume_cycle(self) -> None:

--- a/tests_e2e/tests/recover_network_interface/recover_network_interface.py
+++ b/tests_e2e/tests/recover_network_interface/recover_network_interface.py
@@ -134,7 +134,7 @@ class RecoverNetworkInterface(AgentVmTest):
         """
         log.info("")
         log.info("Using CSE to bring the primary network interface down and call the OSUtil to bring the interface back up. Command to execute: {0}".format(script))
-        custom_script = VirtualMachineExtensionClient(self._context.vm, VmExtensionIds.CustomScript, resource_name="CustomScript")
+        custom_script = VirtualMachineExtensionClient(self._context.vm, VmExtensionIds.CustomScript)
         try:
             custom_script.enable(protected_settings={'commandToExecute': script}, settings={})
         except TimeoutError:


### PR DESCRIPTION
* Remove resource name parameter

* Enable policy tests

(cherry picked from commit daf14590b813ce18752d0fdf576a5477908f0b72)

<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).