### PR TITLE
Fixing CSE deletion in ext_update scenario

### DIFF
--- a/tests_e2e/tests/ext_update/ext_update_failure.py
+++ b/tests_e2e/tests/ext_update/ext_update_failure.py
@@ -61,7 +61,7 @@ class ExtensionUpdateFailureTest(AgentVmTest):
 
             log.info("Modifying existing handler commands (disable operation) in HandlerManifest.json to fail the disable operation during update")
 
-            output = self._ssh_client.run_command(f"ext_update-modify_handler_manifest.py --extension-name '{custom_script}' --properties disableCommand=disablefailed continueOnUpdateFailure=false", use_sudo=True)
+            output = self._ssh_client.run_command(f"ext_update-modify_handler_manifest.py --extension-name {custom_script} --properties disableCommand=disablefailed continueOnUpdateFailure=false", use_sudo=True)
             log.info("Modified handlerManifest.json:\n%s", output)
 
             custom_script_2_1 = VirtualMachineExtensionClient(
@@ -90,10 +90,11 @@ class ExtensionUpdateFailureTest(AgentVmTest):
     def _remove_extensions(self, extensions_to_cleanup):
         extensions_on_vm = self._context.vm.get_extensions().value
         extension_names_on_vm = {ext.name for ext in extensions_on_vm}
+        log.info("Extensions currently on VM: %s", extension_names_on_vm)
 
         for ext_name, ext in extensions_to_cleanup.items():
-            if ext_name in extension_names_on_vm:
-                self._ssh_client.run_command(f"ext_update-modify_handler_manifest.py --extension-name '{ext_name}' --reset", use_sudo=True)
+            if ext._resource_name in extension_names_on_vm:
+                self._ssh_client.run_command(f"ext_update-modify_handler_manifest.py --extension-name {ext_name} --reset", use_sudo=True)
                 ext.delete()
                 log.info("Removed extension %s", ext_name)
 

--- a/tests_e2e/tests/scripts/ext_update-modify_handler_manifest.py
+++ b/tests_e2e/tests/scripts/ext_update-modify_handler_manifest.py
@@ -35,7 +35,7 @@ def main():
     operation = parser.add_argument_group('Main operation')
     operation_parser = operation.add_mutually_exclusive_group(required=True)
     operation_parser.add_argument('--properties', dest='properties', nargs='+', help='List of property=value to update in the handlerManifest file')
-    operation_parser.add_argument("--reset", dest='reset', help='Reset the handlerManifest file to the default values')
+    operation_parser.add_argument("--reset", dest='reset', action='store_true', help='Reset the handlerManifest file to the default values')
 
     args, _ = parser.parse_known_args()
     extension_name = args.extension_name
@@ -53,7 +53,7 @@ def main():
     manifest_file = matched_files[0]
     log.info("HandlerManifest file found for extension '{0}': {1}".format(extension_name, manifest_file))
 
-    if reset is not None:
+    if reset:
         log.info("Resetting handlerManifest file for extension '{0}' to default values".format(extension_name))
         # Reset the handlerManifest file to the default values
         backup_file = manifest_file + ".bak"


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->
<!--
Please add an informative description that covers that changes made by the pull request.
-->
## Description
In ext_update scenario, we make CSE update fail to test some scenario and at the end we clean up cse, so that other tests won't carry this CSE behavior. But cleanup logic has issue, before delete we check if extension that is to be deleted on the vm. Test use full extension name but get extension on vm query returns resource_name of the extension, causing a mismatch.

Issue # <!-- if any -->
---
<!--
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->
### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).
---
<!--
This checklist is used to track contributions from distro maintainers.
-->
### Distro maintenance information, if applicable
- [ ] This is a contribution from a distro maintainer
- [ ] The changes in this PR have been taken as a downstream patch (Note: it is not recommended to patch the agent without upstream review and approval)
