### PR TITLE
Improve artifact download failure telemetry (#3550)

### DIFF
--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -44,7 +44,8 @@ from azurelinuxagent.common.telemetryevent import GuestAgentExtensionEventsSchem
 from azurelinuxagent.common.utils import fileutil, restutil
 from azurelinuxagent.common.utils.cryptutil import CryptUtil
 from azurelinuxagent.common.utils.restutil import TELEMETRY_THROTTLE_DELAY_IN_SECONDS, \
-    TELEMETRY_FLUSH_THROTTLE_DELAY_IN_SECONDS, TELEMETRY_DATA
+    TELEMETRY_FLUSH_THROTTLE_DELAY_IN_SECONDS, TELEMETRY_DATA, read_response_error, INVALID_CONTAINER_CONFIGURATION, \
+    HEADERS_TO_INCLUDE_IN_FAILURE_MSG
 from azurelinuxagent.common.utils.textutil import parse_doc, findall, find, \
     findtext, gettext, remove_bom, get_bytes_from_pem, parse_json, redact_sas_token
 from azurelinuxagent.common.version import AGENT_NAME, CURRENT_VERSION
@@ -768,7 +769,19 @@ class WireClient(object):
 
     def _fetch_response(self, uri, headers=None, use_proxy=None, retry_codes=None, ok_codes=None):
         resp = None
+        headers_for_failure_msg = {}
+        if headers is not None:
+            for k, v in headers.items():
+                if k in HEADERS_TO_INCLUDE_IN_FAILURE_MSG:
+                    headers_for_failure_msg[k] = v
         try:
+            # TODO: This method was originally meant to be used for calls to storage, but at some point during
+            #   refactoring it ended up being used for calls to HGAP /extensionArtifact. Calls to HGAP should follow a
+            #   similar pattern to fetch_config, which goes through call_wireserver. Those methods enforce certain
+            #   behavior, such as never using a proxy, which is critical on calls to WireServer. Similarly, calls to
+            #   HGAP should never use a proxy, but that is not being enforced in this method. It would be better to
+            #   follow a similar pattern to fetch_config than depend on developers passing in the correct value for
+            #   use_proxy.
             resp = self.call_storage_service(
                 restutil.http_get,
                 uri,
@@ -778,11 +791,30 @@ class WireClient(object):
 
             host_plugin = self.get_host_plugin()
 
+            response_error = None
+
+            # If we got a 400 (bad request) because the container id is invalid, it could indicate a stale goal
+            # state. The caller will handle this exception by forcing a goal state refresh, which in turn updates the
+            # container-id header passed to HostGAPlugin, and retrying the call.
+            # See Issue #1294, PR #1299.
+            # TODO: This behavior is specific to HGAP requests. It should be moved to a different method which is
+            #  exclusively used for HGAP requests
+            if resp.status == httpclient.BAD_REQUEST:
+                response_error = read_response_error(resp)
+                if INVALID_CONTAINER_CONFIGURATION in response_error:
+                    raise InvalidContainerError(response_error)
+
             if restutil.request_failed(resp, ok_codes=ok_codes):
-                error_response = restutil.read_response_error(resp)
-                msg = "Fetch failed from [{0}]: {1}".format(uri, error_response)
+                error_response = response_error if response_error is not None else restutil.read_response_error(resp)
+                if len(headers_for_failure_msg) > 0:
+                    msg = "Fetch failed from [{0}] with headers [{1}]: {2}".format(uri, json.dumps(headers_for_failure_msg), error_response)
+                else:
+                    msg = "Fetch failed from [{0}]: {1}".format(uri, error_response)
                 logger.warn(msg)
 
+                # TODO: The call to report_fetch_health should be limited to HGAP requests. That method should only
+                #  be used to report failures in HGAP's artifact downloads API. This logic should be moved to a
+                #  different method which is exclusively used for HGAP requests.
                 if host_plugin is not None:
                     host_plugin.report_fetch_health(uri,
                                                     is_healthy=not restutil.request_failed_at_hostplugin(resp),
@@ -794,10 +826,24 @@ class WireClient(object):
                     host_plugin.report_fetch_health(uri, source='WireClient')
 
         except (HttpError, ProtocolError, IOError) as error:
+            # These exception types already have URI and headers in their message, so we don't need to add it to the
+            # telemetry event message here
             msg = "Fetch failed: {0}".format(error)
             logger.warn(msg)
             report_event(op=WALAEventOperation.HttpGet, is_success=False, message=msg, log_event=False)
             raise
+
+        except Exception as error:
+            # Add the URI and relevant request headers to the telemetry event for any unexpected exceptions
+            if len(headers_for_failure_msg) > 0:
+                error_msg = "Fetch failed with exception from [{0}] with headers [{1}]: {2}".format(uri, json.dumps(headers_for_failure_msg), error)
+            else:
+                error_msg = "Fetch failed with exception from [{0}]: {1}".format(uri, error)
+            msg = "Fetch failed: {0}".format(error_msg)
+            logger.warn(msg)
+            report_event(op=WALAEventOperation.HttpGet, is_success=False, message=msg, log_event=False)
+            # Re-raise any unexpected exception as ProtocolError
+            raise ProtocolError(error_msg)
 
         return resp
 

--- a/azurelinuxagent/common/utils/restutil.py
+++ b/azurelinuxagent/common/utils/restutil.py
@@ -17,6 +17,7 @@
 # Requires Python 2.6+ and Openssl 1.0+
 #
 
+import json
 import os
 import threading
 import time
@@ -27,7 +28,7 @@ import azurelinuxagent.common.conf as conf
 import azurelinuxagent.common.logger as logger
 import azurelinuxagent.common.utils.textutil as textutil
 
-from azurelinuxagent.common.exception import HttpError, ResourceGoneError, InvalidContainerError
+from azurelinuxagent.common.exception import HttpError, ResourceGoneError
 from azurelinuxagent.common.future import httpclient, urlparse, ustr
 from azurelinuxagent.common.version import PY_VERSION_MAJOR, AGENT_NAME, GOAL_STATE_AGENT_VERSION
 
@@ -110,6 +111,10 @@ KNOWN_WIRESERVER_IP = '168.63.129.16'
 HOST_PLUGIN_PORT = 32526
 
 TELEMETRY_DATA = "telemetrydata"
+
+# The URI for HGAP /extensionArtifact requests does not include the requested artifact. Include these headers in the
+# failure message if they exist for any failed request to improve the error reporting
+HEADERS_TO_INCLUDE_IN_FAILURE_MSG = ["x-ms-artifact-location", "x-ms-artifact-manifest-location"]
 
 class IOErrorCounter(object):
     _lock = threading.RLock()
@@ -417,6 +422,13 @@ def http_request(method,
             logger.warn("Python does not support HTTPS tunnelling")
             SECURE_WARNING_EMITTED = True
 
+    # Get the headers to include in messages for failed requests to improve error reporting
+    headers_for_failure_msg = {}
+    if headers is not None:
+        for k, v in headers.items():
+            if k in HEADERS_TO_INCLUDE_IN_FAILURE_MSG:
+                headers_for_failure_msg[k] = v
+
     msg = ''
     attempt = 0
     delay = 0
@@ -465,7 +477,10 @@ def http_request(method,
 
             if request_failed(resp):
                 if _is_retry_status(resp.status, retry_codes=retry_codes):
-                    msg = '[HTTP Retry] {0} {1} -- Status Code {2}'.format(method, url, resp.status)
+                    if len(headers_for_failure_msg) > 0:
+                        msg = '[HTTP Retry] {0} {1} {2} -- {3}'.format(method, url, json.dumps(headers_for_failure_msg), read_response_error(resp))
+                    else:
+                        msg = '[HTTP Retry] {0} {1} -- {2}'.format(method, url, read_response_error(resp))
                     # Note if throttled and ensure a safe, minimum number of
                     # retry attempts
                     if _is_throttle_status(resp.status):
@@ -482,20 +497,16 @@ def http_request(method,
                 response_error = read_response_error(resp)
                 raise ResourceGoneError(response_error)
 
-            # If we got a 400 (bad request) because the container id is invalid, it could indicate a stale goal
-            # state. The caller will handle this exception by forcing a goal state refresh and retrying the call.
-            if resp.status == httpclient.BAD_REQUEST:
-                response_error = read_response_error(resp)
-                if INVALID_CONTAINER_CONFIGURATION in response_error:
-                    raise InvalidContainerError(response_error)
-
             return resp
 
         except httpclient.HTTPException as e:
             if return_raw_response:  # skip all error handling
                 raise
             clean_url = _trim_url_parameters(url)
-            msg = '[HTTP Failed] {0} {1} -- HttpException {2}'.format(method, clean_url, e)
+            if len(headers_for_failure_msg) > 0:
+                msg = '[HTTP Failed] {0} {1} {2} -- HttpException {3}'.format(method, clean_url, json.dumps(headers_for_failure_msg), e)
+            else:
+                msg = '[HTTP Failed] {0} {1} -- HttpException {2}'.format(method, clean_url, e)
             if _is_retry_exception(e):
                 continue
             break
@@ -505,7 +516,10 @@ def http_request(method,
                 raise
             IOErrorCounter.increment(host=host, port=port)
             clean_url = _trim_url_parameters(url)
-            msg = '[HTTP Failed] {0} {1} -- IOError {2}'.format(method, clean_url, e)
+            if len(headers_for_failure_msg) > 0:
+                msg = '[HTTP Failed] {0} {1} {2} -- IOError {3}'.format(method, clean_url, json.dumps(headers_for_failure_msg), e)
+            else:
+                msg = '[HTTP Failed] {0} {1} -- IOError {2}'.format(method, clean_url, e)
             continue
 
     raise HttpError("{0} -- {1} attempts made".format(msg, attempt))
@@ -662,7 +676,7 @@ def read_response_error(resp):
             result = "[HTTP Failed] [{0}: {1}] {2}".format(
                         resp.status, 
                         resp.reason, 
-                        resp.read()) 
+                        resp.read())
 
             # this result string is passed upstream to several methods
             # which do a raise HttpError() or a format() of some kind;

--- a/tests/common/protocol/test_wire.py
+++ b/tests/common/protocol/test_wire.py
@@ -26,8 +26,9 @@ import uuid
 
 from azurelinuxagent.common.agent_supported_feature import get_agent_supported_features_list_for_crp, _MultiConfigFeature, _GAVersioningGovernanceFeature
 from azurelinuxagent.common.event import WALAEventOperation
-from azurelinuxagent.common.exception import ResourceGoneError, ProtocolError, \
-    ExtensionDownloadError, HttpError
+from azurelinuxagent.common.exception import ResourceGoneError, ProtocolError, ExtensionDownloadError, HttpError, \
+    InvalidContainerError
+from azurelinuxagent.common.future import httpclient
 from azurelinuxagent.common.protocol.extensions_goal_state_from_extensions_config import ExtensionsGoalStateFromExtensionsConfig
 from azurelinuxagent.common.protocol.goal_state import GoalStateProperties
 from azurelinuxagent.common.protocol.hostplugin import HostPluginProtocol
@@ -36,6 +37,7 @@ from azurelinuxagent.common.protocol.wire import WireProtocol, WireClient, \
 from azurelinuxagent.common.telemetryevent import GuestAgentExtensionEventsSchema, \
     TelemetryEventParam, TelemetryEvent
 from azurelinuxagent.common.utils import restutil
+from azurelinuxagent.common.utils.restutil import KNOWN_WIRESERVER_IP
 from azurelinuxagent.common.version import CURRENT_VERSION, DISTRO_NAME, DISTRO_VERSION
 from azurelinuxagent.ga.exthandlers import get_exthandlers_handler
 from azurelinuxagent.ga.signature_validation_util import SignatureValidationError
@@ -45,7 +47,7 @@ from tests.lib.mock_wire_protocol import mock_wire_protocol, MockHttpResponse
 from tests.lib.http_request_predicates import HttpRequestPredicates
 from tests.lib.wire_protocol_data import DATA_FILE_NO_EXT, DATA_FILE
 from tests.lib.wire_protocol_data import WireProtocolData
-from tests.lib.tools import patch, AgentTestCase, load_bin_data
+from tests.lib.tools import patch, AgentTestCase, load_bin_data, Mock
 
 data_with_bom = b'\xef\xbb\xbfhehe'
 testurl = 'http://foo'
@@ -507,6 +509,20 @@ class TestWireProtocol(AgentTestCase, HttpRequestPredicates):
 
 
 class TestWireClient(HttpRequestPredicates, AgentTestCase):
+    @patch("azurelinuxagent.common.utils.restutil._http_request")
+    def test_http_request_raises_for_invalid_container_configuration(self, _http_request):
+        def read():
+            return b'{ "errorCode": "InvalidContainerConfiguration", "message": "Invalid request." }'
+
+        _http_request.side_effect = [
+            Mock(status=httpclient.BAD_REQUEST, reason='Bad Request', read=read)
+        ]
+
+        with patch.object(WireClient, "get_host_plugin", return_value=Mock()):
+            client = WireClient(endpoint=KNOWN_WIRESERVER_IP)
+            self.assertRaises(InvalidContainerError, client._fetch_response, "https://foo.bar")
+            self.assertEqual(1, _http_request.call_count)
+
     def test_get_ext_conf_without_extensions_should_retrieve_vmagent_manifests_info(self, *args):  # pylint: disable=unused-argument
         # Basic test for extensions_goal_state when extensions are not present in the config. The test verifies that
         # extensions_goal_state fetches the correct data by comparing the returned data with the test data provided the
@@ -645,7 +661,7 @@ class TestWireClient(HttpRequestPredicates, AgentTestCase):
             self.assertTrue(os.path.exists(target_directory), 'The extension package was not downloaded')
             self.assertTrue(HostPluginProtocol.is_default_channel, "The host channel should have been set as the default")
 
-    def test_download_zip_package_should_retry_the_host_channel_after_refreshing_host_plugin(self):
+    def test_download_zip_package_should_retry_the_host_channel_after_refreshing_host_plugin_on_resource_gone_error(self):
         extension_url = 'https://fake_host/fake_extension.zip'
         target_file = os.path.join(self.tmp_dir, 'fake_extension.zip')
         target_directory = os.path.join(self.tmp_dir, "fake_extension")
@@ -684,6 +700,55 @@ class TestWireClient(HttpRequestPredicates, AgentTestCase):
                 self.assertTrue(self.is_host_plugin_extension_artifact_request(urls[3]), "The third attempt should have been over the host channel")
                 self.assertTrue(os.path.exists(target_directory), 'The extension package was not downloaded')
                 self.assertTrue(HostPluginProtocol.is_default_channel, "The host channel should have been set as the default")
+            finally:
+                HostPluginProtocol.is_default_channel = False
+
+    def test_download_zip_package_should_retry_the_host_channel_after_refreshing_host_plugin_on_invalid_container_error(self):
+        extension_url = 'https://fake_host/fake_extension.zip'
+        target_file = os.path.join(self.tmp_dir, 'fake_extension.zip')
+        target_directory = os.path.join(self.tmp_dir, "fake_extension")
+
+        def http_get_handler(url, *_, **kwargs):
+            if url == extension_url:
+                return HttpError("Exception to fake an error on the direct channel")
+            if self.is_host_plugin_extension_request(url, kwargs, extension_url):
+                # fake a stale resource due to invalid container then succeed once the goal state has been refreshed
+                if http_get_handler.goal_state_requests == 0:
+                    http_get_handler.goal_state_requests += 1
+                    return MockHttpResponse(400, reason='Bad Request', body=b'{ "errorCode": "InvalidContainerConfiguration", "message": "Invalid request." }')
+                return MockHttpResponse(200, body=load_bin_data("ga/fake_extension.zip"))
+            if self.is_goal_state_request(url):
+                protocol.track_url(url)  # track requests for the goal state
+            return None
+
+        http_get_handler.goal_state_requests = 0
+
+        with mock_wire_protocol(wire_protocol_data.DATA_FILE) as protocol:
+            HostPluginProtocol.is_default_channel = False
+
+            try:
+                # initialization of the host plugin triggers a request for the goal state; do it here before we start tracking those requests.
+                protocol.client.get_host_plugin()
+
+                protocol.set_http_handlers(http_get_handler=http_get_handler)
+
+                protocol.client.download_zip_package("Microsoft.FakeExtension-1.0.0.0", [extension_url],
+                                                     target_file, target_directory, use_verify_header=False,
+                                                     signature="", ignore_signature_validation_errors=True)
+
+                urls = protocol.get_tracked_urls()
+                self.assertEqual(len(urls), 4, "Unexpected number of HTTP requests: [{0}]".format(urls))
+                self.assertEqual(urls[0], extension_url,
+                                 "The first attempt should have been over the direct channel")
+                self.assertTrue(self.is_host_plugin_extension_artifact_request(urls[1]),
+                                "The second attempt should have been over the host channel")
+                self.assertTrue(self.is_goal_state_request(urls[2]),
+                                "The host channel should have been refreshed the goal state")
+                self.assertTrue(self.is_host_plugin_extension_artifact_request(urls[3]),
+                                "The third attempt should have been over the host channel")
+                self.assertTrue(os.path.exists(target_directory), 'The extension package was not downloaded')
+                self.assertTrue(HostPluginProtocol.is_default_channel,
+                                "The host channel should have been set as the default")
             finally:
                 HostPluginProtocol.is_default_channel = False
 
@@ -786,7 +851,7 @@ class TestWireClient(HttpRequestPredicates, AgentTestCase):
             finally:
                 HostPluginProtocol.is_default_channel = False  # Reset default channel
 
-    def test_fetch_manifest_should_retry_the_host_channel_after_refreshing_the_host_plugin_and_set_the_host_as_default(self):
+    def test_fetch_manifest_should_retry_the_host_channel_after_refreshing_the_host_plugin_on_resource_gone_error_and_set_the_host_as_default(self):
         manifest_url = 'https://fake_host/fake_manifest.xml'
         manifest_xml = '<?xml version="1.0" encoding="utf-8"?><PluginVersionManifest/>'
 
@@ -822,6 +887,51 @@ class TestWireClient(HttpRequestPredicates, AgentTestCase):
                 self.assertTrue(self.is_goal_state_request(urls[2]), "The host channel should have been refreshed the goal state")
                 self.assertTrue(self.is_host_plugin_extension_artifact_request(urls[3]), "The third attempt should have been over the host channel")
                 self.assertTrue(HostPluginProtocol.is_default_channel, "The host should have been set as the default channel")
+            finally:
+                HostPluginProtocol.is_default_channel = False  # Reset default channel
+
+    def test_fetch_manifest_should_retry_the_host_channel_after_refreshing_the_host_plugin_on_invalid_container_error_and_set_the_host_as_default(self):
+        manifest_url = 'https://fake_host/fake_manifest.xml'
+        manifest_xml = '<?xml version="1.0" encoding="utf-8"?><PluginVersionManifest/>'
+
+        def http_get_handler(url, *_, **kwargs):
+            if url == manifest_url:
+                return HttpError("Exception to fake an error on the direct channel")
+            if self.is_host_plugin_extension_request(url, kwargs, manifest_url):
+                # fake a stale resource due to invalid container then succeed once the goal state has been refreshed
+                if http_get_handler.goal_state_requests == 0:
+                    http_get_handler.goal_state_requests += 1
+                    return MockHttpResponse(400, reason='Bad Request', body=b'{ "errorCode": "InvalidContainerConfiguration", "message": "Invalid request." }')
+                return MockHttpResponse(200, manifest_xml.encode('utf-8'))
+            elif self.is_goal_state_request(url):
+                protocol.track_url(url)  # keep track of goal state requests
+            return None
+
+        http_get_handler.goal_state_requests = 0
+
+        with mock_wire_protocol(wire_protocol_data.DATA_FILE) as protocol:
+            HostPluginProtocol.is_default_channel = False
+
+            try:
+                # initialization of the host plugin triggers a request for the goal state; do it here before we start tracking those requests.
+                protocol.client.get_host_plugin()
+
+                protocol.set_http_handlers(http_get_handler=http_get_handler)
+                manifest = protocol.client.fetch_manifest("test", [manifest_url], use_verify_header=False)
+
+                urls = protocol.get_tracked_urls()
+                self.assertEqual(manifest, manifest_xml)
+                self.assertEqual(len(urls), 4, "Unexpected number of HTTP requests: [{0}]".format(urls))
+                self.assertEqual(urls[0], manifest_url,
+                                 "The first attempt should have been over the direct channel")
+                self.assertTrue(self.is_host_plugin_extension_artifact_request(urls[1]),
+                                "The second attempt should have been over the host channel")
+                self.assertTrue(self.is_goal_state_request(urls[2]),
+                                "The host channel should have been refreshed the goal state")
+                self.assertTrue(self.is_host_plugin_extension_artifact_request(urls[3]),
+                                "The third attempt should have been over the host channel")
+                self.assertTrue(HostPluginProtocol.is_default_channel,
+                                "The host should have been set as the default channel")
             finally:
                 HostPluginProtocol.is_default_channel = False  # Reset default channel
 
@@ -897,7 +1007,7 @@ class TestWireClient(HttpRequestPredicates, AgentTestCase):
             finally:
                 HostPluginProtocol.is_default_channel = False
 
-    def test_get_artifacts_profile_should_retry_the_host_channel_after_refreshing_the_host_plugin(self):
+    def test_get_artifacts_profile_should_retry_the_host_channel_after_refreshing_the_host_plugin_on_resource_gone_error(self):
         def http_get_handler(url, *_, **kwargs):
             if self.is_in_vm_artifacts_profile_request(url):
                 return HttpError("Exception to fake an error on the direct channel")
@@ -932,7 +1042,49 @@ class TestWireClient(HttpRequestPredicates, AgentTestCase):
             finally:
                 HostPluginProtocol.is_default_channel = False
 
-    def test_get_artifacts_profile_should_refresh_the_host_plugin_and_not_change_default_channel_if_host_plugin_fails(self):
+    def test_get_artifacts_profile_should_retry_the_host_channel_after_refreshing_the_host_plugin_on_invalid_container_error(self):
+        def http_get_handler(url, *_, **kwargs):
+            if self.is_in_vm_artifacts_profile_request(url):
+                return HttpError("Exception to fake an error on the direct channel")
+            if self.is_host_plugin_in_vm_artifacts_profile_request(url, kwargs):
+                # fake a stale resource due to invalid container then succeed once the goal state has been refreshed
+                if http_get_handler.host_plugin_calls == 0:
+                    http_get_handler.host_plugin_calls += 1
+                    return MockHttpResponse(400, reason='Bad Request', body=b'{ "errorCode": "InvalidContainerConfiguration", "message": "Invalid request." }')
+                protocol.track_url(url)
+            if self.is_goal_state_request(url) and http_get_handler.host_plugin_calls == 1:
+                protocol.track_url(url)
+            return None
+
+        http_get_handler.host_plugin_calls = 0
+
+        with mock_wire_protocol(wire_protocol_data.DATA_FILE_IN_VM_ARTIFACTS_PROFILE) as protocol:
+            HostPluginProtocol.is_default_channel = False
+
+            try:
+                # initialization of the host plugin triggers a request for the goal state; do it here before we start tracking those requests.
+                protocol.client.get_host_plugin()
+
+                protocol.set_http_handlers(http_get_handler=http_get_handler)
+
+                protocol.client.reset_goal_state()
+
+                urls = protocol.get_tracked_urls()
+                self.assertEqual(len(urls), 4, "Invalid number of requests: [{0}]".format(urls))
+                self.assertTrue(self.is_in_vm_artifacts_profile_request(urls[0]),
+                                "The first request should have been over the direct channel")
+                self.assertTrue(self.is_host_plugin_extension_artifact_request(urls[1]),
+                                "The second request should have been over the host channel")
+                self.assertTrue(self.is_goal_state_request(urls[2]),
+                                "The goal state should have been refreshed before retrying the host channel")
+                self.assertTrue(self.is_host_plugin_extension_artifact_request(urls[3]),
+                                "The retry request should have been over the host channel")
+                self.assertTrue(HostPluginProtocol.is_default_channel,
+                                "The default channel should have changed to the host")
+            finally:
+                HostPluginProtocol.is_default_channel = False
+
+    def test_get_artifacts_profile_should_refresh_the_host_plugin_on_resource_gone_error_and_not_change_default_channel_if_host_plugin_fails(self):
         def http_get_handler(url, *_, **kwargs):
             if self.is_in_vm_artifacts_profile_request(url):
                 return HttpError("Exception to fake an error on the direct channel")
@@ -960,6 +1112,42 @@ class TestWireClient(HttpRequestPredicates, AgentTestCase):
             self.assertTrue(self.is_host_plugin_extension_artifact_request(urls[1]), "The second request should have been over the host channel")
             self.assertTrue(self.is_goal_state_request(urls[2]), "The goal state should have been refreshed before retrying the host channel")
             self.assertTrue(self.is_host_plugin_extension_artifact_request(urls[3]), "The retry request should have been over the host channel")
+            self.assertFalse(HostPluginProtocol.is_default_channel, "The default channel should not have changed")
+
+    def test_get_artifacts_profile_should_refresh_the_host_plugin_on_invalid_container_error_and_not_change_default_channel_if_host_plugin_fails(self):
+        def http_get_handler(url, *_, **kwargs):
+            if self.is_in_vm_artifacts_profile_request(url):
+                return HttpError("Exception to fake an error on the direct channel")
+            if self.is_host_plugin_in_vm_artifacts_profile_request(url, kwargs):
+                # fake a stale resource due to invalid container then succeed once the goal state has been refreshed
+                http_get_handler.host_plugin_calls += 1
+                return MockHttpResponse(400, reason='Bad Request', body=b'{ "errorCode": "InvalidContainerConfiguration", "message": "Invalid request." }')
+            if self.is_goal_state_request(url) and http_get_handler.host_plugin_calls == 1:
+                protocol.track_url(url)
+            return None
+
+        http_get_handler.host_plugin_calls = 0
+
+        with mock_wire_protocol(wire_protocol_data.DATA_FILE_IN_VM_ARTIFACTS_PROFILE) as protocol:
+            HostPluginProtocol.is_default_channel = False
+
+            # initialization of the host plugin triggers a request for the goal state; do it here before we start tracking those requests.
+            protocol.client.get_host_plugin()
+
+            protocol.set_http_handlers(http_get_handler=http_get_handler)
+
+            protocol.client.reset_goal_state()
+
+            urls = protocol.get_tracked_urls()
+            self.assertEqual(len(urls), 4, "Invalid number of requests: [{0}]".format(urls))
+            self.assertTrue(self.is_in_vm_artifacts_profile_request(urls[0]),
+                            "The first request should have been over the direct channel")
+            self.assertTrue(self.is_host_plugin_extension_artifact_request(urls[1]),
+                            "The second request should have been over the host channel")
+            self.assertTrue(self.is_goal_state_request(urls[2]),
+                            "The goal state should have been refreshed before retrying the host channel")
+            self.assertTrue(self.is_host_plugin_extension_artifact_request(urls[3]),
+                            "The retry request should have been over the host channel")
             self.assertFalse(HostPluginProtocol.is_default_channel, "The default channel should not have changed")
 
     @staticmethod

--- a/tests/common/utils/test_rest_util.py
+++ b/tests/common/utils/test_rest_util.py
@@ -18,7 +18,7 @@
 import os
 import unittest
 
-from azurelinuxagent.common.exception import HttpError, ResourceGoneError, InvalidContainerError
+from azurelinuxagent.common.exception import HttpError, ResourceGoneError
 import azurelinuxagent.common.utils.restutil as restutil
 from azurelinuxagent.common.utils.restutil import HTTP_USER_AGENT
 from azurelinuxagent.common.future import httpclient, ustr
@@ -622,19 +622,6 @@ class TestHttpOperations(AgentTestCase):
         ]
 
         self.assertRaises(ResourceGoneError, restutil.http_get, "https://foo.bar")
-        self.assertEqual(1, _http_request.call_count)
-
-    @patch("time.sleep")
-    @patch("azurelinuxagent.common.utils.restutil._http_request")
-    def test_http_request_raises_for_invalid_container_configuration(self, _http_request, _sleep):
-        def read():
-            return b'{ "errorCode": "InvalidContainerConfiguration", "message": "Invalid request." }'
-
-        _http_request.side_effect = [
-            Mock(status=httpclient.BAD_REQUEST, reason='Bad Request', read=read)
-        ]
-
-        self.assertRaises(InvalidContainerError, restutil.http_get, "https://foo.bar")
         self.assertEqual(1, _http_request.call_count)
 
     @patch("time.sleep")

--- a/tests_e2e/tests/lib/agent_log.py
+++ b/tests_e2e/tests/lib/agent_log.py
@@ -240,7 +240,7 @@ class AgentLog(object):
             #
             # Warning downloading extension manifest. If the issue persists, this would cause errors elsewhere so safe to ignore
             {
-                'message': r"\[http://168.63.129.16:32526/extensionArtifact\]: \[HTTP Failed\] \[400: Bad Request\]",
+                'message': r"\[http://168.63.129.16:32526/extensionArtifact\]( with headers \[\{.+\}\])?: \[HTTP Failed\] \[400: Bad Request\]",
                 'if': lambda r: r.level == "WARNING"
             },
             #


### PR DESCRIPTION
* Improve telemetry for artifact download failures

* Ignore new log warning for primary channel failures

* Address comments

* Clean up changes

* revert whitespace change

* py 2.6 does not support dict comprehension

* Add comments to separate HGAP specific behavior to separate method

* Remove unnecessary comment

(cherry picked from commit 99a222f5042e48d22d0761e4d55ab7adae2c5a69)

<!-- DO NOT DELETE THIS TEMPLATE -->
<!--
Please add an informative description that covers that changes made by the pull request.
-->
## Description

Issue # <!-- if any -->
---
<!--
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->
### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).
---
<!--
This checklist is used to track contributions from distro maintainers.
-->
### Distro maintenance information, if applicable
- [ ] This is a contribution from a distro maintainer
- [ ] The changes in this PR have been taken as a downstream patch (Note: it is not recommended to patch the agent without upstream review and approval)
