### PR TITLE
Fix flakiness in publish_hostname e2e test

### DIFF
--- a/tests_e2e/tests/publish_hostname/publish_hostname.py
+++ b/tests_e2e/tests/publish_hostname/publish_hostname.py
@@ -158,7 +158,7 @@ class PublishHostname(AgentVmTest):
                     hostname_detected = ""
                     for retry in range(4, -1, -1):
                         try:
-                            hostname_detected = self.retry_ssh_if_connection_reset("grep -n 'Detected hostname change:.*-> {0}' /var/log/waagent.log".format(hostname), use_sudo=True)
+                            hostname_detected = self.retry_ssh_if_connection_reset("grep -a -n 'Detected hostname change:.*-> {0}' /var/log/waagent.log".format(hostname), use_sudo=True)
                             if hostname_detected:
                                 log.info("Agent detected hostname change: {0}".format(hostname_detected))
                                 break


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->
<!--
Please add an informative description that covers that changes made by the pull request.
-->
## Description
When there are non-text bytes in /var/log/waagent.log (due to some extension output), the following grep command can prematurely quit before finding the specified text:
`# grep -n 'Detected hostname change:.*-> {0}' /var/log/waagent.log`
`grep: /var/log/waagent.log: binary file matches`

Use grep -a option to always treat waagent.log file as text file to prevent the command from exiting early

Issue # <!-- if any -->
---
<!--
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->
### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).
---
<!--
This checklist is used to track contributions from distro maintainers.
-->
### Distro maintenance information, if applicable
- [ ] This is a contribution from a distro maintainer
- [ ] The changes in this PR have been taken as a downstream patch (Note: it is not recommended to patch the agent without upstream review and approval)
