### PR TITLE
Skip tests requiring a scale set when using a VHD

### DIFF
--- a/tests_e2e/orchestrator/lib/agent_test_result.py
+++ b/tests_e2e/orchestrator/lib/agent_test_result.py
@@ -25,10 +25,18 @@ from lisa.messages import TestStatus, TestResultMessage  # pylint: disable=E0401
 
 from azurelinuxagent.common.future import UTC
 
+
 class AgentTestResultMessage(TestResultMessage):
-    def __init__(self):
+    def __init__(self, suite_name: str, test_name: str, status: TestStatus):
         super().__init__()
         self.type = "AgentTestResultMessage"
+        self.id_ = str(uuid.uuid4())
+        self.status = status
+        self.suite_full_name = suite_name
+        self.suite_name = suite_name
+        self.full_name = test_name
+        self.name = test_name
+        self.elapsed = 0
 
 
 class AgentTestResult:
@@ -45,14 +53,7 @@ class AgentTestResult:
         Reports a test result to the junit notifier
         """
         # The junit notifier requires an initial RUNNING message in order to register the test in its internal cache.
-        msg: AgentTestResultMessage = AgentTestResultMessage()
-        msg.id_ = str(uuid.uuid4())
-        msg.status = TestStatus.RUNNING
-        msg.suite_full_name = suite_name
-        msg.suite_name = msg.suite_full_name
-        msg.full_name = test_name
-        msg.name = msg.full_name
-        msg.elapsed = 0
+        msg: AgentTestResultMessage = AgentTestResultMessage(suite_name, test_name, TestStatus.RUNNING)
 
         notifier.notify(msg)
 

--- a/tests_e2e/orchestrator/lib/agent_test_result.py
+++ b/tests_e2e/orchestrator/lib/agent_test_result.py
@@ -20,12 +20,15 @@ import uuid
 
 # Disable those warnings, since 'lisa' is an external, non-standard, dependency
 #     E0401: Unable to import 'lisa' (import-error)
-#     etc
-from lisa import (  # pylint: disable=E0401
-    notifier
-)
+from lisa import notifier  # pylint: disable=E0401
 from lisa.messages import TestStatus, TestResultMessage  # pylint: disable=E0401
+
 from azurelinuxagent.common.future import UTC
+
+class AgentTestResultMessage(TestResultMessage):
+    def __init__(self):
+        super().__init__()
+        self.type = "AgentTestResultMessage"
 
 
 class AgentTestResult:
@@ -42,8 +45,7 @@ class AgentTestResult:
         Reports a test result to the junit notifier
         """
         # The junit notifier requires an initial RUNNING message in order to register the test in its internal cache.
-        msg: TestResultMessage = TestResultMessage()
-        msg.type = "AgentTestResultMessage"
+        msg: AgentTestResultMessage = AgentTestResultMessage()
         msg.id_ = str(uuid.uuid4())
         msg.status = TestStatus.RUNNING
         msg.suite_full_name = suite_name

--- a/tests_e2e/orchestrator/lib/agent_test_result.py
+++ b/tests_e2e/orchestrator/lib/agent_test_result.py
@@ -23,20 +23,24 @@ import uuid
 from lisa import notifier  # pylint: disable=E0401
 from lisa.messages import TestStatus, TestResultMessage  # pylint: disable=E0401
 
+from typing import Optional
+
 from azurelinuxagent.common.future import UTC
 
 
 class AgentTestResultMessage(TestResultMessage):
     def __init__(self, suite_name: str, test_name: str, status: TestStatus):
         super().__init__()
-        self.type = "AgentTestResultMessage"
-        self.id_ = str(uuid.uuid4())
-        self.status = status
-        self.suite_full_name = suite_name
-        self.suite_name = suite_name
-        self.full_name = test_name
-        self.name = test_name
-        self.elapsed = 0
+        self.type: str = "AgentTestResultMessage"
+        self.id_: str = str(uuid.uuid4())
+        self.status: TestStatus = status
+        self.suite_full_name: str = suite_name
+        self.suite_name: str = suite_name
+        self.full_name: str = test_name
+        self.name: str = test_name
+        self.elapsed: float = 0
+        self.message: str = ""
+        self.stacktrace: Optional[str] = None
 
 
 class AgentTestResult:

--- a/tests_e2e/orchestrator/lib/agent_test_suite_combinator.py
+++ b/tests_e2e/orchestrator/lib/agent_test_suite_combinator.py
@@ -154,6 +154,8 @@ class AgentTestSuitesCombinator(Combinator):
 
         runbook_images = self._get_runbook_images(loader)
 
+        all_suites_require_vmss = all(s.executes_on_scale_set for s in loader.test_suites)
+
         skip_test_suites: List[str] = []
         skip_test_suites_images: List[Tuple[str, str]] = []
         for test_suite_info in loader.test_suites:
@@ -190,7 +192,16 @@ class AgentTestSuitesCombinator(Combinator):
                     shared_gallery = ""
 
                 if test_suite_info.executes_on_scale_set and (vhd != "" or shared_gallery != ""):
-                    raise Exception("VHDS and images from galleries are currently not supported on scale sets.")
+                    if all_suites_require_vmss:
+                        raise Exception("VHDs and images from galleries are currently not supported on scale sets")
+                    
+                    AgentTestResult.report(
+                        f"{test_suite_info.name}-{image_name}",
+                        test_suite_info.name,
+                        TestStatus.SKIPPED,
+                        datetime.datetime.now(datetime.timezone.utc),
+                        message="VHDs and images from galleries are currently not supported on scale sets.")
+                    continue
 
                 vm_size = self._get_vm_size(image)
 


### PR DESCRIPTION
VHDs and gallery images are currently not supported for test suites that require a VMSS.

Previously, we were aborting the test under this condition. Now we skip the test suite, unless all the suites in the test run require a VMSS.