### PR TITLE
Improve retry strategy for artifact download

### DIFF
--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -607,7 +607,9 @@ class WireClient(object):
         """
         host_ga_plugin = self.get_host_plugin()
 
-        direct_download = lambda uri: self.fetch(uri)[0]
+        # Fail fast on request timeouts when doing direct downloads, as these may indicate no outbound connection on
+        # the VM and should fall back quickly to the host channel.
+        direct_download = lambda uri: self.fetch(uri, fail_fast_on_timeout=True)[0]
 
         def hgap_download(uri):
             request_uri, request_headers = host_ga_plugin.get_artifact_request(uri, use_verify_header=use_verify_header)
@@ -635,11 +637,13 @@ class WireClient(object):
         """
         host_ga_plugin = self.get_host_plugin()
 
-        direct_download = lambda uri: self.stream(uri, target_file, headers=None, use_proxy=True)
+        # Fail fast on request timeouts when doing direct downloads, as these may indicate no outbound connection on
+        # the VM and should fall back quickly to the host channel.
+        direct_download = lambda uri: self.stream(uri, target_file, headers=None, use_proxy=True, fail_fast_on_timeout=True)
 
         def hgap_download(uri):
             request_uri, request_headers = host_ga_plugin.get_artifact_request(uri, use_verify_header=use_verify_header, artifact_manifest_url=host_ga_plugin.manifest_uri)
-            return self.stream(request_uri, target_file, headers=request_headers, use_proxy=False)
+            return self.stream(request_uri, target_file, headers=request_headers, use_proxy=False, retry_codes=restutil.HGAP_GET_EXTENSION_ARTIFACT_RETRY_CODES)
 
         def on_downloaded():
             # If the 'signature' parameter is not an empty string, validate the zip package signature immediately after download.
@@ -733,14 +737,14 @@ class WireClient(object):
             except Exception as exception:
                 logger.warn("Cannot delete {0}: {1}", target_file, ustr(exception))
 
-    def stream(self, uri, destination, headers=None, use_proxy=None):
+    def stream(self, uri, destination, headers=None, use_proxy=None, retry_codes=None, fail_fast_on_timeout=False):
         """
         Downloads the content of the given 'uri' and saves it to the 'destination' file.
         """
         try:
             logger.verbose("Fetch [{0}] with headers [{1}] to file [{2}]", uri, headers, destination)
 
-            response = self._fetch_response(uri, headers, use_proxy)
+            response = self._fetch_response(uri, headers, use_proxy, retry_codes, fail_fast_on_timeout=fail_fast_on_timeout)
             if response is not None and not restutil.request_failed(response):
                 chunk_size = 1024 * 1024  # 1MB buffer
                 with open(destination, 'wb', chunk_size) as destination_fh:
@@ -758,21 +762,21 @@ class WireClient(object):
                     logger.warn("Can't delete {0}: {1}", destination, ustr(exception))
             raise
 
-    def fetch(self, uri, headers=None, use_proxy=None, decode=True, retry_codes=None, ok_codes=None):
+    def fetch(self, uri, headers=None, use_proxy=None, decode=True, retry_codes=None, ok_codes=None, fail_fast_on_timeout=False):
         """
         Returns a tuple with the content and headers of the response. The headers are a list of (name, value) tuples.
         """
         logger.verbose("Fetch [{0}] with headers [{1}]", uri, headers)
         content = None
         response_headers = None
-        response = self._fetch_response(uri, headers, use_proxy, retry_codes=retry_codes, ok_codes=ok_codes)
+        response = self._fetch_response(uri, headers, use_proxy, retry_codes=retry_codes, ok_codes=ok_codes, fail_fast_on_timeout=fail_fast_on_timeout)
         if response is not None and not restutil.request_failed(response, ok_codes=ok_codes):
             response_content = response.read()
             content = self.decode_config(response_content) if decode else response_content
             response_headers = response.getheaders()
         return content, response_headers
 
-    def _fetch_response(self, uri, headers=None, use_proxy=None, retry_codes=None, ok_codes=None):
+    def _fetch_response(self, uri, headers=None, use_proxy=None, retry_codes=None, ok_codes=None, fail_fast_on_timeout=False):
         resp = None
         headers_for_failure_msg = {}
         if headers is not None:
@@ -792,7 +796,8 @@ class WireClient(object):
                 uri,
                 headers=headers,
                 use_proxy=use_proxy,
-                retry_codes=retry_codes)
+                retry_codes=retry_codes,
+                fail_fast_on_timeout=fail_fast_on_timeout)
 
             host_plugin = self.get_host_plugin()
 

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -608,7 +608,8 @@ class WireClient(object):
         host_ga_plugin = self.get_host_plugin()
 
         # Fail fast on request timeouts when doing direct downloads, as these may indicate no outbound connection on
-        # the VM and should fall back quickly to the host channel.
+        # the VM and should fall back quickly to the host channel. Reconsider this strategy if we switch the primary
+        # download channel to HGAP.
         direct_download = lambda uri: self.fetch(uri, fail_fast_on_timeout=True)[0]
 
         def hgap_download(uri):
@@ -638,7 +639,8 @@ class WireClient(object):
         host_ga_plugin = self.get_host_plugin()
 
         # Fail fast on request timeouts when doing direct downloads, as these may indicate no outbound connection on
-        # the VM and should fall back quickly to the host channel.
+        # the VM and should fall back quickly to the host channel. Reconsider this strategy if we switch the primary
+        # download channel to HGAP.
         direct_download = lambda uri: self.stream(uri, target_file, headers=None, use_proxy=True, fail_fast_on_timeout=True)
 
         def hgap_download(uri):

--- a/azurelinuxagent/common/utils/restutil.py
+++ b/azurelinuxagent/common/utils/restutil.py
@@ -37,6 +37,8 @@ SECURE_WARNING_EMITTED = False
 DEFAULT_RETRIES = 6
 DELAY_IN_SECONDS = 1
 
+FAIL_FAST_REQUEST_TIMEOUT = 5
+
 THROTTLE_RETRIES = 25
 THROTTLE_DELAY_IN_SECONDS = 1
 # Reducing next attempt calls when throttled since telemetrydata endpoint has a limit 15 calls per 15 secs,
@@ -461,7 +463,7 @@ def http_request(method,
         try:
             # If fail_fast_on_timeout is True, use a shorter timeout for the first attempt to fail fast in the case of
             # no outbound connection on the VM.
-            req_timeout = timeout if not fail_fast_on_timeout or attempt > 1 else min(timeout, 5)
+            req_timeout = timeout if not fail_fast_on_timeout or attempt > 1 else min(timeout, FAIL_FAST_REQUEST_TIMEOUT)
             resp = _http_request(method,
                                  host,
                                  rel_uri,

--- a/azurelinuxagent/common/utils/restutil.py
+++ b/azurelinuxagent/common/utils/restutil.py
@@ -372,7 +372,8 @@ def http_request(method,
                  retry_delay=DELAY_IN_SECONDS,
                  throttle_delay=THROTTLE_DELAY_IN_SECONDS,
                  redact_data=False,
-                 return_raw_response=False):
+                 return_raw_response=False,
+                 fail_fast_on_timeout=False):
     """
     NOTE: This method provides some logic to handle errors in the HTTP request, including checking the HTTP status of the response
           and handling some exceptions. If return_raw_response is set to True all the error handling will be skipped and the
@@ -458,10 +459,13 @@ def http_request(method,
         attempt += 1
 
         try:
+            # If fail_fast_on_timeout is True, use a shorter timeout for the first attempt to fail fast in the case of
+            # no outbound connection on the VM.
+            req_timeout = timeout if not fail_fast_on_timeout or attempt > 1 else min(timeout, 5)
             resp = _http_request(method,
                                  host,
                                  rel_uri,
-                                 timeout,
+                                 req_timeout,
                                  port=port,
                                  data=data,
                                  secure=secure,
@@ -520,6 +524,11 @@ def http_request(method,
                 msg = '[HTTP Failed] {0} {1} {2} -- IOError {3}'.format(method, clean_url, json.dumps(headers_for_failure_msg), e)
             else:
                 msg = '[HTTP Failed] {0} {1} -- IOError {2}'.format(method, clean_url, e)
+            # If the error was an IOError and fail_fast_on_timeout is True, check if the error message contains
+            # "timed out" or "timeout" and break the loop to fail fast in the case of no outbound connection on the VM.
+            # Otherwise, continue with the retries.
+            if fail_fast_on_timeout and "timed out" in ustr(e) or "timeout" in ustr(e):
+                break
             continue
 
     raise HttpError("{0} -- {1} attempts made".format(msg, attempt))
@@ -532,7 +541,8 @@ def http_get(url,
              retry_codes=None,
              retry_delay=DELAY_IN_SECONDS,
              return_raw_response=False,
-             timeout=10):
+             timeout=10,
+             fail_fast_on_timeout=False):
     """
     NOTE: This method provides some logic to handle errors in the HTTP request, including checking the HTTP status of the response
           and handling some exceptions. If return_raw_response is set to True all the error handling will be skipped and the
@@ -551,7 +561,8 @@ def http_get(url,
                         max_retry=max_retry,
                         retry_codes=retry_codes,
                         retry_delay=retry_delay,
-                        return_raw_response=return_raw_response)
+                        return_raw_response=return_raw_response,
+                        fail_fast_on_timeout=fail_fast_on_timeout)
 
 
 def http_head(url,

--- a/tests/common/protocol/test_wire.py
+++ b/tests/common/protocol/test_wire.py
@@ -635,6 +635,33 @@ class TestWireClient(HttpRequestPredicates, AgentTestCase):
             self.assertTrue(os.path.exists(target_directory), "The extension package was not downloaded")
             self.assertFalse(HostPluginProtocol.is_default_channel, "The host channel should not have been set as the default")
 
+    def test_download_zip_package_should_fallback_fast_on_direct_channel_timeout_and_set_host_as_default(self):
+        extension_url = 'https://fake_host/fake_extension.zip'
+        target_file = os.path.join(self.tmp_dir, 'fake_extension.zip')
+        target_directory = os.path.join(self.tmp_dir, "fake_extension")
+
+        def http_get_handler(url, fail_fast_on_timeout, *_, **kwargs):
+            if url == extension_url:
+                self.assertTrue(fail_fast_on_timeout, "The direct channel request should have been configured to fail fast on timeout")
+                return HttpError("Exception to fake an error on the direct channel")
+            if self.is_host_plugin_extension_request(url, kwargs, extension_url):
+                self.assertFalse(fail_fast_on_timeout, "The host channel request should not have been configured to fail fast on timeout")
+                return MockHttpResponse(200, body=load_bin_data("ga/fake_extension.zip"))
+            return None
+
+        with mock_wire_protocol(wire_protocol_data.DATA_FILE, http_get_handler=http_get_handler) as protocol:
+            HostPluginProtocol.is_default_channel = False
+
+            protocol.client.download_zip_package("Microsoft.FakeExtension-1.0.0.0", [extension_url], target_file, target_directory, use_verify_header=False,
+                                                 signature="", ignore_signature_validation_errors=True)
+
+            urls = protocol.get_tracked_urls()
+            self.assertEqual(len(urls), 2, "Unexpected number of HTTP requests: [{0}]".format(urls))
+            self.assertEqual(urls[0], extension_url, "The first attempt should have been over the direct channel")
+            self.assertTrue(self.is_host_plugin_extension_artifact_request(urls[1]), "The retry attempt should have been over the host channel")
+            self.assertTrue(os.path.exists(target_directory), 'The extension package was not downloaded')
+            self.assertTrue(HostPluginProtocol.is_default_channel, "The host channel should have been set as the default")
+
     def test_download_zip_package_should_use_host_channel_when_direct_channel_fails_and_set_host_as_default(self):
         extension_url = 'https://fake_host/fake_extension.zip'
         target_file = os.path.join(self.tmp_dir, 'fake_extension.zip')
@@ -850,6 +877,34 @@ class TestWireClient(HttpRequestPredicates, AgentTestCase):
             finally:
                 HostPluginProtocol.is_default_channel = False  # Reset default channel
 
+    def test_fetch_manifest_should_fallback_fast_on_direct_channel_timeout_and_set_host_as_default(self):
+        manifest_url = 'https://fake_host/fake_manifest.xml'
+        manifest_xml = '<?xml version="1.0" encoding="utf-8"?><PluginVersionManifest/>'
+
+        def http_get_handler(url, fail_fast_on_timeout, *_, **kwargs):
+            if url == manifest_url:
+                self.assertTrue(fail_fast_on_timeout, "The direct channel request should have been configured to fail fast on timeout")
+                return HttpError("Exception to fake an error on the direct channel")
+            if self.is_host_plugin_extension_request(url, kwargs, manifest_url):
+                self.assertFalse(fail_fast_on_timeout, "The host channel request should not have been configured to fail fast on timeout")
+                return MockHttpResponse(200, body=manifest_xml.encode('utf-8'))
+            return None
+
+        with mock_wire_protocol(wire_protocol_data.DATA_FILE, http_get_handler=http_get_handler) as protocol:
+            HostPluginProtocol.is_default_channel = False
+
+            try:
+                manifest = protocol.client.fetch_manifest("test", [manifest_url], use_verify_header=False)
+
+                urls = protocol.get_tracked_urls()
+                self.assertEqual(manifest, manifest_xml, 'The expected manifest was not downloaded')
+                self.assertEqual(len(urls), 2, "Unexpected number of HTTP requests: [{0}]".format(urls))
+                self.assertEqual(urls[0], manifest_url, "The first attempt should have been over the direct channel")
+                self.assertTrue(self.is_host_plugin_extension_artifact_request(urls[1]), "The retry should have been over the host channel")
+                self.assertTrue(HostPluginProtocol.is_default_channel, "The host should have been set as the default channel")
+            finally:
+                HostPluginProtocol.is_default_channel = False  # Reset default channel
+
     def test_fetch_manifest_should_retry_the_host_channel_after_refreshing_the_host_plugin_on_resource_gone_error_and_set_the_host_as_default(self):
         manifest_url = 'https://fake_host/fake_manifest.xml'
         manifest_xml = '<?xml version="1.0" encoding="utf-8"?><PluginVersionManifest/>'
@@ -988,6 +1043,31 @@ class TestWireClient(HttpRequestPredicates, AgentTestCase):
             if self.is_in_vm_artifacts_profile_request(url):
                 return HttpError("Exception to fake an error on the direct channel")
             if self.is_host_plugin_in_vm_artifacts_profile_request(url, kwargs):
+                protocol.track_url(url)
+            return None
+
+        with mock_wire_protocol(wire_protocol_data.DATA_FILE_IN_VM_ARTIFACTS_PROFILE) as protocol:
+            protocol.set_http_handlers(http_get_handler=http_get_handler)
+
+            HostPluginProtocol.is_default_channel = False
+            try:
+                protocol.client.reset_goal_state()
+
+                urls = protocol.get_tracked_urls()
+                self.assertEqual(len(urls), 2, "Invalid number of requests: [{0}]".format(urls))
+                self.assertTrue(self.is_in_vm_artifacts_profile_request(urls[0]), "The first request should have been over the direct channel")
+                self.assertTrue(self.is_host_plugin_extension_artifact_request(urls[1]), "The second request should have been over the host channel")
+                self.assertTrue(HostPluginProtocol.is_default_channel, "The default channel should have changed to the host")
+            finally:
+                HostPluginProtocol.is_default_channel = False
+
+    def test_get_artifacts_profile_should_fallback_fast_on_direct_channel_timeout_and_set_host_as_default(self):
+        def http_get_handler(url, fail_fast_on_timeout, *_, **kwargs):
+            if self.is_in_vm_artifacts_profile_request(url):
+                self.assertTrue(fail_fast_on_timeout, "The direct channel request should have been configured to fail fast on timeout")
+                return HttpError("Exception to fake an error on the direct channel")
+            if self.is_host_plugin_in_vm_artifacts_profile_request(url, kwargs):
+                self.assertFalse(fail_fast_on_timeout, "The host channel request should not have been configured to fail fast on timeout")
                 protocol.track_url(url)
             return None
 

--- a/tests/common/utils/test_rest_util.py
+++ b/tests/common/utils/test_rest_util.py
@@ -674,6 +674,32 @@ class TestHttpOperations(AgentTestCase):
         self.assertEqual(2, _http_request.call_count)
         self.assertEqual(1, _sleep.call_count)
 
+    @patch("azurelinuxagent.common.utils.restutil._http_request")
+    def test_http_request_fails_fast_for_timed_out_ioerror(self, _http_request):
+        ioerror = IOError("timed out")
+
+        _http_request.side_effect = [
+            ioerror
+        ]
+
+        self.assertRaises(HttpError, restutil.http_get, "https://foo.bar", fail_fast_on_timeout=True)
+        self.assertEqual(1, _http_request.call_count)
+
+    @patch("time.sleep")
+    @patch("azurelinuxagent.common.utils.restutil._http_request")
+    def test_http_request_retries_for_non_timed_out_ioerror(self, _http_request, _sleep):
+        ioerror = IOError()
+        ioerror.errno = 42
+
+        _http_request.side_effect = [
+            ioerror,
+            Mock(status=httpclient.OK)
+        ]
+
+        restutil.http_get("https://foo.bar", fail_fast_on_timeout=True)
+        self.assertEqual(2, _http_request.call_count)
+        self.assertEqual(1, _sleep.call_count)
+
     def test_request_failed(self):
         self.assertTrue(restutil.request_failed(None))
 

--- a/tests_e2e/tests/no_outbound_connections/check_fallback_to_hgap.py
+++ b/tests_e2e/tests/no_outbound_connections/check_fallback_to_hgap.py
@@ -16,8 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from assertpy import assert_that
-
 from tests_e2e.tests.lib.agent_test import AgentVmTest
 from tests_e2e.tests.lib.logging import log
 from tests_e2e.tests.lib.ssh_client import SshClient
@@ -25,25 +23,14 @@ from tests_e2e.tests.lib.ssh_client import SshClient
 
 class CheckFallbackToHGAP(AgentVmTest):
     """
-    Check the agent log to verify that the default channel was changed to HostGAPlugin before executing any extensions.
+    Check the agent log to verify that the default channel was changed to HostGAPlugin after 1 attempt on the Direct
+    channel and before executing any extensions.
     """
     def run(self):
-        # 2023-04-14T14:49:43.005530Z INFO ExtHandler ExtHandler Default channel changed to HostGAPlugin channel.
-        # 2023-04-14T14:49:44.625061Z INFO ExtHandler [Microsoft.Azure.Monitor.AzureMonitorLinuxAgent-1.25.2] Target handler state: enabled [incarnation_2]
-
         ssh_client: SshClient = self._context.create_ssh_client()
-        log.info("Parsing agent log on the test VM")
-        output = ssh_client.run_command("grep -E 'INFO ExtHandler.*(Default channel changed to HostGAPlugin)|(Target handler state:)' /var/log/waagent.log | head").split('\n')
-        log.info("Output (first 10 lines) from the agent log:\n\t\t%s", '\n\t\t'.join(output))
-
-        assert_that(len(output) > 1).is_true().described_as(
-            "The agent log should contain multiple matching records"
-        )
-        assert_that(output[0]).contains("Default channel changed to HostGAPlugin").described_as(
-            "The agent log should contain a record indicating that the default channel was changed to HostGAPlugin before executing any extensions"
-        )
-
-        log.info("The agent log indicates that the default channel was changed to HostGAPlugin before executing any extensions")
+        log.info("Checking agent log on the test VM to verify download channel fallback behavior...")
+        self._run_remote_test(ssh_client, "no_outbound_connections-verify_download_channel_fallback.py")
+        log.info("Successfully verified download channel fallback behavior in the agent log.")
 
 
 if __name__ == "__main__":

--- a/tests_e2e/tests/scripts/no_outbound_connections-verify_download_channel_fallback.py
+++ b/tests_e2e/tests/scripts/no_outbound_connections-verify_download_channel_fallback.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env pypy3
+
+# Microsoft Azure Linux Agent
+#
+# Copyright 2018 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Verifies the download channel fallback behavior on a vm with no outbound connections.
+#
+import re
+
+from assertpy import assert_that
+
+from tests_e2e.tests.lib.agent_log import AgentLog
+from tests_e2e.tests.lib.logging import log
+
+
+def main():
+    # 2026-02-20T22:39:22.691020Z INFO ExtHandler ExtHandler Downloading artifacts profile blob
+    # 2026-02-20T22:39:27.714015Z WARNING ExtHandler ExtHandler Fetch failed: [HttpError] [HTTP Failed] GET https://md-hdd-nqxfsnnvnjr3.z27.blob.storage.azure.net/$system/lisa-maddieford-20260220-223218-252-e0-n0.49e33a82-9f6e-4482-86a3-0db71c338ebc.vmSettings -- IOError timed out -- 1 attempts made
+    # 2026-02-20T22:39:27.740385Z INFO ExtHandler ExtHandler Default channel changed to HostGAPlugin channel.
+    # 2026-02-20T22:39:30.733714Z INFO ExtHandler ExtHandler ProcessExtensionsGoalState started [incarnation_1 channel: WireServer source: Fabric activity: 1082ed79-bbc7-4925-a932-aefe84bca6e9 correlation 2ad608f9-327b-4b2a-8673-6b40ca7ee6e7 created: 2026-02-20T22:33:22.800011Z]
+    # Patterns to match
+    downloading_vmap = re.compile(r"Downloading artifacts profile blob")                        # This is the artifact download we expect to see the channel change happen on
+    fetch_failed_on_direct_pattern = re.compile(r"Fetch failed:.*1 attempts made")              # There should only be one attempt on the Direct channel before falling back to HostGAPlugin
+    default_channel_pattern = re.compile(r"Default channel changed to HostGAPlugin channel")    # The agent should log that it is changing the default channel to HostGAPlugin
+    process_extensions_pattern = re.compile(r"ProcessExtensionsGoalState started")              # The agent should switch channels before executing any extensions
+
+    # Track the match timestamps
+    found = []
+
+    agentlog = AgentLog()
+    for record in agentlog.read():
+        # We only care about logs from the ExtHandler
+        if record.thread != "ExtHandler" and record.prefix != "ExtHandler":
+            continue
+        if len(found) == 0 and downloading_vmap.search(record.text):
+            found.append(record.timestamp)
+            log.info("Found log indicating VMAP download started:\n\t{0}".format(record.text))
+        elif len(found) == 1 and fetch_failed_on_direct_pattern.search(record.text):
+            found.append(record.timestamp)
+            log.info("Found log indicating download failed on Direct channel after 1 attempt:\n\t{0}".format(record.text))
+        elif len(found) == 2 and default_channel_pattern.search(record.text):
+            found.append(record.timestamp)
+            log.info("Found log indicating default channel was changed to HostGAPlugin:\n\t{0}".format(record.text))
+        elif len(found) == 3 and process_extensions_pattern.search(record.text):
+            found.append(record.timestamp)
+            log.info("Found log indicating that the Agent started processing extensions:\n\t{0}".format(record.text))
+            break
+
+    assert_that(len(found) == 4).is_true().described_as(
+        "The agent log should show that the download failed on the Direct channel after 1 attempt, that the default "
+        "channel was changed to HostGAPlugin, and that the Agent started processing extensions (in that order), "
+        "but it does not"
+    )
+    failed_download_duration = (found[1] - found[0]).total_seconds()
+    assert_that(failed_download_duration < 6).is_true().described_as("The direct download request should fail fast")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests_e2e/tests/scripts/no_outbound_connections-verify_download_channel_fallback.py
+++ b/tests_e2e/tests/scripts/no_outbound_connections-verify_download_channel_fallback.py
@@ -33,7 +33,7 @@ def main():
     # 2026-02-20T22:39:30.733714Z INFO ExtHandler ExtHandler ProcessExtensionsGoalState started [incarnation_1 channel: WireServer source: Fabric activity: 1082ed79-bbc7-4925-a932-aefe84bca6e9 correlation 2ad608f9-327b-4b2a-8673-6b40ca7ee6e7 created: 2026-02-20T22:33:22.800011Z]
     # Patterns to match
     downloading_vmap = re.compile(r"Downloading artifacts profile blob")                        # This is the artifact download we expect to see the channel change happen on
-    fetch_failed_on_direct_pattern = re.compile(r"Fetch failed:.*1 attempts made")              # There should only be one attempt on the Direct channel before falling back to HostGAPlugin
+    fetch_failed_on_direct_pattern = re.compile(r"Fetch failed:.* 1 attempts made")              # There should only be one attempt on the Direct channel before falling back to HostGAPlugin
     default_channel_pattern = re.compile(r"Default channel changed to HostGAPlugin channel")    # The agent should log that it is changing the default channel to HostGAPlugin
     process_extensions_pattern = re.compile(r"ProcessExtensionsGoalState started")              # The agent should switch channels before executing any extensions
 


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->
<!--
Please add an informative description that covers that changes made by the pull request.
-->
## Description
Current artifact download retries are expensive for VMs where outbound connections are disabled. Since direct downloads are the primary download channel, each request on these VMs takes 10 seconds to timeout. The agent currently retries up to 6 times, with a varying delay between each retry (this takes up to 2.5 minutes), before falling back to the host channel for downloads. This is impacting TDPR for those VMs.

We did a release to Canary where HGAP was the primary download channel in an attempt to address the above issue. We saw an increase in 400 responses on HGAP requests due to a cache issue in HGAP that may produce a BAD_REQUEST failure for valid URIs when using the extensionArtifact API. Retries should help address that cache issue, but the HGAP dev also cited performance concerns w.r.t making HGAP the primary download.

As a result of the above concerns making HGAP the primary download channel, this PR keeps the direct download channel as the primary, but makes some changes to account for those VMs where outbound connections are disabled. For direct artifact downloads, there will be no retries on timed out requests (and the timeout will be decreases to 5 seconds for the first request). As a result, the agent will fallback to the host channel much faster, reducing the delay on those VMs from 2.5 mins to 5 seconds.

In addition, the PR makes a change to make the BAD_REQUEST response retryable on zip downloads via the host channel to address the cache issue described above. BAD_REQUEST is already treated as retryable for manifest and VMAP downloads on Host channel, and HGAP devs confirmed it should be treated as retryable for zip downloads too.


Issue # <!-- if any -->
---
<!--
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->
### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).
---
<!--
This checklist is used to track contributions from distro maintainers.
-->
### Distro maintenance information, if applicable
- [ ] This is a contribution from a distro maintainer
- [ ] The changes in this PR have been taken as a downstream patch (Note: it is not recommended to patch the agent without upstream review and approval)
