### PR TITLE
Define 'backslashreplace' error handler for Python <= 3.4

### DIFF
--- a/azurelinuxagent/common/future.py
+++ b/azurelinuxagent/common/future.py
@@ -69,6 +69,35 @@ elif sys.version_info[0] == 2:
 else:
     raise ImportError("Unknown python version: {0}".format(sys.version_info))
 
+#
+# Python <= 3.4 doesn't have a 'backslashreplace' error handler for encoding/decoding strings; for those versions, we register
+# a custom implementation as 'waagent_backslashreplace'.
+#
+# BACKSLASH_REPLACE points to the name of this custom implementation; on Python versions where this is not needed, BACKSLASH_REPLACE
+# points to the standard implementation in Python.
+#
+if not (sys.version_info[0] == 2 or sys.version_info[0] == 3 and sys.version_info[1] <= 4):
+    BACKSLASH_REPLACE = 'backslashreplace'
+else:
+    import codecs
+
+    def __waagent_backslashreplace__(unicode_error):
+        obj, start, end = unicode_error.object, unicode_error.start, unicode_error.end
+        replacement = ustr('')
+        if isinstance(unicode_error, UnicodeDecodeError):
+            for c in obj[start:end]:
+                if not isinstance(c, int):
+                    c = ord(c)  # obj is str in Python 2, bytes in Python 3
+                replacement += ustr('\\x{0:02x}'.format(c))
+        else:  # Encoding error
+            for c in obj[start:end]:
+                c = ord(c)
+                replacement += ustr('\\U{0:08x}'.format(c)) if c >= 0x10000 else ustr('\\u{0:04x}'.format(c))
+        return replacement, end
+
+    BACKSLASH_REPLACE = 'waagent_backslashreplace'
+
+    codecs.register_error(BACKSLASH_REPLACE, __waagent_backslashreplace__)
 
 #
 # datetime.utcnow triggers a DeprecationWarning on 3.12 and will be removed in a future version.

--- a/azurelinuxagent/ga/logcollector.py
+++ b/azurelinuxagent/ga/logcollector.py
@@ -28,7 +28,7 @@ from heapq import heappush, heappop
 
 from azurelinuxagent.common.conf import get_lib_dir, get_ext_log_dir, get_agent_log_file
 from azurelinuxagent.common.event import initialize_event_logger_vminfo_common_parameters_and_protocol, add_event, WALAEventOperation
-from azurelinuxagent.common.future import ustr, UTC
+from azurelinuxagent.common.future import ustr, UTC, BACKSLASH_REPLACE
 from azurelinuxagent.ga.logcollector_manifests import MANIFEST_NORMAL, MANIFEST_FULL
 
 # Please note: be careful when adding agent dependencies in this module.
@@ -128,7 +128,7 @@ class LogCollector(object):
             return " ".join(cmd) if isinstance(cmd, list) else command
 
         def _encode_command_output(output):
-            return ustr(output, encoding="utf-8", errors="backslashreplace")
+            return ustr(output, encoding="utf-8", errors=BACKSLASH_REPLACE)
 
         try:
             process = subprocess.Popen(command, stdout=stdout, stderr=subprocess.PIPE, shell=False)

--- a/tests/common/utils/test_future.py
+++ b/tests/common/utils/test_future.py
@@ -1,0 +1,28 @@
+# Copyright 2018 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Requires Python 2.6+ and Openssl 1.0+
+#
+
+from azurelinuxagent.common.future import BACKSLASH_REPLACE, ustr
+from tests.lib.tools import AgentTestCase
+
+
+class TestBackslashReplace(AgentTestCase):
+    def test_it_should_replace_unicode_characters_when_encoding_to_utf8(self):
+        self.assertEqual(ustr("\\xc2Hello\\xffWorld!\\xa1"), ustr(b"\xc2Hello\xffWorld!\xa1", encoding='utf-8', errors=BACKSLASH_REPLACE))
+
+    def test_it_should_replace_unicode_characters_when_decoding_from_utf8(self):
+        self.assertEqual(ustr("\\xc2Hello\\xffWorld!\\xa1"), b"\xc2Hello\xffWorld!\xa1".decode('utf-8', BACKSLASH_REPLACE))
+

--- a/tests_e2e/tests/lib/resource_group_client.py
+++ b/tests_e2e/tests/lib/resource_group_client.py
@@ -22,7 +22,19 @@ from typing import Dict, Any
 
 from azure.mgmt.compute import ComputeManagementClient
 from azure.mgmt.resource import ResourceManagementClient
-from azure.mgmt.resource.resources.models import DeploymentProperties, DeploymentMode
+#
+# TODO: DeploymentProperties and DeploymentMode have been moved to a different module. This requires updating LISA and the Docker images.
+#
+# When fixing that, look at the list of breaking changes at https://pypi.org/project/azure-mgmt-resource/:
+#
+# 25.0.0 (2026-02-04)
+# Breaking Changes
+#
+# * Operation Group Deployments and DeploymentOperations of ResourceManagementClient are moved to DeploymentsMgmtClient of independent package azure-mgmt-resource-deployments.
+#   If you called ResourceManagementClient(...).deployments.xx(...) before, just need to change to DeploymentsMgmtClient(...).deployments.xx(...).
+#   And same for DeploymentOperations.
+#
+from azure.mgmt.resource.resources.models import DeploymentProperties, DeploymentMode  # pylint: disable=no-name-in-module
 
 from tests_e2e.tests.lib.azure_sdk_client import AzureSdkClient
 from tests_e2e.tests.lib.logging import log


### PR DESCRIPTION
First PR to address 'backslashreplace' on Python <= 3.4

The PR defines an error handler for Unicode encoding/decoding errors on Python <= 3.4. Callers can opt-in to use this implementation using  azurelinuxagent.common.future.BACKSLASH_REPLACE.

BACKSLASH_REPLACE is a temporary mechanism to use the error handler. Once all the code has been updated to use this error handler, I will remove BACKSLASH_REPLACE and use the error handler by default on Python <= 3.4.