### PR TITLE
Move FIPS test to West US 2

### DIFF
--- a/tests_e2e/test_suites/fips.yml
+++ b/tests_e2e/test_suites/fips.yml
@@ -17,11 +17,14 @@ images:
   - "rhel_95"
 
 #
-# Support for FIPS 140-3 is currently deployed only to a few regions on AzureCloud, and deployment has not started on AzureChinaCloud.
+# The test uses a keyvault located on westus2.
 #
 locations:
-  - "AzureCloud:eastus2euap"
+  - "AzureCloud:westus2"
 
+#
+# Support for FIPS 140-3 has not been deployed AzureChinaCloud.
+#
 skip_on_clouds:
   - "AzureChinaCloud"
 

--- a/tests_e2e/tests/fips/fips.py
+++ b/tests_e2e/tests/fips/fips.py
@@ -188,8 +188,8 @@ class Fips(AgentVmTest):
 
             certificates_by_cloud = {
                 'AzureCloud': {
-                    'source_vault': f"/subscriptions/{self._context.vm.subscription}/resourceGroups/waagent-tests/providers/Microsoft.KeyVault/vaults/waagenttests-canary",
-                    'certificate_url': 'https://waagenttests-canary.vault.azure.net/secrets/rsa/85d92c80443e44058cb034b2008e1e75'
+                    'source_vault': f"/subscriptions/{self._context.vm.subscription}/resourceGroups/waagent-tests/providers/Microsoft.KeyVault/vaults/waagenttests-westus2",
+                    'certificate_url': 'https://waagenttests-westus2.vault.azure.net/secrets/rsa/b46881d1dd73496fb98b2d008e9d471a'
                 },
                 'AzureUSGovernment': {
                     'source_vault': f"/subscriptions/{self._context.vm.subscription}/resourceGroups/waagent-tests/providers/Microsoft.KeyVault/vaults/waagenttests",


### PR DESCRIPTION
The test was previously on the Canary regions waiting for a deployment of FIPS support on CRP/Fabric. The deployment has been completed for several months, so moving the test to our default region (West US 2).