### PR TITLE
Disable policy tests

### DIFF
--- a/tests_e2e/orchestrator/runbook.yml
+++ b/tests_e2e/orchestrator/runbook.yml
@@ -44,8 +44,11 @@ variable:
       - agent_status
       - agent_update
       - ext_cgroups
-      - ext_policy
-      - ext_policy_with_dependencies
+#
+# TODO: These tests are disabled temporarily since our test account does not have quota to create the Confidential VMs required by the tests.
+#
+#      - ext_policy
+#      - ext_policy_with_dependencies
       - ext_sequencing
       - ext_telemetry_pipeline
       - ext_update


### PR DESCRIPTION
Disabling temporarily since our test account does not have quota to create the Confidential VMs required by the tests.