### PR TITLE
Skip tests on gov cloud

### DIFF
--- a/tests_e2e/test_suites/ext_policy_with_dependencies.yml
+++ b/tests_e2e/test_suites/ext_policy_with_dependencies.yml
@@ -9,6 +9,12 @@ executes_on_scale_set: true
 owns_vm: false
 # This test is executed in southcentralus as a workaround for recurring fabric "ServiceUnavailableFault" issues observed in westus2.
 locations: "AzureCloud:southcentralus"
+
+# TODO: Currently AlmaLinux is not available for scale sets; enable this image when it is available.
 skip_on_images:
   - "alma_8"
-  - "alma_9"  # TODO: Currently AlmaLinux is not available for scale sets; enable this image when it is available.
+  - "alma_9"
+
+# TODO: The current deployment of VmAccess 1.5.22 prevents the extension from uninstalling; enable this test when the issue is fixed
+skip_on_clouds:
+  - "AzureUSGovernment"

--- a/tests_e2e/test_suites/ext_sequencing.yml
+++ b/tests_e2e/test_suites/ext_sequencing.yml
@@ -8,6 +8,12 @@ tests:
 images: "endorsed"
 # This scenario is executed on instances of a scaleset created by the agent test suite.
 executes_on_scale_set: true
+
+# TODO: Currently AlmaLinux is not available for scale sets; enable this image when it is available.
 skip_on_images:
   - "alma_8"
-  - "alma_9"  # TODO: Currently AlmaLinux is not available for scale sets; enable this image when it is available.
+  - "alma_9"
+
+# TODO: The current deployment of VmAccess 1.5.22 prevents the extension from uninstalling; enable this test when the issue is fixed
+skip_on_clouds:
+  - "AzureUSGovernment"


### PR DESCRIPTION
The current deployment of VmAccess 1.5.22 prevents the extension from uninstalling; disabling these tests while the issue is fixed.