### PR TITLE
Use "iptables -L" to verify the results of "iptables -C"

### DIFF
--- a/azurelinuxagent/agent.py
+++ b/azurelinuxagent/agent.py
@@ -36,7 +36,7 @@ from azurelinuxagent.ga import logcollector, cgroupconfigurator
 from azurelinuxagent.ga.cgroupcontroller import AGENT_LOG_COLLECTOR
 from azurelinuxagent.ga.cpucontroller import _CpuController
 from azurelinuxagent.ga.cgroupapi import create_cgroup_api, InvalidCgroupMountpointException
-from azurelinuxagent.ga.firewall_manager import FirewallManager
+from azurelinuxagent.ga.firewall_manager import FirewallManager, IpTables
 
 import azurelinuxagent.common.conf as conf
 import azurelinuxagent.common.event as event
@@ -317,6 +317,13 @@ class Agent(object):
 
         try:
             firewall_manager = FirewallManager.create(endpoint)
+            if isinstance(firewall_manager, IpTables):
+                try:
+                    logger.info("Attempting to load the conntrack module (iptables -C should not find any matching rules)...")
+                    logger.info("{0}", firewall_manager.load_conntrack())
+                except Exception as e:
+                    logger.warn("Failed to load the conntrack module: {0}", ustr(e))
+
         except Exception as error:
             logger.warn("{0}", ustr(error))
             sys.exit(1)

--- a/azurelinuxagent/agent.py
+++ b/azurelinuxagent/agent.py
@@ -319,7 +319,11 @@ class Agent(object):
             firewall_manager = FirewallManager.create(endpoint)
             if isinstance(firewall_manager, IpTables):
                 try:
-                    logger.info("Attempting to load the conntrack module (iptables -C should not find any matching rules)...")
+                    #
+                    # We execute "iptables -C -m conntrack" to force loading of the conntrack module with the intention of avoiding the
+                    # issue described in IpTables.check().
+                    #
+                    logger.info("Attempting to load the conntrack module (iptables -C should not find any matching rules, so that error can be ignored)...")
                     logger.info("{0}", firewall_manager.load_conntrack())
                 except Exception as e:
                     logger.warn("Failed to load the conntrack module: {0}", ustr(e))

--- a/azurelinuxagent/common/event.py
+++ b/azurelinuxagent/common/event.py
@@ -96,6 +96,7 @@ class WALAEventOperation:
     FetchGoalState = "FetchGoalState"
     Firewall = "Firewall"
     FirewallBootSetup = "FirewallBootSetup"
+    FirewallInconsistency = "FirewallInconsistency"
     GoalState = "GoalState"
     GoalStateCertificates = "GoalStateCertificates"
     GoalStateUnsupportedFeatures = "GoalStateUnsupportedFeatures"

--- a/azurelinuxagent/ga/firewall_manager.py
+++ b/azurelinuxagent/ga/firewall_manager.py
@@ -42,6 +42,25 @@ class FirewallStateError(Exception):
     """
 
 
+class FirewallRulesMissingError(FirewallStateError):
+    """
+    Exception raised when some firewall rules are missing.
+    """
+    def __init__(self, missing_rules):
+        super(FirewallRulesMissingError, self).__init__("The following rules are missing: {0}".format(missing_rules))
+        self.missing_rules = missing_rules
+
+
+class IptablesInconsistencyError(FirewallStateError):
+    """
+    Exception raised when "iptables -C OUTPUT" does not detect a rule, but "iptables -L OUTPUT" reports that it does exist.
+    """
+    def __init__(self, missing_rules, output_chain):
+        super(IptablesInconsistencyError, self).__init__("Inconsistent results from iptables: -C reports that some rules are missing ({0}), but -L shows some of them exist:\n{1}".format(missing_rules, output_chain))
+        self.missing_rules = missing_rules
+        self.output_chain = output_chain
+
+
 class FirewallManager(object):
     """
     FirewallManager abstracts the interface for managing the firewall rules on the WireServer address. Concrete implementations
@@ -138,88 +157,98 @@ class FirewallManager(object):
         raise NotImplementedError()
 
 
-class _FirewallManagerMultipleRules(FirewallManager):
+class _FirewallManagerIndividualRules(FirewallManager):
     """
-    Base class for firewall managers that handle multiple rules, each rule being manipulated with a different command line (e.g. iptables, firewalld)
+    Base class for firewall managers (iptables, firewalld) that manipulate the firewall rules individually when checking/adding/removing them.
     """
+    def __init__(self, wire_server_address):
+        super(_FirewallManagerIndividualRules, self).__init__(wire_server_address)
+        #
+        # We use this array to iterate over all the firewall rules when setting/checking/removing them.
+        # The order of the items is critical since we process each item them sequentially and the firewall rules will follow the order in the array: the first
+        # item will be at the top of the chain, etc.
+        #
+        # Each item in the array is a tuple with the friendly name of the rule and a function that returns the command used to process that rule. This function
+        # takes as argument the option (-A, -C, -D  for iptables and --passthrough, --query-passthrough, --remove-passthrough for firewallcmd) that is passed to
+        # the corresponding command
+        #
+        self._firewall_commands = [
+            (FirewallManager.ACCEPT_DNS, self._get_accept_dns_rule_command),
+            (FirewallManager.ACCEPT, self._get_accept_rule_command),
+            (FirewallManager.DROP, self._get_drop_rule_command)
+        ]
+
+    @property
+    def _append(self):
+        """
+        Command-line option to append a firewall rule.
+        """
+        raise NotImplementedError()
+
+    @property
+    def _check(self):
+        """
+        Command-line option to check for existence of a firewall rule
+        """
+        raise NotImplementedError()
+
+    @property
+    def _delete(self):
+        """
+        Command-line option to delete a firewall rule
+        """
+        raise NotImplementedError()
+
     def setup(self):
-        for command in self._get_commands(self._get_append_command_option()):
-            shellutil.run_command(command[1])
+        for _, get_command in self._firewall_commands:
+            shellutil.run_command(get_command(self._append))
 
     def remove(self):
-        existing_rules = []
-
-        for rule, command in self._get_commands(self._get_check_command_option()):
-            try:
-                shellutil.run_command(command)
-                existing_rules.append(rule)
-            except CommandError as e:
-                if e.returncode == 1:  # rule does not exist
-                    pass
-                else:
-                    raise
-
-        for rule, command in self._get_commands(self._get_delete_command_option()):
-            if rule in existing_rules:
-                self._execute_delete_command(command)
+        for _, get_command in self._firewall_commands:
+            if self._rule_exists(get_command(self._check)):
+                self._delete_rule(get_command(self._delete))
 
     def remove_legacy_rule(self):
-        check_command = self._get_legacy_rule_command(self._get_check_command_option())
-        try:
-            shellutil.run_command(check_command)
-        except CommandError as e:
-            if e.returncode == 1:  # rule does not exist
-                logger.info("Did not find a legacy firewall rule: {0}", check_command)
-                return
-
+        check_command = self._get_legacy_rule_command(self._check)
+        if not self._rule_exists(check_command):
+            logger.info("Did not find a legacy firewall rule: {0}", check_command)
+            return
         logger.info("Found legacy firewall rule: {0}", check_command)
-        delete_command = self._get_legacy_rule_command(self._get_delete_command_option())
-        self._execute_delete_command(delete_command)
-        event.info(WALAEventOperation.Firewall, "Removed legacy firewall rule: {0}", delete_command)
 
-    def _execute_delete_command(self, command):
-        """
-        Executes the delete command; derived classes can customize the behavior if needed (for example, to add retries).
-        """
-        shellutil.run_command(command)
+        delete_command = self._get_legacy_rule_command(self._delete)
+        self._delete_rule(delete_command)
+        event.info(WALAEventOperation.Firewall, "Removed legacy firewall rule: {0}", delete_command)
 
     def check(self):
         missing_rules = []
         existing_rules = []
-        missing_rules_reasons = []
 
-        for rule, command in self._get_commands(self._get_check_command_option()):
-            try:
-                shellutil.run_command(command)
+        for rule, get_command in self._firewall_commands:
+            if self._rule_exists(get_command(self._check)):
                 existing_rules.append(rule)
-            except CommandError as e:
-                if e.returncode == 1:  # rule does not exist
-                    missing_rules.append(rule)
-                    # Issue: Even though the drop rule exists, the agent perceives it as missing when checking all rules.
-                    # This might occur because we mark the rule as missing due to the same error code being returned for other reasons.
-                    # So logging the error message to understand the reason for the rule being marked as missing.
-                    missing_rules_reasons.append(e.stderr)
-                else:
-                    raise
+            else:
+                missing_rules.append(rule)
 
         if len(missing_rules) == 0:  # all rules are present
             return True
 
         if len(existing_rules) > 0:  # some rules are present, but not all
-            raise FirewallStateError("The following rules are missing: {0} due to: {1}".format(missing_rules, missing_rules_reasons))
+            raise FirewallRulesMissingError(missing_rules)
 
         return False
 
-    def _get_commands(self, command_option):
-        """
-        Yields each of the commands needed to set up the firewall rules, using the given command option.
+    @staticmethod
+    def _rule_exists(check_command):
+        try:
+            shellutil.run_command(check_command)
+        except CommandError as e:
+            if e.returncode != 1:  # if 1, the command failed because the rule does not exist
+                raise
+            return False
+        return True
 
-        IMPORTANT: The order in which these rules are returned is critical, since rules are appended sequentially.
-                   The first item in the array will be at the top of the chain, etc.
-        """
-        yield FirewallManager.ACCEPT_DNS, self._get_accept_dns_rule_command(command_option)
-        yield FirewallManager.ACCEPT, self._get_accept_rule_command(command_option)
-        yield FirewallManager.DROP, self._get_drop_rule_command(command_option)
+    def _delete_rule(self, command):
+        raise NotImplementedError()
 
     def _get_accept_dns_rule_command(self, command_option):
         """
@@ -247,34 +276,15 @@ class _FirewallManagerMultipleRules(FirewallManager):
         """
         raise NotImplementedError()
 
-    def _get_append_command_option(self):
-        """
-        Returns the command-line option to append a firewall to the output chain.
-        """
-        raise NotImplementedError()
 
-    def _get_check_command_option(self):
-        """
-        Returns the command-line option to check for existence of rule on the output chain.
-        """
-        raise NotImplementedError()
-
-    def _get_delete_command_option(self):
-        """
-        Returns the command-line option to delete a firewall rule from the output chain.
-        """
-        raise NotImplementedError()
-
-
-class IpTables(_FirewallManagerMultipleRules):
+class IpTables(_FirewallManagerIndividualRules):
     """
     FirewallManager based on the iptables command-line tool.
     """
     def __init__(self, wire_server_address):
         super(IpTables, self).__init__(wire_server_address)
-
         #
-        # The wait option, "-w" was introduced in iptables 1.4.21. Check if we can use it.
+        # Get the version of iptables and check whether we can use the wait option ("-w"), which was introduced in iptables 1.4.21.
         #
         try:
             output = shellutil.run_command(["iptables", "--version"])
@@ -304,11 +314,62 @@ class IpTables(_FirewallManagerMultipleRules):
         else:
             self._base_command = ["iptables", "-t", "security"]
 
+        #
+        # We use these regular expressions to match rules in the output of "iptables -L"
+        #
+        #     # iptables -w -t security -L OUTPUT -nvx
+        #     Chain OUTPUT (policy ACCEPT 1384 packets, 126406 bytes)
+        #         pkts      bytes target     prot opt in     out     source               destination
+        #            0        0 ACCEPT     tcp  --  *      *       0.0.0.0/0            168.63.129.16
+        #            0        0 ACCEPT     tcp  --  *      *       0.0.0.0/0            168.63.129.16        owner UID match 0
+        #            0        0 DROP       tcp  --  *      *       0.0.0.0/0            168.63.129.16        ctstate INVALID,NEW
+        #
+        wire_server_address_regex = wire_server_address.replace('.', r'\.')
+        self._ip_tables_rule_regex = {
+            FirewallManager.ACCEPT_DNS: r'\sACCEPT\s+tcp\s+.+\s{0}\s+tcp dpt:53'.format(wire_server_address_regex),
+            FirewallManager.ACCEPT:     r'\sACCEPT\s+tcp\s+.+\s{0}\s+owner UID match 0'.format(wire_server_address_regex),
+            FirewallManager.DROP:       r'\sDROP\s+tcp\s+.+\s{0}\s+ctstate INVALID,NEW'.format(wire_server_address_regex)
+        }
+
     @property
     def version(self):
         return self._version
 
-    def _execute_delete_command(self, command):
+    @property
+    def _append(self):
+        return '-A'
+
+    @property
+    def _check(self):
+        return '-C'
+
+    @property
+    def _delete(self):
+        return '-D'
+
+    def check(self):
+        try:
+            return super(IpTables, self).check()
+        except FirewallRulesMissingError as e:
+            output_chain = shellutil.run_command(self._base_command + ["-L", "OUTPUT", "-nxv"])
+            for rule in e.missing_rules:
+                if re.search(self._ip_tables_rule_regex[rule], output_chain) is not None:
+                    raise IptablesInconsistencyError(e.missing_rules, output_chain)
+            raise
+
+    def load_conntrack(self):
+        """
+        Forces the conntrack module to be loaded by executing "iptables -C -m conntrack..."
+
+        Returns a string containing the command that was execute and its output.
+        """
+        try:
+            command = self._get_drop_rule_command(self._check)  # The DROP rule uses conntrack
+            return "{0}: {1}", command, shellutil.run_command(command)
+        except CommandError as e:
+            return ustr(e)
+
+    def _delete_rule(self, command):
         """
         Continually execute the delete operation until the return code is non-zero or the limit has been reached.
         """
@@ -322,7 +383,7 @@ class IpTables(_FirewallManagerMultipleRules):
                     raise Exception("Invalid firewall deletion command '{0}'".format(command))
 
     def _get_state_command(self):
-        return self._base_command + ["-t", "security", "-L", "-nxv"]
+        return self._base_command + ["-L", "-nxv"]
 
     def _get_accept_dns_rule_command(self, command_option):
         return self._base_command + [command_option, "OUTPUT", "-d", self._wire_server_address, "-p", "tcp", "--destination-port", "53", "-j", "ACCEPT"]
@@ -339,17 +400,8 @@ class IpTables(_FirewallManagerMultipleRules):
         # has aged out, keep this cleanup in place.
         return self._base_command + [command_option, "OUTPUT", "-d", self._wire_server_address, "-p", "tcp", "-m", "conntrack", "--ctstate", "INVALID,NEW", "-j", "ACCEPT"]
 
-    def _get_append_command_option(self):
-        return "-A"
 
-    def _get_check_command_option(self):
-        return "-C"
-
-    def _get_delete_command_option(self):
-        return "-D"
-
-
-class FirewallCmd(_FirewallManagerMultipleRules):
+class FirewallCmd(_FirewallManagerIndividualRules):
     """
     FirewallManager based on the firewalld command-line tool.
     """
@@ -367,6 +419,21 @@ class FirewallCmd(_FirewallManagerMultipleRules):
     def version(self):
         return self._version
 
+    @property
+    def _append(self):
+        return '--passthrough'
+
+    @property
+    def _check(self):
+        return '--query-passthrough'
+
+    @property
+    def _delete(self):
+        return '--remove-passthrough'
+
+    def _delete_rule(self, command):
+        shellutil.run_command(command)
+
     def _get_state_command(self):
         return ["firewall-cmd", "--permanent", "--direct", "--get-all-passthroughs"]
 
@@ -383,15 +450,6 @@ class FirewallCmd(_FirewallManagerMultipleRules):
         # Agents <= 2.7.0.6 inserted (-I) the rule to accept DNS traffic; later agents changed that to append (-A) the rule.
         # The insert rule needs to be removed, otherwise there will be duplicate rules for DNS.
         return ["firewall-cmd", "--permanent", "--direct", command_option, "ipv4", "-t", "security", "-I", "OUTPUT", "-d", self._wire_server_address, "-p", "tcp", '--destination-port', '53', '-j', 'ACCEPT']
-
-    def _get_append_command_option(self):
-        return "--passthrough"
-
-    def _get_check_command_option(self):
-        return "--query-passthrough"
-
-    def _get_delete_command_option(self):
-        return "--remove-passthrough"
 
 
 class NfTables(FirewallManager):

--- a/azurelinuxagent/ga/firewall_manager.py
+++ b/azurelinuxagent/ga/firewall_manager.py
@@ -159,7 +159,7 @@ class FirewallManager(object):
 
 class _FirewallManagerIndividualRules(FirewallManager):
     """
-    Base class for firewall managers (iptables, firewalld) that manipulate the firewall rules individually when checking/adding/removing them. For contrast, nft manipulated the entire table.
+    Base class for firewall managers (iptables, firewalld) that manipulate the firewall rules individually when checking/adding/removing them. For contrast, nft manipulates the entire table.
     """
     def __init__(self, wire_server_address):
         super(_FirewallManagerIndividualRules, self).__init__(wire_server_address)

--- a/azurelinuxagent/ga/firewall_manager.py
+++ b/azurelinuxagent/ga/firewall_manager.py
@@ -159,18 +159,18 @@ class FirewallManager(object):
 
 class _FirewallManagerIndividualRules(FirewallManager):
     """
-    Base class for firewall managers (iptables, firewalld) that manipulate the firewall rules individually when checking/adding/removing them.
+    Base class for firewall managers (iptables, firewalld) that manipulate the firewall rules individually when checking/adding/removing them. For contrast, nft manipulated the entire table.
     """
     def __init__(self, wire_server_address):
         super(_FirewallManagerIndividualRules, self).__init__(wire_server_address)
         #
         # We use this array to iterate over all the firewall rules when setting/checking/removing them.
-        # The order of the items is critical since we process each item them sequentially and the firewall rules will follow the order in the array: the first
+        # The order of the items is critical since we process each item sequentially and the firewall rules will follow the order in the array: the first
         # item will be at the top of the chain, etc.
         #
         # Each item in the array is a tuple with the friendly name of the rule and a function that returns the command used to process that rule. This function
-        # takes as argument the option (-A, -C, -D  for iptables and --passthrough, --query-passthrough, --remove-passthrough for firewallcmd) that is passed to
-        # the corresponding command
+        # takes as argument the option that is passed to the corresponding command  (-A, -C, and -D for iptables, and --passthrough, --query-passthrough, and --remove-passthrough
+        # for firewallcmd)
         #
         self._firewall_commands = [
             (FirewallManager.ACCEPT_DNS, self._get_accept_dns_rule_command),
@@ -348,6 +348,16 @@ class IpTables(_FirewallManagerIndividualRules):
         return '-D'
 
     def check(self):
+        # A few users have reported an issue where the Agent creates duplicate DROP rule, with one of them at the top of the OUTPUT chain, that block communication
+        # with the WireServer (see, for example, incident 21000000779819). These VMs are running RedHat/CentOS 7/8.
+        #
+        # Debugging showed that the DROP rule created by waagent-network-setup during boot cannot detected by waagent using "iptables -C" (and "iptables -D" won't delete
+        # the rule either) causing waagent to create duplicate rules. This issue may be related to https://access.redhat.com/solutions/6514071, which has identical
+        # symptoms. Our debugging showed that the first rule created when the conntrack module has not been loaded yet is not visible to "-C" or "-D".
+        #
+        # We work around this issue by checking against the output of "iptables -L" when the check() method reports that some rules do not exist. If any of those rules
+        # shows up in the output of "-L", we do not modify the firewall.
+        #
         try:
             return super(IpTables, self).check()
         except FirewallRulesMissingError as e:

--- a/azurelinuxagent/ga/firewall_manager.py
+++ b/azurelinuxagent/ga/firewall_manager.py
@@ -320,7 +320,7 @@ class IpTables(_FirewallManagerIndividualRules):
         #     # iptables -w -t security -L OUTPUT -nvx
         #     Chain OUTPUT (policy ACCEPT 1384 packets, 126406 bytes)
         #         pkts      bytes target     prot opt in     out     source               destination
-        #            0        0 ACCEPT     tcp  --  *      *       0.0.0.0/0            168.63.129.16
+        #            0        0 ACCEPT     tcp  --  *      *       0.0.0.0/0            168.63.129.16        tcp dpt:53
         #            0        0 ACCEPT     tcp  --  *      *       0.0.0.0/0            168.63.129.16        owner UID match 0
         #            0        0 DROP       tcp  --  *      *       0.0.0.0/0            168.63.129.16        ctstate INVALID,NEW
         #

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -40,7 +40,7 @@ from azurelinuxagent.ga.cgroupconfigurator import CGroupConfigurator
 from azurelinuxagent.common.event import add_event, initialize_event_logger_vminfo_common_parameters_and_protocol, \
     WALAEventOperation, EVENTS_DIRECTORY
 from azurelinuxagent.common.exception import ExitException, AgentUpgradeExitException, AgentMemoryExceededException
-from azurelinuxagent.ga.firewall_manager import FirewallManager, FirewallStateError
+from azurelinuxagent.ga.firewall_manager import FirewallManager, FirewallStateError, IptablesInconsistencyError
 from azurelinuxagent.common.future import ustr, UTC, datetime_min_utc
 from azurelinuxagent.common.osutil import get_osutil, systemd
 from azurelinuxagent.ga.persist_firewall_rules import PersistFirewallRulesHandler
@@ -1171,6 +1171,8 @@ class UpdateHandler(object):
                 else:
                     firewall_manager.setup()
                     event.info(WALAEventOperation.Firewall, "Created firewall rules for Azure Fabric:\n{0}", firewall_manager.get_state())
+            except IptablesInconsistencyError as e:
+                event.warn(WALAEventOperation.FirewallInconsistency, "{0}", ustr(e))
             except FirewallStateError as e:
                 event.warn(WALAEventOperation.Firewall, "The firewall rules for Azure Fabric are not setup correctly (the environment thread will fix it): {0}. Current state:\n{1}", ustr(e), firewall_manager.get_state())
 

--- a/tests/ga/test_env.py
+++ b/tests/ga/test_env.py
@@ -179,13 +179,39 @@ class TestEnableFirewall(AgentTestCase):
 
                 enable_firewall.run()
 
-                self.assertGreaterEqual(len(mock_iptables.call_list), 3, "Expected at least 3 iptables commands, got {0} (Test case: {1})".format(mock_iptables.call_list, test_case))
-
                 self.assertEqual(
                     [
                         mock_iptables.get_accept_dns_command("-A"),
                         mock_iptables.get_accept_command("-A"),
                         mock_iptables.get_drop_command("-A"),
+                        mock_iptables.get_list_command(),
                     ],
-                    mock_iptables.call_list[-3:],
+                    mock_iptables.call_list[-4:],
                     "Expected the 3 firewall rules to be restored (Test case: {0})".format(test_case))
+
+    def test_it_should_not_modify_the_firewall_rules_when_the_check_command_is_inconsistent_with_the_list_command(self):
+        with MockIpTables(check_matches_list=False) as mock_iptables:
+            enable_firewall = EnableFirewall('168.63.129.16')
+
+            test_cases = [  # Exit codes for the "-C" (check) command
+                {"accept_dns": 1, "accept": 0, "drop": 0, "legacy": 0},
+                {"accept_dns": 0, "accept": 1, "drop": 0, "legacy": 0},
+                {"accept_dns": 0, "accept": 1, "drop": 0, "legacy": 0},
+                {"accept_dns": 1, "accept": 1, "drop": 1, "legacy": 0},
+            ]
+
+            for test_case in test_cases:
+                mock_iptables.set_return_values("-C", **test_case)
+
+                enable_firewall.run()
+
+                self.assertFalse(any("-D" in command or "-A" in command for command in mock_iptables.call_list), "The -D or -A commands should not have been invoked (Test case: {0}). Commands: {1}".format(test_case, mock_iptables.call_list))
+
+                self.assertEqual(
+                    [
+                        mock_iptables.get_accept_dns_command("-C"),
+                        mock_iptables.get_accept_command("-C"),
+                        mock_iptables.get_drop_command("-C"),
+                    ],
+                    mock_iptables.call_list[:3],
+                    "Expected the 3 firewall rules to have been checked (Test case: {0})".format(test_case))

--- a/tests/ga/test_env.py
+++ b/tests/ga/test_env.py
@@ -161,6 +161,7 @@ class MonitorDhcpClientRestartTestCase(AgentTestCase):
                     monitor_dhcp_client_restart.run()
                     self.assertEqual(mock_conf_routes.call_count, 2)  # count did not change
 
+
 class TestEnableFirewall(AgentTestCase):
     def test_it_should_restore_missing_firewall_rules(self):
         with MockIpTables() as mock_iptables:

--- a/tests/ga/test_firewall_manager.py
+++ b/tests/ga/test_firewall_manager.py
@@ -93,10 +93,10 @@ class _TestFirewallCommand(AgentTestCase):
             self.assertEqual(
                 [
                     mock.get_accept_dns_command(mock.check_option),
-                    mock.get_accept_command(mock.check_option),
-                    mock.get_drop_command(mock.check_option),
                     mock.get_accept_dns_command(mock.delete_option),
+                    mock.get_accept_command(mock.check_option),
                     mock.get_accept_command(mock.delete_option),
+                    mock.get_drop_command(mock.check_option),
                     mock.get_drop_command(mock.delete_option)
                 ],
                 mock.call_list,
@@ -112,9 +112,9 @@ class _TestFirewallCommand(AgentTestCase):
             self.assertEqual(
                 [
                     mock.get_accept_dns_command(mock.check_option),
+                    mock.get_accept_dns_command(mock.delete_option),
                     mock.get_accept_command(mock.check_option),
                     mock.get_drop_command(mock.check_option),
-                    mock.get_accept_dns_command(mock.delete_option),
                     mock.get_drop_command(mock.delete_option),
                 ],
                 mock.call_list,

--- a/tests/ga/test_update.py
+++ b/tests/ga/test_update.py
@@ -1055,6 +1055,7 @@ class TestUpdate(UpdateTestCase):
                                 MockIpTables.get_accept_dns_command("-A"),
                                 MockIpTables.get_accept_command("-A"),
                                 MockIpTables.get_drop_command("-A"),
+                                MockIpTables.get_list_command()
                             ],
                             mock_iptables.call_list,
                             "Expected 2 calls for the legacy rule (-C and -D), followed by 3 sets of calls for the current rules (-C and -A)")
@@ -1074,6 +1075,7 @@ class TestUpdate(UpdateTestCase):
                                 MockFirewallCmd.get_accept_dns_command("--passthrough"),
                                 MockFirewallCmd.get_accept_command("--passthrough"),
                                 MockFirewallCmd.get_drop_command("--passthrough"),
+                                MockFirewallCmd.get_list_command()
                             ],
                             mock_firewall_cmd.call_list,
                             "Expected 2 calls for the legacy rule (-C and -D), followed by 3 sets of calls for the current rules (-C and -A)")

--- a/tests/lib/mock_firewall_command.py
+++ b/tests/lib/mock_firewall_command.py
@@ -20,6 +20,7 @@ import re
 from azurelinuxagent.common.utils import shellutil
 from tests.lib.tools import patch
 
+
 class _MockFirewallCommand(object):
     """
     Abstract base class for the MockIpTables and MockFirewallCmd classes.
@@ -69,8 +70,11 @@ class _MockFirewallCommand(object):
     def _mock_run_command(self, command, *args, **kwargs):
         if command[0] == self._command_name:
             command_string = " ".join(command)
-            command = ['sh', '-c', "exit {0}".format(self._get_return_value(command_string))]
             self._call_list.append(command_string)
+            exit_code, stdout, stderr = self._get_return_value(command_string)
+            if exit_code != 0:
+                raise shellutil.CommandError(command=command_string, return_code=exit_code, stdout=stdout, stderr=stderr)
+            return stdout
         return self._original_run_command(command, *args, **kwargs)
 
     @property
@@ -125,11 +129,12 @@ class MockIpTables(_MockFirewallCommand):
     """
     Mock for the iptables command
     """
-    def __init__(self, version='1.4.21'):
+    def __init__(self, version='1.4.21', check_matches_list=True):
         super(MockIpTables, self).__init__(command_name="iptables", check_option="-C", add_option="-A", delete_option="-D")
         self._version = version
         # Currently the Agent calls delete repeatedly until it returns 1, indicating that the rule does not exist (and hence the rule has been deleted successfully)
         self.set_return_values("-D", 1, 1, 1, 1)
+        self._check_matches_list = check_matches_list
 
     def _mock_run_command(self, command, *args, **kwargs):
         if command[0] == 'iptables' and command[1] == '--version':
@@ -147,19 +152,46 @@ class MockIpTables(_MockFirewallCommand):
 
         """
         match = re.match(r"iptables (-w )?-t security (?P<option>-[ACD]) OUTPUT -d 168.63.129.16 -p tcp (?P<rule>--destination-port 53 -j ACCEPT|-m owner --uid-owner \d+ -j ACCEPT|.+ -j (DROP|ACCEPT))", command)
-        if match is None:
-            raise Exception("Unexpected command: {0}".format(command))
-        option = match.group("option")
-        rule = match.group("rule")
-        if rule == "--destination-port 53 -j ACCEPT":
-            return self._return_values[option]["ACCEPT DNS"]
-        if rule == "-m owner --uid-owner {0} -j ACCEPT".format(os.getuid()):
-            return self._return_values[option]["ACCEPT"]
-        if rule == "-m conntrack --ctstate INVALID,NEW -j DROP":
-            return self._return_values[option]["DROP"]
-        if rule == "-m conntrack --ctstate INVALID,NEW -j ACCEPT":
-            return self._return_values[option]["legacy"]
-        raise Exception("Unexpected rule: {0}".format(rule))
+        if match is not None:
+            option = match.group("option")
+            rule = match.group("rule")
+            if rule == "--destination-port 53 -j ACCEPT":
+                exit_code = self._return_values[option]["ACCEPT DNS"]
+            elif rule == "-m owner --uid-owner {0} -j ACCEPT".format(os.getuid()):
+                exit_code = self._return_values[option]["ACCEPT"]
+            elif rule == "-m conntrack --ctstate INVALID,NEW -j DROP":
+                exit_code = self._return_values[option]["DROP"]
+            elif rule == "-m conntrack --ctstate INVALID,NEW -j ACCEPT":
+                exit_code = self._return_values[option]["legacy"]
+            else:
+                raise Exception("Unexpected rule: {0}".format(rule))
+            return exit_code, "Mocked stdout", "Mocked stderr"
+
+        match = re.match(r"iptables (-w )?-t security -L OUTPUT -nxv", command)
+        if match is not None:
+            #
+            # Create the mock output for iptables -L
+            #
+            #     # iptables -w -t security -L OUTPUT -nvx
+            #     Chain OUTPUT (policy ACCEPT 1384 packets, 126406 bytes)
+            #         pkts      bytes target     prot opt in     out     source               destination
+            #            0        0 ACCEPT     tcp  --  *      *       0.0.0.0/0            168.63.129.16        tcp dpt:53
+            #            0        0 ACCEPT     tcp  --  *      *       0.0.0.0/0            168.63.129.16        owner UID match 0
+            #            0        0 DROP       tcp  --  *      *       0.0.0.0/0            168.63.129.16        ctstate INVALID,NEW
+            #
+            stdout = [
+                "Chain OUTPUT (policy ACCEPT 1384 packets, 126406 bytes)\n",
+                "    pkts      bytes target     prot opt in     out     source               destination\n"
+            ]
+            if (self._return_values["-C"]["ACCEPT DNS"] == 0) == self._check_matches_list:
+                stdout.append("       0        0 ACCEPT     tcp  --  *      *       0.0.0.0/0            168.63.129.16        tcp dpt:53\n")
+            if (self._return_values["-C"]["ACCEPT"] == 0) == self._check_matches_list:
+                stdout.append("       0        0 ACCEPT     tcp  --  *      *       0.0.0.0/0            168.63.129.16        owner UID match 0\n")
+            if (self._return_values["-C"]["DROP"] == 0) == self._check_matches_list:
+                stdout.append("       0        0 DROP       tcp  --  *      *       0.0.0.0/0            168.63.129.16        ctstate INVALID,NEW\n")
+            return 0, "".join(stdout), ""
+
+        raise Exception("Unexpected command: {0}".format(command))
 
     @staticmethod
     def get_accept_dns_command(option):
@@ -176,6 +208,10 @@ class MockIpTables(_MockFirewallCommand):
     @staticmethod
     def get_legacy_command(option):
         return "iptables -w -t security {0} OUTPUT -d 168.63.129.16 -p tcp -m conntrack --ctstate INVALID,NEW -j ACCEPT".format(option)
+
+    @staticmethod
+    def get_list_command():
+        return "iptables -w -t security -L -nxv"
 
 
 class MockFirewallCmd(_MockFirewallCommand):

--- a/tests/lib/mock_firewall_command.py
+++ b/tests/lib/mock_firewall_command.py
@@ -222,8 +222,10 @@ class MockFirewallCmd(_MockFirewallCommand):
         super(MockFirewallCmd, self).__init__(command_name="firewall-cmd", check_option="--query-passthrough", add_option="--passthrough", delete_option="--remove-passthrough")
 
     def _mock_run_command(self, command, *args, **kwargs):
+        if command[0] == 'firewall-cmd' and command[1] == '--version':
+            return '1.0.0 (mocked)'
         if command[0] == 'firewall-cmd' and command[1] == '--state':
-            return self._original_run_command(['echo', 'running'], *args, **kwargs)
+            return 'running\n'
         return super(MockFirewallCmd, self)._mock_run_command(command, *args, **kwargs)
 
     def _get_return_value(self, command):
@@ -239,18 +241,20 @@ class MockFirewallCmd(_MockFirewallCommand):
         match = re.match(r"firewall-cmd --permanent --direct (?P<option>--passthrough|--query-passthrough|--remove-passthrough) ipv4 -t security (?P<add_option>-[AI]) OUTPUT -d 168.63.129.16 -p tcp (?P<rule>--destination-port 53 -j ACCEPT|-m owner --uid-owner \d+ -j ACCEPT|.+ -j DROP)", command)
         if match is None:
             raise Exception("Unexpected command: {0}".format(command))
+
         option = match.group("option")
         rule = match.group("rule")
         add_option = match.group("add_option")
         if rule == "--destination-port 53 -j ACCEPT":
-            if add_option == "-I":
-                return self._return_values[option]["legacy"]
-            return self._return_values[option]["ACCEPT DNS"]
-        if rule == "-m owner --uid-owner {0} -j ACCEPT".format(os.getuid()):
-            return self._return_values[option]["ACCEPT"]
-        if rule == "-m conntrack --ctstate INVALID,NEW -j DROP":
-            return self._return_values[option]["DROP"]
-        raise Exception("Unexpected rule: {0}".format(rule))
+            exit_code = self._return_values[option]["legacy"] if add_option == "-I" else self._return_values[option]["ACCEPT DNS"]
+        elif rule == "-m owner --uid-owner {0} -j ACCEPT".format(os.getuid()):
+            exit_code = self._return_values[option]["ACCEPT"]
+        elif rule == "-m conntrack --ctstate INVALID,NEW -j DROP":
+            exit_code = self._return_values[option]["DROP"]
+        else:
+            raise Exception("Unexpected rule: {0}".format(rule))
+
+        return exit_code, "Mocked stdout", "Mocked stderr"
 
     @staticmethod
     def get_accept_dns_command(option):
@@ -267,6 +271,10 @@ class MockFirewallCmd(_MockFirewallCommand):
     @staticmethod
     def get_legacy_command(option):
         return "firewall-cmd --permanent --direct {0} ipv4 -t security -I OUTPUT -d 168.63.129.16 -p tcp --destination-port 53 -j ACCEPT".format(option)
+
+    @staticmethod
+    def get_list_command():
+        return "firewall-cmd --permanent --direct --get-all-passthroughs"
 
 
 class MockNft(object):

--- a/tests_e2e/tests/agent_persist_firewall/agent_persist_firewall.py
+++ b/tests_e2e/tests/agent_persist_firewall/agent_persist_firewall.py
@@ -89,10 +89,9 @@ class AgentPersistFirewallTest(AgentVmTest):
             # 2024-07-30T23:36:35.705717Z WARNING ExtHandler ExtHandler The permanent firewall rules for Azure Fabric are not setup correctly (The following rules are missing: ['ACCEPT DNS']), will reset them.
             # 2024-07-30T23:37:23.612352Z WARNING ExtHandler ExtHandler The permanent firewall rules for Azure Fabric are not setup correctly (The following rules are missing: ['ACCEPT']), will reset them.
             # 2024-07-30T23:38:11.083028Z WARNING ExtHandler ExtHandler The permanent firewall rules for Azure Fabric are not setup correctly (The following rules are missing: ['DROP']), will reset them.
-            # 2024-12-27T19:42:51.531056Z WARNING ExtHandler ExtHandler The permanent firewall rules for Azure Fabric are not setup correctly (The following rules are missing: ['ACCEPT'] due to: ['']), will reset them
             #
             {
-                'message': r"The permanent firewall rules for Azure Fabric are not setup correctly \(The following rules are missing: \[('ACCEPT DNS'|'ACCEPT'|'DROP'|, )+\] due to.*\), will reset them.",
+                'message': r"The permanent firewall rules for Azure Fabric are not setup correctly \(The following rules are missing: \[('ACCEPT DNS'|'ACCEPT'|'DROP'|, )+\]\), will reset them.",
                 'if': lambda r: r.level == "WARNING"
             }
         ]


### PR DESCRIPTION
Fix for "iptables -C" not being able to detect the DROP rule in some environments. More details in the comment for the IpTables.check() method.

The PR also includes some refactoring that I started doing when I was planning to change the way we delete the firewall rules. It makes the code easier to work with and a little more readable.