### PR TITLE
Disable and enable the agent service in the test agent setup

### DIFF
--- a/tests_e2e/orchestrator/scripts/install-agent
+++ b/tests_e2e/orchestrator/scripts/install-agent
@@ -161,6 +161,9 @@ fi
 #
 echo "========== Installing Agent =========="
 
+# In some distros, e.g. OracleLinux, stopping the agent service is not enough as it gets restarted automatically.
+# So disabling the service to ensure it does not restart during the installation.
+agent-service disable
 agent-service stop
 
 # Rename the previous log to ensure the new log starts with the agent we just installed
@@ -172,6 +175,7 @@ rm -rfv /var/lib/waagent/WALinuxAgent-*
 echo "Installing $package as version $version..."
 unzip.py "$package" "/var/lib/waagent/WALinuxAgent-$version"
 
+agent-service enable
 agent-service start
 
 #


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->
<!--
Please add an informative description that covers that changes made by the pull request.
-->
## Description

In some distros, e.g. OracleLinux, stopping the agent service is not enough as it gets restarted automatically. So disabling the service to ensure it does not restart during the test agent installation

Issue # <!-- if any -->
---
<!--
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->
### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).
---
<!--
This checklist is used to track contributions from distro maintainers.
-->
### Distro maintenance information, if applicable
- [ ] This is a contribution from a distro maintainer
- [ ] The changes in this PR have been taken as a downstream patch (Note: it is not recommended to patch the agent without upstream review and approval)
