### PR TITLE
Cgroup2fs filesystem detection in cgroups api check

### DIFF
--- a/azurelinuxagent/ga/cgroupapi.py
+++ b/azurelinuxagent/ga/cgroupapi.py
@@ -243,19 +243,27 @@ def create_cgroup_api():
 
     root_hierarchy_mode = shellutil.run_command(["stat", "-f", "--format=%T", CGROUP_FILE_SYSTEM_ROOT]).rstrip()
 
-    if root_hierarchy_mode == "cgroup2fs":
+    # Distro Ubuntu 25.10 ship Rust-based coreutils. Its 'stat' lacks a human-readable mapping for the cgroup v2 (cgroup2fs) magic number, so it prints
+    # UNKNOWN with that magic value 0x63677270. Add an explicit check for this hex to detect cgroup v2
+    # #stat -f --format=%T /sys/fs/cgroup/
+    # UNKNOWN (0x63677270)
+    #
+
+    if root_hierarchy_mode == "cgroup2fs" or (root_hierarchy_mode.startswith("UNKNOWN") and "0x63677270" in root_hierarchy_mode):
         return SystemdCgroupApiv2()
 
     elif root_hierarchy_mode == "tmpfs":
         # Check if a hybrid mode is being used
         unified_hierarchy_path = os.path.join(CGROUP_FILE_SYSTEM_ROOT, "unified")
-        if os.path.exists(unified_hierarchy_path) and shellutil.run_command(["stat", "-f", "--format=%T", unified_hierarchy_path]).rstrip() == "cgroup2fs":
-            # Hybrid mode is being used. Check if any controllers are available to be enabled in the unified hierarchy.
-            available_unified_controllers_file = os.path.join(unified_hierarchy_path, "cgroup.controllers")
-            if os.path.exists(available_unified_controllers_file):
-                available_unified_controllers = fileutil.read_file(available_unified_controllers_file).rstrip()
-                if available_unified_controllers != "":
-                    raise CGroupsException("Detected hybrid cgroup mode, but there are controllers available to be enabled in unified hierarchy: {0}".format(available_unified_controllers))
+        if os.path.exists(unified_hierarchy_path):
+            unified_hierarchy_mode = shellutil.run_command( ["stat", "-f", "--format=%T", unified_hierarchy_path]).rstrip()
+            if unified_hierarchy_mode == "cgroup2fs" or (unified_hierarchy_mode.startswith("UNKNOWN") and "0x63677270" in unified_hierarchy_mode):
+                # Hybrid mode is being used. Check if any controllers are available to be enabled in the unified hierarchy.
+                available_unified_controllers_file = os.path.join(unified_hierarchy_path, "cgroup.controllers")
+                if os.path.exists(available_unified_controllers_file):
+                    available_unified_controllers = fileutil.read_file(available_unified_controllers_file).rstrip()
+                    if available_unified_controllers != "":
+                        raise CGroupsException("Detected hybrid cgroup mode, but there are controllers available to be enabled in unified hierarchy: {0}".format(available_unified_controllers))
 
         cgroup_api_v1 = SystemdCgroupApiv1()
         # Previously the agent supported users mounting cgroup v1 controllers in locations other than the systemd

--- a/tests_e2e/test_suites/agent_cgroups.yml
+++ b/tests_e2e/test_suites/agent_cgroups.yml
@@ -8,7 +8,10 @@ tests:
   - "agent_cgroups/agent_cpu_quota.py"
   - "agent_cgroups/agent_memory_quota.py"
   - "agent_cgroups/agent_cgroups_process_check.py"
-images: "cgroups-endorsed"
+images:
+  - "cgroups-endorsed"
+  # TODO : Currently some extensions(AMA, VMAccess) do not support 25_10. Move this image to the "cgroups-endorsed" image set once those issues have been fixed.
+  - "ubuntu_2510"
 owns_vm: true
 skip_on_images: # AMA extension used in agent_cgroups_process_check, and it is not supported on these images
   - "rhel_95_arm64"

--- a/tests_e2e/tests/agent_cgroups/agent_cgroups_process_check.py
+++ b/tests_e2e/tests/agent_cgroups/agent_cgroups_process_check.py
@@ -42,6 +42,9 @@ class AgentCgroupsProcessCheck(AgentVmTest):
         3. Restart the ext_handler process to re-initialize the cgroups setup
         4. Verify that agent detects extension processes and will not enable the cgroups
         """
+        if self._ssh_client.get_distro() == "ubuntu_2510":
+            log.info("Skipping test on ubuntu_2510 as AMA extension is not supported to test this scenario")
+            return
 
         log.info("=====Validating agent cgroups process check")
         self._run_remote_test(self._ssh_client, "agent_cgroups_process_check-unknown_process_check.py", use_sudo=True)


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->
<!--
Please add an informative description that covers that changes made by the pull request.
-->
## Description
Distro Ubuntu 25.10 ship Rust-based coreutils. Its 'stat' lacks a human-readable mapping for the cgroup v2 (cgroup2fs) magic number, so it prints UNKNOWN with that magic value 0x63677270. So, adding an explicit check for this hex to detect cgroup v2
```

 # stat -f --format=%T /sys/fs/cgroup/
  UNKNOWN (0x63677270)
```
Issue # <!-- if any -->
---
<!--
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->
### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).
---
<!--
This checklist is used to track contributions from distro maintainers.
-->
### Distro maintenance information, if applicable
- [ ] This is a contribution from a distro maintainer
- [ ] The changes in this PR have been taken as a downstream patch (Note: it is not recommended to patch the agent without upstream review and approval)
