### PR TITLE
Add check for get_nm_controlled before invoking it

### DIFF
--- a/tests_e2e/tests/scripts/recover_network_interface-get_nm_controlled.py
+++ b/tests_e2e/tests/scripts/recover_network_interface-get_nm_controlled.py
@@ -25,7 +25,7 @@ from azurelinuxagent.common.osutil import get_osutil
 def main():
     os_util = get_osutil()
     ifname = os_util.get_if_name()
-    nm_controlled = os_util.get_nm_controlled(ifname)
+    nm_controlled = hasattr(os_util, 'get_nm_controlled') and os_util.get_nm_controlled(ifname)  # get_nm_controlled is implemented only on some subclasses of OSUtil
 
     if nm_controlled:
         print("Interface is NM controlled")


### PR DESCRIPTION
get_nm_controlled is defined only on some subclasses of OSUtil. If the test runs on an OS where it is not defined, it fails with

`AttributeError: 'Ubuntu18OSUtil' object has no attribute 'get_nm_controlled'
`