### PR TITLE
Remove telemetry reporting if Agent memory usage > limit

### DIFF
--- a/azurelinuxagent/ga/cgroupconfigurator.py
+++ b/azurelinuxagent/ga/cgroupconfigurator.py
@@ -566,8 +566,6 @@ class CGroupConfigurator(object):
                 if not self.enabled():
                     return
 
-                self._report_agent_cgroups_memory_usage(cgroup_metrics)
-
                 errors = []
 
                 process_check_success = False
@@ -764,21 +762,6 @@ class CGroupConfigurator(object):
                 if 'UNKNOWN' in proc_name:
                     msg = "Agent includes following processes when UNKNOWN process found: {0}".format("\n".join([ustr(proc) for proc in agent_cgroup_proc_names]))
                     add_event(op=WALAEventOperation.CGroupsInfo, message=msg)
-
-        @staticmethod
-        def _report_agent_cgroups_memory_usage(cgroup_metrics):
-            """
-            Reports the agent's current memory usage when it exceeds the configured limit.
-            """
-            limit_in_bytes = conf.get_agent_memory_quota()
-            current_usage = 0
-            for metric in cgroup_metrics:
-                if metric.instance == AGENT_NAME_TELEMETRY and (metric.counter == MetricsCounter.TOTAL_MEM_USAGE or metric.counter == MetricsCounter.SWAP_MEM_USAGE):
-                    current_usage += metric.value
-
-            if current_usage > limit_in_bytes:
-                msg = "Agent memory usage is {0} bytes which is over the configured limit of {1} bytes.".format(current_usage, limit_in_bytes)
-                add_event(op=WALAEventOperation.CGroupsInfo, message=msg)
 
         @staticmethod
         def _check_agent_throttled_time(cgroup_metrics):


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->
<!--
Please add an informative description that covers that changes made by the pull request.
-->
## Description

This code is sending telemetry for agents (VMs) that do not have a memory limit configured. As a result, it is creating confusion and generating unnecessarily verbose logs.

Instead, we can get this information from the Performance Counter table

Issue # <!-- if any -->
---
<!--
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->
### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).
---
<!--
This checklist is used to track contributions from distro maintainers.
-->
### Distro maintenance information, if applicable
- [ ] This is a contribution from a distro maintainer
- [ ] The changes in this PR have been taken as a downstream patch (Note: it is not recommended to patch the agent without upstream review and approval)
