### PR TITLE
Do not fetch goal state from RemoteAccessHandler

### DIFF
--- a/azurelinuxagent/common/protocol/goal_state.py
+++ b/azurelinuxagent/common/protocol/goal_state.py
@@ -479,6 +479,7 @@ class GoalState(object):
 
             remote_access = None
             if GoalStateProperties.RemoteAccessInfo & self._goal_state_properties:
+                container = find(xml_doc, "Container")
                 remote_access_uri = findtext(container, "RemoteAccessInfo")
                 if remote_access_uri is not None:
                     xml_text = self._wire_client.fetch_config(remote_access_uri, self._wire_client.get_header_for_remote_access())

--- a/azurelinuxagent/ga/remoteaccess.py
+++ b/azurelinuxagent/ga/remoteaccess.py
@@ -50,11 +50,11 @@ class RemoteAccessHandler(object):
         self._remote_access = None
         self._check_existing_jit_users = True
 
-    def run(self):
+    def run(self, remote_access):
         try:
             if self._os_util.jit_enabled:
                 # Handle remote access if any.
-                self._remote_access = self._protocol.client.get_goal_state().remote_access
+                self._remote_access = remote_access
                 self._handle_remote_access()
         except Exception as e:
             msg = u"Exception processing goal state for remote access users: {0}".format(textutil.format_exception(e))

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -667,7 +667,7 @@ class UpdateHandler(object):
             self._report_status(exthandlers_handler, agent_update_handler)
 
             if self._processing_new_incarnation():
-                remote_access_handler.run()
+                remote_access_handler.run(self._goal_state.remote_access)
 
             # lastly, archive the goal state history (but do it only on new goal states - no need to do it on every iteration)
             if self._processing_new_extensions_goal_state():


### PR DESCRIPTION
This PR continues the refactoring to detach the goal state from the WireClient (eliminate the calls to WireClient.get_goal_state())

Instead of the RemoteAccessHandler getting the goal state, the UpdateHandler passes it the remote access section of the goal state.