### PR TITLE
Remove CPU and memory accounting enablement in CgroupV2

### DIFF
--- a/azurelinuxagent/ga/cgroupapi.py
+++ b/azurelinuxagent/ga/cgroupapi.py
@@ -342,16 +342,31 @@ class _SystemdCgroupApi(object):
         """
         raise NotImplementedError()
 
+    def get_accounting_properties(self):
+        """
+        Returns the accounting properties to set for a unit.
+        Override in subclasses for version-specific behavior.
+        """
+        raise NotImplementedError()
+
     def start_extension_command(self, extension_name, command, cmd_name, timeout, shell, cwd, env, stdout, stderr,
                                 error_code=ExtensionErrorCodes.PluginUnknownFailure):
         scope = "{0}_{1}".format(cmd_name, uuid.uuid4())
         extension_slice_name = CGroupUtil.get_extension_slice_name(extension_name)
+
+        # For v1: Disable accounting to prevent nested cgroups (slice already has accounting enabled), so that all the counters will be present in extension Cgroup
+        # For v2: No accounting properties needed as they are enabled by default.
+        accounting_props, accounting_vals = self.get_accounting_properties()
+        accounting_args = ""
+        for prop, _ in zip(accounting_props, accounting_vals):
+            # Set accounting to 'no' to prevent nested cgroups under the extension slice
+            accounting_args += " --property={0}=no".format(prop)
+
         with self._systemd_run_commands_lock:
+            systemd_run_cmd = "systemd-run{0} --unit={1} --scope --slice={2} {3}".format(
+                accounting_args, scope, extension_slice_name, command)
             process = subprocess.Popen(  # pylint: disable=W1509
-                # Some distros like ubuntu20 by default cpu and memory accounting enabled. Thus create nested cgroups under the extension slice
-                # So disabling CPU and Memory accounting prevents from creating nested cgroups, so that all the counters will be present in extension Cgroup
-                # since slice unit file configured with accounting enabled.
-                "systemd-run --property=CPUAccounting=no --property=MemoryAccounting=no --unit={0} --scope --slice={1} {2}".format(scope, extension_slice_name, command),
+                systemd_run_cmd,
                 shell=shell,
                 cwd=cwd,
                 stdout=stdout,
@@ -544,6 +559,12 @@ class SystemdCgroupApiv1(_SystemdCgroupApi):
     def can_enforce_memory(self):
         return False
 
+    def get_accounting_properties(self):
+        """
+        For cgroup v1, explicit accounting must be enabled.
+        """
+        return ("CPUAccounting", "MemoryAccounting"), ("yes", "yes")
+
 
 class SystemdCgroupApiv2(_SystemdCgroupApi):
     """
@@ -661,6 +682,13 @@ class SystemdCgroupApiv2(_SystemdCgroupApi):
 
     def can_enforce_memory(self):
         return CgroupV2.MEMORY_CONTROLLER in self._controllers_enabled_at_root
+
+    def get_accounting_properties(self):
+        """
+        For cgroup v2, accounting is enabled by default in the unified hierarchy. No explicit setting needed.
+         and also, systemd 258+ deprecated CPUAccounting property
+        """
+        return (), ()
 
 
 class Cgroup(object):

--- a/azurelinuxagent/ga/cgroupconfigurator.py
+++ b/azurelinuxagent/ga/cgroupconfigurator.py
@@ -308,7 +308,8 @@ class CGroupConfigurator(object):
                 files_to_create.append((azure_slice, _AZURE_SLICE_CONTENTS))
 
             # Slice has only accounting properties, so no need explicit set in cgroupv2
-            if not os.path.exists(vmextensions_slice) and not self.using_cgroup_v2():
+            accounting_props, _ = self._cgroups_api.get_accounting_properties()
+            if not os.path.exists(vmextensions_slice) and len(accounting_props) > 0:
                 files_to_create.append((vmextensions_slice, _VMEXTENSIONS_SLICE_CONTENTS))
 
             if fileutil.findre_in_file(agent_unit_file, r"Slice=") is not None:

--- a/azurelinuxagent/ga/cgroupconfigurator.py
+++ b/azurelinuxagent/ga/cgroupconfigurator.py
@@ -56,16 +56,6 @@ Before=slices.target
 CPUAccounting=yes
 MemoryAccounting=yes
 """
-_EXTENSION_SLICE_CONTENTS = """
-[Unit]
-Description=Slice for Azure VM extension {extension_name}
-DefaultDependencies=no
-Before=slices.target
-[Slice]
-CPUAccounting=yes
-CPUQuota={cpu_quota}
-MemoryAccounting=yes
-"""
 LOGCOLLECTOR_SLICE = "azure-walinuxagent-logcollector.slice"
 # More info on resource limits properties in systemd here:
 # https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/resource_management_guide/sec-modifying_control_groups
@@ -277,15 +267,14 @@ class CGroupConfigurator(object):
             # New agent will setup limits for scope instead slice, so removing existing logcollector slice.
             CGroupConfigurator._Impl._cleanup_unit_file(logcollector_slice)
 
-            # Cleanup the old drop-in files, new agent will use systemdctl set-property to enable accounting and limits
+            # Cleanup the old drop-in files, new agent will use systemctl set-property to enable accounting and limits
             CGroupConfigurator._Impl._cleanup_unit_file(agent_drop_in_file_cpu_accounting)
 
             CGroupConfigurator._Impl._cleanup_unit_file(agent_drop_in_file_memory_accounting)
 
             CGroupConfigurator._Impl._cleanup_unit_file(agent_drop_in_file_cpu_quota)
 
-        @staticmethod
-        def _setup_azure_slice():
+        def _setup_azure_slice(self):
             """
             The agent creates "azure.slice" for use by extensions and the agent. The agent runs under "azure.slice" directly and each
             extension runs under its own slice ("Microsoft.CPlat.Extension.slice" in the example below). All the slices for
@@ -318,7 +307,8 @@ class CGroupConfigurator(object):
             if not os.path.exists(azure_slice):
                 files_to_create.append((azure_slice, _AZURE_SLICE_CONTENTS))
 
-            if not os.path.exists(vmextensions_slice):
+            # Slice has only accounting properties, so no need explicit set in cgroupv2
+            if not os.path.exists(vmextensions_slice) and not self.using_cgroup_v2():
                 files_to_create.append((vmextensions_slice, _VMEXTENSIONS_SLICE_CONTENTS))
 
             if fileutil.findre_in_file(agent_unit_file, r"Slice=") is not None:
@@ -369,19 +359,18 @@ class CGroupConfigurator(object):
             except Exception as err:
                 logger.warn("Error while resetting the quotas: {0}".format(err))
 
-        @staticmethod
-        def _enable_accounting(unit_name):
+        def _enable_accounting(self, unit_name):
             """
-            Enable CPU and Memory accounting for the unit
+            Enable CPU and Memory accounting for the unit.
+            Note: On cgroup v2, accounting is enabled by default.
             """
             try:
-                # since we don't use daemon-reload and drop-files for accounting, so it will be enabled with systemctl set-property
-                accounting_properties = ("CPUAccounting", "MemoryAccounting")
-                values = ("yes", "yes")
-                log_cgroup_info("Enabling accounting properties for the agent: {0}".format(accounting_properties))
-                systemd.set_unit_run_time_properties(unit_name, accounting_properties, values)
+                accounting_properties, values = self._cgroups_api.get_accounting_properties()
+                if len(accounting_properties) > 0:
+                    log_cgroup_info("Enabling accounting properties for {0}: {1}".format(unit_name, accounting_properties))
+                    systemd.set_unit_run_time_properties(unit_name, accounting_properties, values)
             except Exception as exception:
-                log_cgroup_warning("Failed to set accounting properties for the agent: {0}".format(ustr(exception)))
+                log_cgroup_warning("Failed to set accounting properties for {0}: {1}".format(unit_name, ustr(exception)))
 
         # W0238: Unused private member `_Impl.__create_unit_file(path, contents)` (unused-private-member)
         @staticmethod
@@ -439,6 +428,9 @@ class CGroupConfigurator(object):
 
         def using_cgroup_v2(self):
             return isinstance(self._cgroups_api, SystemdCgroupApiv2)
+
+        def get_cgroups_api(self):
+            return self._cgroups_api
 
         def enable(self):
             if not self.supported():
@@ -670,14 +662,22 @@ class CGroupConfigurator(object):
 
             Each property should be explicitly set (even if already included in the log collector slice) for the log
             collector process to run in the transient scope directory with the expected accounting and limits.
+
+            Note: On cgroup v2, accounting is enabled by default. No need explicit set
             """
-            logcollector_properties = ["--property=CPUAccounting=yes", "--property=MemoryAccounting=yes", "--property=CPUQuota={0}".format(LOGCOLLECTOR_CPU_QUOTA_FOR_V1_AND_V2)]
-            if not self.using_cgroup_v2():
-                return logcollector_properties
+            logcollector_properties = ["--property=CPUQuota={0}".format(LOGCOLLECTOR_CPU_QUOTA_FOR_V1_AND_V2)]
+
+            # Add accounting properties based on cgroup version
+            accounting_props, accounting_vals = self._cgroups_api.get_accounting_properties()
+            for prop, val in zip(accounting_props, accounting_vals):
+                logcollector_properties.append("--property={0}={1}".format(prop, val))
+
             # Memory throttling limit is used when running log collector on v2 machines using the 'MemoryHigh' property.
             # We do not use a systemd property to enforce memory on V1 because it invokes the OOM killer if the limit
             # is exceeded.
-            logcollector_properties.append("--property=MemoryHigh={0}".format(LOGCOLLECTOR_MEMORY_THROTTLE_LIMIT_FOR_V2))
+            if self.using_cgroup_v2():
+                logcollector_properties.append("--property=MemoryHigh={0}".format(LOGCOLLECTOR_MEMORY_THROTTLE_LIMIT_FOR_V2))
+
             return logcollector_properties
 
         @staticmethod
@@ -873,27 +873,28 @@ class CGroupConfigurator(object):
             process = subprocess.Popen(command, shell=shell, cwd=cwd, env=env, stdout=stdout, stderr=stderr, preexec_fn=os.setsid)  # pylint: disable=W1509
             return handle_process_completion(process=process, command=command, timeout=timeout, stdout=stdout, stderr=stderr, error_code=error_code)
 
-        @staticmethod
-        def _get_unit_properties_requiring_update(unit_name, cpu_quota=""):
+        def _get_unit_properties_requiring_update(self, unit_name, cpu_quota=""):
             """
             Check if the cgroups setup is completed for the unit and return the properties that need an update.
             """
             properties_to_update = ()
             properties_values = ()
-            cpu_accounting = systemd.get_unit_property(unit_name, "CPUAccounting")
-            if cpu_accounting != "yes":
-                properties_to_update += ("CPUAccounting",)
-                properties_values += ("yes",)
-            memory_accounting = systemd.get_unit_property(unit_name, "MemoryAccounting")
-            if memory_accounting != "yes":
-                properties_to_update += ("MemoryAccounting",)
-                properties_values += ("yes",)
+
+            # Get accounting properties based on cgroup version
+            accounting_props, accounting_vals = self._cgroups_api.get_accounting_properties()
+            for prop, val in zip(accounting_props, accounting_vals):
+                current = systemd.get_unit_property(unit_name, prop)
+                if current != val:
+                    properties_to_update += (prop,)
+                    properties_values += (val,)
+
             current_cpu_quota = CGroupUtil.get_current_cpu_quota(unit_name)
             if current_cpu_quota != cpu_quota:
                 properties_to_update += ("CPUQuota",)
                 # no-quota expressed as empty string while setting property
                 cpu_quota = cpu_quota if cpu_quota != "infinity" else ""
                 properties_values += (cpu_quota,)
+
             return properties_to_update, properties_values
 
         def setup_extension_slice(self, extension_name, cpu_quota):

--- a/azurelinuxagent/ga/cpucontroller.py
+++ b/azurelinuxagent/ga/cpucontroller.py
@@ -125,7 +125,7 @@ class _CpuController(_CgroupController):
         return tracked
 
     def get_unit_properties(self):
-        return ["CPUAccounting", "CPUQuotaPerSecUSec"]
+        return ["CPUQuotaPerSecUSec"]
 
     def get_controller_type(self):
         return "cpu"
@@ -206,6 +206,14 @@ class CpuControllerV1(_CpuController):
         self._current_throttled_time = self._get_cpu_stat_counter(counter_name='throttled_time')
 
         return round(float(self._current_throttled_time - self._previous_throttled_time) / 1E9, 3)
+
+    def get_unit_properties(self):
+        """
+        V1 need to collect CPUAccounting property to know whether the cgroup is accounting for CPU usage or not
+        """
+        properties = super(CpuControllerV1, self).get_unit_properties()
+        properties.append("CPUAccounting")
+        return properties
 
 
 class CpuControllerV2(_CpuController):

--- a/azurelinuxagent/ga/memorycontroller.py
+++ b/azurelinuxagent/ga/memorycontroller.py
@@ -118,7 +118,7 @@ class _MemoryController(_CgroupController):
         ]
 
     def get_unit_properties(self):
-        return ["MemoryAccounting"]
+        raise NotImplementedError()
 
     def get_controller_type(self):
         return "memory"
@@ -128,6 +128,9 @@ class MemoryControllerV1(_MemoryController):
     def get_memory_usage(self):
         # In v1, anon memory is reported in the 'rss' counter
         return self._get_memory_stat_counter("rss"), self._get_memory_stat_counter("cache")
+
+    def get_unit_properties(self):
+        return ["MemoryAccounting"]
 
     def try_swap_memory_usage(self):
         # In v1, swap memory should be collected from memory.stat, because memory.memsw.usage_in_bytes reports total Memory+SWAP.
@@ -159,9 +162,7 @@ class MemoryControllerV2(_MemoryController):
         return self._get_memory_stat_counter("anon"), self._get_memory_stat_counter("file")
 
     def get_unit_properties(self):
-        properties = super(MemoryControllerV2, self).get_unit_properties()
-        properties.append("MemoryHigh")
-        return properties
+        return ["MemoryHigh"]
 
     def get_memory_pressure_events(self):
         """

--- a/azurelinuxagent/ga/signature_validation_util.py
+++ b/azurelinuxagent/ga/signature_validation_util.py
@@ -208,8 +208,15 @@ def validate_signature(package_path, signature, package_full_name):
         if use_cgroups:
             slice_name = EXT_SIGNATURE_VALIDATION_SLICE_NAME + ".slice"
             scope_name = EXT_SIGNATURE_VALIDATION_CGROUPS_UNIT_NAME + ".scope"
-            systemd_cmd = ['systemd-run', '--unit={0}'.format(scope_name), '--slice={0}'.format(slice_name), '--scope', '--property=CPUAccounting=yes',
-                           '--property=CPUQuota={0}'.format(EXT_SIGNATURE_VALIDATION_CPU_QUOTA)] + base_command
+            systemd_cmd = ['systemd-run', '--unit={0}'.format(scope_name), '--slice={0}'.format(slice_name), '--scope',
+                           '--property=CPUQuota={0}'.format(EXT_SIGNATURE_VALIDATION_CPU_QUOTA)]
+
+            # Add accounting properties based on cgroup version
+            accounting_props, accounting_vals = CGroupConfigurator.get_instance().get_cgroups_api().get_accounting_properties()
+            for prop, val in zip(accounting_props, accounting_vals):
+                systemd_cmd.append('--property={0}={1}'.format(prop, val))
+
+            systemd_cmd.extend(base_command)
             try:
                 run_command(systemd_cmd)
             except CommandError as ex:

--- a/tests/ga/test_cgroupapi.py
+++ b/tests/ga/test_cgroupapi.py
@@ -141,13 +141,10 @@ class SystemdCgroupsApiTestCase(AgentTestCase):
             self.assertTrue("/sys/fs/cgroup has an unexpected file type: {0}".format(unknown_cgroup_type) in str(context.exception))
 
     def test_get_unit_property_should_return_the_value_of_the_given_property(self):
-        # We expect same behavior for v1 and v2
-        mock_envs = [mock_cgroup_v1_environment(self.tmp_dir), mock_cgroup_v2_environment(self.tmp_dir)]
-        for env in mock_envs:
-            with env:
-                cpu_accounting = systemd.get_unit_property("walinuxagent.service", "CPUAccounting")
+        with mock_cgroup_v1_environment(self.tmp_dir):
+            cpu_accounting = systemd.get_unit_property("walinuxagent.service", "CPUAccounting")
 
-                self.assertEqual(cpu_accounting, "no", "Property {0} of {1} is incorrect".format("CPUAccounting", "walinuxagent.service"))
+            self.assertEqual(cpu_accounting, "no", "Property {0} of {1} is incorrect".format("CPUAccounting", "walinuxagent.service"))
 
 
 class SystemdCgroupsApiv1TestCase(AgentTestCase):

--- a/tests/ga/test_cgroupconfigurator.py
+++ b/tests/ga/test_cgroupconfigurator.py
@@ -237,6 +237,9 @@ class CGroupConfiguratorSystemdTestCase(AgentTestCase):
         with self._get_cgroup_configurator_v2() as configurator:
             cmd = 'systemctl set-property walinuxagent.service CPUAccounting=yes MemoryAccounting=yes --runtime'
             self.assertNotIn(cmd, configurator.mocks.commands_call_list, "The command to set CPU and Memory accounting was called")
+            for cmd in configurator.mocks.commands_call_list:
+                self.assertNotIn("CPUAccounting=yes", cmd, "CPUAccounting was set explicitly in cgroup v2")
+                self.assertNotIn("MemoryAccounting=yes", cmd, "MemoryAccounting was set explicitly in cgroup v2")
 
     def test_extension_enforcement_enabled_in_v2(self):
         service_list = [

--- a/tests/ga/test_cgroupconfigurator.py
+++ b/tests/ga/test_cgroupconfigurator.py
@@ -233,6 +233,11 @@ class CGroupConfiguratorSystemdTestCase(AgentTestCase):
             self.assertIn(cmd1, configurator.mocks.commands_call_list, "The command to set CPU quota was not called")
             self.assertIn(cmd2, configurator.mocks.commands_call_list, "The command to set Memory quota was not called")
 
+    def test_accounting_properties_not_set_explicitly_in_cgroupv2(self):
+        with self._get_cgroup_configurator_v2() as configurator:
+            cmd = 'systemctl set-property walinuxagent.service CPUAccounting=yes MemoryAccounting=yes --runtime'
+            self.assertNotIn(cmd, configurator.mocks.commands_call_list, "The command to set CPU and Memory accounting was called")
+
     def test_extension_enforcement_enabled_in_v2(self):
         service_list = [
             {
@@ -242,11 +247,11 @@ class CGroupConfiguratorSystemdTestCase(AgentTestCase):
         ]
         with self._get_cgroup_configurator_v2() as configurator:
             configurator.setup_extension_slice(extension_name="Microsoft.CPlat.Extension", cpu_quota=5)
-            cmd = 'systemctl set-property azure-vmextensions-Microsoft.CPlat.Extension.slice CPUAccounting=yes MemoryAccounting=yes CPUQuota=5% --runtime'
+            cmd = 'systemctl set-property azure-vmextensions-Microsoft.CPlat.Extension.slice CPUQuota=5% --runtime'
             self.assertIn(cmd, configurator.mocks.commands_call_list,
                             "The command to set the CPU quota was not called")
             configurator.set_extension_services_cpu_memory_quota(service_list)
-            cmd = 'systemctl set-property extension.service CPUAccounting=yes MemoryAccounting=yes CPUQuota=5% --runtime'
+            cmd = 'systemctl set-property extension.service CPUQuota=5% --runtime'
             self.assertIn(cmd, configurator.mocks.commands_call_list,
                           "The command to set the reset CPU quota was not called")
 
@@ -468,6 +473,8 @@ class CGroupConfiguratorSystemdTestCase(AgentTestCase):
 
                 self.assertEqual(len(command_calls), 1, "The test command should have been called exactly once [{0}]".format(command_calls))
                 self.assertIn("systemd-run", command_calls[0], "The extension should have been invoked using systemd")
+                self.assertIn("CPUAccounting=no", command_calls[0], "The systemd-run command should include CPUAccounting when using cgroups v1")
+                self.assertIn("MemoryAccounting=no", command_calls[0], "The systemd-run command should include MemoryAccounting when using cgroups v1")
 
     @patch('time.sleep', side_effect=lambda _: mock_sleep())
     def test_start_extension_command_should_start_tracking_the_extension_cgroups(self, _):
@@ -537,6 +544,9 @@ class CGroupConfiguratorSystemdTestCase(AgentTestCase):
 
                 self.assertEqual(len(command_calls), 1, "The test command should have been called exactly once [{0}]".format(command_calls))
                 self.assertIn("systemd-run", command_calls[0], "The extension should have been invoked using systemd")
+
+                self.assertNotIn("CPUAccounting", command_calls[0], "The systemd-run command should not include CPUAccounting when using cgroups v2")
+                self.assertNotIn("MemoryAccounting", command_calls[0], "The systemd-run command should not include MemoryAccounting when using cgroups v2")
 
     @patch('time.sleep', side_effect=lambda _: mock_sleep())
     def test_start_extension_command_should_disable_cgroups_and_invoke_the_command_directly_if_systemd_fails(self, _):
@@ -1155,7 +1165,7 @@ exit 0
 
     def test_get_log_collector_properties_should_return_correct_props(self):
         with self._get_cgroup_configurator() as configurator:
-            self.assertEqual(configurator.get_logcollector_unit_properties(), ["--property=CPUAccounting=yes", "--property=MemoryAccounting=yes", "--property=CPUQuota=5%"])
+            self.assertEqual(configurator.get_logcollector_unit_properties(), ["--property=CPUQuota=5%", "--property=CPUAccounting=yes", "--property=MemoryAccounting=yes"])
 
         with self._get_cgroup_configurator_v2() as configurator:
-            self.assertEqual(configurator.get_logcollector_unit_properties(), ["--property=CPUAccounting=yes", "--property=MemoryAccounting=yes", "--property=CPUQuota=5%", "--property=MemoryHigh=170M"])
+            self.assertEqual(configurator.get_logcollector_unit_properties(), ["--property=CPUQuota=5%", "--property=MemoryHigh=170M"])

--- a/tests/ga/test_collect_logs.py
+++ b/tests/ga/test_collect_logs.py
@@ -63,29 +63,33 @@ def _create_collect_logs_handler(iterations=1, cgroup_version=CgroupVersions.V1,
 
                         # Grab the singleton to patch it
                         cgroups_configurator_singleton = CGroupConfigurator.get_instance()
+                        mock_cgroups_api = MagicMock()
+                        mock_cgroups_api.get_accounting_properties.return_value = ((), ())
 
                         if cgroup_version == CgroupVersions.V1:
                             with patch.object(cgroups_configurator_singleton, "enabled", return_value=cgroups_enabled):
-                                def run_and_wait():
-                                    collect_logs_handler.run()
-                                    collect_logs_handler.join()
+                                with patch.object(cgroups_configurator_singleton, "_cgroups_api", mock_cgroups_api, create=True):
+                                    def run_and_wait():
+                                        collect_logs_handler.run()
+                                        collect_logs_handler.join()
 
-                                collect_logs_handler = get_collect_logs_handler()
-                                collect_logs_handler.get_mock_wire_protocol = lambda: protocol
-                                collect_logs_handler.run_and_wait = run_and_wait
-                                yield collect_logs_handler
+                                    collect_logs_handler = get_collect_logs_handler()
+                                    collect_logs_handler.get_mock_wire_protocol = lambda: protocol
+                                    collect_logs_handler.run_and_wait = run_and_wait
+                                    yield collect_logs_handler
                         else:
                             with patch("azurelinuxagent.ga.collect_logs.conf.get_enable_cgroup_v2_resource_limiting", return_value=cgroupv2_resource_limiting_conf):
                                 with patch.object(cgroups_configurator_singleton, "enabled", return_value=False):
-                                    with patch("azurelinuxagent.ga.cgroupconfigurator.CGroupConfigurator._Impl.using_cgroup_v2", return_value=True):
-                                        def run_and_wait():
-                                            collect_logs_handler.run()
-                                            collect_logs_handler.join()
+                                    with patch.object(cgroups_configurator_singleton, "_cgroups_api", mock_cgroups_api, create=True):
+                                        with patch("azurelinuxagent.ga.cgroupconfigurator.CGroupConfigurator._Impl.using_cgroup_v2", return_value=True):
+                                            def run_and_wait():
+                                                collect_logs_handler.run()
+                                                collect_logs_handler.join()
 
-                                        collect_logs_handler = get_collect_logs_handler()
-                                        collect_logs_handler.get_mock_wire_protocol = lambda: protocol
-                                        collect_logs_handler.run_and_wait = run_and_wait
-                                        yield collect_logs_handler
+                                            collect_logs_handler = get_collect_logs_handler()
+                                            collect_logs_handler.get_mock_wire_protocol = lambda: protocol
+                                            collect_logs_handler.run_and_wait = run_and_wait
+                                            yield collect_logs_handler
 
 
 @skip_if_predicate_true(is_python_version_26, "Disabled on Python 2.6")

--- a/tests/ga/test_signature_validation_sudo.py
+++ b/tests/ga/test_signature_validation_sudo.py
@@ -16,10 +16,11 @@
 #
 # Requires Python 2.6+ and Openssl 1.0+
 #
+import contextlib
 import os
 import re
 
-from tests.lib.tools import AgentTestCase, data_dir, patch, i_am_root
+from tests.lib.tools import AgentTestCase, data_dir, patch, i_am_root, MagicMock
 from azurelinuxagent.ga.signing_certificate_util import write_signing_certificates
 from azurelinuxagent.ga.signature_validation_util import validate_signature, SignatureValidationError
 from azurelinuxagent.common.utils import shellutil
@@ -80,9 +81,22 @@ class TestSignatureValidationSudo(AgentTestCase):
         self.assertTrue(i_am_root(), "Test does not run when non-root")
         TestSignatureValidationSudo._validate_signature_in_another_year(2026, self.vm_access_zip_path, self.vm_access_signature, self.package_name_and_version)
 
+
+    @contextlib.contextmanager
+    def _create_cgroupconfigurator_mock(self, cgroups_enabled):
+        with patch("azurelinuxagent.ga.signature_validation_util.CGroupConfigurator.get_instance") as mock_get_instance:
+            mock_cgroups_api = MagicMock()
+            mock_cgroups_api.get_accounting_properties.return_value = ((), ())
+            mock_instance = MagicMock()
+            mock_instance.get_cgroups_api.return_value = mock_cgroups_api
+            mock_instance.enabled.return_value = cgroups_enabled
+            mock_instance.disable = MagicMock()
+            mock_get_instance.return_value = mock_instance
+            yield mock_instance
+
     def test_validate_signature_should_use_systemd_run(self):
         self.assertTrue(i_am_root(), "Test does not run when non-root")
-        with patch("azurelinuxagent.ga.signature_validation_util.CGroupConfigurator._Impl.enabled", return_value=True):
+        with self._create_cgroupconfigurator_mock(cgroups_enabled=True):
             original_run_command = shellutil.run_command
             run_command_calls = []
 
@@ -105,7 +119,7 @@ class TestSignatureValidationSudo(AgentTestCase):
             )
 
     def test_validate_signature_should_not_use_systemd_run_when_cgroups_disabled(self):
-        with patch("azurelinuxagent.ga.signature_validation_util.CGroupConfigurator._Impl.enabled", return_value=False):
+        with self._create_cgroupconfigurator_mock(cgroups_enabled=False):
             original_run_command = shellutil.run_command
             run_command_calls = []
 
@@ -124,7 +138,7 @@ class TestSignatureValidationSudo(AgentTestCase):
                            msg="Openssl cms -verify command should not have been called with systemd-run when cgroups disabled")
 
     def test_validate_signature_should_raise_error_on_openssl_failure(self):
-        with patch("azurelinuxagent.ga.signature_validation_util.CGroupConfigurator._Impl.enabled", return_value=True):
+        with self._create_cgroupconfigurator_mock(cgroups_enabled=True):
             original_run_command = shellutil.run_command
 
             def mock_run_command(command, *args, **kwargs):
@@ -139,36 +153,35 @@ class TestSignatureValidationSudo(AgentTestCase):
                     validate_signature(self.vm_access_zip_path, self.vm_access_signature, self.package_name_and_version)
 
     def test_validate_signature_should_retry_on_systemd_error(self):
-        with patch("azurelinuxagent.ga.signature_validation_util.CGroupConfigurator._Impl.enabled", return_value=True):
-            with patch("azurelinuxagent.ga.signature_validation_util.CGroupConfigurator._Impl.disable") as mock_disable:
-                original_run_command = shellutil.run_command
-                run_command_calls = []
+        with self._create_cgroupconfigurator_mock(cgroups_enabled=True) as mock_cgroup:
+            original_run_command = shellutil.run_command
+            run_command_calls = []
 
-                def mock_run_command(command, *args, **kwargs):
-                    cmd = ' '.join(command)
-                    run_command_calls.append(cmd)
-                    if cmd.startswith('systemd-run'):
-                        error_msg = 'Unit {0} not found.'.format(EXT_SIGNATURE_VALIDATION_CGROUPS_UNIT_NAME)
-                        raise shellutil.CommandError(command=cmd, return_code=1, stdout=ustr(""), stderr=ustr(error_msg))
-                    return original_run_command(command, *args, **kwargs)
+            def mock_run_command(command, *args, **kwargs):
+                cmd = ' '.join(command)
+                run_command_calls.append(cmd)
+                if cmd.startswith('systemd-run'):
+                    error_msg = 'Unit {0} not found.'.format(EXT_SIGNATURE_VALIDATION_CGROUPS_UNIT_NAME)
+                    raise shellutil.CommandError(command=cmd, return_code=1, stdout=ustr(""), stderr=ustr(error_msg))
+                return original_run_command(command, *args, **kwargs)
 
-                with patch("azurelinuxagent.ga.signature_validation_util.run_command", side_effect=mock_run_command):
-                    validate_signature(self.vm_access_zip_path, self.vm_access_signature, self.package_name_and_version)
+            with patch("azurelinuxagent.ga.signature_validation_util.run_command", side_effect=mock_run_command):
+                validate_signature(self.vm_access_zip_path, self.vm_access_signature, self.package_name_and_version)
 
-                # Find all openssl cms -verify calls
-                openssl_calls = [cmd for cmd in run_command_calls if self.openssl_cmd_pattern.search(cmd)]
+            # Find all openssl cms -verify calls
+            openssl_calls = [cmd for cmd in run_command_calls if self.openssl_cmd_pattern.search(cmd)]
 
-                self.assertEqual(2, len(openssl_calls), msg="Expected exactly 2 openssl calls (first with systemd-run, second direct)")
+            self.assertEqual(2, len(openssl_calls), msg="Expected exactly 2 openssl calls (first with systemd-run, second direct)")
 
-                # First openssl cms verify call should use systemd-run
-                self.assertTrue(openssl_calls[0].startswith('systemd-run'), msg="First openssl call should have used systemd-run, got: {0}".format(openssl_calls[0]))
+            # First openssl cms verify call should use systemd-run
+            self.assertTrue(openssl_calls[0].startswith('systemd-run'), msg="First openssl call should have used systemd-run, got: {0}".format(openssl_calls[0]))
 
-                # Second openssl cms verify call should be direct (not using systemd-run)
-                self.assertFalse(openssl_calls[1].startswith('systemd-run'),
-                               msg="Second openssl call should be direct (without systemd-run), got: {0}".format(openssl_calls[1]))
+            # Second openssl cms verify call should be direct (not using systemd-run)
+            self.assertFalse(openssl_calls[1].startswith('systemd-run'),
+                           msg="Second openssl call should be direct (without systemd-run), got: {0}".format(openssl_calls[1]))
 
-                # Verify that cgroups were disabled
-                self.assertEqual(1, mock_disable.call_count, "disable() should have been called exactly once")
-                reason = mock_disable.call_args[1]['reason']
-                self.assertTrue(reason.startswith("'systemd-run' invocation failed for signature validation"),
-                                msg="Expected cgroup disable reason to indicate systemd-run error during signature validation")
+            # Verify that cgroups were disabled
+            self.assertEqual(1, mock_cgroup.disable.call_count, "disable() should have been called exactly once")
+            reason = mock_cgroup.disable.call_args[1]['reason']
+            self.assertTrue(reason.startswith("'systemd-run' invocation failed for signature validation"),
+                            msg="Expected cgroup disable reason to indicate systemd-run error during signature validation")

--- a/tests/lib/mock_cgroup_environment.py
+++ b/tests/lib/mock_cgroup_environment.py
@@ -43,13 +43,6 @@ _MOCKED_COMMANDS_COMMON = [
 '''CPUQuotaPerSecUSec=infinity
 '''),
 
-    MockCommand(r"^systemctl show (.+) --property CPUAccounting$",
-'''CPUAccounting=no
-'''),
-
-    MockCommand(r"^systemctl show (.+) --property MemoryAccounting$",
-'''MemoryAccounting=no
-'''),
 
     MockCommand(r"^systemctl show (.+) --property LoadState$",
 '''LoadState=loaded
@@ -58,12 +51,6 @@ _MOCKED_COMMANDS_COMMON = [
     MockCommand(r"^systemctl set-property (.+) --runtime", ""),
 
     MockCommand(r"^systemctl stop ([^\s]+)"),
-
-    MockCommand(r"^systemd-run (.+) --unit=([^\s]+) --scope ([^\s]+)",
-''' 
-Running scope as unit: TEST_UNIT.scope
-Thu 28 May 2020 07:25:55 AM PDT
-'''),
 
 ]
 
@@ -88,6 +75,20 @@ _MOCKED_COMMANDS_V1 = [
 
     MockCommand(r"^stat -f --format=%T /sys/fs/cgroup$", 'tmpfs'),
 
+    MockCommand(r"^systemd-run (.+) --unit=([^\s]+) --scope ([^\s]+)",
+''' 
+Running scope as unit: TEST_UNIT.scope
+Thu 28 May 2020 07:25:55 AM PDT
+'''),
+
+    MockCommand(r"^systemctl show (.+) --property CPUAccounting$",
+'''CPUAccounting=no
+'''),
+
+    MockCommand(r"^systemctl show (.+) --property MemoryAccounting$",
+'''MemoryAccounting=no
+'''),
+
 ]
 
 _MOCKED_COMMANDS_V2 = [
@@ -101,6 +102,11 @@ _MOCKED_COMMANDS_V2 = [
 
     MockCommand(r"^systemctl show (.+) --property MemoryHigh$",
 '''MemoryHigh=infinity
+'''),
+    MockCommand(r"^systemd-run --unit=([^\s]+) --scope ([^\s]+)",
+''' 
+Running scope as unit: TEST_UNIT.scope
+Thu 28 May 2020 07:25:55 AM PDT
 '''),
 
 ]


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->
<!--
Please add an informative description that covers that changes made by the pull request.
-->
## Description

Fixing https://github.com/Azure/WALinuxAgent/issues/3557

The issue is 
```
systemd 258
DefaultCPUAccounting= setting is deprecated, because CPU accounting is always available on the unified cgroup hierarchy and such setting has no effect.
```
In the agent, we explicitly set CPUAccounting and MemoryAccounting to true using systemd to enable the related resource metrics. This is required for cgroup v1–based distros. When we onboarded cgroup v2 distros, the same logic was applied there as well, even though it is not needed(since cgroup v2 enables CPU and memory accounting by default).

Now, newer distros like Ubuntu 26 are adopting the latest systemd version, where CPU accounting deprecated as mentioned above, as a result agent failing with

`Feb 17 10:55:50 rwala python3[7874]: 2026-02-17T10:55:50.235937Z INFO ExtHandler ExtHandler [CGW] Error initializing cgroups: Can't find property CPUAccounting of walinuxagent.service`

This PR removes the explicit accounting enablement for cgroup v2 distros.

Issue # <!-- if any -->
---
<!--
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->
### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).
---
<!--
This checklist is used to track contributions from distro maintainers.
-->
### Distro maintenance information, if applicable
- [ ] This is a contribution from a distro maintainer
- [ ] The changes in this PR have been taken as a downstream patch (Note: it is not recommended to patch the agent without upstream review and approval)
