### PR TITLE
Do not change firewall rules in waagent-network-setup.service when firewalld is enabled

### DIFF
--- a/azurelinuxagent/agent.py
+++ b/azurelinuxagent/agent.py
@@ -47,6 +47,7 @@ from azurelinuxagent.ga.logcollector import LogCollector, OUTPUT_RESULTS_FILE_PA
 from azurelinuxagent.common.osutil import get_osutil
 from azurelinuxagent.common.utils import fileutil, textutil
 from azurelinuxagent.common.utils.flexible_version import FlexibleVersion
+from azurelinuxagent.common.utils.shellutil import run_command, CommandError
 from azurelinuxagent.common.version import AGENT_NAME, AGENT_LONG_VERSION, AGENT_VERSION, \
     DISTRO_NAME, DISTRO_VERSION, \
     PY_VERSION_MAJOR, PY_VERSION_MINOR, \
@@ -305,9 +306,22 @@ class Agent(object):
         threading.current_thread().name = "Firewall"
         event.info(event.WALAEventOperation.Firewall, "Setting up firewall after boot. Endpoint: {0}", ustr(endpoint))
         try:
+            try:
+                stdout = run_command(['systemctl', 'list-unit-files', '--type=service', '--no-legend', 'firewalld.service']).rstrip()
+                event.info(event.WALAEventOperation.Firewall, "Firewalld is installed (state: {0}). Will not setup the firewall rules.", stdout)
+                sys.exit(0)
+            except CommandError as command_error:
+                if command_error.returncode == 1 and (command_error.stdout, command_error.stderr) == ('', ''):
+                    pass  # Not installed, continue
+                else:
+                    raise
+        except Exception as error:
+            event.error(event.WALAEventOperation.Firewall, "Unable to determine whether firewalld is installed. Will not setup the firewall rules. Error: {0}", ustr(error))
+            sys.exit(1)
+        try:
             firewall_manager = FirewallManager.create(endpoint)
             firewall_manager.setup()
-            event.info(event.WALAEventOperation.Firewall, "Successfully set the firewall rules")
+            event.info(event.WALAEventOperation.Firewall, "Successfully set up the firewall rules:\n{0}", firewall_manager.get_state())
         except Exception as error:
             event.error(event.WALAEventOperation.Firewall, "Unable to add firewall rules. Error: {0}", ustr(error))
             sys.exit(1)

--- a/azurelinuxagent/agent.py
+++ b/azurelinuxagent/agent.py
@@ -301,29 +301,49 @@ class Agent(object):
                 log_collector_monitor.stop()
 
     @staticmethod
+    def _is_firewalld_enabled():
+        #
+        # Check first whether it's installed
+        #
+        try:
+            run_command(['systemctl', 'list-unit-files', '--type=service', '--no-legend', 'firewalld.service']).rstrip()
+        except CommandError as command_error:
+            if command_error.returncode == 1 and (command_error.stdout, command_error.stderr) == ('', ''):  # exit code 1 with no output means it is not installed
+                return False
+            raise
+        #
+        # Now check it is enabled
+        #
+        try:
+            stdout = run_command(['systemctl', 'is-enabled', '--type=service', 'firewalld.service']).rstrip()
+            logger.info("Firewalld is enabled (state: {0}).", stdout)
+            return True
+        except CommandError as command_error:
+            if command_error.stderr != '':  # If stderr is not empty, the command failed for some other reason (say, for example, failure contacting dbus)
+                raise
+            logger.info("Firewalld is installed, but not enabled (state: {0}).", command_error.stdout)
+            return False
+
+    @staticmethod
     def setup_firewall(endpoint):
         logger.set_prefix("Firewall")
         threading.current_thread().name = "Firewall"
-        event.info(event.WALAEventOperation.Firewall, "Setting up firewall after boot. Endpoint: {0}", ustr(endpoint))
+        logger.info("Setting up firewall during boot. Endpoint: {0}", ustr(endpoint))
+
         try:
-            try:
-                stdout = run_command(['systemctl', 'list-unit-files', '--type=service', '--no-legend', 'firewalld.service']).rstrip()
-                event.info(event.WALAEventOperation.Firewall, "Firewalld is installed (state: {0}). Will not setup the firewall rules.", stdout)
+            if Agent._is_firewalld_enabled():
+                logger.info("Firewalld is enabled. Will not setup the firewall rules.")
                 sys.exit(0)
-            except CommandError as command_error:
-                if command_error.returncode == 1 and (command_error.stdout, command_error.stderr) == ('', ''):
-                    pass  # Not installed, continue
-                else:
-                    raise
         except Exception as error:
-            event.error(event.WALAEventOperation.Firewall, "Unable to determine whether firewalld is installed. Will not setup the firewall rules. Error: {0}", ustr(error))
+            logger.warn("Unable to determine whether firewalld is installed/enabled. Will not setup the firewall rules. Error: {0}", ustr(error))
             sys.exit(1)
+
         try:
             firewall_manager = FirewallManager.create(endpoint)
             firewall_manager.setup()
-            event.info(event.WALAEventOperation.Firewall, "Successfully set up the firewall rules:\n{0}", firewall_manager.get_state())
+            logger.info("Successfully set up the firewall rules:\n{0}", firewall_manager.get_state())
         except Exception as error:
-            event.error(event.WALAEventOperation.Firewall, "Unable to add firewall rules. Error: {0}", ustr(error))
+            logger.warn("Unable to add firewall rules. Error: {0}", ustr(error))
             sys.exit(1)
 
 

--- a/azurelinuxagent/agent.py
+++ b/azurelinuxagent/agent.py
@@ -317,10 +317,15 @@ class Agent(object):
 
         try:
             firewall_manager = FirewallManager.create(endpoint)
+        except Exception as error:
+            logger.warn("{0}", ustr(error))
+            sys.exit(1)
+
+        try:
             firewall_manager.setup()
             logger.info("Successfully set up the firewall rules:\n{0}", firewall_manager.get_state())
         except Exception as error:
-            logger.warn("Unable to add firewall rules. Error: {0}", ustr(error))
+            logger.warn("Unable to add firewall rules.\nError: {0}\n\nFirewall state:\n{1}", ustr(error), firewall_manager.get_state())
             sys.exit(1)
 
 

--- a/azurelinuxagent/agent.py
+++ b/azurelinuxagent/agent.py
@@ -301,42 +301,19 @@ class Agent(object):
                 log_collector_monitor.stop()
 
     @staticmethod
-    def _is_firewalld_enabled():
-        #
-        # Check first whether it's installed
-        #
-        try:
-            run_command(['systemctl', 'list-unit-files', '--type=service', '--no-legend', 'firewalld.service']).rstrip()
-        except CommandError as command_error:
-            if command_error.returncode == 1 and (command_error.stdout, command_error.stderr) == ('', ''):  # exit code 1 with no output means it is not installed
-                return False
-            raise
-        #
-        # Now check it is enabled
-        #
-        try:
-            stdout = run_command(['systemctl', 'is-enabled', '--type=service', 'firewalld.service']).rstrip()
-            logger.info("Firewalld is enabled (state: {0}).", stdout)
-            return True
-        except CommandError as command_error:
-            if command_error.stderr != '':  # If stderr is not empty, the command failed for some other reason (say, for example, failure contacting dbus)
-                raise
-            logger.info("Firewalld is installed, but not enabled (state: {0}).", command_error.stdout)
-            return False
-
-    @staticmethod
     def setup_firewall(endpoint):
         logger.set_prefix("Firewall")
         threading.current_thread().name = "Firewall"
         logger.info("Setting up firewall during boot. Endpoint: {0}", ustr(endpoint))
 
         try:
-            if Agent._is_firewalld_enabled():
-                logger.info("Firewalld is enabled. Will not setup the firewall rules.")
-                sys.exit(0)
-        except Exception as error:
-            logger.warn("Unable to determine whether firewalld is installed/enabled. Will not setup the firewall rules. Error: {0}", ustr(error))
-            sys.exit(1)
+            run_command(['systemctl', 'is-enabled', '--type=service', 'firewalld.service']).rstrip()
+            logger.info("Firewalld is enabled. Will not setup the firewall rules to avoid conflicts.")
+            sys.exit(0)
+        except CommandError:
+            # Differences across versions of systemd make hard to determine whether the command failed because firewalld is not installed
+            # or for another reason. Assume it is not installed and continue.
+            pass
 
         try:
             firewall_manager = FirewallManager.create(endpoint)

--- a/azurelinuxagent/common/event.py
+++ b/azurelinuxagent/common/event.py
@@ -95,6 +95,7 @@ class WALAEventOperation:
     ExtensionTelemetryEventProcessing = "ExtensionTelemetryEventProcessing"
     FetchGoalState = "FetchGoalState"
     Firewall = "Firewall"
+    FirewallBootSetup = "FirewallBootSetup"
     GoalState = "GoalState"
     GoalStateCertificates = "GoalStateCertificates"
     GoalStateUnsupportedFeatures = "GoalStateUnsupportedFeatures"

--- a/azurelinuxagent/ga/persist_firewall_rules.py
+++ b/azurelinuxagent/ga/persist_firewall_rules.py
@@ -296,7 +296,7 @@ if __name__ == '__main__':
         # Log service status and logs if we can fetch them from journalctl and send it to Kusto,
         # else just log the error of the failure of fetching logs
         add_event(
-            op=WALAEventOperation.PersistFirewallRules,
+            op=WALAEventOperation.FirewallBootSetup,
             is_success=(not service_failed),
             message=msg,
             log_event=False)

--- a/azurelinuxagent/ga/persist_firewall_rules.py
+++ b/azurelinuxagent/ga/persist_firewall_rules.py
@@ -156,7 +156,10 @@ if __name__ == '__main__':
 
         # Remove custom service if exists to avoid problems with firewalld
         try:
-            fileutil.rm_files(*[self.get_service_file_path(), os.path.join(conf.get_lib_dir(), self.BINARY_FILE_NAME)])
+            for file in [self.get_service_file_path(), os.path.join(conf.get_lib_dir(), self.BINARY_FILE_NAME)]:
+                if os.path.isfile(file):
+                    logger.info("Removing custom firewall service: {0}".format(file))
+                    os.remove(file)
         except Exception as error:
             logger.info("Unable to delete existing service {0}: {1}".format(self._network_setup_service_name, ustr(error)))
 

--- a/tests_e2e/orchestrator/lib/agent_test_loader.py
+++ b/tests_e2e/orchestrator/lib/agent_test_loader.py
@@ -153,6 +153,9 @@ class AgentTestLoader(object):
     # Matches a reference to a random subset of images within a set with an optional count: random(<image_set>, [<count>]), e.g. random(endorsed, 3), random(endorsed)
     RANDOM_IMAGES_RE = re.compile(r"random\((?P<image_set>[^,]+)(\s*,\s*(?P<count>\d+))?\)")
 
+    # Matches an image URN, which must consist of 4 components separated by ':', e.g. "Canonical:ubuntu-24_04-lts:server:latest"
+    IMAGE_URN_RE = re.compile(r"^[^:]+:[^:]+:[^:]+:[^:]+$")
+
     def _validate(self):
         """
         Performs some basic validations on the data loaded from the YAML description files
@@ -172,7 +175,7 @@ class AgentTestLoader(object):
             for image in suite.images:
                 image = _parse_image(image)
                 # skip validation if suite image from gallery image
-                if CustomImage._is_image_from_gallery(image):
+                if CustomImage._is_image_from_gallery(image) or AgentTestLoader.IMAGE_URN_RE.match(image) is not None:
                     continue
                 if image not in self.images:
                     raise Exception(f"Invalid image reference in test suite {suite.name}: Can't find {image} in images.yml or image from a shared gallery")
@@ -248,7 +251,8 @@ class AgentTestLoader(object):
                           rest of the tests in the suite will not be executed). By default, a failure on a test does not stop execution of
                           the test suite.
         * images   - A string, or a list of strings, specifying the images on which the test suite must be executed. Each value
-                     can be the name of a single image (e.g."ubuntu_2004"), or the name of an image set (e.g. "endorsed") or shared gallery image(e.g. "gallery/wait-cloud-init/1.0.2").
+                     can be the name of a single image (e.g."ubuntu_2004"), the name of an image set (e.g. "endorsed"), a shared gallery image
+                     (e.g. "gallery/wait-cloud-init/1.0.2"), or a URN (e.g.""Canonical:ubuntu-24_04-lts:server:latest").
                      The names for images and image sets are defined in WALinuxAgent/tests_e2e/tests_suites/images.yml.
         * locations - [Optional; string or list of strings] If given, the test suite must be executed on that cloud location(e.g. "AzureCloud:eastus2euap").
                      If not specified, or set to an empty string, the test suite will be executed in the default location. This is useful

--- a/tests_e2e/orchestrator/lib/agent_test_suite_combinator.py
+++ b/tests_e2e/orchestrator/lib/agent_test_suite_combinator.py
@@ -486,8 +486,7 @@ class AgentTestSuitesCombinator(Combinator):
         for image in suite.images:
             match = AgentTestLoader.RANDOM_IMAGES_RE.match(image)
             if match is None:
-                # Added this condition for galley image as they don't have definition in images.yml
-                if CustomImage._is_image_from_gallery(image):
+                if CustomImage._is_image_from_gallery(image) or AgentTestLoader.IMAGE_URN_RE.match(image) is not None:
                     i = VmImageInfo()
                     i.urn = image
                     i.locations = []

--- a/tests_e2e/orchestrator/runbook.yml
+++ b/tests_e2e/orchestrator/runbook.yml
@@ -44,21 +44,22 @@ variable:
       - agent_status
       - agent_update
       - ext_cgroups
-      - extensions_disabled
       - ext_policy
       - ext_policy_with_dependencies
       - ext_sequencing
+      - ext_signature_validation
       - ext_telemetry_pipeline
+      - ext_update
+      - extensions_disabled
       - fips
+      - firewalld
       - hibernation
       - keyvault_certificates
+      - log_collector
       - multi_config_ext
       - no_outbound_connections
       - publish_hostname
       - recover_network_interface
-      - log_collector
-      - ext_signature_validation
-      - ext_update
 
   #
   # Additional arguments pass to the test suites

--- a/tests_e2e/test_suites/firewalld.yml
+++ b/tests_e2e/test_suites/firewalld.yml
@@ -5,5 +5,9 @@ name: "Firewalld"
 tests:
   - "firewalld/boot_conflicts.py"
 images:
+  - "alma_9"
+  - "centos_82"
+  - "oracle_95"
   - "rhel_95"
-owns_vm: true
+  - "rocky_9"
+owns_vm: true  # We cannot share the VM with the Persist Firewall tests, since we change the state of firewalld

--- a/tests_e2e/test_suites/firewalld.yml
+++ b/tests_e2e/test_suites/firewalld.yml
@@ -1,0 +1,9 @@
+#
+# Set of tests around configuration of the firewalld and waagent-network-setup services
+#
+name: "Firewalld"
+tests:
+  - "firewalld/boot_conflicts.py"
+images:
+  - "rhel_95"
+owns_vm: true

--- a/tests_e2e/test_suites/firewalld.yml
+++ b/tests_e2e/test_suites/firewalld.yml
@@ -5,9 +5,6 @@ name: "Firewalld"
 tests:
   - "firewalld/boot_conflicts.py"
 images:
-  - "alma_9"
   - "centos_82"
   - "oracle_95"
   - "rhel_95"
-  - "rocky_9"
-owns_vm: true  # We cannot share the VM with the Persist Firewall tests, since we change the state of firewalld

--- a/tests_e2e/tests/firewalld/boot_conflicts.py
+++ b/tests_e2e/tests/firewalld/boot_conflicts.py
@@ -57,6 +57,12 @@ class BootConflicts(AgentVmTest):
         waagent_log = self._wait_for_log_message(waagent_log_size, r"legacy firewall rule.+--destination-port., .53.", "Removed legacy firewall rule")
         log.info(f"The Agent removed the legacy firewall rule, as expected:\n{indent(waagent_log)}")
 
+        waagent_log = self._wait_for_log_message(waagent_log_size, "waagent-network-setup.service", r"Removing custom firewall service:")
+        log.info(f"The Agent removed waagent-network-setup.service, as expected:\n{indent(waagent_log)}")
+
+        waagent_log = self._wait_for_log_message(waagent_log_size, "waagent-network-setup.py", r"Removing custom firewall service:")
+        log.info(f"The Agent removed waagent-network-setup.py, as expected:\n{indent(waagent_log)}")
+
         log.info("Checking permanent firewall rules...")
         firewall_rules = self._ssh_client.run_command("firewall-cmd --direct --permanent --get-all-passthroughs", use_sudo=True)
         log.info(f"Permanent firewall rules:\n{indent(firewall_rules)}")

--- a/tests_e2e/tests/firewalld/boot_conflicts.py
+++ b/tests_e2e/tests/firewalld/boot_conflicts.py
@@ -118,7 +118,7 @@ class BootConflicts(AgentVmTest):
         limit = datetime.now() + timedelta(minutes=5)
 
         while True:
-            waagent_log = self._ssh_client.run_command(f"tail --bytes=+{offset} /var/log/waagent.log | tr -d '\000' | grep -E '{selector_re}' || true")  # some tests write NULL characters to the log; we delete them
+            waagent_log = self._ssh_client.run_command(r"tail --bytes=+{0} /var/log/waagent.log | tr -d '\000' | grep -E '{1}' || true".format(offset, selector_re))  # some tests write NULL characters to the log; we delete them
             if re.search(message, waagent_log) is not None:
                 return waagent_log
             if datetime.now() > limit - timedelta(seconds=30):

--- a/tests_e2e/tests/firewalld/boot_conflicts.py
+++ b/tests_e2e/tests/firewalld/boot_conflicts.py
@@ -90,6 +90,8 @@ class BootConflicts(AgentVmTest):
 <passthrough ipv="ipv4">-t security -A OUTPUT -d 168.63.129.16 -p tcp -m conntrack --ctstate INVALID,NEW -j DROP</passthrough>
 </direct>"""
         log.info("Creating stale permanent firewall rules in /etc/firewalld/direct.xml...")
+        # create /etc/firewalld if it does not exist and remove any existing direct.xml files
+        self._ssh_client.run_command("mkdir -p /etc/firewalld", use_sudo=True)
         self._ssh_client.run_command("find /etc/firewalld -name 'direct.xml*' -exec rm -f {} \\;", use_sudo=True)
         output = self._ssh_client.run_command(f"echo '{stale_rules}' | sudo tee /etc/firewalld/direct.xml")
         log.info(f"Stale firewall rules created:\n{indent(output)}")
@@ -99,7 +101,7 @@ class BootConflicts(AgentVmTest):
         log.info("Starting waagent service to install waagent-network-setup.service...")
         self._ssh_client.run_command("systemctl start waagent", use_sudo=True)
 
-        waagent_log = self._wait_for_log_message(waagent_log_size, r"firewalld|waagent-network-setup\.service", "Successfully added and enabled the waagent-network-setup.service")
+        waagent_log = self._wait_for_log_message(waagent_log_size, r"waagent-network-setup.service", r"Successfully added and enabled the waagent-network-setup.service|waagent-network-setup.service already enabled. No change needed")
         log.info(f"waagent-network-setup.service was installed:\n{indent(waagent_log)}")
 
         log.info("Re-installing firewalld...")
@@ -117,12 +119,12 @@ class BootConflicts(AgentVmTest):
 
         while True:
             waagent_log = self._ssh_client.run_command(f"tail --bytes=+{offset} /var/log/waagent.log | grep -E -i '{selector_re}' || true")
-            if message in waagent_log:
+            if re.search(message, waagent_log) is not None:
                 return waagent_log
             if datetime.now() > limit - timedelta(seconds=30):
                 break
             log.info(f"Can't find message in Agent's log ('{message}'). Will retry after a short pause.")
-            time.sleep(30)
+            time.sleep(15)
         raise TimeoutError(f"Timed out waiting for waagent message '{message}'")
 
 

--- a/tests_e2e/tests/firewalld/boot_conflicts.py
+++ b/tests_e2e/tests/firewalld/boot_conflicts.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+# Microsoft Azure Linux Agent
+#
+# Copyright 2018 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import re
+import time
+
+from assertpy import fail
+from datetime import datetime, timedelta
+
+from tests_e2e.tests.lib.agent_test import AgentVmTest
+from tests_e2e.tests.lib.agent_test_context import AgentVmTestContext
+from tests_e2e.tests.lib.logging import log, indent
+from tests_e2e.tests.lib.ssh_client import SshClient
+
+
+class BootConflicts(AgentVmTest):
+    """
+    When firewalld is not installed/running on the VM, the Agent will install the waagent-network-setup service to setup the firewall
+    rules during boot. However, if firewalld is installed or started after the Agent has installed waagent-network-setup, both services
+    will end up running concurrently during boot, which can lead to an incorrect firewall setup. The waagent-network-setup service
+    should detect this condition and exit without setting up any rules. This test verifies that functionality.
+
+    In addition, the RHEL 9 images (and possibly others) include a set of stale firewall rules in /etc/firewalld/direct.xml. This test
+    simulates that condition and verifies that the Agent handles those rules correctly. Note that these stale rules include a duplicate
+    of the DNS rule (-t security -I OUTPUT -d 168.63.129.16 -p tcp --destination-port 53 -j ACCEPT).
+    """
+    def __init__(self, context: AgentVmTestContext):
+        super().__init__(context)
+        self._ssh_client: SshClient = self._context.create_ssh_client()
+
+    def run(self):
+        self._setup()
+
+        waagent_log_size = self._get_waagent_log_size()
+
+        log.info("Restarting machine to verify boot behavior...")
+        self._context.vm.restart(wait_for_boot=True, ssh_client=self._ssh_client)
+        log.info("Boot completed")
+
+        waagent_log = self._wait_for_log_message(waagent_log_size, r"^[0-9TZ:.-]+ INFO Firewall Firewall", "Will not setup the firewall rules")
+        log.info(f"waagent-network-setup.service did not setup the firewall rules, as expected:\n{indent(waagent_log)}")
+
+        waagent_log = self._wait_for_log_message(waagent_log_size, r"legacy firewall rule.+--destination-port., .53.", "Removed legacy firewall rule")
+        log.info(f"The Agent removed the legacy firewall rule, as expected:\n{indent(waagent_log)}")
+
+        log.info("Checking permanent firewall rules...")
+        firewall_rules = self._ssh_client.run_command("firewall-cmd --direct --permanent --get-all-passthroughs", use_sudo=True)
+        log.info(f"Permanent firewall rules:\n{indent(firewall_rules)}")
+        firewall_rules = firewall_rules.splitlines()
+        if len(firewall_rules) != 3:
+            fail(f"There should be exactly 3 permanent firewall rules, got: {firewall_rules}")
+        if re.search("-d 168.63.129.16.*--destination-port 53.*-j ACCEPT", firewall_rules[0]) is None:
+            fail(f"The first rule should accept connections access to DNS (port 53), got: {firewall_rules[0]}")
+        if re.search("-d 168.63.129.16.*--uid-owner 0.*-j ACCEPT", firewall_rules[1]) is None:
+            fail(f"The second firewall rule should accept connections from root, got: {firewall_rules[1]}")
+        if re.search("-d 168.63.129.16.*-j DROP", firewall_rules[2]) is None:
+            fail("The third firewall rule should drop all connections")
+
+    def _setup(self):
+        log.info("Beginning test setup...")
+        log.info("Stopping waagent service to prevent it from changing the firewall rules during test setup...")
+        self._ssh_client.run_command("systemctl stop waagent", use_sudo=True)
+
+        # Firewalld has been remove from some images in the marketplaces derived from RHEL (these images come with the stale rules, though)
+        # We simulate this setup by uninstalling firewalld.
+        log.info("Uninstalling firewalld...")
+        output = self._ssh_client.run_command("yum remove -y firewalld", use_sudo=True)
+        log.info(f"Firewalld was uninstalled:\n{indent(output)}")
+
+        stale_rules = \
+"""<?xml version="1.0" encoding="utf-8"?>
+<direct>
+<passthrough ipv="ipv4">-t security -I OUTPUT -d 168.63.129.16 -p tcp --destination-port 53 -j ACCEPT</passthrough>
+<passthrough ipv="ipv4">-t security -A OUTPUT -d 168.63.129.16 -p tcp --destination-port 53 -j ACCEPT</passthrough>
+<passthrough ipv="ipv4">-t security -A OUTPUT -d 168.63.129.16 -p tcp -m owner --uid-owner 0 -j ACCEPT</passthrough>
+<passthrough ipv="ipv4">-t security -A OUTPUT -d 168.63.129.16 -p tcp -m conntrack --ctstate INVALID,NEW -j DROP</passthrough>
+</direct>"""
+        log.info("Creating stale permanent firewall rules in /etc/firewalld/direct.xml...")
+        self._ssh_client.run_command("find /etc/firewalld -name 'direct.xml*' -exec rm -f {} \\;", use_sudo=True)
+        output = self._ssh_client.run_command(f"echo '{stale_rules}' | sudo tee /etc/firewalld/direct.xml")
+        log.info(f"Stale firewall rules created:\n{indent(output)}")
+
+        waagent_log_size = self._get_waagent_log_size()
+
+        log.info("Starting waagent service to create waagent-network-setup.service...")
+        self._ssh_client.run_command("systemctl start waagent", use_sudo=True)
+
+        waagent_log = self._wait_for_log_message(waagent_log_size, r"firewalld|waagent-network-setup\.service", "Successfully added and enabled the waagent-network-setup.service")
+        log.info(f"waagent-network-setup.service was installed:\n{indent(waagent_log)}")
+
+        log.info("Re-installing firewalld...")
+        output = self._ssh_client.run_command("yum install -y firewalld", use_sudo=True)
+        log.info(f"Firewalld was installed:\n{output}")
+        log.info("Completed test setup.")
+
+    def _get_waagent_log_size(self) -> int:
+        return int(self._ssh_client.run_command("stat --format '%s' /var/log/waagent.log").rstrip())
+
+    def _wait_for_log_message(self, offset: int, selector_re: str, message: str) -> str:
+        log.info(f"Checking waagent.log starting at offset {offset}")
+        log.info(f"{(offset, selector_re, message)}")
+
+        limit = datetime.now() + timedelta(minutes=5)
+
+        while True:
+            waagent_log = self._ssh_client.run_command(f"tail --bytes=+{offset} /var/log/waagent.log | grep -E -i '{selector_re}' || true")
+            if message in waagent_log:
+                return waagent_log
+            if datetime.now() > limit - timedelta(seconds=30):
+                break
+            log.info(f"Can't find message in Agent's log ('{message}'). Will retry after a short pause.")
+            time.sleep(30)
+        raise TimeoutError(f"Timed out waiting for waagent message '{message}'")
+
+
+if __name__ == "__main__":
+    BootConflicts.run_from_command_line()

--- a/tests_e2e/tests/firewalld/boot_conflicts.py
+++ b/tests_e2e/tests/firewalld/boot_conflicts.py
@@ -75,7 +75,7 @@ class BootConflicts(AgentVmTest):
         log.info("Stopping waagent service to prevent it from changing the firewall rules during test setup...")
         self._ssh_client.run_command("systemctl stop waagent", use_sudo=True)
 
-        # Firewalld has been remove from some images in the marketplaces derived from RHEL (these images come with the stale rules, though)
+        # Firewalld has been removed from some images in the marketplaces derived from RHEL (these images come with the stale rules, though)
         # We simulate this setup by uninstalling firewalld.
         log.info("Uninstalling firewalld...")
         output = self._ssh_client.run_command("yum remove -y firewalld", use_sudo=True)

--- a/tests_e2e/tests/firewalld/boot_conflicts.py
+++ b/tests_e2e/tests/firewalld/boot_conflicts.py
@@ -118,7 +118,7 @@ class BootConflicts(AgentVmTest):
         limit = datetime.now() + timedelta(minutes=5)
 
         while True:
-            waagent_log = self._ssh_client.run_command(f"tail --bytes=+{offset} /var/log/waagent.log | grep -E -i '{selector_re}' || true")
+            waagent_log = self._ssh_client.run_command(f"tail --bytes=+{offset} /var/log/waagent.log | tr '\0' 0 | grep -E '{selector_re}' || true")  # some tests write NULL characters to the log; we convert them to '0'
             if re.search(message, waagent_log) is not None:
                 return waagent_log
             if datetime.now() > limit - timedelta(seconds=30):

--- a/tests_e2e/tests/firewalld/boot_conflicts.py
+++ b/tests_e2e/tests/firewalld/boot_conflicts.py
@@ -118,7 +118,7 @@ class BootConflicts(AgentVmTest):
         limit = datetime.now() + timedelta(minutes=5)
 
         while True:
-            waagent_log = self._ssh_client.run_command(f"tail --bytes=+{offset} /var/log/waagent.log | tr '\0' 0 | grep -E '{selector_re}' || true")  # some tests write NULL characters to the log; we convert them to '0'
+            waagent_log = self._ssh_client.run_command(f"tail --bytes=+{offset} /var/log/waagent.log | tr -d '\000' | grep -E '{selector_re}' || true")  # some tests write NULL characters to the log; we delete them
             if re.search(message, waagent_log) is not None:
                 return waagent_log
             if datetime.now() > limit - timedelta(seconds=30):

--- a/tests_e2e/tests/firewalld/boot_conflicts.py
+++ b/tests_e2e/tests/firewalld/boot_conflicts.py
@@ -96,7 +96,7 @@ class BootConflicts(AgentVmTest):
 
         waagent_log_size = self._get_waagent_log_size()
 
-        log.info("Starting waagent service to create waagent-network-setup.service...")
+        log.info("Starting waagent service to install waagent-network-setup.service...")
         self._ssh_client.run_command("systemctl start waagent", use_sudo=True)
 
         waagent_log = self._wait_for_log_message(waagent_log_size, r"firewalld|waagent-network-setup\.service", "Successfully added and enabled the waagent-network-setup.service")
@@ -112,7 +112,6 @@ class BootConflicts(AgentVmTest):
 
     def _wait_for_log_message(self, offset: int, selector_re: str, message: str) -> str:
         log.info(f"Checking waagent.log starting at offset {offset}")
-        log.info(f"{(offset, selector_re, message)}")
 
         limit = datetime.now() + timedelta(minutes=5)
 

--- a/tests_e2e/tests/firewalld/boot_conflicts.py
+++ b/tests_e2e/tests/firewalld/boot_conflicts.py
@@ -122,15 +122,16 @@ class BootConflicts(AgentVmTest):
         log.info(f"Checking waagent.log starting at offset {offset}")
 
         limit = datetime.now() + timedelta(minutes=5)
+        delay = timedelta(seconds=15)
 
         while True:
             waagent_log = self._ssh_client.run_command(r"tail --bytes=+{0} /var/log/waagent.log | tr -d '\000' | grep -E '{1}' || true".format(offset, selector_re))  # some tests write NULL characters to the log; we delete them
             if re.search(message, waagent_log) is not None:
                 return waagent_log
-            if datetime.now() > limit - timedelta(seconds=30):
+            if datetime.now() > limit - delay:
                 break
             log.info(f"Can't find message in Agent's log ('{message}'). Will retry after a short pause.")
-            time.sleep(15)
+            time.sleep(delay.seconds)
         raise TimeoutError(f"Timed out waiting for waagent message '{message}'")
 
 

--- a/tests_e2e/tests/lib/logging.py
+++ b/tests_e2e/tests/lib/logging.py
@@ -170,3 +170,5 @@ def set_thread_name(name: str):
         current_thread().name = initial_name
 
 
+def indent(text: str, prefix: str = "\t"):
+    return "\n".join(f"{prefix}{line}" for line in text.splitlines())


### PR DESCRIPTION
When firewalld is not installed/running on the VM, the Agent will install the waagent-network-setup service to setup the firewall rules during boot. However, if firewalld is installed or started after the Agent has installed waagent-network-setup, both services will end up running concurrently during boot, which can lead to an incorrect firewall setup. The waagent-network-setup service should detect this condition and exit without setting up any rules. 

In addition, some RHEL 9 images in the marketplace include a set of stale firewall rules in /etc/firewalld/direct.xml. The test added in this PR verifies that those rules are handled appropriately.