### PR TITLE
firewall_manager: Add fallbacks when missing kernel modules

### DIFF
--- a/azurelinuxagent/ga/firewall_manager.py
+++ b/azurelinuxagent/ga/firewall_manager.py
@@ -446,6 +446,14 @@ class FirewallCmd(_FirewallManagerIndividualRules):
     def __init__(self, wire_server_address):
         super(FirewallCmd, self).__init__(wire_server_address)
 
+        # firewall-cmd --permanent --direct passthrough uses iptables-style rules; the stack relies on a working
+        # iptables userland, so probe listing rules before we depend on FirewallCmd.
+        try:
+            shellutil.run_command(["iptables", "-L"], log_error=False)
+        except Exception as exception:
+            if isinstance(exception, OSError) and exception.errno == errno.ENOENT:  # pylint: disable=no-member
+                raise FirewallManagerNotAvailableError("iptables is not available")
+
         try:
             self._version = shellutil.run_command(["firewall-cmd", "--version"]).strip()
         except Exception as exception:

--- a/azurelinuxagent/ga/persist_firewall_rules.py
+++ b/azurelinuxagent/ga/persist_firewall_rules.py
@@ -22,7 +22,7 @@ import azurelinuxagent.common.conf as conf
 from azurelinuxagent.common import logger
 from azurelinuxagent.common import event
 from azurelinuxagent.common.event import add_event, WALAEventOperation
-from azurelinuxagent.ga.firewall_manager import FirewallCmd, FirewallStateError
+from azurelinuxagent.ga.firewall_manager import FirewallCmd, FirewallStateError, FirewallManagerNotAvailableError
 from azurelinuxagent.common.future import ustr
 from azurelinuxagent.common.osutil import get_osutil, systemd
 from azurelinuxagent.common.utils import shellutil, fileutil, textutil
@@ -132,7 +132,14 @@ if __name__ == '__main__':
         # In case of a failure, this would throw. In such a case, we don't need to try to setup our custom service
         # because on system reboot, all iptables rules are reset by firewalld.service, so it would be a no-op.
         # setup permanent firewalld rules
-        firewall_manager = FirewallCmd(self._dst_ip)
+        try:
+            firewall_manager = FirewallCmd(self._dst_ip)
+        except FirewallManagerNotAvailableError as e:
+            # e.g. iptables unusable for firewalld --direct; use boot-time setup service.
+            event.warn(WALAEventOperation.PersistFirewallRules, "Cannot use firewall-cmd for persistent rules: {0}. Falling back to custom network-setup service.", ustr(e))
+            self._setup_network_setup_service()
+            return
+
         event.info(WALAEventOperation.Firewall, "Using firewall-cmd [version {0}] to manage the persistent firewall rules", firewall_manager.version)
 
         try:

--- a/tests/lib/mock_firewall_command.py
+++ b/tests/lib/mock_firewall_command.py
@@ -248,6 +248,8 @@ class MockFirewallCmd(_MockFirewallCommand):
         super(MockFirewallCmd, self).__init__(command_name="firewall-cmd", check_option="--query-passthrough", add_option="--passthrough", delete_option="--remove-passthrough")
 
     def _mock_run_command(self, command, *args, **kwargs):
+        if command[0] == "iptables" and command[1] == "-L":
+            return ''
         if command[0] == 'firewall-cmd' and command[1] == '--version':
             return '1.0.0 (mocked)'
         if command[0] == 'firewall-cmd' and command[1] == '--state':


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->
<!--
Please add an informative description that covers that changes made by the pull request.
-->
## Description
There are firewall rules invoked without checking the existence of the dependent kernel modules, e.g. xt_owner and xt_conntrack. These modules reside in kernel-modules-extra in distros like RHEL. The kernel-modules-extra package is not a dependency of iptables in terms of UKI. Thus the existence deserves checking. In case they are not present, fallback to nftables from iptables; to network-setup service from firewall-cmd respectively.

Issue #3510
---
<!--
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->
### PR information
- [x] Ensure development PR is based on the `develop` branch.
- [x] If applicable, the PR references the bug/issue that it fixes in the description.
- [x] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [x] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).
---
<!--
This checklist is used to track contributions from distro maintainers.
-->
### Distro maintenance information, if applicable
- [ ] This is a contribution from a distro maintainer
- [ ] The changes in this PR have been taken as a downstream patch (Note: it is not recommended to patch the agent without upstream review and approval)
