### PR TITLE
Fixing test test_agent_enforcement_enabled_in_v2

### DIFF
--- a/tests/lib/mock_cgroup_environment.py
+++ b/tests/lib/mock_cgroup_environment.py
@@ -99,6 +99,10 @@ _MOCKED_COMMANDS_V2 = [
 
     MockCommand(r"^stat -f --format=%T /sys/fs/cgroup$", 'cgroup2fs'),
 
+    MockCommand(r"^systemctl show (.+) --property MemoryHigh$",
+'''MemoryHigh=infinity
+'''),
+
 ]
 
 _MOCKED_COMMANDS_HYBRID = [


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->
<!--
Please add an informative description that covers that changes made by the pull request.
-->
## Description

Test is failing due to mock on get MemoryHigh missing

self = <tests.ga.test_cgroupconfigurator.CGroupConfiguratorSystemdTestCase testMethod=test_agent_enforcement_enabled_in_v2>

    def test_agent_enforcement_enabled_in_v2(self):
        with self._get_cgroup_configurator_v2() as configurator:
            cmd1 = 'systemctl set-property walinuxagent.service CPUQuota=50% --runtime'
            cmd2 = 'systemctl set-property walinuxagent.service MemoryHigh=314572800 --runtime'
            self.assertIn(cmd1, configurator.mocks.commands_call_list, "The command to set CPU quota was not called")
>           self.assertIn(cmd2, configurator.mocks.commands_call_list, "The command to set Memory quota was not called")
E           AssertionError: 'systemctl set-property walinuxagent.service MemoryHigh=314572800 --runtime' not found in ['stat -f --format=%T /sys/fs/cgroup', 'findmnt -t cgroup2 --noheadings', 'systemctl show walinuxagent.service --property Slice', 'systemctl show walinuxagent.service --property ControlGroup', 'systemctl set-property walinuxagent.service CPUAccounting=yes MemoryAccounting=yes --runtime', 'systemctl show walinuxagent.service --property CPUAccounting', 'systemctl show walinuxagent.service --property CPUQuotaPerSecUSec', 'systemctl show walinuxagent.service --property CPUQuotaPerSecUSec', 'systemctl set-property walinuxagent.service CPUQuota=50% --runtime', 'systemctl show walinuxagent.service --property MemoryAccounting', 'systemctl show walinuxagent.service --property MemoryHigh', 'systemctl show walinuxagent.service --property MemoryHigh'] : The command to set Memory quota was not called

Issue # <!-- if any -->
---
<!--
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->
### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).
---
<!--
This checklist is used to track contributions from distro maintainers.
-->
### Distro maintenance information, if applicable
- [ ] This is a contribution from a distro maintainer
- [ ] The changes in this PR have been taken as a downstream patch (Note: it is not recommended to patch the agent without upstream review and approval)
