### PR TITLE
Add IsCVM value to KeywordName column in events

### DIFF
--- a/azurelinuxagent/common/AgentGlobals.py
+++ b/azurelinuxagent/common/AgentGlobals.py
@@ -50,6 +50,8 @@ class AgentGlobals(object):
 
     @staticmethod
     def get_is_cvm():
+        if AgentGlobals._is_cvm is None:
+            raise Exception("CVM info has not been initialized yet")
         return AgentGlobals._is_cvm
 
     @staticmethod

--- a/azurelinuxagent/common/AgentGlobals.py
+++ b/azurelinuxagent/common/AgentGlobals.py
@@ -30,6 +30,16 @@ class AgentGlobals(object):
     #
     _container_id = GUID_ZERO
 
+    #
+    # The telemetry modules require the information about whether the agent is running in a CVM or not. This variable
+    # will be updated when the CVM info is initialized in ConfidentialVMInfo. There are three possible values:
+    #   - None
+    #   - True
+    #   - False
+    # The value is None when the CVM info has not yet been initialized.
+    #
+    _is_cvm = None
+
     @staticmethod
     def get_container_id():
         return AgentGlobals._container_id
@@ -37,3 +47,11 @@ class AgentGlobals(object):
     @staticmethod
     def update_container_id(container_id):
         AgentGlobals._container_id = container_id
+
+    @staticmethod
+    def get_is_cvm():
+        return AgentGlobals._is_cvm
+
+    @staticmethod
+    def update_is_cvm(is_cvm):
+        AgentGlobals._is_cvm = is_cvm

--- a/azurelinuxagent/common/event.py
+++ b/azurelinuxagent/common/event.py
@@ -395,8 +395,10 @@ class EventLogger(object):
 
         # Parameters from OS
         osutil = get_osutil()
+        # Determining IsCVM requires a network call. Set as uninitialized for now until common parameters are initialized with real values in initialize_vminfo_common_parameters()
         keyword_name = {
-            "CpuArchitecture": osutil.get_vm_arch()
+            "CpuArchitecture": osutil.get_vm_arch(),
+            "IsCVM": "IsCVM_UNINITIALIZED"
         }
         self._common_parameters.append(TelemetryEventParam(CommonTelemetryEventSchema.OSVersion, EventLogger._get_os_version()))
         self._common_parameters.append(TelemetryEventParam(CommonTelemetryEventSchema.ExecutionMode, AGENT_EXECUTION_MODE))
@@ -473,13 +475,21 @@ class EventLogger(object):
         try:
             keyword_name_str = parameters[CommonTelemetryEventSchema.KeywordName].value                 # Get the current value of keywordName
             keyword_name_json = json.loads(keyword_name_str)                                            # Convert the string to JSON
-            # ConfidentialVMInfo.fetch_and_initialize_cvm_info() is called in the main loop before this method is
-            # called, so the CVM state should already be initialized by the time we get here. If it's not,
-            # ConfidentialVMInfo.is_confidential_vm() will raise and we won't add the IsCVM field to the KeywordName.
-            keyword_name_json["IsCVM"] = ConfidentialVMInfo.is_confidential_vm()                        # Add the security type to the JSON
+            try:
+                keyword_name_json["IsCVM"] = ConfidentialVMInfo.is_confidential_vm()                    # Add the security type to the JSON
+            except RuntimeError:
+                # ConfidentialVMInfo.is_confidential_vm() raises RuntimeError if the security type has not been fetched
+                # and initialized yet. Initializing the CVM info here as a fallback in case it unexpectedly has not
+                # been initialized yet.
+                try:
+                    logger.warn("ConfidentialVMInfo has not been initialized yet; attempting to fetch and initialize CVM info now.")
+                    ConfidentialVMInfo.fetch_and_initialize_cvm_info()
+                except Exception as e:
+                    logger.warn("Failed to get virtual machine security type from IMDS, will assume this is not a Confidential Virtual Machine: {0}", ustr(e))
+                keyword_name_json["IsCVM"] = ConfidentialVMInfo.is_confidential_vm()                    # Add the security type to the JSON
             parameters[CommonTelemetryEventSchema.KeywordName].value = json.dumps(keyword_name_json)    # Convert the JSON back to string and update the value of keywordName
         except Exception as e:
-            logger.warn("Failed to update the KeywordName column with IsCVM: {0}", ustr(e))
+            logger.warn("Failed to update the KeywordName column with IsCVM; will be missing from telemetry: {0}", ustr(e))
 
     def save_event(self, data):
         if self.event_dir is None:

--- a/azurelinuxagent/common/event.py
+++ b/azurelinuxagent/common/event.py
@@ -39,6 +39,7 @@ from azurelinuxagent.common.utils.textutil import parse_doc, findall, find, geta
     redact_sas_token
 from azurelinuxagent.common.version import CURRENT_VERSION, CURRENT_AGENT, AGENT_NAME, DISTRO_NAME, DISTRO_VERSION, DISTRO_CODE_NAME, AGENT_EXECUTION_MODE
 from azurelinuxagent.common.protocol.imds import get_imds_client
+from azurelinuxagent.ga.confidential_vm_info import ConfidentialVMInfo
 
 EVENTS_DIRECTORY = "events"
 
@@ -462,6 +463,23 @@ class EventLogger(object):
             parameters[CommonTelemetryEventSchema.ImageOrigin].value = int(imds_info.image_origin)
         except Exception as e:
             logger.warn("Failed to get IMDS info; will be missing from telemetry: {0}", ustr(e))
+
+        # The KeywordName column is initialized with the CPUArch in EventLogger.__init__(). The security type is
+        # not yet discovered at that time because it requires a network call, so we update KeywordName here with the
+        # IsCVM value.
+        # We get the security type from the ConfidentialVMInfo class because it fetches metadata from IMDS with the
+        # minimum version that supports the security type field. We do not use that minimum version in the IMDS request
+        # in this method due to inadequate saturation of that version in the fleet.
+        try:
+            keyword_name_str = parameters[CommonTelemetryEventSchema.KeywordName].value                 # Get the current value of keywordName
+            keyword_name_json = json.loads(keyword_name_str)                                            # Convert the string to JSON
+            # ConfidentialVMInfo.fetch_and_initialize_cvm_info() is called in the main loop before this method is
+            # called, so the CVM state should already be initialized by the time we get here. If it's not,
+            # ConfidentialVMInfo.is_confidential_vm() will raise and we won't add the IsCVM field to the KeywordName.
+            keyword_name_json["IsCVM"] = ConfidentialVMInfo.is_confidential_vm()                        # Add the security type to the JSON
+            parameters[CommonTelemetryEventSchema.KeywordName].value = json.dumps(keyword_name_json)    # Convert the JSON back to string and update the value of keywordName
+        except Exception as e:
+            logger.warn("Failed to update the KeywordName column with IsCVM: {0}", ustr(e))
 
     def save_event(self, data):
         if self.event_dir is None:

--- a/azurelinuxagent/common/event.py
+++ b/azurelinuxagent/common/event.py
@@ -476,7 +476,7 @@ class EventLogger(object):
             keyword_name_str = parameters[CommonTelemetryEventSchema.KeywordName].value                 # Get the current value of keywordName
             keyword_name_json = json.loads(keyword_name_str)                                            # Convert the string to JSON
             try:
-                keyword_name_json["IsCVM"] = ConfidentialVMInfo.is_confidential_vm()                    # Add the security type to the JSON
+                keyword_name_json["IsCVM"] = ConfidentialVMInfo.is_confidential_vm()                    # Update the security type in the JSON
             except RuntimeError:
                 # ConfidentialVMInfo.is_confidential_vm() raises RuntimeError if the security type has not been fetched
                 # and initialized yet. Initializing the CVM info here as a fallback in case it unexpectedly has not
@@ -486,7 +486,7 @@ class EventLogger(object):
                     ConfidentialVMInfo.fetch_and_initialize_cvm_info()
                 except Exception as e:
                     logger.warn("Failed to get virtual machine security type from IMDS, will assume this is not a Confidential Virtual Machine: {0}", ustr(e))
-                keyword_name_json["IsCVM"] = ConfidentialVMInfo.is_confidential_vm()                    # Add the security type to the JSON
+                keyword_name_json["IsCVM"] = ConfidentialVMInfo.is_confidential_vm()                    # Update the security type in the JSON
             parameters[CommonTelemetryEventSchema.KeywordName].value = json.dumps(keyword_name_json)    # Convert the JSON back to string and update the value of keywordName
         except Exception as e:
             logger.warn("Failed to update the KeywordName column with IsCVM; will be missing from telemetry: {0}", ustr(e))

--- a/azurelinuxagent/common/event.py
+++ b/azurelinuxagent/common/event.py
@@ -394,7 +394,8 @@ class EventLogger(object):
 
         # Parameters from OS
         osutil = get_osutil()
-        # Determining IsCVM requires a network call. Set as uninitialized for now until common parameters are initialized with real values in initialize_vminfo_common_parameters()
+        # Determining IsCVM requires a network call. Set as uninitialized for now until common parameters are
+        # initialized with real values in initialize_vminfo_common_parameters()
         keyword_name = {
             "CpuArchitecture": osutil.get_vm_arch(),
             "IsCVM": "IsCVM_UNINITIALIZED"
@@ -474,15 +475,13 @@ class EventLogger(object):
         # class attributes are initialized, AgentGlobals is also updated with the security type, so we can get the
         # security type in this module without introducing dependencies on the ConfidentialVMInfo class.
         try:
-            keyword_name_str = parameters[CommonTelemetryEventSchema.KeywordName].value                     # Get the current value of keywordName
-            keyword_name_json = json.loads(keyword_name_str)                                                # Convert the string to JSON
-            is_cvm = AgentGlobals.get_is_cvm()                                                              # Get the CVM state from AgentGlobals
-            if is_cvm is None:
-                # The CVM state should have been initialized. If not, log a warning.
-                logger.warn("CVM state is not yet initialized; IsCVM will be missing from telemetry.")
-            else:
-                keyword_name_json["IsCVM"] = is_cvm                                                         # Update the security type in the JSON
-                parameters[CommonTelemetryEventSchema.KeywordName].value = json.dumps(keyword_name_json)    # Convert the JSON back to string and update the value of keywordName
+            keyword_name_str = parameters[CommonTelemetryEventSchema.KeywordName].value               # Get the current value of keywordName
+            keyword_name_json = json.loads(keyword_name_str)                                          # Convert the string to JSON
+            # AgentGlobals.get_is_cvm() raises if cvm info is not initialized so the IsCVM value in the keywordName
+            # column would remain uninitialized in that case
+            is_cvm = AgentGlobals.get_is_cvm()                                                        # Get the CVM state from AgentGlobals
+            keyword_name_json["IsCVM"] = is_cvm                                                       # Update the security type in the JSON
+            parameters[CommonTelemetryEventSchema.KeywordName].value = json.dumps(keyword_name_json)  # Convert the JSON back to string and update the value of keywordName
         except Exception as e:
             logger.warn("Failed to update the KeywordName column with IsCVM; will be missing from telemetry: {0}", ustr(e))
 

--- a/azurelinuxagent/common/event.py
+++ b/azurelinuxagent/common/event.py
@@ -39,7 +39,6 @@ from azurelinuxagent.common.utils.textutil import parse_doc, findall, find, geta
     redact_sas_token
 from azurelinuxagent.common.version import CURRENT_VERSION, CURRENT_AGENT, AGENT_NAME, DISTRO_NAME, DISTRO_VERSION, DISTRO_CODE_NAME, AGENT_EXECUTION_MODE
 from azurelinuxagent.common.protocol.imds import get_imds_client
-from azurelinuxagent.ga.confidential_vm_info import ConfidentialVMInfo
 
 EVENTS_DIRECTORY = "events"
 
@@ -469,25 +468,21 @@ class EventLogger(object):
         # The KeywordName column is initialized with the CPUArch in EventLogger.__init__(). The security type is
         # not yet discovered at that time because it requires a network call, so we update KeywordName here with the
         # IsCVM value.
-        # We get the security type from the ConfidentialVMInfo class because it fetches metadata from IMDS with the
-        # minimum version that supports the security type field. We do not use that minimum version in the IMDS request
-        # in this method due to inadequate saturation of that version in the fleet.
+        # The security type is initialized by the ConfidentialVMInfo class because it fetches metadata from IMDS with
+        # the minimum version that supports the security type field. We do not use that minimum version in the IMDS
+        # request in this method due to inadequate saturation of that version in the fleet. When the ConfidentialVMInfo
+        # class attributes are initialized, AgentGlobals is also updated with the security type, so we can get the
+        # security type in this module without introducing dependencies on the ConfidentialVMInfo class.
         try:
-            keyword_name_str = parameters[CommonTelemetryEventSchema.KeywordName].value                 # Get the current value of keywordName
-            keyword_name_json = json.loads(keyword_name_str)                                            # Convert the string to JSON
-            try:
-                keyword_name_json["IsCVM"] = ConfidentialVMInfo.is_confidential_vm()                    # Update the security type in the JSON
-            except RuntimeError:
-                # ConfidentialVMInfo.is_confidential_vm() raises RuntimeError if the security type has not been fetched
-                # and initialized yet. Initializing the CVM info here as a fallback in case it unexpectedly has not
-                # been initialized yet.
-                try:
-                    logger.warn("ConfidentialVMInfo has not been initialized yet; attempting to fetch and initialize CVM info now.")
-                    ConfidentialVMInfo.fetch_and_initialize_cvm_info()
-                except Exception as e:
-                    logger.warn("Failed to get virtual machine security type from IMDS, will assume this is not a Confidential Virtual Machine: {0}", ustr(e))
-                keyword_name_json["IsCVM"] = ConfidentialVMInfo.is_confidential_vm()                    # Update the security type in the JSON
-            parameters[CommonTelemetryEventSchema.KeywordName].value = json.dumps(keyword_name_json)    # Convert the JSON back to string and update the value of keywordName
+            keyword_name_str = parameters[CommonTelemetryEventSchema.KeywordName].value                     # Get the current value of keywordName
+            keyword_name_json = json.loads(keyword_name_str)                                                # Convert the string to JSON
+            is_cvm = AgentGlobals.get_is_cvm()                                                              # Get the CVM state from AgentGlobals
+            if is_cvm is None:
+                # The CVM state should have been initialized. If not, log a warning.
+                logger.warn("CVM state is not yet initialized; IsCVM will be missing from telemetry.")
+            else:
+                keyword_name_json["IsCVM"] = is_cvm                                                         # Update the security type in the JSON
+                parameters[CommonTelemetryEventSchema.KeywordName].value = json.dumps(keyword_name_json)    # Convert the JSON back to string and update the value of keywordName
         except Exception as e:
             logger.warn("Failed to update the KeywordName column with IsCVM; will be missing from telemetry: {0}", ustr(e))
 

--- a/azurelinuxagent/ga/confidential_vm_info.py
+++ b/azurelinuxagent/ga/confidential_vm_info.py
@@ -19,6 +19,7 @@
 
 import json
 
+from azurelinuxagent.common.AgentGlobals import AgentGlobals
 from azurelinuxagent.common.protocol.imds import ImdsClient
 from azurelinuxagent.common.future import ustr
 from azurelinuxagent.common.exception import HttpError
@@ -77,10 +78,12 @@ class ConfidentialVMInfo(object):
         try:
             security_type = ConfidentialVMInfo._fetch_security_type_from_imds()
             ConfidentialVMInfo._is_confidential_vm = (security_type == SecurityType.ConfidentialVM)
+            AgentGlobals.update_is_cvm(ConfidentialVMInfo._is_confidential_vm)
         except Exception as ex:
             # TODO: For now, in the case of IMDS failure, we treat the VM as non-CVM until the next agent service start.
             # This should be improved to better distinguish IMDS issues from true security type.
             ConfidentialVMInfo._is_confidential_vm = False
+            AgentGlobals.update_is_cvm(False)
             raise ex
 
     @staticmethod

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -358,9 +358,8 @@ class UpdateHandler(object):
             logger.info(os_info_msg)
 
             # Initialize Confidential VM info but defer sending telemetry until common parameters are initialized.
-            # ConfidentialVMInfo.fetch_and_initialize_cvm_info() should be called before
-            # initialize_event_logger_vminfo_common_parameters_and_protocol() since we populate the KeywordName with
-            # IsCVM in that method.
+            # ConfidentialVMInfo.fetch_and_initialize_cvm_info() should be called to initialize AgentGlobals._is_cvm
+            # before initialize_event_logger_vminfo_common_parameters_and_protocol() is called.
             cvm_info_err = None
             try:
                 ConfidentialVMInfo.fetch_and_initialize_cvm_info()

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -357,7 +357,10 @@ class UpdateHandler(object):
                 )
             logger.info(os_info_msg)
 
-            # Initialize Confidential VM info but defer sending telemetry until common parameters are initialized
+            # Initialize Confidential VM info but defer sending telemetry until common parameters are initialized.
+            # ConfidentialVMInfo.fetch_and_initialize_cvm_info() should be called before
+            # initialize_event_logger_vminfo_common_parameters_and_protocol() since we populate the KeywordName with
+            # IsCVM in that method.
             cvm_info_err = None
             try:
                 ConfidentialVMInfo.fetch_and_initialize_cvm_info()

--- a/tests/common/test_event.py
+++ b/tests/common/test_event.py
@@ -71,7 +71,7 @@ class TestEvent(HttpRequestPredicates, AgentTestCase):
             CommonTelemetryEventSchema.EventTid: threading.current_thread().ident,
             CommonTelemetryEventSchema.EventPid: os.getpid(),
             CommonTelemetryEventSchema.TaskName: threading.current_thread().name,
-            CommonTelemetryEventSchema.KeywordName: json.dumps({"CpuArchitecture": platform.machine()}),
+            CommonTelemetryEventSchema.KeywordName: json.dumps({"CpuArchitecture": platform.machine(), "IsCVM": False}),
             # common parameters computed from the OS platform
             CommonTelemetryEventSchema.OSVersion: EventLoggerTools.get_expected_os_version(),
             CommonTelemetryEventSchema.ExecutionMode: AGENT_EXECUTION_MODE,

--- a/tests/ga/test_confidential_vm_info.py
+++ b/tests/ga/test_confidential_vm_info.py
@@ -17,6 +17,7 @@
 
 import os
 
+from azurelinuxagent.common.AgentGlobals import AgentGlobals
 from azurelinuxagent.ga.confidential_vm_info import ConfidentialVMInfo
 from tests.lib.tools import AgentTestCase, MagicMock, patch, data_dir
 
@@ -39,6 +40,7 @@ class TestConfidentialVMInfo(AgentTestCase):
             ConfidentialVMInfo.fetch_and_initialize_cvm_info()
             is_cvm = ConfidentialVMInfo.is_confidential_vm()
             self.assertTrue(is_cvm)
+            self.assertTrue(AgentGlobals.get_is_cvm())      # Verify that AgentGlobals was also updated
 
     def test_should_identify_non_confidential_vm(self):
         with patch('azurelinuxagent.ga.confidential_vm_info.ImdsClient.get_metadata') as mock_get_metadata:
@@ -46,6 +48,9 @@ class TestConfidentialVMInfo(AgentTestCase):
             ConfidentialVMInfo.fetch_and_initialize_cvm_info()
             is_cvm = ConfidentialVMInfo.is_confidential_vm()
             self.assertFalse(is_cvm)
+            # Verify that AgentGlobals was also updated
+            self.assertFalse(AgentGlobals.get_is_cvm())
+            self.assertIsNotNone(AgentGlobals.get_is_cvm())
 
     def test_should_return_false_when_imds_unavailable(self):
         with patch('azurelinuxagent.ga.confidential_vm_info.ImdsClient.get_metadata') as mock_get_metadata:
@@ -61,6 +66,9 @@ class TestConfidentialVMInfo(AgentTestCase):
             # After exception, is_confidential_vm should be False
             is_cvm = ConfidentialVMInfo.is_confidential_vm()
             self.assertFalse(is_cvm)
+            # Verify that AgentGlobals was also updated
+            self.assertFalse(AgentGlobals.get_is_cvm())
+            self.assertIsNotNone(AgentGlobals.get_is_cvm())
 
     def test_should_always_return_false_after_transient_imds_failure(self):
         with patch('azurelinuxagent.ga.confidential_vm_info.ImdsClient.get_metadata') as mock_get_metadata:
@@ -78,8 +86,14 @@ class TestConfidentialVMInfo(AgentTestCase):
                 ConfidentialVMInfo.fetch_and_initialize_cvm_info()
             first_call = ConfidentialVMInfo.is_confidential_vm()
             self.assertFalse(first_call)
+            # Verify that AgentGlobals was also updated
+            self.assertFalse(AgentGlobals.get_is_cvm())
+            self.assertIsNotNone(AgentGlobals.get_is_cvm())
             second_call = ConfidentialVMInfo.is_confidential_vm()
             self.assertFalse(second_call)
+            # Verify that AgentGlobals was also updated
+            self.assertFalse(AgentGlobals.get_is_cvm())
+            self.assertIsNotNone(AgentGlobals.get_is_cvm())
 
             # Verify IMDS was only called once
             self.assertEqual(mock_get_metadata.call_count, 1)

--- a/tests/ga/test_send_telemetry_events.py
+++ b/tests/ga/test_send_telemetry_events.py
@@ -77,6 +77,8 @@ class TestSendTelemetryEventsHandler(AgentTestCase, HttpRequestPredicates):
             protocol_util.get_protocol = Mock(return_value=protocol)
             send_telemetry_events_handler = get_send_telemetry_events_handler(protocol_util)
             send_telemetry_events_handler.event_calls = []
+            ConfidentialVMInfo = MagicMock()
+            ConfidentialVMInfo.is_confidential_vm = Mock(return_vale=False)
             with patch("azurelinuxagent.ga.send_telemetry_events.SendTelemetryEventsHandler._MIN_EVENTS_TO_BATCH",
                        batching_queue_limit):
                 with patch("azurelinuxagent.ga.send_telemetry_events.SendTelemetryEventsHandler._MAX_TIMEOUT", timeout):
@@ -383,7 +385,7 @@ class TestSendTelemetryEventsHandler(AgentTestCase, HttpRequestPredicates):
                              '<Param Name="ImageOrigin" Value="2468" T="mt:uint64" />' \
                              ']]></Event>'.format(AGENT_VERSION, TestSendTelemetryEventsHandler._TEST_EVENT_OPERATION, CURRENT_AGENT, test_opcodename, test_eventtid,
                                                   test_eventpid, test_taskname, osversion, int(osutil.get_total_mem()),
-                                                  osutil.get_processor_cores(), json.dumps({"CpuArchitecture": platform.machine()})).encode('utf-8')
+                                                  osutil.get_processor_cores(), json.dumps({"CpuArchitecture": platform.machine(), "IsCVM": False})).encode('utf-8')
 
             self.assertIn(sample_message, collected_event)
 

--- a/tests/lib/event_logger_tools.py
+++ b/tests/lib/event_logger_tools.py
@@ -55,7 +55,7 @@ class EventLoggerTools(object):
 
         with mock_wire_protocol(wire_protocol_data.DATA_FILE) as mock_protocol:
             with tools.patch("azurelinuxagent.common.event.get_imds_client", return_value=mock_imds_client):
-                with tools.patch("azurelinuxagent.ga.confidential_vm_info.ConfidentialVMInfo.is_confidential_vm", return_value=False):
+                with tools.patch("azurelinuxagent.common.AgentGlobals.AgentGlobals.get_is_cvm", return_value=False):
                     event.initialize_event_logger_vminfo_common_parameters_and_protocol(mock_protocol)
 
     @staticmethod

--- a/tests/lib/event_logger_tools.py
+++ b/tests/lib/event_logger_tools.py
@@ -55,7 +55,8 @@ class EventLoggerTools(object):
 
         with mock_wire_protocol(wire_protocol_data.DATA_FILE) as mock_protocol:
             with tools.patch("azurelinuxagent.common.event.get_imds_client", return_value=mock_imds_client):
-                event.initialize_event_logger_vminfo_common_parameters_and_protocol(mock_protocol)
+                with tools.patch("azurelinuxagent.ga.confidential_vm_info.ConfidentialVMInfo.is_confidential_vm", return_value=False):
+                    event.initialize_event_logger_vminfo_common_parameters_and_protocol(mock_protocol)
 
     @staticmethod
     def get_expected_os_version():


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->
<!--
Please add an informative description that covers that changes made by the pull request.
-->
## Description
Currently, we send a single telemetry event on service initialization which indicates if the VM is a CVM or not. 
As we prepare telemetry releases for CVM-only features, we will need to write queries that efficiently filter events for CVMs only. This PR adds the IsCVM key to the KeywordName column. The agent currently discovers if the VM is a CVM over a network call, so the first few events in agent initialization will not have the 'IsCVM' key.

Issue # <!-- if any -->
---
<!--
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->
### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).
---
<!--
This checklist is used to track contributions from distro maintainers.
-->
### Distro maintenance information, if applicable
- [ ] This is a contribution from a distro maintainer
- [ ] The changes in this PR have been taken as a downstream patch (Note: it is not recommended to patch the agent without upstream review and approval)
