### PR TITLE
Prepare agent for rollback scenario in e2e tests

### DIFF
--- a/tests_e2e/tests/lib/agent_update_helpers.py
+++ b/tests_e2e/tests/lib/agent_update_helpers.py
@@ -111,3 +111,11 @@ def verify_current_agent_version(ssh_client: SshClient, requested_version: str) 
     waagent_version: str = ssh_client.run_command("waagent-version", use_sudo=True)
     log.info(
         f"Successfully verified agent updated to published version. Current agent version running:\n {waagent_version}")
+
+def verify_agent_reported_supported_feature_flag(ssh_client: SshClient) -> None:
+    """
+    RSM update relies on the supported feature flag reported by the agent to CRP. This check ensures the Guest Agent correctly reports the feature flag in its status.
+    """
+    log.info("Running remote script agent_update-verify_versioning_supported_feature.py to verify that the agent reports the supported feature flag required for CRP to send RSM update requests")
+    ssh_client.run_command("agent_update-verify_versioning_supported_feature.py --supported True", use_sudo=True)
+    log.info("Successfully verified that Agent reported VersioningGovernance supported feature flag")


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->
<!--
Please add an informative description that covers that changes made by the pull request.
-->
## Description

Previously, we had a bug when sending the GAversion supported-features flag to CRP, and the rollback scenario depended on that behavior. The latest agent includes a fix, which caused this rollback scenario to fail. We’re now updating the test to fix the rollback scenario accordingly.

Issue # <!-- if any -->
---
<!--
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->
### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).
---
<!--
This checklist is used to track contributions from distro maintainers.
-->
### Distro maintenance information, if applicable
- [ ] This is a contribution from a distro maintainer
- [ ] The changes in this PR have been taken as a downstream patch (Note: it is not recommended to patch the agent without upstream review and approval)
