### PR TITLE
Set soft limit for agents' memory cgroup in v2 machines

### DIFF
--- a/azurelinuxagent/common/conf.py
+++ b/azurelinuxagent/common/conf.py
@@ -609,6 +609,15 @@ def get_agent_cpu_quota(conf=__conf__):
     return conf.get_int("Debug.AgentCpuQuota", 50)
 
 
+def get_agent_memory_quota(conf=__conf__):
+    """
+    Memory quota for the agent in Bytes defined as soft limit
+
+    NOTE: This option is experimental and may be removed in later versions of the Agent.
+    """
+    return conf.get_int("Debug.AgentMemoryQuota", 300 * 1024 ** 2)
+
+
 def get_agent_cpu_throttled_time_threshold(conf=__conf__):
     """
     Throttled time threshold for agent cpu in seconds.
@@ -616,15 +625,6 @@ def get_agent_cpu_throttled_time_threshold(conf=__conf__):
     NOTE: This option is experimental and may be removed in later versions of the Agent.
     """
     return conf.get_int("Debug.AgentCpuThrottledTimeThreshold", 120)
-
-
-def get_agent_memory_quota(conf=__conf__):
-    """
-    Memory quota for the agent in bytes.
-
-    NOTE: This option is experimental and may be removed in later versions of the Agent.
-    """
-    return conf.get_int("Debug.AgentMemoryQuota", 30 * 1024 ** 2)
 
 
 def get_enable_agent_memory_usage_check(conf=__conf__):

--- a/azurelinuxagent/ga/cgroupapi.py
+++ b/azurelinuxagent/ga/cgroupapi.py
@@ -159,6 +159,31 @@ class CGroupUtil(object):
             return "unknown"
 
     @staticmethod
+    def get_current_memory_quota(unit_name):
+        """
+        Returns the memory quota for the given unit in bytes, or 'infinity' or 'unknown' if not set.
+        """
+        try:
+            mem_quota = systemd.get_unit_property(unit_name, "MemoryHigh").strip().lower()
+            if mem_quota == "infinity":
+                return mem_quota  # No limit on memory usage
+            elif mem_quota.endswith("k"):
+                mem_quota_bytes = int(mem_quota[:-1]) * 1024
+            elif mem_quota.endswith("m"):
+                mem_quota_bytes = int(mem_quota[:-1]) * 1024 * 1024
+            elif mem_quota.endswith("g"):
+                mem_quota_bytes = int(mem_quota[:-1]) * 1024 * 1024 * 1024
+            elif mem_quota.endswith("t"):
+                mem_quota_bytes = int(mem_quota[:-1]) * 1024 * 1024 * 1024 * 1024
+            else:
+                mem_quota_bytes = mem_quota
+
+            return str(mem_quota_bytes)
+        except Exception as e:
+            log_cgroup_warning("Error parsing current MemoryHigh: {0}".format(ustr(e)))
+            return "unknown"
+
+    @staticmethod
     def has_cpu_quota(unit_name):
         """
         Returns True if quota set for the unit.
@@ -298,6 +323,12 @@ class _SystemdCgroupApi(object):
         raise NotImplementedError()
 
     def can_enforce_cpu(self):
+        """
+        Cgroup version specific. Returns if controller can be used for enforcement
+        """
+        raise NotImplementedError()
+
+    def can_enforce_memory(self):
         """
         Cgroup version specific. Returns if controller can be used for enforcement
         """
@@ -509,6 +540,9 @@ class SystemdCgroupApiv1(_SystemdCgroupApi):
     def can_enforce_cpu(self):
         return CgroupV1.CPU_CONTROLLER in self._cgroup_mountpoints
 
+    def can_enforce_memory(self):
+        return False
+
 
 class SystemdCgroupApiv2(_SystemdCgroupApi):
     """
@@ -623,6 +657,9 @@ class SystemdCgroupApiv2(_SystemdCgroupApi):
 
     def can_enforce_cpu(self):
         return CgroupV2.CPU_CONTROLLER in self._controllers_enabled_at_root
+
+    def can_enforce_memory(self):
+        return CgroupV2.MEMORY_CONTROLLER in self._controllers_enabled_at_root
 
 
 class Cgroup(object):

--- a/azurelinuxagent/ga/cgroupapi.py
+++ b/azurelinuxagent/ga/cgroupapi.py
@@ -161,7 +161,7 @@ class CGroupUtil(object):
     @staticmethod
     def get_current_memory_quota(unit_name):
         """
-        Returns the memory quota for the given unit in bytes, or 'infinity' or 'unknown' if not set.
+        Returns the memory quota for the given unit in bytes, or 'infinity' if not set, or 'unknown' if an error occurs.
         """
         try:
             mem_quota = systemd.get_unit_property(unit_name, "MemoryHigh").strip().lower()
@@ -180,7 +180,7 @@ class CGroupUtil(object):
 
             return str(mem_quota_bytes)
         except Exception as e:
-            log_cgroup_warning("Error parsing current MemoryHigh: {0}".format(ustr(e)))
+            log_cgroup_warning("Error in getting current MemoryHigh: {0}".format(ustr(e)))
             return "unknown"
 
     @staticmethod

--- a/azurelinuxagent/ga/cgroupconfigurator.py
+++ b/azurelinuxagent/ga/cgroupconfigurator.py
@@ -36,6 +36,7 @@ from azurelinuxagent.common.version import get_distro
 from azurelinuxagent.common.utils import shellutil, fileutil
 from azurelinuxagent.ga.extensionprocessutil import handle_process_completion
 from azurelinuxagent.common.event import add_event, WALAEventOperation
+from azurelinuxagent.ga.resourcequota import CpuQuota, MemoryQuota, ResourceName
 
 AZURE_SLICE = "azure.slice"
 _AZURE_SLICE_CONTENTS = """
@@ -186,9 +187,10 @@ class CGroupConfigurator(object):
                     for prop in controller.get_unit_properties():
                         log_cgroup_info('Agent {0} unit property value: {1}'.format(prop, systemd.get_unit_property(systemd.get_agent_unit_name(), prop)))
                     if isinstance(controller, _CpuController) and self._cgroups_api.can_enforce_cpu():
-                        self._set_cpu_quota(agent_unit_name, conf.get_agent_cpu_quota())
+                        self._set_resource_quota(agent_unit_name, ResourceName.CPU, conf.get_agent_cpu_quota())
                         controller.track_throttle_time(True)  # CPU controller track the throttle time only when CPU quota is set
-                    elif isinstance(controller, _MemoryController):
+                    elif isinstance(controller, _MemoryController) and self._cgroups_api.can_enforce_memory():
+                        self._set_resource_quota(agent_unit_name, ResourceName.MEMORY, conf.get_agent_memory_quota())
                         self._agent_memory_metrics = controller
                     CGroupsTelemetry.track_cgroup_controller(controller)
 
@@ -201,7 +203,7 @@ class CGroupConfigurator(object):
                 if self._cgroups_api is not None and not self._cgroups_api.can_enforce_cpu():
                     # If agent cgroups are not enabled or quotas not enabled, reset the quota for the agent unit
                     log_cgroup_info("Reset CPU quota if agent cgroups were not enabled for enforcement")
-                    self._reset_cpu_quota(systemd.get_agent_unit_name())
+                    self._reset_resource_quota(systemd.get_agent_unit_name(), ResourceName.CPU, ignore_enforce_check=True)
 
         def _check_cgroups_supported(self):
             distro_supported = CGroupUtil.distro_supported()
@@ -355,7 +357,7 @@ class CGroupConfigurator(object):
                     if len(files_to_cleanup) > 0:
                         log_cgroup_info("Found drop-in files; attempting agent cgroup setup cleanup", send_event=False)
                         self._cleanup_all_files(files_to_cleanup)
-                        self._reset_cpu_quota(systemd.get_agent_unit_name())
+                        self._reset_resource_quota(systemd.get_agent_unit_name(), ResourceName.CPU, ignore_enforce_check=True)
 
             except Exception as err:
                 logger.warn("Error while resetting the quotas: {0}".format(err))
@@ -448,7 +450,7 @@ class CGroupConfigurator(object):
             try:
                 if disable_cgroups == DisableCgroups.ALL:  # disable all
                     # Reset quotas
-                    self._reset_cpu_quota(systemd.get_agent_unit_name())
+                    self._reset_resource_quota(systemd.get_agent_unit_name(), ResourceName.ALL)
                     extension_services = self.get_extension_services_list()
                     for extension in extension_services:
                         log_cgroup_info("Resetting extension : {0} and it's services: {1} Quota".format(extension, extension_services[extension]), send_event=False)
@@ -458,7 +460,7 @@ class CGroupConfigurator(object):
                     self._agent_cgroups_enabled = False
                     self._extensions_cgroups_enabled = False
                 elif disable_cgroups == DisableCgroups.AGENT:  # disable agent
-                    self._reset_cpu_quota(systemd.get_agent_unit_name())
+                    self._reset_resource_quota(systemd.get_agent_unit_name(), ResourceName.ALL)
                     agent_controllers = self._agent_cgroup.get_controllers()
                     for controller in agent_controllers:
                         if isinstance(controller, _CpuController):
@@ -470,45 +472,81 @@ class CGroupConfigurator(object):
             except Exception as exception:
                 log_cgroup_warning("Error disabling cgroups: {0}".format(ustr(exception)))
 
-        def _set_cpu_quota(self, unit_name, quota):
-            """
-            Sets CPU quota to the given percentage (100% == 1 CPU)
+        def _get_resource_quotas(self):
+            if self._cgroups_api is None:
+                return []
+            return [CpuQuota(self._cgroups_api), MemoryQuota(self._cgroups_api)]
 
-            NOTE: This is done using a systemtcl set-property --runtime; any local overrides in /etc folder on the VM will take precedence
-            over this setting.
+        def _set_resource_quota(self, unit_name, resource_type, quota):
             """
-            if self._cgroups_api.can_enforce_cpu():
-                quota_percentage = "{0}%".format(quota)
-                log_cgroup_info("Setting {0}'s CPUQuota to {1}".format(unit_name, quota_percentage))
-                CGroupConfigurator._Impl._try_set_cpu_quota(unit_name, quota_percentage)
-
-        def _reset_cpu_quota(self, unit_name):
+            Sets the quota for the given resource type ('CPU', 'Memory', or 'All').
             """
-            Removes any CPUQuota on the agent
-
-            NOTE: This resets the quota on the agent's default dropin file; any local overrides on the VM will take precedence
-            over this setting.
-            """
-            log_cgroup_info("Resetting {0}'s CPUQuota".format(unit_name), send_event=False)
-            if CGroupConfigurator._Impl._try_set_cpu_quota(unit_name, "infinity"): # systemd expresses no-quota as infinity, following the same convention
-                try:
-                    log_cgroup_info('Current CPUQuota: {0}'.format(systemd.get_unit_property(unit_name, "CPUQuotaPerSecUSec")))
-                except Exception as e:
-                    log_cgroup_warning('Failed to get current CPUQuotaPerSecUSec after reset: {0}'.format(ustr(e)))
-
-        # W0238: Unused private member `_Impl.__try_set_cpu_quota(quota)` (unused-private-member)
-        @staticmethod
-        def _try_set_cpu_quota(unit_name, quota):  # pylint: disable=unused-private-member
             try:
-                current_cpu_quota = CGroupUtil.get_current_cpu_quota(unit_name)
-                if current_cpu_quota == quota:
-                    return True
-                quota = quota if quota != "infinity" else ""  # no-quota expressed as empty string while setting property
-                systemd.set_unit_run_time_property(unit_name, "CPUQuota", quota)
+                quotas = self._get_resource_quotas()
+                property_names = []
+                values = []
+                if resource_type == ResourceName.ALL:
+                    for rq in quotas:
+                        if rq.can_enforce():
+                            q = quota.get(rq.name) if isinstance(quota, dict) else quota
+                            value = rq.format(q)
+                            current = rq.get_current_quota(unit_name)
+                            if current != value:
+                                property_names.append(rq.property)
+                                values.append(value)
+                    if property_names:
+                        log_cgroup_info("Setting {0} properties: {1}".format(unit_name, dict(zip(property_names, values))))
+                        systemd.set_unit_run_time_properties(unit_name, property_names, values)
+                else:
+                    for rq in quotas:
+                        if rq.name == resource_type and rq.can_enforce():
+                            value = rq.format(quota)
+                            current = rq.get_current_quota(unit_name)
+                            if current != value:
+                                log_cgroup_info("Setting {0}'s {1} to {2}".format(unit_name, rq.property, value))
+                                systemd.set_unit_run_time_property(unit_name, rq.property, value)
+                            break
             except Exception as exception:
-                log_cgroup_warning('Failed to set CPUQuota: {0}'.format(ustr(exception)))
-                return False
-            return True
+                log_cgroup_warning('Failed to set resource quota: {0}'.format(ustr(exception)))
+
+        def _reset_resource_quota(self, unit_name, resource_type, ignore_enforce_check=False):
+            """
+            Resets the quota for the given resource type ('CPU', 'Memory', or 'All').
+            Only resets if the current value is not already 'infinity'.
+            """
+            try:
+                quotas = self._get_resource_quotas()
+                if resource_type == ResourceName.ALL:
+                    property_names = []
+                    values = []
+                    for rq in quotas:
+                        if ignore_enforce_check or rq.can_enforce():
+                            current = rq.get_current_quota(unit_name)
+                            if current != "infinity":
+                                property_names.append(rq.property)
+                                values.append("")  # systemd convention
+                    if property_names:
+                        log_cgroup_info("Resetting {0} properties: {1}".format(unit_name, property_names), send_event=False)
+                        systemd.set_unit_run_time_properties(unit_name, property_names, values)
+
+                        for rq in quotas:
+                            current = rq.get_current_quota(unit_name)
+                            log_cgroup_info('Current {0}: {1}'.format(rq.property, current))
+
+                else:
+                    for rq in quotas:
+                        if rq.name == resource_type and (ignore_enforce_check or rq.can_enforce()):
+                            current = rq.get_current_quota(unit_name)
+                            if current != "infinity":
+                                log_cgroup_info("Resetting {0}'s {1}".format(unit_name, rq.property))
+                                systemd.set_unit_run_time_property(unit_name, rq.property, "")
+
+                                current = rq.get_current_quota(unit_name)
+                                log_cgroup_info('Current {0}: {1}'.format(rq.property, current))
+                            break
+
+            except Exception as exception:
+                log_cgroup_warning('Failed to reset resource quota: {0}'.format(ustr(exception)))
 
         def _check_fails_if_processes_found_in_agent_cgroup_before_enable(self, agent_slice):
             """
@@ -535,6 +573,8 @@ class CGroupConfigurator(object):
             try:
                 if not self.enabled():
                     return
+
+                self._report_agent_cgroups_memory_usage(cgroup_metrics)
 
                 errors = []
 
@@ -734,6 +774,23 @@ class CGroupConfigurator(object):
                     add_event(op=WALAEventOperation.CGroupsInfo, message=msg)
 
         @staticmethod
+        def _report_agent_cgroups_memory_usage(cgroup_metrics):
+            """
+            Reports the agent's current memory usage when it exceeds the configured limit.
+            """
+            limit_in_bytes = conf.get_agent_memory_quota()
+            current_usage = 0
+            for metric in cgroup_metrics:
+                if metric.counter == MetricsCounter.TOTAL_MEM_USAGE:
+                    current_usage += metric.value
+                elif metric.counter == MetricsCounter.SWAP_MEM_USAGE:
+                    current_usage += metric.value
+
+            if current_usage > limit_in_bytes:
+                msg = "Agent memory usage is {0} bytes which is over the configured limit of {1} bytes.".format(current_usage, limit_in_bytes)
+                add_event(op=WALAEventOperation.CGroupsInfo, message=msg)
+
+        @staticmethod
         def _check_agent_throttled_time(cgroup_metrics):
             for metric in cgroup_metrics:
                 if metric.instance == AGENT_NAME_TELEMETRY and metric.counter == MetricsCounter.THROTTLED_TIME:
@@ -912,7 +969,7 @@ class CGroupConfigurator(object):
             """
             if self.enabled():
                 try:
-                    self._reset_cpu_quota(CGroupUtil.get_extension_slice_name(extension_name))
+                    self._reset_resource_quota(CGroupUtil.get_extension_slice_name(extension_name), ResourceName.CPU)
                 except Exception as exception:
                     log_cgroup_warning('Failed to reset for {0}: {1}'.format(extension_name, ustr(exception)))
 
@@ -975,7 +1032,7 @@ class CGroupConfigurator(object):
                     for service in services_list:
                         service_name = service.get('name', None)
                         if service_name is not None and systemd.is_unit_loaded(service_name):
-                            self._reset_cpu_quota(service_name)
+                            self._reset_resource_quota(service_name, ResourceName.CPU)
                 except Exception as exception:
                     log_cgroup_warning('Failed to reset for {0} : {1}'.format(service_name, ustr(exception)))
 

--- a/azurelinuxagent/ga/cgroupconfigurator.py
+++ b/azurelinuxagent/ga/cgroupconfigurator.py
@@ -335,6 +335,9 @@ class CGroupConfigurator(object):
                         return
 
         def _reset_agent_cgroup_setup(self):
+            """
+            This clean up added when cpu support added in distro but later distro removed from the supported list. At that time, memory support not added, so no need to reset quota.
+            """
             try:
                 agent_drop_in_path = systemd.get_agent_drop_in_path()
                 if os.path.exists(agent_drop_in_path) and os.path.isdir(agent_drop_in_path) and len(os.listdir(agent_drop_in_path)) > 0:
@@ -448,9 +451,10 @@ class CGroupConfigurator(object):
             significant delay to the extension execution.
             """
             try:
+                # Reset quotas for agent
+                self._reset_resource_quota(systemd.get_agent_unit_name(), ResourceName.ALL)
                 if disable_cgroups == DisableCgroups.ALL:  # disable all
-                    # Reset quotas
-                    self._reset_resource_quota(systemd.get_agent_unit_name(), ResourceName.ALL)
+                    # Reset quotas for extensions
                     extension_services = self.get_extension_services_list()
                     for extension in extension_services:
                         log_cgroup_info("Resetting extension : {0} and it's services: {1} Quota".format(extension, extension_services[extension]), send_event=False)
@@ -460,90 +464,75 @@ class CGroupConfigurator(object):
                     self._agent_cgroups_enabled = False
                     self._extensions_cgroups_enabled = False
                 elif disable_cgroups == DisableCgroups.AGENT:  # disable agent
-                    self._reset_resource_quota(systemd.get_agent_unit_name(), ResourceName.ALL)
                     agent_controllers = self._agent_cgroup.get_controllers()
                     for controller in agent_controllers:
-                        if isinstance(controller, _CpuController):
-                            CGroupsTelemetry.stop_tracking(controller)
-                            break
+                        CGroupsTelemetry.stop_tracking(controller)
                     self._agent_cgroups_enabled = False
 
                 log_cgroup_warning("Disabling resource usage monitoring. Reason: {0}".format(reason), op=WALAEventOperation.CGroupsDisabled)
             except Exception as exception:
                 log_cgroup_warning("Error disabling cgroups: {0}".format(ustr(exception)))
 
-        def _get_resource_quotas(self):
+        def _get_resource_quotas(self, resource_name):
             if self._cgroups_api is None:
                 return []
-            return [CpuQuota(self._cgroups_api), MemoryQuota(self._cgroups_api)]
+            if resource_name == ResourceName.CPU:
+                return [CpuQuota(self._cgroups_api)]
+            elif resource_name == ResourceName.MEMORY:
+                return [MemoryQuota(self._cgroups_api)]
+            elif resource_name == ResourceName.ALL:
+                return [CpuQuota(self._cgroups_api), MemoryQuota(self._cgroups_api)]
 
-        def _set_resource_quota(self, unit_name, resource_type, quota):
+            return []
+
+        def _set_resource_quota(self, unit_name, new_quotas):
             """
             Sets the quota for the given resource type ('CPU', 'Memory', or 'All').
+            new_quotas is a dictionary with resource names as keys and quota values as values.
             """
             try:
-                quotas = self._get_resource_quotas()
+                quotas = self._get_resource_quotas(ResourceName.ALL)
                 property_names = []
                 values = []
-                if resource_type == ResourceName.ALL:
-                    for rq in quotas:
-                        if rq.can_enforce():
-                            q = quota.get(rq.name) if isinstance(quota, dict) else quota
-                            value = rq.format(q)
-                            current = rq.get_current_quota(unit_name)
-                            if current != value:
-                                property_names.append(rq.property)
-                                values.append(value)
-                    if property_names:
-                        log_cgroup_info("Setting {0} properties: {1}".format(unit_name, dict(zip(property_names, values))))
-                        systemd.set_unit_run_time_properties(unit_name, property_names, values)
-                else:
-                    for rq in quotas:
-                        if rq.name == resource_type and rq.can_enforce():
-                            value = rq.format(quota)
-                            current = rq.get_current_quota(unit_name)
-                            if current != value:
-                                log_cgroup_info("Setting {0}'s {1} to {2}".format(unit_name, rq.property, value))
-                                systemd.set_unit_run_time_property(unit_name, rq.property, value)
-                            break
+                for rq in quotas:
+                    if rq.can_enforce():
+                        q = new_quotas.get(rq.name)
+                        value = rq.format(q)
+                        current = rq.get_current_quota(unit_name)
+                        if current != value:
+                            property_names.append(rq.property)
+                            values.append(value)
+                if property_names:
+                    log_cgroup_info("Setting {0} properties: {1}".format(unit_name, dict(zip(property_names, values))))
+                    systemd.set_unit_run_time_properties(unit_name, property_names, values)
+
             except Exception as exception:
                 log_cgroup_warning('Failed to set resource quota: {0}'.format(ustr(exception)))
 
-        def _reset_resource_quota(self, unit_name, resource_type, ignore_enforce_check=False):
+        def _reset_resource_quota(self, unit_name, resource_name, ignore_enforce_check=False):
             """
             Resets the quota for the given resource type ('CPU', 'Memory', or 'All').
             Only resets if the current value is not already 'infinity'.
+
+            ignore_enforce_check - True In some scenarios(e.g. distro removed from supported list in new agent), we want to reset the quota even if the quota is not enforced.
             """
             try:
-                quotas = self._get_resource_quotas()
-                if resource_type == ResourceName.ALL:
-                    property_names = []
-                    values = []
+                quotas = self._get_resource_quotas(resource_name)
+                property_names = []
+                values = []
+                for rq in quotas:
+                    if ignore_enforce_check or rq.can_enforce():
+                        current = rq.get_current_quota(unit_name)
+                        if current != "infinity":
+                            property_names.append(rq.property)
+                            values.append("")  # systemd convention
+                if property_names:
+                    log_cgroup_info("Resetting {0} properties: {1}".format(unit_name, property_names), send_event=False)
+                    systemd.set_unit_run_time_properties(unit_name, property_names, values)
+
                     for rq in quotas:
-                        if ignore_enforce_check or rq.can_enforce():
-                            current = rq.get_current_quota(unit_name)
-                            if current != "infinity":
-                                property_names.append(rq.property)
-                                values.append("")  # systemd convention
-                    if property_names:
-                        log_cgroup_info("Resetting {0} properties: {1}".format(unit_name, property_names), send_event=False)
-                        systemd.set_unit_run_time_properties(unit_name, property_names, values)
-
-                        for rq in quotas:
-                            current = rq.get_current_quota(unit_name)
-                            log_cgroup_info('Current {0}: {1}'.format(rq.property, current))
-
-                else:
-                    for rq in quotas:
-                        if rq.name == resource_type and (ignore_enforce_check or rq.can_enforce()):
-                            current = rq.get_current_quota(unit_name)
-                            if current != "infinity":
-                                log_cgroup_info("Resetting {0}'s {1}".format(unit_name, rq.property))
-                                systemd.set_unit_run_time_property(unit_name, rq.property, "")
-
-                                current = rq.get_current_quota(unit_name)
-                                log_cgroup_info('Current {0}: {1}'.format(rq.property, current))
-                            break
+                        current = rq.get_current_quota(unit_name)
+                        log_cgroup_info('Current {0}: {1}'.format(rq.property, current))
 
             except Exception as exception:
                 log_cgroup_warning('Failed to reset resource quota: {0}'.format(ustr(exception)))
@@ -781,9 +770,7 @@ class CGroupConfigurator(object):
             limit_in_bytes = conf.get_agent_memory_quota()
             current_usage = 0
             for metric in cgroup_metrics:
-                if metric.counter == MetricsCounter.TOTAL_MEM_USAGE:
-                    current_usage += metric.value
-                elif metric.counter == MetricsCounter.SWAP_MEM_USAGE:
+                if metric.counter == MetricsCounter.TOTAL_MEM_USAGE or metric.counter == MetricsCounter.SWAP_MEM_USAGE:
                     current_usage += metric.value
 
             if current_usage > limit_in_bytes:

--- a/azurelinuxagent/ga/cgroupconfigurator.py
+++ b/azurelinuxagent/ga/cgroupconfigurator.py
@@ -504,7 +504,7 @@ class CGroupConfigurator(object):
                         if current != value:
                             property_names.append(rq.property)
                             values.append(value)
-                if property_names:
+                if len(property_names) > 0:
                     log_cgroup_info("Setting {0} properties: {1}".format(unit_name, dict(zip(property_names, values))))
                     systemd.set_unit_run_time_properties(unit_name, property_names, values)
 
@@ -528,7 +528,7 @@ class CGroupConfigurator(object):
                         if current != "infinity":
                             property_names.append(rq.property)
                             values.append("")  # systemd convention
-                if property_names:
+                if len(property_names) > 0:
                     log_cgroup_info("Resetting {0} properties: {1}".format(unit_name, property_names), send_event=False)
                     systemd.set_unit_run_time_properties(unit_name, property_names, values)
 

--- a/azurelinuxagent/ga/cgroupconfigurator.py
+++ b/azurelinuxagent/ga/cgroupconfigurator.py
@@ -187,10 +187,10 @@ class CGroupConfigurator(object):
                     for prop in controller.get_unit_properties():
                         log_cgroup_info('Agent {0} unit property value: {1}'.format(prop, systemd.get_unit_property(systemd.get_agent_unit_name(), prop)))
                     if isinstance(controller, _CpuController) and self._cgroups_api.can_enforce_cpu():
-                        self._set_resource_quota(agent_unit_name, ResourceName.CPU, conf.get_agent_cpu_quota())
+                        self._set_resource_quota(agent_unit_name, {ResourceName.CPU:conf.get_agent_cpu_quota()})
                         controller.track_throttle_time(True)  # CPU controller track the throttle time only when CPU quota is set
                     elif isinstance(controller, _MemoryController) and self._cgroups_api.can_enforce_memory():
-                        self._set_resource_quota(agent_unit_name, ResourceName.MEMORY, conf.get_agent_memory_quota())
+                        self._set_resource_quota(agent_unit_name, {ResourceName.MEMORY:conf.get_agent_memory_quota()})
                         self._agent_memory_metrics = controller
                     CGroupsTelemetry.track_cgroup_controller(controller)
 
@@ -336,7 +336,7 @@ class CGroupConfigurator(object):
 
         def _reset_agent_cgroup_setup(self):
             """
-            This clean up added when cpu support added in distro but later distro removed from the supported list. At that time, memory support not added, so no need to reset quota.
+            This clean up added when cpu support added in distro but later distro removed from the supported list. At that time, memory support was not added, so no need to reset memory quota.
             """
             try:
                 agent_drop_in_path = systemd.get_agent_drop_in_path()
@@ -466,7 +466,9 @@ class CGroupConfigurator(object):
                 elif disable_cgroups == DisableCgroups.AGENT:  # disable agent
                     agent_controllers = self._agent_cgroup.get_controllers()
                     for controller in agent_controllers:
-                        CGroupsTelemetry.stop_tracking(controller)
+                        if isinstance(controller, _CpuController):
+                            CGroupsTelemetry.stop_tracking(controller)
+                            break
                     self._agent_cgroups_enabled = False
 
                 log_cgroup_warning("Disabling resource usage monitoring. Reason: {0}".format(reason), op=WALAEventOperation.CGroupsDisabled)
@@ -495,7 +497,7 @@ class CGroupConfigurator(object):
                 property_names = []
                 values = []
                 for rq in quotas:
-                    if rq.can_enforce():
+                    if rq.can_enforce() and rq.name in new_quotas:
                         q = new_quotas.get(rq.name)
                         value = rq.format(q)
                         current = rq.get_current_quota(unit_name)
@@ -531,8 +533,9 @@ class CGroupConfigurator(object):
                     systemd.set_unit_run_time_properties(unit_name, property_names, values)
 
                     for rq in quotas:
-                        current = rq.get_current_quota(unit_name)
-                        log_cgroup_info('Current {0}: {1}'.format(rq.property, current))
+                        if rq.property in property_names:
+                            current = rq.get_current_quota(unit_name)
+                            log_cgroup_info('Current {0}: {1}'.format(rq.property, current))
 
             except Exception as exception:
                 log_cgroup_warning('Failed to reset resource quota: {0}'.format(ustr(exception)))

--- a/azurelinuxagent/ga/cgroupcontroller.py
+++ b/azurelinuxagent/ga/cgroupcontroller.py
@@ -25,7 +25,6 @@ from azurelinuxagent.common.future import ustr
 from azurelinuxagent.common.utils import fileutil
 
 _REPORT_EVERY_HOUR = timedelta(hours=1)
-_DEFAULT_REPORT_PERIOD = timedelta(seconds=conf.get_cgroup_check_period())
 
 AGENT_NAME_TELEMETRY = "walinuxagent.service"  # Name used for telemetry; it needs to be consistent even if the name of the service changes
 AGENT_LOG_COLLECTOR = "azure-walinuxagent-logcollector"
@@ -40,12 +39,12 @@ class MetricValue(object):
     Class for defining all the required metric fields to send telemetry.
     """
 
-    def __init__(self, category, counter, instance, value, report_period=_DEFAULT_REPORT_PERIOD):
+    def __init__(self, category, counter, instance, value, report_period=None):
         self._category = category
         self._counter = counter
         self._instance = instance
         self._value = value
-        self._report_period = report_period
+        self._report_period = timedelta(seconds=conf.get_cgroup_check_period()) if report_period is None else report_period
 
     @property
     def category(self):
@@ -82,6 +81,7 @@ class MetricsCounter(object):
     MAX_MEM_USAGE = "Max Memory Usage (B)"
     SWAP_MEM_USAGE = "Swap Memory Usage (B)"
     MEM_THROTTLED = "Total Memory Throttled Events"
+    MEM_PRESSURE = "Memory Pressure (s)"
     AVAILABLE_MEM = "Available Memory (MB)"
     USED_MEM = "Used Memory (MB)"
 

--- a/azurelinuxagent/ga/memorycontroller.py
+++ b/azurelinuxagent/ga/memorycontroller.py
@@ -118,7 +118,7 @@ class _MemoryController(_CgroupController):
         ]
 
     def get_unit_properties(self):
-        return["MemoryAccounting"]
+        return ["MemoryAccounting"]
 
     def get_controller_type(self):
         return "memory"
@@ -157,6 +157,39 @@ class MemoryControllerV2(_MemoryController):
     def get_memory_usage(self):
         # In v2, cache memory is reported in the 'file' counter
         return self._get_memory_stat_counter("anon"), self._get_memory_stat_counter("file")
+
+    def get_unit_properties(self):
+        properties = super(MemoryControllerV2, self).get_unit_properties()
+        properties.append("MemoryHigh")
+        return properties
+
+    def get_memory_pressure_events(self):
+        """
+        We use the share of time in which processes of the cgroup have experienced memory pressure.
+        :return: Total time some processes stalled due to memory pressure in last 300 seconds
+        :rtype: int
+        """
+        try:
+            with open(os.path.join(self.path, 'memory.pressure')) as memory_events:
+                #
+                # Sample file:
+                #   # cat memory.pressure
+                #   some avg10=0.00 avg60=0.00 avg300=0.00 total=0
+                #   full avg10=0.00 avg60=0.00 avg300=0.00 total=0
+                #
+                for line in memory_events:
+                    match = re.search(r'avg300=([0-9.]+)', line)
+                    if match is not None:
+                        percentage = float(match.group(1))
+                        time_spent = 300 * (percentage / 100)
+                        return round(time_spent,  2)
+        except (IOError, OSError) as e:
+            if e.errno != errno.ENOENT:  # File is not present in some distros, so we do not raise in that case
+                raise CGroupsException("Failed to read memory.pressure: {0}".format(ustr(e)))
+        except Exception as e:
+            raise CGroupsException("Failed to read memory.pressure: {0}".format(ustr(e)))
+
+        return float(0)
 
     def get_memory_throttled_events(self):
         """
@@ -220,4 +253,7 @@ class MemoryControllerV2(_MemoryController):
         throttled_value = MetricValue(MetricsCategory.MEMORY_CATEGORY, MetricsCounter.MEM_THROTTLED, self.name,
                                       self.get_memory_throttled_events())
         metrics.append(throttled_value)
+        pressure_value = self.get_memory_pressure_events()
+        if pressure_value > float(0):  # Only report if there is any memory pressure
+            metrics.append(MetricValue(MetricsCategory.MEMORY_CATEGORY, MetricsCounter.MEM_PRESSURE, self.name, pressure_value))
         return metrics

--- a/azurelinuxagent/ga/memorycontroller.py
+++ b/azurelinuxagent/ga/memorycontroller.py
@@ -168,8 +168,8 @@ class MemoryControllerV2(_MemoryController):
         We use the share of time in which processes of the cgroup have experienced memory pressure.
         :return: Total time some processes stalled due to memory pressure in last 300 seconds
         :rtype: float
-        Note: we get 0 if process not stalled or we return explict 0 if file is not present as it is not supported in some distros.
-        But we don't consider 0 values in the metrics report as they are not meaningful data, so don't need to worry about false zeros for now.
+        Note: we get 0 if process not stalled or we return explict 0 if file is not present which is expected in some distros.
+        But we don't consider 0 values in the metrics report as they are not meaningful data, so no need to worry about false zeros.
         """
         try:
             with open(os.path.join(self.path, 'memory.pressure')) as memory_pressure:

--- a/azurelinuxagent/ga/memorycontroller.py
+++ b/azurelinuxagent/ga/memorycontroller.py
@@ -167,17 +167,19 @@ class MemoryControllerV2(_MemoryController):
         """
         We use the share of time in which processes of the cgroup have experienced memory pressure.
         :return: Total time some processes stalled due to memory pressure in last 300 seconds
-        :rtype: int
+        :rtype: float
+        Note: we get 0 if process not stalled or we return explict 0 if file is not present as it is not supported in some distros.
+        But we don't consider 0 values in the metrics report as they are not meaningful data, so don't need to worry about false zeros for now.
         """
         try:
-            with open(os.path.join(self.path, 'memory.pressure')) as memory_events:
+            with open(os.path.join(self.path, 'memory.pressure')) as memory_pressure:
                 #
                 # Sample file:
                 #   # cat memory.pressure
                 #   some avg10=0.00 avg60=0.00 avg300=0.00 total=0
                 #   full avg10=0.00 avg60=0.00 avg300=0.00 total=0
                 #
-                for line in memory_events:
+                for line in memory_pressure:
                     match = re.search(r'avg300=([0-9.]+)', line)
                     if match is not None:
                         percentage = float(match.group(1))

--- a/azurelinuxagent/ga/resourcequota.py
+++ b/azurelinuxagent/ga/resourcequota.py
@@ -30,35 +30,55 @@ class ResourceQuota(object):
     Represents a resource quota configuration
     1. name: Resource name (CPU, Memory, etc)
     2. property: The cgroup property name associated with the resource quota
-    3. format: A function that formats the quota value setting
-    4. can_enforce: A function that checks if the resource quota can be enforced
-    5. get_current_quota: A function that retrieves the current quota setting
     """
-    def __init__(self, name, property_name, format_func, can_enforce_func, get_current_func):
+    def __init__(self, name, property_name):
         self.name = name
         self.property = property_name
-        self.format = format_func
-        self.can_enforce = can_enforce_func
-        self.get_current_quota = get_current_func
+    def format(self, quota):
+        """
+        function that formats the quota value setting
+        """
+        raise NotImplementedError()
+
+    def can_enforce(self):
+        """
+        function that checks if the resource quota can be enforced
+        """
+        raise NotImplementedError()
+
+    def get_current_quota(self, unit_name):
+        """
+        function that retrieves the current quota setting
+        """
+        raise NotImplementedError()
 
 
 class CpuQuota(ResourceQuota):
     def __init__(self, cgroups_api):
-        super(CpuQuota, self).__init__(
-            ResourceName.CPU,
-            "CPUQuota",
-            "{0}%".format,
-            cgroups_api.can_enforce_cpu,
-            CGroupUtil.get_current_cpu_quota
-        )
+        super(CpuQuota, self).__init__(ResourceName.CPU,"CPUQuota")
+        self._cgroups_api = cgroups_api
+
+    def format(self, quota):
+        return "{0}%".format(quota)
+
+    def can_enforce(self):
+        return self._cgroups_api.can_enforce_cpu()
+
+    def get_current_quota(self, unit_name):
+        return CGroupUtil.get_current_cpu_quota(unit_name)
 
 
 class MemoryQuota(ResourceQuota):
     def __init__(self, cgroups_api):
-        super(MemoryQuota, self).__init__(
-            ResourceName.MEMORY,
-            "MemoryHigh",
-            "{0}".format,
-            cgroups_api.can_enforce_memory,
-            CGroupUtil.get_current_memory_quota
-        )
+        super(MemoryQuota, self).__init__(ResourceName.MEMORY,"MemoryHigh")
+        self._cgroups_api = cgroups_api
+
+    def format(self, quota):
+        return "{0}".format(quota)
+
+    def can_enforce(self):
+        return self._cgroups_api.can_enforce_memory()
+
+    def get_current_quota(self, unit_name):
+        return CGroupUtil.get_current_memory_quota(unit_name)
+

--- a/azurelinuxagent/ga/resourcequota.py
+++ b/azurelinuxagent/ga/resourcequota.py
@@ -1,0 +1,64 @@
+# Microsoft Azure Linux Agent
+#
+# Copyright 2020 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Requires Python 2.6+ and Openssl 1.0+
+
+from azurelinuxagent.ga.cgroupapi import CGroupUtil
+
+
+class ResourceName(object):
+    CPU = "CPU"
+    MEMORY = "Memory"
+    ALL = "All"
+
+
+class ResourceQuota(object):
+    """
+    Represents a resource quota configuration
+    1. name: Resource name (CPU, Memory, etc)
+    2. property: The cgroup property name associated with the resource quota
+    3. format: A function that formats the quota value setting
+    4. can_enforce: A function that checks if the resource quota can be enforced
+    5. get_current_quota: A function that retrieves the current quota setting
+    """
+    def __init__(self, name, property_name, format_func, can_enforce_func, get_current_func):
+        self.name = name
+        self.property = property_name
+        self.format = format_func
+        self.can_enforce = can_enforce_func
+        self.get_current_quota = get_current_func
+
+
+class CpuQuota(ResourceQuota):
+    def __init__(self, cgroups_api):
+        super(CpuQuota, self).__init__(
+            ResourceName.CPU,
+            "CPUQuota",
+            "{0}%".format,
+            cgroups_api.can_enforce_cpu,
+            CGroupUtil.get_current_cpu_quota
+        )
+
+
+class MemoryQuota(ResourceQuota):
+    def __init__(self, cgroups_api):
+        super(MemoryQuota, self).__init__(
+            ResourceName.MEMORY,
+            "MemoryHigh",
+            "{0}".format,
+            cgroups_api.can_enforce_memory,
+            CGroupUtil.get_current_memory_quota
+        )

--- a/tests/data/cgroups/v2/memory.pressure
+++ b/tests/data/cgroups/v2/memory.pressure
@@ -1,0 +1,2 @@
+some avg10=0.00 avg60=0.00 avg300=5.00 total=0
+full avg10=0.00 avg60=0.00 avg300=0.00 total=0

--- a/tests/ga/test_memorycontroller.py
+++ b/tests/ga/test_memorycontroller.py
@@ -87,6 +87,9 @@ class TestMemoryControllerV2(AgentTestCase):
         memory_throttled_events = test_mem_controller.get_memory_throttled_events()
         self.assertEqual(9, memory_throttled_events)
 
+        memory_pressure_events = test_mem_controller.get_memory_pressure_events()
+        self.assertEqual(15.00, memory_pressure_events)
+
     def test_get_metrics_v2_when_files_not_present(self):
         test_mem_controller = MemoryControllerV2("test_extension", os.path.join(data_dir, "cgroups"))
 
@@ -110,7 +113,10 @@ class TestMemoryControllerV2(AgentTestCase):
 
         self.assertEqual(e.exception.errno, errno.ENOENT)
 
-    def test_get_memory_usage_v1_counters_not_found(self):
+        # Not raising IOError for memory pressure events as the file is optional in cgroup v2
+        test_mem_controller.get_memory_pressure_events()
+
+    def test_get_memory_usage_v2_counters_not_found(self):
         test_stat_file = os.path.join(self.tmp_dir, "memory.stat")
         shutil.copyfile(os.path.join(data_dir, "cgroups", "v2", "memory.stat_missing"), test_stat_file)
         test_events_file = os.path.join(self.tmp_dir, "memory.events")

--- a/tests_e2e/test_suites/agent_cgroups.yml
+++ b/tests_e2e/test_suites/agent_cgroups.yml
@@ -6,6 +6,7 @@ name: "AgentCgroups"
 tests:
   - "agent_cgroups/agent_cgroups.py"
   - "agent_cgroups/agent_cpu_quota.py"
+  - "agent_cgroups/agent_memory_quota.py"
   - "agent_cgroups/agent_cgroups_process_check.py"
 images: "cgroups-endorsed"
 owns_vm: true

--- a/tests_e2e/tests/agent_cgroups/agent_memory_quota.py
+++ b/tests_e2e/tests/agent_cgroups/agent_memory_quota.py
@@ -1,0 +1,21 @@
+from tests_e2e.tests.lib.agent_test import AgentVmTest
+from tests_e2e.tests.lib.agent_test_context import AgentVmTestContext
+from tests_e2e.tests.lib.logging import log
+
+
+class AgentMemoryQuota(AgentVmTest):
+    """
+    The test verify that the agent detects when it is throttled for using too much Memory, that it detects processes that do belong to the agent's cgroup, and that resource metrics are generated.
+    """
+    def __init__(self, context: AgentVmTestContext):
+        super().__init__(context)
+        self._ssh_client = self._context.create_ssh_client()
+
+    def run(self):
+        log.info("=====Validating agent memory quota checks")
+        self._run_remote_test(self._ssh_client, "agent_memory_quota-check_agent_memory_quota.py", use_sudo=True)
+        log.info("Successfully Verified that agent running in expected Memory quotas")
+
+
+if __name__ == "__main__":
+    AgentMemoryQuota.run_from_command_line()

--- a/tests_e2e/tests/lib/agent_log.py
+++ b/tests_e2e/tests/lib/agent_log.py
@@ -387,6 +387,11 @@ class AgentLog(object):
             {'message': r"Error parsing current CPUQuotaPerSecUSec: (could not convert string to float|invalid literal for float)",
              'if': lambda r: re.match(r"((ubuntu16\.04)|(centos7\.9))\D*", "{0}{1}".format(DISTRO_NAME, DISTRO_VERSION), flags=re.IGNORECASE)
             },
+
+            # 2025-12-01T18:53:28.482291Z INFO ExtHandler ExtHandler [CGW] Error parsing current MemoryHigh: Can't find property MemoryHigh of walinuxagent.service
+            {'message': r"Error parsing current MemoryHigh: Can't find property MemoryHigh",
+             'if': lambda r: re.match(r"((ubuntu16\.04)|(centos7\.9))\D*", "{0}{1}".format(DISTRO_NAME, DISTRO_VERSION), flags=re.IGNORECASE)
+            },
             #
             # GuestConfiguration produces a lot of errors in test runs due to issues in the extension. Some samples:
             #

--- a/tests_e2e/tests/lib/agent_log.py
+++ b/tests_e2e/tests/lib/agent_log.py
@@ -387,11 +387,6 @@ class AgentLog(object):
             {'message': r"Error parsing current CPUQuotaPerSecUSec: (could not convert string to float|invalid literal for float)",
              'if': lambda r: re.match(r"((ubuntu16\.04)|(centos7\.9))\D*", "{0}{1}".format(DISTRO_NAME, DISTRO_VERSION), flags=re.IGNORECASE)
             },
-
-            # 2025-12-01T18:53:28.482291Z INFO ExtHandler ExtHandler [CGW] Error parsing current MemoryHigh: Can't find property MemoryHigh of walinuxagent.service
-            {'message': r"Error parsing current MemoryHigh: Can't find property MemoryHigh",
-             'if': lambda r: re.match(r"((ubuntu16\.04)|(centos7\.9))\D*", "{0}{1}".format(DISTRO_NAME, DISTRO_VERSION), flags=re.IGNORECASE)
-            },
             #
             # GuestConfiguration produces a lot of errors in test runs due to issues in the extension. Some samples:
             #

--- a/tests_e2e/tests/lib/cgroup_helpers.py
+++ b/tests_e2e/tests/lib/cgroup_helpers.py
@@ -117,6 +117,20 @@ def verify_agent_cgroup_assigned_correctly():
     log.info("Successfully verified the agent cgroup assigned correctly by systemd\n")
 
 
+def get_agent_memory_quota():
+    """
+    Returns the memory quota for the agent service
+    """
+    output = shellutil.run_command(["systemctl", "show", AGENT_SERVICE_NAME, "--property", "MemoryHigh"])
+    # Output is similar to
+    #   systemctl show walinuxagent --property MemoryLimit
+    #   MemoryLimit=1073741824
+    match = re.match("[^=]+=(?P<value>.+)", output)
+    if match is not None:
+        return match.group('value')
+    return None
+
+
 def get_agent_cpu_quota():
     """
     Returns the cpu quota for the agent service

--- a/tests_e2e/tests/scripts/agent_cgroups_process_check-unknown_process_check.py
+++ b/tests_e2e/tests/scripts/agent_cgroups_process_check-unknown_process_check.py
@@ -38,7 +38,7 @@ def prepare_agent():
                                     "Debug.CgroupDisableOnQuotaCheckFailure=n"])
     log.info("Successfully enabled agent cgroups config flag: {0}".format(result))
 
-    found: bool = retry_if_false(lambda: check_log_message(" Agent cgroups enabled: True", after_timestamp=check_time))
+    found: bool = retry_if_false(lambda: check_log_message("Agent cgroups enabled: True", after_timestamp=check_time))
     if not found:
         fail("Agent cgroups not enabled")
 

--- a/tests_e2e/tests/scripts/agent_cpu_quota-check_agent_cpu_quota.py
+++ b/tests_e2e/tests/scripts/agent_cpu_quota-check_agent_cpu_quota.py
@@ -29,7 +29,7 @@ from azurelinuxagent.common.osutil import systemd
 from azurelinuxagent.common.utils import shellutil
 from tests_e2e.tests.lib.agent_log import AgentLog
 from tests_e2e.tests.lib.cgroup_helpers import check_agent_quota_disabled, \
-    get_agent_cpu_quota, check_log_message
+    get_agent_cpu_quota
 from tests_e2e.tests.lib.logging import log
 from tests_e2e.tests.lib.remote_test import run_remote_test
 from tests_e2e.tests.lib.retry import retry_if_false
@@ -171,27 +171,10 @@ def verify_throttling_time_check_on_agent_cgroups():
         fail("The agent did not disable its CPUQuota: {0}".format(get_agent_cpu_quota()))
 
 
-def cleanup_test_setup():
-    log.info("Cleaning up test setup")
-    drop_in_file = os.path.join(systemd.get_agent_drop_in_path(), "99-ExecStart.conf")
-    if os.path.exists(drop_in_file):
-        log.info("Removing %s...", drop_in_file)
-        os.remove(drop_in_file)
-        shellutil.run_command(["systemctl", "daemon-reload"])
-
-    check_time = datetime.datetime.now(UTC)
-    shellutil.run_command(["agent-service", "restart"])
-
-    found: bool = retry_if_false(lambda: check_log_message(" Agent cgroups enabled: True", after_timestamp=check_time))
-    if not found:
-        fail("Agent cgroups not enabled yet")
-
-
 def main():
     prepare_agent()
     verify_agent_reported_metrics()
     verify_throttling_time_check_on_agent_cgroups()
-    cleanup_test_setup()
 
 
 run_remote_test(main)

--- a/tests_e2e/tests/scripts/agent_cpu_quota-start_service.py
+++ b/tests_e2e/tests/scripts/agent_cpu_quota-start_service.py
@@ -42,6 +42,9 @@ class CpuConsumer(threading.Thread):
                 dd_command = ["dd", "if=/dev/zero", "of=/dev/null"]
                 logger.info("Starting dummy dd command: {0} to stress CPU", ' '.join(dd_command))
                 subprocess.Popen(dd_command)
+                cmd = "dd if=/dev/zero of=/dev/shm/pressure_test bs=1M count=4096"
+                logger.info("Starting dummy command: {0} to stress Memory", cmd)
+                subprocess.Popen(cmd, shell=True)
                 logger.info("dd command completed; sleeping...")
                 i = 0
                 while i < 30 and not self._stopped:

--- a/tests_e2e/tests/scripts/agent_memory_quota-check_agent_memory_quota.py
+++ b/tests_e2e/tests/scripts/agent_memory_quota-check_agent_memory_quota.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env pypy3
+# Microsoft Azure Linux Agent
+#
+# Copyright 2018 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import datetime
+import os
+import re
+import sys
+
+from assertpy import fail
+
+from azurelinuxagent.common.future import UTC
+from azurelinuxagent.common.osutil import systemd
+from azurelinuxagent.common.utils import shellutil
+from tests_e2e.tests.lib.agent_log import AgentLog
+from tests_e2e.tests.lib.cgroup_helpers import check_log_message, get_agent_memory_quota, using_cgroupv2
+
+from tests_e2e.tests.lib.logging import log
+from tests_e2e.tests.lib.remote_test import run_remote_test
+from tests_e2e.tests.lib.retry import retry_if_false
+
+
+def skip_if_distro_not_supports_memory_quota():
+    if not using_cgroupv2():
+        log.info("Skipping  memory quota test as the distro is not using cgroupv2")
+        cleanup_test_setup()
+        sys.exit(0)
+
+
+def prepare_agent():
+    check_time = datetime.datetime.now(UTC)
+    log.info("Executing script update-waagent-conf to enable agent cgroups config flag")
+    result = shellutil.run_command(["update-waagent-conf", "Debug.CgroupCheckPeriod=30", "Debug.CgroupLogMetrics=y",
+                                    "Debug.CgroupDisableOnProcessCheckFailure=n",
+                                    "Debug.CgroupDisableOnQuotaCheckFailure=n",
+                                    "Debug.AgentMemoryQuota=104857600"])
+    log.info("Successfully enabled agent cgroups config flag: {0}".format(result))
+
+    found: bool = retry_if_false(
+        lambda: check_log_message("Agent cgroups enabled: True", after_timestamp=check_time))
+    if not found:
+        fail("Agent cgroups not enabled")
+
+
+def verify_agent_has_memory_quota_set():
+    """
+    This method verifies that the agent's cgroup has memory quota set
+    """
+    log.info("** Verifying agent cgroup has memory quota set")
+
+    def check_memory_quota() -> bool:
+        quota = get_agent_memory_quota()
+        if quota is None or quota == "infinity":
+            return False
+        return True
+
+    found: bool = retry_if_false(check_memory_quota)
+    if found:
+        log.info("Agent Memory Quota: %s", get_agent_memory_quota())
+        log.info("Successfully verified agent cgroup has memory quota set")
+    else:
+        fail("The agent's cgroup doesn't seem to have memory quota set. Agent Memory Quota: {0}".format(get_agent_memory_quota()))
+
+
+def verify_agent_reported_memory_metrics():
+    """
+    This method verifies that the agent reports Memory Usage metrics
+    """
+    log.info("** Verifying agent reported memory metrics")
+    log.info("Parsing agent log for memory metrics")
+    memory_usage = []
+
+    def check_agent_log_for_metrics() -> bool:
+        for record in AgentLog().read():
+            # This regex matches "Memory Usage" with optional (B) and extracts the value
+            match = re.search(r"Memory/.*Memory Usage(?: \(B\))?\s*\[walinuxagent\.service\]\s*=\s*([0-9.]+)", record.message)
+            if match is not None:
+                memory_usage.append(match.group(1))
+        if len(memory_usage) < 1:
+            return False
+        return True
+
+    found: bool = retry_if_false(check_agent_log_for_metrics)
+    if found:
+        log.info("Memory Usage: %s", memory_usage)
+        log.info("Successfully verified agent reported memory usage metrics")
+    else:
+        fail(
+            "The agent doesn't seem to be collecting Memory Usage metrics. Agent found Memory Usage: {0}".format(
+                memory_usage))
+
+
+def verify_memory_throttling_check_on_agent_cgroups():
+    """
+    This method verifies that the agent detects memory throttling on its cgroup
+    """
+    log.info("** Verifying agent detected memory throttling on its cgroup")
+
+    throttled_events = []
+    pressure_time = []
+
+    def check_agent_log_for_metrics() -> bool:
+        for record in AgentLog().read():
+            match = re.search(r"Memory/Total Memory Throttled Events \s*\[walinuxagent.service\]\s*=\s*([0-9.]+)", record.message)
+            if match is not None:
+                throttled_events.append(float(match.group(1)))
+            else:
+                match = re.search(r"Memory/Memory Pressure \(s\)\s*\[walinuxagent.service\]\s*=\s*([0-9.]+)", record.message)
+                if match is not None:
+                    pressure_time.append(float(match.group(1)))
+        if len(pressure_time) < 1 or len(throttled_events) < 1:
+            return False
+        return True
+
+    distro = shellutil.run_command("get_distro.py").rstrip().lower()
+
+    if "rhel" in distro:
+        log.info("Skipping memory throttling check verification on RHEL distros due to known issues with memory pressure file not present.")
+        return
+
+    found: bool = retry_if_false(check_agent_log_for_metrics, delay=60)
+    if found:
+        log.info("Memory Throttle Events: %s", throttled_events)
+        log.info("Memory Pressure Time: %s", pressure_time)
+        log.info("Successfully verified agent reported memory throttling metrics")
+    else:
+        fail(
+            "The agent doesn't seem to be collecting Memory Throttling metrics. Agent found Memory Throttle Events: {0} and Pressure: {1}".format(
+                throttled_events, pressure_time))
+
+
+def cleanup_test_setup():
+    log.info("Cleaning up test setup")
+    drop_in_file = os.path.join(systemd.get_agent_drop_in_path(), "99-ExecStart.conf")
+    if os.path.exists(drop_in_file):
+        log.info("Removing %s...", drop_in_file)
+        os.remove(drop_in_file)
+        shellutil.run_command(["systemctl", "daemon-reload"])
+
+    check_time = datetime.datetime.now(UTC)
+    shellutil.run_command(["agent-service", "restart"])
+
+    found: bool = retry_if_false(lambda: check_log_message(" Agent cgroups enabled: True", after_timestamp=check_time))
+    if not found:
+        fail("Agent cgroups not enabled yet")
+
+
+def main():
+    skip_if_distro_not_supports_memory_quota()
+    prepare_agent()
+    verify_agent_has_memory_quota_set()
+    verify_agent_reported_memory_metrics()
+    verify_memory_throttling_check_on_agent_cgroups()
+    cleanup_test_setup()
+
+
+run_remote_test(main)


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->
<!--
Please add an informative description that covers that changes made by the pull request.
-->
## Description

Set soft limit for agents' memory cgroup in v2 machines to 300 MB as an initial value and also added code to track memory pressure events. This will help evaluate memory usage metrics and pressure events to understand how the agent performs under the limit. Based on the findings, we will define the next plan of action for a long-term solution.

Issue # <!-- if any -->
---
<!--
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->
### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).
---
<!--
This checklist is used to track contributions from distro maintainers.
-->
### Distro maintenance information, if applicable
- [ ] This is a contribution from a distro maintainer
- [ ] The changes in this PR have been taken as a downstream patch (Note: it is not recommended to patch the agent without upstream review and approval)
