### PR TITLE
Add Oracle 10 to end-to-end test run

### DIFF
--- a/tests_e2e/test_suites/images.yml
+++ b/tests_e2e/test_suites/images.yml
@@ -24,6 +24,7 @@ image-sets:
       - "oracle_79"
       - "oracle_810"
       - "oracle_95"
+      - "oracle_10"
       - "rhel_79"
       - "rhel_810"
       - "rhel_95"
@@ -45,6 +46,7 @@ image-sets:
       - "flatcar_arm64"
       - "mariner_2_arm64"
       - "azure-linux_3_arm64"
+      - "oracle_10_arm64"
       - "rhel_95_arm64"
       - "ubuntu_2204_arm64"
       - "ubuntu_2404_arm64"
@@ -209,27 +211,35 @@ images:
       locations:
          AzureChinaCloud: []
          AzureUSGovernment: []
-   oracle_610: "Oracle:Oracle-Linux:6.10:latest"
-   oracle_75:
+   oracle_610: "Oracle:Oracle-Linux:6.10:latest" # Python 2.6.6; not in test run
+   oracle_75: # Python: 2.7.5; used for the recover_network_interface test
       urn: "Oracle:Oracle-Linux:7.5:latest"
       locations:
          AzureChinaCloud: []
          AzureUSGovernment: []
-   oracle_79:
+   oracle_79: # Python: 2.7.5
       urn: "Oracle:Oracle-Linux:ol79-gen2:latest"
       locations:
          AzureChinaCloud: []
-   oracle_82:
+   oracle_82: # Python: 3.6.8; used for the recover_network_interface test
       urn: "Oracle:Oracle-Linux:ol82-gen2:latest"
       locations:
          AzureChinaCloud: []
          AzureUSGovernment: []
-   oracle_810:
+   oracle_810: # Python: 3.6.8
       urn: "Oracle:Oracle-Linux:ol810-lvm-gen2:latest"
       locations:
          AzureChinaCloud: []
-   oracle_95:
+   oracle_95: # Python: 3.9.21
       urn: "Oracle:Oracle-Linux:ol95-lvm-gen2:latest"
+      locations:
+         AzureChinaCloud: []
+   oracle_10:
+      urn: "Oracle:Oracle-Linux:ol10-lvm-gen2:latest"
+      locations:
+         AzureChinaCloud: []
+   oracle_10_arm64:
+      urn: "Oracle:Oracle-Linux:ol10-arm64-lvm-gen2:latest"
       locations:
          AzureChinaCloud: []
    rhel_610: "RedHat:RHEL:6.10:latest"

--- a/tests_e2e/test_suites/images.yml
+++ b/tests_e2e/test_suites/images.yml
@@ -46,7 +46,6 @@ image-sets:
       - "flatcar_arm64"
       - "mariner_2_arm64"
       - "azure-linux_3_arm64"
-      - "oracle_10_arm64"
       - "rhel_95_arm64"
       - "ubuntu_2204_arm64"
       - "ubuntu_2404_arm64"
@@ -238,7 +237,7 @@ images:
       urn: "Oracle:Oracle-Linux:ol10-lvm-gen2:latest"
       locations:
          AzureChinaCloud: []
-   oracle_10_arm64:
+   oracle_10_arm64: # TODO: Oracle 10 ARM64 is failing to deploy; add to 'endorsed-arm64' once it is fixed.
       urn: "Oracle:Oracle-Linux:ol10-arm64-lvm-gen2:latest"
       locations:
          AzureChinaCloud: []

--- a/tests_e2e/test_suites/images.yml
+++ b/tests_e2e/test_suites/images.yml
@@ -242,6 +242,7 @@ images:
       urn: "Oracle:Oracle-Linux:ol10-arm64-lvm-gen2:latest"
       locations:
          AzureChinaCloud: []
+         AzureUSGovernment: [] # TODO: Our test subscription does not have quota to create VMs with this image. Remove once we update our subscription.
    rhel_610: "RedHat:RHEL:6.10:latest"
    rhel_75:
       urn: "RedHat:RHEL:7.5:latest"

--- a/tests_e2e/tests/lib/vm_extension_identifier.py
+++ b/tests_e2e/tests/lib/vm_extension_identifier.py
@@ -34,7 +34,7 @@ class VmExtensionIdentifier(object):
 
     unsupported_distros: Dict[str, List[str]] = {
         "Microsoft.OSTCExtensions.VMAccessForLinux": ["flatcar"],
-        "Microsoft.Azure.Monitor.AzureMonitorLinuxAgent": ["flatcar", "mariner_1", "ubuntu_2404", "sles_15", "rhel_10", "almalinux_10"],
+        "Microsoft.Azure.Monitor.AzureMonitorLinuxAgent": ["flatcar", "mariner_1", "ubuntu_2404", "sles_15", "rhel_10", "almalinux_10", "oracle_10"],
         "Microsoft.GuestConfiguration.ConfigurationforLinux": ["flatcar"],
         "Microsoft.Azure.Security.Monitoring.AzureSecurityLinuxAgent": ["flatcar"],
         # TODO: RCv2 currently fails on AzureCloud on the distros below due to GLIBC < 2.34. Once the extension is fixed to support older GLIB versions, remove this entry.


### PR DESCRIPTION
There are still issues with the ARM64 images, so they are not used for now.