### PR TITLE
Skip firewall tests when the Proxy Agent manages the WireServer endpoint

### DIFF
--- a/tests_e2e/tests/agent_firewall/agent_firewall.py
+++ b/tests_e2e/tests/agent_firewall/agent_firewall.py
@@ -20,6 +20,7 @@ from typing import Any, Dict, List
 
 from tests_e2e.tests.lib.agent_test import AgentVmTest
 from tests_e2e.tests.lib.agent_test_context import AgentVmTestContext
+from tests_e2e.tests.lib.firewall_utilities import FirewallUtilities
 
 
 class AgentFirewall(AgentVmTest):
@@ -32,6 +33,8 @@ class AgentFirewall(AgentVmTest):
         self._ssh_client = self._context.create_ssh_client()
 
     def run(self):
+        FirewallUtilities.skip_test_if_proxy_agent_is_managing_the_wireserver_endpoint(self._ssh_client)
+
         self._run_remote_test(self._ssh_client, f"agent_firewall-verify_all_firewall_rules.py --user {self._context.username}", use_sudo=True)
 
     def get_ignore_error_rules(self) -> List[Dict[str, Any]]:

--- a/tests_e2e/tests/agent_persist_firewall/agent_persist_firewall.py
+++ b/tests_e2e/tests/agent_persist_firewall/agent_persist_firewall.py
@@ -49,6 +49,10 @@ class AgentPersistFirewallTest(AgentVmTest):
         # Test case 3: Re-enable the agent and do an additional reboot. The intention is to check for conflicts between the agent and the persist firewall service
         self._enable_agent()
         self._context.vm.restart(wait_for_boot=True, ssh_client=self._ssh_client)
+
+        # TODO: for now we need to check again after reboot, since the GPA has a race condition on initialization than makes it take over the WireServer endpoint when it shouldn't.
+        FirewallUtilities.skip_test_if_proxy_agent_is_managing_the_wireserver_endpoint(self._ssh_client)
+
         self._verify_persist_firewall_service_running()
         self._verify_firewall_rules_on_boot("second_boot")
         # Test case 4: perform firewalld rules deletion and ensure deleted rules added back to rule set after agent start

--- a/tests_e2e/tests/agent_persist_firewall/agent_persist_firewall.py
+++ b/tests_e2e/tests/agent_persist_firewall/agent_persist_firewall.py
@@ -20,6 +20,7 @@ from typing import Any, Dict, List
 
 from tests_e2e.tests.lib.agent_test import AgentVmTest
 from tests_e2e.tests.lib.agent_test_context import AgentVmTestContext
+from tests_e2e.tests.lib.firewall_utilities import FirewallUtilities
 from tests_e2e.tests.lib.logging import log
 from tests_e2e.tests.lib.ssh_client import SshClient
 
@@ -34,6 +35,8 @@ class AgentPersistFirewallTest(AgentVmTest):
         self._ssh_client: SshClient = self._context.create_ssh_client()
 
     def run(self):
+        FirewallUtilities.skip_test_if_proxy_agent_is_managing_the_wireserver_endpoint(self._ssh_client)
+
         self._test_setup()
         # Test case 1: After test agent install, verify firewalld or network.setup is running
         self._verify_persist_firewall_service_running()

--- a/tests_e2e/tests/lib/firewall_manager.py
+++ b/tests_e2e/tests/lib/firewall_manager.py
@@ -1,3 +1,21 @@
+#!/usr/bin/env pypy3
+
+# Microsoft Azure Linux Agent
+#
+# Copyright 2018 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import errno
 import json
 import re

--- a/tests_e2e/tests/lib/firewall_utilities.py
+++ b/tests_e2e/tests/lib/firewall_utilities.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env pypy3
+
+# Microsoft Azure Linux Agent
+#
+# Copyright 2018 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from tests_e2e.tests.lib.logging import log, indent
+from tests_e2e.tests.lib.shell import CommandError
+from tests_e2e.tests.lib.ssh_client import SshClient
+from tests_e2e.tests.lib.test_result import TestSkipped
+
+
+class FirewallUtilities:
+    @staticmethod
+    def skip_test_if_proxy_agent_is_managing_the_wireserver_endpoint(ssh_client: SshClient):
+        """
+        Raises TestSkipped if the proxy agent is managing the wireserver endpoint.
+
+        If this is the case, the HTTP requests to the WireServer are blocked by the Proxy Agent and they do not reach the firewall endpoint,
+        so the firewall tests are not applicable.
+        """
+        try:
+            stdout = ssh_client.run_command("is-proxy-agent-active.py")
+            log.info(f"Detected the Proxy Agent\n{indent(stdout)}")
+            raise TestSkipped("The Proxy Agent is managing the WireServer endpoint so firewall rules are not applicable.")
+        except CommandError as e:
+            log.info(f"The Proxy Agent is not managing the WireServer endpoint.\n{indent(str(e))}")
+

--- a/tests_e2e/tests/lib/firewall_utilities.py
+++ b/tests_e2e/tests/lib/firewall_utilities.py
@@ -37,6 +37,6 @@ class FirewallUtilities:
             raise TestSkipped("The Proxy Agent is managing the WireServer endpoint so firewall rules are not applicable.")
         except CommandError as e:
             if e.exit_code == 1:
-                log.info(f"The Proxy Agent is not managing the WireServer endpoint.\n{indent(str(e))}")
+                log.info(f"The Proxy Agent is not managing the WireServer endpoint.\n{indent(str(e.stdout))}")
             else:
                 raise

--- a/tests_e2e/tests/lib/firewall_utilities.py
+++ b/tests_e2e/tests/lib/firewall_utilities.py
@@ -36,5 +36,7 @@ class FirewallUtilities:
             log.info(f"Detected the Proxy Agent\n{indent(stdout)}")
             raise TestSkipped("The Proxy Agent is managing the WireServer endpoint so firewall rules are not applicable.")
         except CommandError as e:
-            log.info(f"The Proxy Agent is not managing the WireServer endpoint.\n{indent(str(e))}")
-
+            if e.exit_code == 1:
+                log.info(f"The Proxy Agent is not managing the WireServer endpoint.\n{indent(str(e))}")
+            else:
+                raise

--- a/tests_e2e/tests/lib/retry.py
+++ b/tests_e2e/tests/lib/retry.py
@@ -110,6 +110,8 @@ def retry(operation: Callable[[], Any], attempts: int = 5, delay: int = 30) -> A
         attempts -= 1
         try:
             return operation()
+        except AssertionError:
+            raise
         except Exception as e:
             if attempts == 0:
                 raise

--- a/tests_e2e/tests/scripts/is-proxy-agent-active.py
+++ b/tests_e2e/tests/scripts/is-proxy-agent-active.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env pypy3
+
+# Microsoft Azure Linux Agent
+#
+# Copyright 2018 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+#
+# Script to verify the presence of the Proxy Agent.
+#
+# When the Proxy Agent manages the WireServer endpoint, it will intercept HTTP request even before they reach the firewall and failed them with 403 (Forbidden).
+# Some tests, e.g. those related to firewall, need to be aware of this behavior.
+#
+# The scripts works by issuing a request for the Versions WireServer API as a non-root user. If azure-proxy-agent.service is active and the request fails with
+# 403, we assume that the Proxy Server is managing the WireServer endpoint. Note that the service may be active, but it may not be managing the endpoint, depending
+# on its configuration.
+#
+# If that HTTP request times out, we assume that the request reached the firewall and that the Proxy Agent is not managing the endpoint.
+#
+# If the request succeeds, or fails with a status other than 403, the configuration of the firewall is incorrect, since non-root should not be able to connect
+# to the WireServer.
+#
+# The script returns an exit code of 0 when the Proxy Agent is managing the endpoint, 1 if it is not managing the endpoint, and 2 if an error occurs.
+#
+import os
+import pwd
+import socket
+import sys
+
+import http.client as httpclient
+
+from tests_e2e.tests.lib.logging import log
+from tests_e2e.tests.lib.shell import run_command, CommandError
+from tests_e2e.tests.lib.firewall_manager import get_wireserver_ip
+
+try:
+    if os.geteuid() == 0:
+        raise Exception("This script should not be run as root.")
+
+    try:
+        stdout = run_command(['systemctl', 'is-active', 'azure-proxy-agent.service']).rstrip()
+        log.info(f"The azure-proxy-agent.service is active. State: {stdout}")
+    except CommandError as e:
+        if e.exit_code == 3:
+            log.info("The azure-proxy-agent.service is not active")
+            sys.exit(1)
+        raise
+
+    try:
+        client = httpclient.HTTPConnection(get_wireserver_ip(), timeout=10)
+        client.request('GET', '/?comp=versions')
+        response = client.getresponse()
+        if response.status == 403:
+            log.info("The azure-proxy-agent.service is managing the WireServer endpoint")
+            sys.exit(0)
+        log.error(f"INCORRECT FIREWALL CONFIGURATION. NON-ROOT IS ABLE TO CONNECT TO THE WIRESERVER. User: {pwd.getpwuid(os.geteuid()).pw_name}. Status: {response.status}. Response: {response.read()}")
+    except Exception as e:
+        if isinstance(e, socket.timeout):
+            log.info("The azure-proxy-agent.service is not managing the WireServer endpoint")
+        raise
+except Exception as e:
+    log.error(f"{str(e)}")
+    sys.exit(2)

--- a/tests_e2e/tests/scripts/is-proxy-agent-active.py
+++ b/tests_e2e/tests/scripts/is-proxy-agent-active.py
@@ -53,8 +53,8 @@ try:
         stdout = run_command(['systemctl', 'is-active', 'azure-proxy-agent.service']).rstrip()
         log.info(f"The azure-proxy-agent.service is active. State: {stdout}")
     except CommandError as e:
-        if e.exit_code == 3:
-            log.info("The azure-proxy-agent.service is not active")
+        if e.exit_code in [3, 4]:  # 3 == unit is not active, 4 == no such unit
+            log.info(f"The azure-proxy-agent.service is not {'active' if e.exit_code == 3 else 'installed'}. ")
             sys.exit(1)
         raise
 

--- a/tests_e2e/tests/scripts/is-proxy-agent-active.py
+++ b/tests_e2e/tests/scripts/is-proxy-agent-active.py
@@ -65,10 +65,11 @@ try:
         if response.status == 403:
             log.info("The azure-proxy-agent.service is managing the WireServer endpoint")
             sys.exit(0)
-        log.error(f"INCORRECT FIREWALL CONFIGURATION. NON-ROOT IS ABLE TO CONNECT TO THE WIRESERVER. User: {pwd.getpwuid(os.geteuid()).pw_name}. Status: {response.status}. Response: {response.read()}")
+        raise Exception(f"Incorrect firewall configuration. Non-root is able to connect to the WireServer. User: {pwd.getpwuid(os.geteuid()).pw_name}. HTTP status: {response.status}. HTTP response: {response.read()}")
     except Exception as e:
         if isinstance(e, socket.timeout):
             log.info("The azure-proxy-agent.service is not managing the WireServer endpoint")
+            sys.exit(1)
         raise
 except Exception as e:
     log.error(f"{str(e)}")


### PR DESCRIPTION
The GPA intercepts the HTTP request before they reach the firewall, so in that case these tests are not relevant.