### PR TITLE
Fixing CSE deletion in ext_update e2e test

### DIFF
--- a/tests_e2e/tests/ext_update/ext_update_failure.py
+++ b/tests_e2e/tests/ext_update/ext_update_failure.py
@@ -94,7 +94,8 @@ class ExtensionUpdateFailureTest(AgentVmTest):
 
         for ext_name, ext in extensions_to_cleanup.items():
             if ext._resource_name in extension_names_on_vm:
-                self._ssh_client.run_command(f"ext_update-modify_handler_manifest.py --extension-name {ext_name} --reset", use_sudo=True)
+                output = self._ssh_client.run_command(f"ext_update-modify_handler_manifest.py --extension-name {ext_name} --reset", use_sudo=True)
+                log.info("Reset handlerManifest.json:\n%s", output)
                 ext.delete()
                 log.info("Removed extension %s", ext_name)
 

--- a/tests_e2e/tests/scripts/ext_update-modify_handler_manifest.py
+++ b/tests_e2e/tests/scripts/ext_update-modify_handler_manifest.py
@@ -50,70 +50,72 @@ def main():
         log.info("No handlerManifest.json file found for extension '{0}'".format(extension_name))
         sys.exit(1)
 
-    manifest_file = matched_files[0]
-    log.info("HandlerManifest file found for extension '{0}': {1}".format(extension_name, manifest_file))
+    log.info("HandlerManifest file found for extension '{0}': {1}".format(extension_name, matched_files))
 
     if reset:
-        log.info("Resetting handlerManifest file for extension '{0}' to default values".format(extension_name))
-        # Reset the handlerManifest file to the default values
-        backup_file = manifest_file + ".bak"
-        if os.path.exists(backup_file):
-            shutil.copy(backup_file, manifest_file)
-            log.info("Reset handlerManifest file for extension '{0}' to default values".format(extension_name))
-        else:
-            log.info("No backup file found to reset the handlerManifest file for extension '{0}'".format(extension_name))
+        for manifest_file in matched_files:
+            log.info("Resetting handlerManifest file for extension '{0}' to default values".format(extension_name))
+            # Reset the handlerManifest file to the default values
+            backup_file = manifest_file + ".bak"
+            if os.path.exists(backup_file):
+                shutil.copy(backup_file, manifest_file)
+                log.info("Reset handlerManifest file for extension '{0}' to default values".format(extension_name))
+            else:
+                log.info("No backup file found to reset the handlerManifest file for extension '{0}'".format(extension_name))
         sys.exit(0)
 
     if len(properties) == 0:
         log.info("No properties provided to update in the handlerManifest file for extension '{0}'".format(extension_name))
         sys.exit(1)
 
-    shutil.copy(manifest_file, manifest_file + ".bak")
+    # Update the handlerManifest file
+    for manifest_file in matched_files:
+        shutil.copy(manifest_file, manifest_file + ".bak")
 
-    # Sample handlerManifest.json structure:
-    # [
-    #   {
-    #     "version": 1.0,
-    #     "handlerManifest": {
-    #       "installCommand": "bin/custom-script-shim install",
-    #       "uninstallCommand": "bin/custom-script-shim uninstall",
-    #       "updateCommand": "bin/custom-script-shim update",
-    #       "enableCommand": "bin/custom-script-shim enable",
-    #       "disableCommand": "bin/custom-script-shim disable",
-    #       "rebootAfterInstall": false,
-    #       "reportHeartbeat": false,
-    #       "updateMode": "UpdateWithInstall"
-    #     },
-    #     "signingInfo": {
-    #       "type": "CustomScript",
-    #       "publisher": "Microsoft.Azure.Extensions",
-    #       "version": "2.1.13"
-    #     }
-    #   }
-    # ]
+        # Sample handlerManifest.json structure:
+        # [
+        #   {
+        #     "version": 1.0,
+        #     "handlerManifest": {
+        #       "installCommand": "bin/custom-script-shim install",
+        #       "uninstallCommand": "bin/custom-script-shim uninstall",
+        #       "updateCommand": "bin/custom-script-shim update",
+        #       "enableCommand": "bin/custom-script-shim enable",
+        #       "disableCommand": "bin/custom-script-shim disable",
+        #       "rebootAfterInstall": false,
+        #       "reportHeartbeat": false,
+        #       "updateMode": "UpdateWithInstall"
+        #     },
+        #     "signingInfo": {
+        #       "type": "CustomScript",
+        #       "publisher": "Microsoft.Azure.Extensions",
+        #       "version": "2.1.13"
+        #     }
+        #   }
+        # ]
 
-    with open(manifest_file, 'r') as file:
-        data = json.load(file)
+        with open(manifest_file, 'r') as file:
+            data = json.load(file)
 
-    commands = data[0]['handlerManifest']
+        commands = data[0]['handlerManifest']
 
-    for prop in properties:
-        # Split the property into cmd_name and cmd_value
-        if '=' not in prop:
-            log.info("Property '{0}' is not in the format 'cmd_name=cmd_value'".format(prop))
-            sys.exit(1)
+        for prop in properties:
+            # Split the property into cmd_name and cmd_value
+            if '=' not in prop:
+                log.info("Property '{0}' is not in the format 'cmd_name=cmd_value'".format(prop))
+                sys.exit(1)
 
-        cmd_name, cmd_value = prop.split('=', 1)
-        log.info("Updating command '{0}' with value '{1}'".format(cmd_name, cmd_value))
+            cmd_name, cmd_value = prop.split('=', 1)
+            log.info("Updating command '{0}' with value '{1}'".format(cmd_name, cmd_value))
 
-        # Update the handlerManifest file
-        log.info("Updating handlerManifest file for extension '{0}' for cmd '{1}' and value '{2}'".format(extension_name, cmd_name, cmd_value))
-        commands[cmd_name] = cmd_value
+            # Update the handlerManifest file
+            log.info("Updating handlerManifest file for extension '{0}' for cmd '{1}' and value '{2}'".format(extension_name, cmd_name, cmd_value))
+            commands[cmd_name] = cmd_value
 
-    with open(manifest_file, 'w') as file:
-        json.dump(data, file, indent=4)
+        with open(manifest_file, 'w') as file:
+            json.dump(data, file, indent=4)
 
-    log.info("Updated the handlerManifest file for extension '{0}'".format(extension_name))
+        log.info("Updated the handlerManifest file for extension '{0}'".format(extension_name))
     sys.exit(0)
 
 


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->
<!--
Please add an informative description that covers that changes made by the pull request.
-->
## Description
In the ext_update failure scenario, the test modifies the handlermanifest and injects a dummy value into the disable command to force the update to fail. At the end of the test, it deletes the CSE from the VM and, before deletion, resets the handlermanifest to ensure the deletion succeeds. However, after an update, two CSE version folders can exist, and the test sometimes selects the wrong folder when resetting the handlermanifest

Update the logic to apply handlermanifest resets across all folders for the specific extension when a handlermanifest change is detected for that version

Issue # <!-- if any -->
---
<!--
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->
### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).
---
<!--
This checklist is used to track contributions from distro maintainers.
-->
### Distro maintenance information, if applicable
- [ ] This is a contribution from a distro maintainer
- [ ] The changes in this PR have been taken as a downstream patch (Note: it is not recommended to patch the agent without upstream review and approval)
