### PR TITLE
cloudinitdetect: also check for 'cloudinit' service on non-systemd

### DIFF
--- a/azurelinuxagent/pa/provision/cloudinitdetect.py
+++ b/azurelinuxagent/pa/provision/cloudinitdetect.py
@@ -40,20 +40,19 @@ def _cloud_init_is_enabled_service():
         bool: True if cloud-init is enabled, False if otherwise.
     """
 
-    try:
-        subprocess.check_output([
-            'service',
-            'cloud-init',
-            'status'
-        ], stderr=subprocess.STDOUT)
+    for service_name in ['cloud-init', 'cloudinit']:
+        try:
+            subprocess.check_output([
+                'service',
+                service_name,
+                'status'
+            ], stderr=subprocess.STDOUT)
+            return True
+        # pylint: disable=broad-except
+        except Exception as exc:
+            logger.info('Tried service "{0}", unable to get enabled status: {1}'.format(service_name, exc))
 
-        unit_is_enabled = True
-    # pylint: disable=broad-except
-    except Exception as exc:
-        logger.info('Unable to get cloud-init enabled status from service: {0}'.format(exc))
-        unit_is_enabled = False
-
-    return unit_is_enabled
+    return False
 
 def cloud_init_is_enabled():
     """


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->
<!--
Please add an informative description that covers that changes made by the pull request.
-->
## Description

On all BSD systems, the correct RC service name is 'cloudinit' as per https://github.com/canonical/cloud-init/tree/main/sysvinit.

Issue # <!-- if any -->
---
<!--
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->
### PR information
- [x] Ensure development PR is based on the `develop` branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [x] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).
---
<!--
This checklist is used to track contributions from distro maintainers.
-->
### Distro maintenance information, if applicable
- [ ] This is a contribution from a distro maintainer
- [ ] The changes in this PR have been taken as a downstream patch (Note: it is not recommended to patch the agent without upstream review and approval)
