### PR TITLE
Removing agent update state files

### DIFF
--- a/tests_e2e/tests/lib/agent_update_helpers.py
+++ b/tests_e2e/tests/lib/agent_update_helpers.py
@@ -104,7 +104,7 @@ def verify_current_agent_version(ssh_client: SshClient, requested_version: str) 
 
     waagent_version: str = ""
     log.info("Verifying agent updated to published version: {0}".format(requested_version))
-    success: bool = retry_if_false(lambda: _check_agent_version(requested_version))
+    success: bool = retry_if_false(lambda: _check_agent_version(requested_version), delay=50)
     if not success:
         fail("Guest agent didn't update to published version {0} but found \n {1}. \n ".format(
             requested_version, waagent_version))


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->
<!--
Please add an informative description that covers that changes made by the pull request.
-->
## Description

Test enabling auto-update and restarting the agent service after agent already created the waagent_initial_update state file. As a result, it is blocking first update after enable. So, deleting update state files.

Issue # <!-- if any -->
---
<!--
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->
### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).
---
<!--
This checklist is used to track contributions from distro maintainers.
-->
### Distro maintenance information, if applicable
- [ ] This is a contribution from a distro maintainer
- [ ] The changes in this PR have been taken as a downstream patch (Note: it is not recommended to patch the agent without upstream review and approval)
