### PR TITLE
Update URLs for python environments

### DIFF
--- a/.github/workflows/ci_pr.yml
+++ b/.github/workflows/ci_pr.yml
@@ -66,7 +66,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y curl bzip2 sudo
-        curl -sSf --retry 5 -o /tmp/python-${{ matrix.python-version }}.tar.bz2 https://dcrdata.blob.core.windows.net/python/python-${{ matrix.python-version }}.tar.bz2
+        curl -sSf --retry 5 -o /tmp/python-${{ matrix.python-version }}.tar.bz2 https://pythonenv.blob.core.windows.net/uts/python-${{ matrix.python-version }}.tar.bz2
         sudo tar xjf /tmp/python-${{ matrix.python-version }}.tar.bz2 --directory /
         #
         # The virtual environments have dependencies on old versions of OpenSSL (e.g 1.0/1.1) which are not available on Ubuntu 24. We use this script to patch the environments.

--- a/tests_e2e/orchestrator/scripts/download-pypy
+++ b/tests_e2e/orchestrator/scripts/download-pypy
@@ -21,7 +21,7 @@ if [[ ! -f ~/tmp/$pypy_name ]]; then
   if [[ $cloud_name == "AzureChinaCloud" ]]; then
     url="https://dcrdata.blob.core.chinacloudapi.cn/python/$pypy_name"
   else
-    url="https://dcrdata.blob.core.windows.net/python/$pypy_name"
+    url="https://pythonenv.blob.core.windows.net/e2e/$pypy_name"
   fi
   echo "======== Downloading Pypy tarball"
   echo "Downloading from $url to ~/tmp/$pypy_name"


### PR DESCRIPTION
The Python environments for unit tests and end-to-end tests are now on new locations