### PR TITLE
Decouple initialization of the Transport certificate from protocol detection

### DIFF
--- a/azurelinuxagent/common/event.py
+++ b/azurelinuxagent/common/event.py
@@ -141,6 +141,7 @@ class WALAEventOperation:
     SignatureValidation = "SignatureValidation"                         # Event for general logs related to package signature or manifest validation that don't fall under a specific operation.
     SkipUpdate = "SkipUpdate"
     StatusProcessing = "StatusProcessing"
+    TransportCertificate = "TransportCertificate"
     UnhandledError = "UnhandledError"
     UnInstall = "UnInstall"
     Unknown = "Unknown"

--- a/azurelinuxagent/common/protocol/util.py
+++ b/azurelinuxagent/common/protocol/util.py
@@ -188,7 +188,7 @@ class ProtocolUtil(SingletonPerThread):
                 return
             logger.error("Failed to clear wiresever endpoint: {0}", e)
 
-    def _detect_protocol(self, init_goal_state, create_transport_certificate, save_to_history):
+    def _detect_protocol(self, init_goal_state, save_to_history):
         """
         Probe protocol endpoints in turn.
         """
@@ -223,7 +223,7 @@ class ProtocolUtil(SingletonPerThread):
 
                 try:
                     protocol = WireProtocol(endpoint)
-                    protocol.detect(init_goal_state=init_goal_state, create_transport_certificate=create_transport_certificate, save_to_history=save_to_history)
+                    protocol.detect(init_goal_state=init_goal_state, save_to_history=save_to_history)
                     self._set_wireserver_endpoint(endpoint)
                     return protocol
 
@@ -274,7 +274,7 @@ class ProtocolUtil(SingletonPerThread):
         finally:
             self._lock.release()
 
-    def get_protocol(self, init_goal_state=True, create_transport_certificate=True, save_to_history=False):
+    def get_protocol(self, init_goal_state=True, save_to_history=False):
         """
         Detect protocol by endpoint.
         :returns: protocol instance
@@ -284,8 +284,6 @@ class ProtocolUtil(SingletonPerThread):
             if self._protocol is not None:
                 return self._protocol
 
-            # If the protocol file contains MetadataProtocol we need to fall through to 
-            # _detect_protocol so that we can generate the WireServer transport certificates.
             protocol_file_path = self._get_protocol_file_path()
             if os.path.isfile(protocol_file_path) and fileutil.read_file(protocol_file_path) == WIRE_PROTOCOL_NAME:
                 endpoint = self.get_wireserver_endpoint()
@@ -302,14 +300,14 @@ class ProtocolUtil(SingletonPerThread):
 
             logger.info("Detect protocol endpoint")
 
-            protocol = self._detect_protocol(init_goal_state=init_goal_state, create_transport_certificate=create_transport_certificate, save_to_history=save_to_history)
+            protocol = self._detect_protocol(init_goal_state=init_goal_state, save_to_history=save_to_history)
 
             IOErrorCounter.set_protocol_endpoint(endpoint=protocol.get_endpoint())
             self._save_protocol(WIRE_PROTOCOL_NAME)
 
             self._protocol = protocol
 
-            # Need to clean up MDS artifacts only after _detect_protocol so that we don't
+            # Clean up the metadata server artifacts only after _detect_protocol so that we don't
             # delete MDS certificates if we can't reach WireServer and have to roll back
             # the update
             if is_metadata_server_artifact_present():

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -69,22 +69,27 @@ class UploadError(HttpError):
     pass
 
 
+class TransportCertificateError(ProtocolError):
+    pass
+
+
 class WireProtocol(DataContract):
     def __init__(self, endpoint):
         if endpoint is None:
             raise ProtocolError("WireProtocol endpoint is None")
         self.client = WireClient(endpoint)
 
-    def detect(self, init_goal_state=True, create_transport_certificate=True, save_to_history=False):
-        self.client.check_wire_protocol_version()
+    @staticmethod
+    def create_transport_certificate():
+        try:
+            trans_prv_file = os.path.join(conf.get_lib_dir(), TRANSPORT_PRV_FILE_NAME)
+            trans_cert_file = os.path.join(conf.get_lib_dir(), TRANSPORT_CERT_FILE_NAME)
+            CryptUtil(conf.get_openssl_cmd()).gen_transport_cert(trans_prv_file, trans_cert_file)
+        except Exception as e:
+            raise TransportCertificateError("Cannot create the Transport certificate: {0}".format(ustr(e)))
 
-        if create_transport_certificate:
-            trans_prv_file = os.path.join(conf.get_lib_dir(),
-                                          TRANSPORT_PRV_FILE_NAME)
-            trans_cert_file = os.path.join(conf.get_lib_dir(),
-                                           TRANSPORT_CERT_FILE_NAME)
-            cryptutil = CryptUtil(conf.get_openssl_cmd())
-            cryptutil.gen_transport_cert(trans_prv_file, trans_cert_file)
+    def detect(self, init_goal_state=True, save_to_history=False):
+        self.client.check_wire_protocol_version()
 
         # Initialize the goal state, including all the inner properties
         if init_goal_state:

--- a/azurelinuxagent/daemon/main.py
+++ b/azurelinuxagent/daemon/main.py
@@ -137,9 +137,9 @@ class DaemonHandler(object):
         #
         # Initially this was done to detect changes in the protocol used to communicate with the Host. Azure Stack used to have its own protocol (the "Metadata"
         # protocol) and, since VMs can move between Azure Stack and Azure, protocol detection was needed. Currently, both Azure Stack and Azure use the WireServer
-        # protocol, but there are some side effects of protocol detection that are still needed: generating the Transport certificate for communication with the
-        # WireServer, initializing the goal state, and cleaning up the state saved by Azure Stack. That functionality needs be refactored out from protocol
-        # detection, but in the meanwhile we keep the approach of forcing protocol detection during initialization.
+        # protocol, but there are some side effects of protocol detection that are still needed, for example detecting the WireServer address and cleaning up the
+        # state saved by Azure Stack. That functionality needs be refactored out from protocol detection, but in the meanwhile we keep the approach of forcing
+        # detection during initialization.
         #
         protocol_util = get_protocol_util()
         protocol_util.clear_protocol()

--- a/azurelinuxagent/ga/logcollector.py
+++ b/azurelinuxagent/ga/logcollector.py
@@ -110,7 +110,7 @@ class LogCollector(object):
 
     @staticmethod
     def initialize_telemetry():
-        protocol = get_protocol_util().get_protocol(init_goal_state=False, create_transport_certificate=False, save_to_history=False)
+        protocol = get_protocol_util().get_protocol(init_goal_state=False, save_to_history=False)
         protocol.client.reset_goal_state(goal_state_properties=GoalStateProperties.RoleConfig | GoalStateProperties.HostingEnv)
         # Initialize the common parameters for telemetry events
         initialize_event_logger_vminfo_common_parameters_and_protocol(protocol)

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -1,3 +1,4 @@
+
 # Windows Azure Linux Agent
 #
 # Copyright 2018 Microsoft Corporation
@@ -48,7 +49,7 @@ from azurelinuxagent.common.protocol.goal_state import GoalStateSource, TRANSPOR
 from azurelinuxagent.common.protocol.hostplugin import HostPluginProtocol, VmSettingsNotSupported
 from azurelinuxagent.common.protocol.restapi import VERSION_0
 from azurelinuxagent.common.protocol.util import get_protocol_util
-from azurelinuxagent.common.protocol.wire import TransportCertificateError
+from azurelinuxagent.common.protocol.wire import WireProtocol, TransportCertificateError
 from azurelinuxagent.common.utils import shellutil
 from azurelinuxagent.common.utils.archive import StateArchiver, AGENT_STATUS_FILE
 from azurelinuxagent.common.utils.flexible_version import FlexibleVersion
@@ -367,17 +368,7 @@ class UpdateHandler(object):
             # Initialize the goal state; some components depend on information provided by the goal state and this
             # call ensures the required info is initialized (e.g. telemetry depends on the container ID.)
             #
-            # Also, refresh the transport certificate each time the Agent starts.
-            #
-            protocol = self.protocol_util.get_protocol(save_to_history=True)
-            try:
-                protocol.create_transport_certificate()
-            except TransportCertificateError as e:
-                # Report the error and continue execution; we retry in the main loop
-                message = ustr(e)
-                logger.warn(message)
-                add_event(op=WALAEventOperation.TransportCertificate, message=message, is_success=False, log_event=False)
-
+            protocol = self.protocol_util.get_protocol(init_goal_state=False)
             self._initialize_goal_state(protocol)
 
             # Initialize the common parameters for telemetry events
@@ -493,11 +484,25 @@ class UpdateHandler(object):
 
     def _initialize_goal_state(self, protocol):
         #
-        # Block until we can fetch the first goal state (self._try_update_goal_state() does its own logging and error handling).
+        # Block until we can fetch the first goal state. Also, refresh the transport certificate.
+        #
+        # Note that all the telemetry emitted by this function (and the functions it calls) is not fully associated with the current VM; the
+        # container ID will be populated only after the goal state is actually fetched, and the Resource Group, VM Name, and VM ID will be
+        # populated only after we initialize telemetry (which happens after this function returns).
+        #
+        # To address issue, we should populate any uninitialized fields before pushing the telemetry events to the WireServer.
         #
         event.info(WALAEventOperation.GoalState, "Initializing the goal state...")
+
+        try:
+            event.info(WALAEventOperation.TransportCertificate, "Refreshing/creating the Transport Certificate.")
+            WireProtocol.create_transport_certificate()
+        except TransportCertificateError as e:
+            event.warn(WALAEventOperation.TransportCertificate, "{0}", ustr(e))
+
         while not self._try_update_goal_state(protocol):
             time.sleep(conf.get_goal_state_period())
+
         event.info(WALAEventOperation.GoalState, "Goal state initialization completed.")
 
         #
@@ -558,15 +563,11 @@ class UpdateHandler(object):
 
         try:
             #
-            # Ensure the transport certificate exists (in case we could not create it during Agent initialization)
+            # Ensure the transport certificate exists
             #
             trans_cert_file = os.path.join(conf.get_lib_dir(), TRANSPORT_CERT_FILE_NAME)
             if not os.path.exists(trans_cert_file):
-                try:
-                    protocol.create_transport_certificate()
-                except TransportCertificateError as e:
-                    add_event(op=WALAEventOperation.TransportCertificate, message=ustr(e), is_success=False, log_event=False)
-                    raise
+                protocol.create_transport_certificate()
 
             #
             # For Fast Track goal states we need to ensure that the tenant certificate is in the goal state.

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -567,7 +567,7 @@ class UpdateHandler(object):
             #
             trans_cert_file = os.path.join(conf.get_lib_dir(), TRANSPORT_CERT_FILE_NAME)
             if not os.path.exists(trans_cert_file):
-                protocol.create_transport_certificate()
+                WireProtocol.create_transport_certificate()
 
             #
             # For Fast Track goal states we need to ensure that the tenant certificate is in the goal state.

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -44,10 +44,11 @@ from azurelinuxagent.ga.firewall_manager import FirewallManager, FirewallStateEr
 from azurelinuxagent.common.future import ustr, UTC, datetime_min_utc
 from azurelinuxagent.common.osutil import get_osutil, systemd
 from azurelinuxagent.ga.persist_firewall_rules import PersistFirewallRulesHandler
-from azurelinuxagent.common.protocol.goal_state import GoalStateSource
+from azurelinuxagent.common.protocol.goal_state import GoalStateSource, TRANSPORT_CERT_FILE_NAME
 from azurelinuxagent.common.protocol.hostplugin import HostPluginProtocol, VmSettingsNotSupported
 from azurelinuxagent.common.protocol.restapi import VERSION_0
 from azurelinuxagent.common.protocol.util import get_protocol_util
+from azurelinuxagent.common.protocol.wire import TransportCertificateError
 from azurelinuxagent.common.utils import shellutil
 from azurelinuxagent.common.utils.archive import StateArchiver, AGENT_STATUS_FILE
 from azurelinuxagent.common.utils.flexible_version import FlexibleVersion
@@ -366,7 +367,16 @@ class UpdateHandler(object):
             # Initialize the goal state; some components depend on information provided by the goal state and this
             # call ensures the required info is initialized (e.g. telemetry depends on the container ID.)
             #
+            # Also, refresh the transport certificate each time the Agent starts.
+            #
             protocol = self.protocol_util.get_protocol(save_to_history=True)
+            try:
+                protocol.create_transport_certificate()
+            except TransportCertificateError as e:
+                # Report the error and continue execution; we retry in the main loop
+                message = ustr(e)
+                logger.warn(message)
+                add_event(op=WALAEventOperation.TransportCertificate, message=message, is_success=False, log_event=False)
 
             self._initialize_goal_state(protocol)
 
@@ -547,6 +557,17 @@ class UpdateHandler(object):
         max_errors_to_log = 3
 
         try:
+            #
+            # Ensure the transport certificate exists (in case we could not create it during Agent initialization)
+            #
+            trans_cert_file = os.path.join(conf.get_lib_dir(), TRANSPORT_CERT_FILE_NAME)
+            if not os.path.exists(trans_cert_file):
+                try:
+                    protocol.create_transport_certificate()
+                except TransportCertificateError as e:
+                    add_event(op=WALAEventOperation.TransportCertificate, message=ustr(e), is_success=False, log_event=False)
+                    raise
+
             #
             # For Fast Track goal states we need to ensure that the tenant certificate is in the goal state.
             #

--- a/tests/common/protocol/test_protocol_util.py
+++ b/tests/common/protocol/test_protocol_util.py
@@ -127,14 +127,14 @@ class TestProtocolUtil(AgentTestCase):
         endpoint_file = protocol_util._get_wireserver_endpoint_file_path()  # pylint: disable=unused-variable
 
         # Test wire protocol when no endpoint file has been written
-        protocol_util._detect_protocol(init_goal_state=True, create_transport_certificate=True, save_to_history=False)
+        protocol_util._detect_protocol(init_goal_state=True, save_to_history=False)
         self.assertEqual(KNOWN_WIRESERVER_IP, protocol_util.get_wireserver_endpoint())
 
         # Test wire protocol on dhcp failure
         protocol_util.osutil.is_dhcp_available.return_value = True
         protocol_util.dhcp_handler.run.side_effect = DhcpError()
 
-        self.assertRaises(ProtocolError, lambda: protocol_util._detect_protocol(init_goal_state=True, create_transport_certificate=True, save_to_history=False))
+        self.assertRaises(ProtocolError, lambda: protocol_util._detect_protocol(init_goal_state=True, save_to_history=False))
 
     @patch("azurelinuxagent.common.conf.get_lib_dir")
     @patch("azurelinuxagent.common.protocol.util.WireProtocol")
@@ -151,7 +151,7 @@ class TestProtocolUtil(AgentTestCase):
         protocol_util.dhcp_handler.run = Mock()
 
         # Test wire protocol when no endpoint file has been written, dhcp handler should not be called
-        protocol_util._detect_protocol(init_goal_state=True, create_transport_certificate=True, save_to_history=False)
+        protocol_util._detect_protocol(init_goal_state=True, save_to_history=False)
         self.assertEqual(KNOWN_WIRESERVER_IP, protocol_util.get_wireserver_endpoint())
         self.assertTrue(protocol_util.dhcp_handler.run.call_count == 0)
 
@@ -247,11 +247,6 @@ class TestProtocolUtil(AgentTestCase):
         for mds_cert_path in mds_cert_paths:
             self.assertFalse(os.path.exists(mds_cert_path))
 
-        # Check that WireServer Certs exist
-        ws_cert_paths = [os.path.join(dir, ws_cert) for ws_cert in TestProtocolUtil.WIRESERVER_CERTIFICATES]
-        for ws_cert_path in ws_cert_paths:
-            self.assertTrue(os.path.isfile(ws_cert_path))
-
         # Check firewall rules was reset
         self.assertEqual(1, mock_remove_firewall.call_count, "remove_firewall should be called once")
 
@@ -266,7 +261,7 @@ class TestProtocolUtil(AgentTestCase):
     @patch('azurelinuxagent.common.conf.get_lib_dir')
     @patch('azurelinuxagent.common.conf.enable_firewall')
     @patch('azurelinuxagent.common.protocol.wire.WireClient')
-    def test_get_protocol_new_wireserver_agent_generates_certificates(self, mock_wire_client, mock_enable_firewall, mock_get_lib_dir, _):
+    def test_get_protocol_new_wireserver_agent_initializes_the_protocol_files(self, mock_wire_client, mock_enable_firewall, mock_get_lib_dir, _):
         """
         This is for testing that a new WireServer Linux Agent generates appropriate certificates,
         protocol file, and endpoint file.
@@ -284,11 +279,6 @@ class TestProtocolUtil(AgentTestCase):
         # Run
         with patch("azurelinuxagent.common.protocol.metadata_server_migration_util._remove_firewall") as mock_remove_firewall:
             protocol_util.get_protocol()
-
-        # Check that WireServer Certs exist
-        ws_cert_paths = [os.path.join(dir, ws_cert) for ws_cert in TestProtocolUtil.WIRESERVER_CERTIFICATES]
-        for ws_cert_path in ws_cert_paths:
-            self.assertTrue(os.path.isfile(ws_cert_path))
 
         # Check firewall rules were not reset
         mock_remove_firewall.assert_not_called()

--- a/tests/common/protocol/test_wire.py
+++ b/tests/common/protocol/test_wire.py
@@ -24,17 +24,15 @@ import time
 import unittest
 import uuid
 
+from azurelinuxagent.common import conf
 from azurelinuxagent.common.agent_supported_feature import get_agent_supported_features_list_for_crp, _MultiConfigFeature, _GAVersioningGovernanceFeature
 from azurelinuxagent.common.event import WALAEventOperation
-from azurelinuxagent.common.exception import ResourceGoneError, ProtocolError, \
-    ExtensionDownloadError, HttpError
+from azurelinuxagent.common.exception import ResourceGoneError, ProtocolError, ExtensionDownloadError, HttpError
 from azurelinuxagent.common.protocol.extensions_goal_state_from_extensions_config import ExtensionsGoalStateFromExtensionsConfig
 from azurelinuxagent.common.protocol.goal_state import GoalStateProperties
 from azurelinuxagent.common.protocol.hostplugin import HostPluginProtocol
-from azurelinuxagent.common.protocol.wire import WireProtocol, WireClient, \
-    StatusBlob, VMStatus
-from azurelinuxagent.common.telemetryevent import GuestAgentExtensionEventsSchema, \
-    TelemetryEventParam, TelemetryEvent
+from azurelinuxagent.common.protocol.wire import WireProtocol, WireClient, StatusBlob, VMStatus, TRANSPORT_CERT_FILE_NAME, TRANSPORT_PRV_FILE_NAME
+from azurelinuxagent.common.telemetryevent import GuestAgentExtensionEventsSchema, TelemetryEventParam, TelemetryEvent
 from azurelinuxagent.common.utils import restutil
 from azurelinuxagent.common.version import CURRENT_VERSION, DISTRO_NAME, DISTRO_VERSION
 from azurelinuxagent.ga.exthandlers import get_exthandlers_handler
@@ -84,6 +82,9 @@ class TestWireProtocol(AgentTestCase, HttpRequestPredicates):
 
     def _test_getters(self, test_data, certsMustBePresent, __, MockCryptUtil, _):
         MockCryptUtil.side_effect = test_data.mock_crypt_util
+        private_key = os.path.join(conf.get_lib_dir(), TRANSPORT_PRV_FILE_NAME)
+        certificate = os.path.join(conf.get_lib_dir(), TRANSPORT_CERT_FILE_NAME)
+        test_data.mock_gen_trans_cert(private_key, certificate)
 
         with patch.object(restutil, 'http_get', test_data.mock_http_get):
             protocol = WireProtocol(WIRESERVER_URL)

--- a/tests/lib/mock_wire_protocol.py
+++ b/tests/lib/mock_wire_protocol.py
@@ -24,7 +24,7 @@ from tests.lib import wire_protocol_data
 
 
 @contextlib.contextmanager
-def mock_wire_protocol(mock_wire_data_file, http_get_handler=None, http_post_handler=None, http_put_handler=None, do_not_mock=lambda method, url: False, fail_on_unknown_request=True, save_to_history=False, detect_protocol=True):
+def mock_wire_protocol(mock_wire_data_file, http_get_handler=None, http_post_handler=None, http_put_handler=None, do_not_mock=lambda method, url: False, fail_on_unknown_request=True, save_to_history=False, detect_protocol=True, create_transport_certificate=True):
     """
     Creates a WireProtocol object that handles requests to the WireServer, the Host GA Plugin, and some requests to storage (requests that provide mock data
     in wire_protocol_data.py).
@@ -151,11 +151,17 @@ def mock_wire_protocol(mock_wire_data_file, http_get_handler=None, http_post_han
     # go do it
     try:
         protocol.start()
+
+        if create_transport_certificate:
+            # The mock WireServer response for the Certificates API is encrypted using a specific transport certificate, which is also part of the mock data set. We create the Transport certificate
+            # using that mock data. If, for any reason, a test needs to create its own Transport certificate, it can set the create_transport_certificate parameter to False.
+            private_key = os.path.join(conf.get_lib_dir(), TRANSPORT_PRV_FILE_NAME)
+            certificate = os.path.join(conf.get_lib_dir(), TRANSPORT_CERT_FILE_NAME)
+            protocol.mock_wire_data.mock_gen_trans_cert(private_key, certificate)
+
         if detect_protocol:
             protocol.detect(save_to_history=save_to_history)
-        else:
-            # the transport certificate is generated during protocol detection; if we skip detection we still need to generate it
-            protocol.mock_wire_data.mock_gen_trans_cert(os.path.join(conf.get_lib_dir(), TRANSPORT_PRV_FILE_NAME), os.path.join(conf.get_lib_dir(), TRANSPORT_CERT_FILE_NAME))
+
         yield protocol
     finally:
         protocol.stop()


### PR DESCRIPTION
Refactoring the initialization of the Transport certificate out of protocol detection. Now initialization is done by the UpdateHandler as part of extension processing.