### PR TITLE
Switch from python3-crypt-r to use crypt system libs via ctypes

### DIFF
--- a/azurelinuxagent/common/osutil/default.py
+++ b/azurelinuxagent/common/osutil/default.py
@@ -64,8 +64,14 @@ except ImportError:
         except ImportError:
             pass
     if not __CRYPT_IMPORTED__:
+        try:
+            from azurelinuxagent.fallbacks.crypt import crypt  # type: ignore[assignment]
+            __CRYPT_IMPORTED__ = True
+        except Exception:  # pylint: disable=broad-except
+            pass
+    if not __CRYPT_IMPORTED__:
         def crypt(password, salt):
-            raise OSUtilError("This feature requires one of the 'crypt', 'legacycrypt' or 'crypt-r' Python packages to be installed.")
+            raise OSUtilError("This feature requires the 'crypt' or 'legacycrypt' Python package, or libcrypt from the system, to be available.")
 
 from azurelinuxagent.common import conf
 from azurelinuxagent.common import logger

--- a/azurelinuxagent/fallbacks/__init__.py
+++ b/azurelinuxagent/fallbacks/__init__.py
@@ -1,0 +1,1 @@
+"""Compatibility helpers for third-party Python modules removed from the standard library."""

--- a/azurelinuxagent/fallbacks/crypt.py
+++ b/azurelinuxagent/fallbacks/crypt.py
@@ -1,0 +1,61 @@
+"""Minimal replacement for the deprecated crypt module using libcrypt via ctypes."""
+
+import ctypes
+import ctypes.util
+import threading
+
+__all__ = ["crypt"]
+
+_libcrypt = None
+_libcrypt_lock = threading.Lock()
+
+
+def _load_libcrypt():
+    """Load libcrypt from the system and cache the handle."""
+    global _libcrypt  # pylint: disable=global-statement
+    if _libcrypt is not None:
+        return _libcrypt
+
+    candidates = []
+    libcrypt_name = ctypes.util.find_library("crypt")
+    if libcrypt_name:
+        candidates.append(libcrypt_name)
+    candidates.extend(["libcrypt.so.2", "libcrypt.so.1", "libcrypt.so"])
+
+    for candidate in candidates:
+        if not candidate:
+            continue
+        try:
+            library = ctypes.CDLL(candidate, use_errno=True)
+            library.crypt.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
+            library.crypt.restype = ctypes.c_char_p
+            _libcrypt = library
+            return _libcrypt
+        except (AttributeError, OSError):
+            continue
+    raise ImportError("libcrypt not found")
+
+
+def crypt(word, salt):
+    """Hash *word* with *salt* using libcrypt."""
+    library = _load_libcrypt()
+    word_bytes = word.encode("utf-8") if isinstance(word, str) else word
+    salt_bytes = salt.encode("utf-8") if isinstance(salt, str) else salt
+
+    if isinstance(word_bytes, bytearray):
+        word_bytes = bytes(word_bytes)
+    if isinstance(salt_bytes, bytearray):
+        salt_bytes = bytes(salt_bytes)
+
+    if not isinstance(word_bytes, (bytes, bytearray)):
+        raise TypeError("word must be str or bytes")
+    if not isinstance(salt_bytes, (bytes, bytearray)):
+        raise TypeError("salt must be str or bytes")
+
+    with _libcrypt_lock:
+        ctypes.set_errno(0)
+        result = library.crypt(word_bytes, salt_bytes)
+        errno_value = ctypes.get_errno()
+    if not result:
+        raise OSError(errno_value, "libcrypt failed to hash password")
+    return result.decode("utf-8")

--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -2180,6 +2180,15 @@ class ExtHandlerInstance(object):
 
                     # Add the os environment variables before executing command
                     env.update(os.environ)
+
+                    fallback_python_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "fallbacks")
+                    fallback_module = os.path.join(fallback_python_dir, "crypt.py")
+                    if os.path.isfile(fallback_module):
+                        existing_pythonpath = env.get("PYTHONPATH")
+                        path_entries = [] if not existing_pythonpath else [p for p in existing_pythonpath.split(os.pathsep) if p]
+                        if fallback_python_dir not in path_entries:
+                            path_entries.insert(0, fallback_python_dir)
+                            env["PYTHONPATH"] = os.pathsep.join(path_entries)
                     process_output = CGroupConfigurator.get_instance().start_extension_command(
                         extension_name=self.get_full_name(extension),
                         command=command_full_path,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 distro; python_version >= '3.8'
 pyasn1
-crypt-r; python_version >= '3.13'

--- a/setup.py
+++ b/setup.py
@@ -352,13 +352,12 @@ class install(_install):  # pylint: disable=C0103
 #   module was deprecated. Depending on the Linux distribution the
 #   implementation may be broken prior to Python 3.8 where the functionality
 #   will be removed from Python 3.
-# * In version 3.13 of Python, the crypt module was removed and crypt-r is
-#   required instead.
+# * In version 3.13 of Python, the crypt module was removed from the standard
+#   library; WALinuxAgent now falls back to libcrypt via ctypes when the module
+#   is unavailable.
 requires = []
 if sys.version_info[0] >= 3 and sys.version_info[1] >= 8:
     requires.append('distro')
-if sys.version_info[0] >= 3 and sys.version_info[1] >= 13:
-    requires.append('crypt-r')
 
 modules = []  # pylint: disable=invalid-name
 


### PR DESCRIPTION
Hello team, 

## Description

Since Python 3.13 removed the `crypt` module, the agent uses a copy of that deprecated package, which is called python3-crypt-r.  I know this was discussed at https://github.com/Azure/WALinuxAgent/pull/3141 .

Unfortunately, in Ubuntu, it is not a viable solution due to the concerns about security and maintenance of python3-crypt-r, so the package resides in the universe repository without the possibility of being accepted into the main repository, but the walinuxagent package only uses packages in the main repository as dependencies (see  https://bugs.launchpad.net/ubuntu/+source/walinuxagent/+bug/2106484/comments/1 for reference).

I built a package for Ubuntu development series (resolute) with these changes as PoC at https://launchpad.net/~mirespace/+archive/ubuntu/azure/+sourcepub/18050206/+listing-archive-extra. There are no errors during normal operations (upgrade, install, remove), no errors in the logs, and the service is active as well.

An overview of the commit is: 
 - Provide a minimal libcrypt-backed crypt implementation in crypt.py and expose fallbacks via __init__.py.
 - Teach default.py:63-77 to load the new fallback before emitting an error and clarify the failure message.
 - Inject the fallbacks directory into PYTHONPATH for extension processes in exthandlers.py:2180-2193 so child interpreters can use the wrapper.
 - Drop the crypt-r requirement from requirements.txt:1-3 and setup.py:352-361 now that libcrypt covers Python 3.13+.
 
 I understand that this could be too general to cover all distros' necessities (especially if crypt system libraries are in non-standard locations), but I think it could be a starting point for expanding it and accommodating them, if you like this proposal.
 
The package passed the tests during build time, as shown in the logs at https://launchpadlibrarian.net/843491146/buildlog_ubuntu-resolute-amd64.walinuxagent_2.15.0.1-0ubuntu1~miriam12_BUILDING.txt.gz. 
 
I would appreciate your feedback on this.

---
### PR information
- [x] Ensure development PR is based on the `develop` branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [x ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).
---
### Distro maintenance information, if applicable
- [x] This is a contribution from a distro maintainer
- [ ] The changes in this PR have been taken as a downstream patch (Note: it is not recommended to patch the agent without upstream review and approval)
