### PR TITLE
Self-update should attempt next highest version on download/package v…

### DIFF
--- a/azurelinuxagent/ga/agent_update_handler.py
+++ b/azurelinuxagent/ga/agent_update_handler.py
@@ -176,12 +176,11 @@ class AgentUpdateHandler(object):
             if not self._updater.is_update_allowed_this_time(ext_gs_updated):
                 return
 
-            self._updater.retrieve_agent_version(agent_family, goal_state)
-
-            if not self._updater.is_retrieved_version_allowed_to_update(agent_family):
+            # Retrieve the target version, validate update eligibility of the version, and download.
+            # Each updater controls the full retrieve-validate-download flow and returns None if the update should not be attempted.
+            agent = self._updater.retrieve_and_download_agent(self._protocol, agent_family, goal_state)
+            if agent is None:
                 return
-            self._updater.log_new_agent_update_message()
-            agent = self._updater.download_and_get_new_agent(self._protocol, agent_family, goal_state)
 
             # Below condition is to break the update loop if new agent is in bad state in previous attempts
             # If the bad agent update already attempted 3 times, we don't want to continue with update anymore.
@@ -213,7 +212,7 @@ class AgentUpdateHandler(object):
             else:
                 error_msg = "Unable to update Agent: {0}".format(textutil.format_exception(err))
             if log_error:
-                error_msg = "[{0}]{1}".format(self.get_current_update_mode(), error_msg)
+                error_msg = "[{0}] {1}".format(self.get_current_update_mode(), error_msg)
                 logger.warn(error_msg)
                 add_event(op=WALAEventOperation.AgentUpgrade, is_success=False, message=error_msg, log_event=False)
             self._last_attempted_update_error_msg = error_msg

--- a/azurelinuxagent/ga/ga_version_updater.py
+++ b/azurelinuxagent/ga/ga_version_updater.py
@@ -55,32 +55,22 @@ class GAVersionUpdater(object):
         """
         raise NotImplementedError
 
-    def retrieve_agent_version(self, agent_family, goal_state):
-        """
-        This function fetches the agent version from the goal state for the given family.
-        @param agent_family: agent family
-        @param goal_state: goal state
-        """
-        raise NotImplementedError
-
-    def is_retrieved_version_allowed_to_update(self, agent_family):
-        """
-        Checks all base condition if new version allow to update.
-        @param agent_family: agent family
-        @return: True if allowed to update else False
-        """
-        raise NotImplementedError
-
-    def log_new_agent_update_message(self):
-        """
-        This function logs the update message after we check agent allowed to update.
-        """
-        raise NotImplementedError
-
     def proceed_with_update(self):
         """
         performs upgrade/downgrade
         @return: AgentUpgradeExitException
+        """
+        raise NotImplementedError
+
+    def retrieve_and_download_agent(self, protocol, agent_family, goal_state):
+        """
+        Retrieve the target agent version, validate eligibility, and download it.
+        Subclasses control the full retrieve-validate-download flow.
+        @param protocol: protocol object for download
+        @param agent_family: agent family
+        @param goal_state: goal state
+        @return: GuestAgent if an update is ready, None if no update should be attempted at this time
+        @raises: AgentUpdateError if the download fails
         """
         raise NotImplementedError
 
@@ -126,7 +116,7 @@ class GAVersionUpdater(object):
                 logger.warn("Unable to delete Agent directory: {0}".format(err))
             raise AgentUpdateError("Downloaded agent package: {0} is missing agent handler manifest file: {1}".format(agent_name, agent_handler_manifest_file))
 
-    def download_and_get_new_agent(self, protocol, agent_family, goal_state):
+    def _download_and_get_new_agent(self, protocol, agent_family, goal_state):
         """
         Function downloads the new agent and returns the downloaded version.
         @param protocol: protocol object

--- a/azurelinuxagent/ga/rsm_version_updater.py
+++ b/azurelinuxagent/ga/rsm_version_updater.py
@@ -78,13 +78,13 @@ class RSMVersionUpdater(GAVersionUpdater):
 
         return True
 
-    def retrieve_agent_version(self, agent_family, goal_state):
+    def _retrieve_agent_version(self, agent_family):
         """
         Get the agent version from the goal state
         """
         self._version = FlexibleVersion(agent_family.version)
 
-    def is_retrieved_version_allowed_to_update(self, agent_family):
+    def _is_retrieved_version_allowed_to_update(self, agent_family):
         """
         Once version retrieved from goal state, we check if we allowed to update for that version
         allow update If new version not same as current version, not below than daemon version and if version is from rsm request.
@@ -106,7 +106,7 @@ class RSMVersionUpdater(GAVersionUpdater):
 
         return True
 
-    def log_new_agent_update_message(self):
+    def _log_new_agent_update_message(self):
         """
         This function logs the update message after we check version allowed to update.
         """
@@ -114,6 +114,18 @@ class RSMVersionUpdater(GAVersionUpdater):
             str(self._version), self._gs_id)
         logger.info(msg)
         add_event(op=WALAEventOperation.AgentUpgrade, message=msg, log_event=False)
+
+    def retrieve_and_download_agent(self, protocol, agent_family, goal_state):
+        """
+        Retrieve the RSM-requested version, validate it, and download it.
+        Returns GuestAgent if the version is valid and downloaded, None if no update should be attempted.
+        """
+        self._retrieve_agent_version(agent_family)
+        if not self._is_retrieved_version_allowed_to_update(agent_family):
+            return None
+        self._log_new_agent_update_message()
+        agent = self._download_and_get_new_agent(protocol, agent_family, goal_state)
+        return agent
 
     def proceed_with_update(self):
         """

--- a/azurelinuxagent/ga/self_update_version_updater.py
+++ b/azurelinuxagent/ga/self_update_version_updater.py
@@ -164,7 +164,7 @@ class SelfUpdateVersionUpdater(GAVersionUpdater):
         4. Iterate candidates descending, attempting download for each. On failure, try the next.
 
         @return: GuestAgent if a version was successfully downloaded, None if no update should be attempted.
-        @raises: AgentUpdateError if all candidate downloads fail.
+        @raises: If all candidate downloads/validations fail, an appropriate Exception will be raised based on the failure
         """
         # Fetch manifest and get all agent versions sorted highest-first
         sorted_versions = self._retrieve_sorted_agent_versions(agent_family, goal_state)
@@ -189,9 +189,9 @@ class SelfUpdateVersionUpdater(GAVersionUpdater):
                 return self._download_and_get_new_agent(protocol, agent_family, goal_state)
             except Exception as err:
                 if i < len(update_candidates) - 1:
-                    msg = "Self-update: failed to download version {0}, trying next largest version. Error: {1}".format(self._version, ustr(err))
+                    msg = "Self-update: failed to prepare version {0} for update, trying next largest version. Error: {1}".format(self._version, ustr(err))
                     logger.warn(msg)
-                    add_event(op=WALAEventOperation.AgentUpgrade, message=msg, log_event=False)
+                    add_event(op=WALAEventOperation.AgentUpgrade, message=msg, log_event=False, is_success=False)
                 else:
                     raise
 

--- a/azurelinuxagent/ga/self_update_version_updater.py
+++ b/azurelinuxagent/ga/self_update_version_updater.py
@@ -22,7 +22,7 @@ import random
 from azurelinuxagent.common import conf, logger
 from azurelinuxagent.common.event import add_event, WALAEventOperation
 from azurelinuxagent.common.exception import AgentUpgradeExitException, AgentUpdateError
-from azurelinuxagent.common.future import UTC, datetime_min_utc
+from azurelinuxagent.common.future import UTC, datetime_min_utc, ustr
 from azurelinuxagent.common.utils.flexible_version import FlexibleVersion
 from azurelinuxagent.common.utils import timeutil
 from azurelinuxagent.common.version import CURRENT_VERSION
@@ -43,18 +43,6 @@ class SelfUpdateVersionUpdater(GAVersionUpdater):
         super(SelfUpdateVersionUpdater, self).__init__(gs_id)
         self._last_attempted_manifest_download_time = datetime_min_utc
         self._next_update_time = datetime_min_utc
-
-    @staticmethod
-    def _get_largest_version(agent_manifest):
-        """
-        Get the largest version from the agent manifest
-        """
-        largest_version = FlexibleVersion("0.0.0.0")
-        for pkg in agent_manifest.pkg_list.versions:
-            pkg_version = FlexibleVersion(pkg.version)
-            if pkg_version > largest_version:
-                largest_version = pkg_version
-        return largest_version
 
     @staticmethod
     def _get_agent_upgrade_type(version):
@@ -145,37 +133,17 @@ class SelfUpdateVersionUpdater(GAVersionUpdater):
 
         return False
 
-    def retrieve_agent_version(self, agent_family, goal_state):
+    def _retrieve_sorted_agent_versions(self, agent_family, goal_state):
         """
-        Get the largest version from the agent manifest
+        Fetch the agent manifest and return all versions from the agent manifest, sorted highest-first.
         """
         self._agent_manifest = goal_state.fetch_agent_manifest(agent_family.name, agent_family.uris)
-        largest_version = self._get_largest_version(self._agent_manifest)
-        self._version = largest_version
+        return sorted(
+            [FlexibleVersion(pkg.version) for pkg in self._agent_manifest.pkg_list.versions],
+            reverse=True
+        )
 
-    def is_retrieved_version_allowed_to_update(self, agent_family):
-        """
-        we don't allow new version update, if
-            1) The version is not greater than current version
-            2) if current time is before next update time
-
-        Allow the update, if
-            1) Initial update
-            2) If current time is on or after next update time
-        """
-        if self._version <= CURRENT_VERSION:
-            return False
-
-        # very first update need to proceed without any delay
-        if GuestAgentUpdateUtil.is_initial_update():
-            return True
-
-        if not self._new_agent_allowed_now_to_update():
-            return False
-
-        return True
-
-    def log_new_agent_update_message(self):
+    def _log_new_agent_update_message(self):
         """
         This function logs the update message after we check version allowed to update.
         """
@@ -183,6 +151,51 @@ class SelfUpdateVersionUpdater(GAVersionUpdater):
             str(self._version), self._gs_id)
         logger.info(msg)
         add_event(op=WALAEventOperation.AgentUpgrade, message=msg, log_event=False)
+
+    def retrieve_and_download_agent(self, protocol, agent_family, goal_state):
+        """
+        Retrieve the target agent version, validate eligibility, and download it.
+        On download/unzip failure, falls back to the next highest version in the manifest.
+
+        The flow is:
+        1. Fetch manifest and determine versions > CURRENT_VERSION.
+        2. If there are no eligible candidates, return None.
+        3. Run the timing gate once (may mutate _next_update_time) using the largest version's upgrade type.
+        4. Iterate candidates descending, attempting download for each. On failure, try the next.
+
+        @return: GuestAgent if a version was successfully downloaded, None if no update should be attempted.
+        @raises: AgentUpdateError if all candidate downloads fail.
+        """
+        # Fetch manifest and get all agent versions sorted highest-first
+        sorted_versions = self._retrieve_sorted_agent_versions(agent_family, goal_state)
+
+        # We should attempt to update to latest version in manifest
+        self._version = sorted_versions[0] if len(sorted_versions) > 0 else FlexibleVersion("0.0.0.0")
+        if self._version <= CURRENT_VERSION:
+            return None
+
+        # If this is not the first update attempt, check if the agent is allowed to update now
+        if not GuestAgentUpdateUtil.is_initial_update():
+            if not self._new_agent_allowed_now_to_update():
+                return None
+
+        # Try downloading the latest version. If there's any issue with the download, try the next highest version until 
+        # we exhaust all options to prevent baked-in agent from processing extensions.
+        update_candidates = [v for v in sorted_versions if v > CURRENT_VERSION]
+        for i in range(len(update_candidates)):
+            self._version = update_candidates[i]
+            self._log_new_agent_update_message()
+            try:
+                return self._download_and_get_new_agent(protocol, agent_family, goal_state)
+            except Exception as err:
+                if i < len(update_candidates) - 1:
+                    msg = "Self-update: failed to download version {0}, trying next largest version. Error: {1}".format(self._version, ustr(err))
+                    logger.warn(msg)
+                    add_event(op=WALAEventOperation.AgentUpgrade, message=msg, log_event=False)
+                else:
+                    raise
+
+        return None
 
     def proceed_with_update(self):
         """

--- a/tests/data/wire/ga_manifest_no_uris.xml
+++ b/tests/data/wire/ga_manifest_no_uris.xml
@@ -3,33 +3,21 @@
     <Plugins>
         <Plugin>
             <Version>1.0.0</Version>
-            <Uris>
-                <Uri>http://mock-goal-state/ga-manifests/OSTCExtensions.WALinuxAgent__1.0.0</Uri>
-            </Uris>
         </Plugin>
         <Plugin>
             <Version>1.1.0</Version>
-            <Uris>
-                <Uri>http://mock-goal-state/ga-manifests/OSTCExtensions.WALinuxAgent__1.1.0</Uri>
-            </Uris>
         </Plugin>
         <Plugin>
             <Version>1.2.0</Version>
-            <Uris>
-                <Uri>http://mock-goal-state/ga-manifests/OSTCExtensions.WALinuxAgent__1.2.0</Uri>
-            </Uris>
         </Plugin>
         <Plugin>
-            <Version>2.0.0</Version><Uris><Uri>http://mock-goal-state/ga-manifests/OSTCExtensions.WALinuxAgent__2.0.0</Uri></Uris>
+            <Version>2.0.0</Version>
         </Plugin>
         <Plugin>
-            <Version>2.1.0</Version><Uris><Uri>http://mock-goal-state/ga-manifests/OSTCExtensions.WALinuxAgent__2.1.0</Uri></Uris>
+            <Version>2.1.0</Version>
         </Plugin>
         <Plugin>
             <Version>9.9.9.10</Version>
-            <Uris>
-                <Uri>http://mock-goal-state/ga-manifests/OSTCExtensions.WALinuxAgent__99999.0.0.0</Uri>
-            </Uris>
         </Plugin>
         <Plugin>
             <Version>99999.0.0.0</Version>

--- a/tests/data/wire/ga_manifest_no_uris_for_largest.xml
+++ b/tests/data/wire/ga_manifest_no_uris_for_largest.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PluginVersionManifest xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+    <Plugins>
+        <Plugin>
+            <Version>1.0.0</Version>
+            <Uris>
+                <Uri>http://mock-goal-state/ga-manifests/OSTCExtensions.WALinuxAgent__1.0.0</Uri>
+            </Uris>
+        </Plugin>
+        <Plugin>
+            <Version>1.1.0</Version>
+            <Uris>
+                <Uri>http://mock-goal-state/ga-manifests/OSTCExtensions.WALinuxAgent__1.1.0</Uri>
+            </Uris>
+        </Plugin>
+        <Plugin>
+            <Version>1.2.0</Version>
+            <Uris>
+                <Uri>http://mock-goal-state/ga-manifests/OSTCExtensions.WALinuxAgent__1.2.0</Uri>
+            </Uris>
+        </Plugin>
+        <Plugin>
+            <Version>2.0.0</Version>
+            <Uris>
+                <Uri>http://mock-goal-state/ga-manifests/OSTCExtensions.WALinuxAgent__2.0.0</Uri>
+            </Uris>
+        </Plugin>
+        <Plugin>
+            <Version>2.1.0</Version>
+            <Uris>
+                <Uri>http://mock-goal-state/ga-manifests/OSTCExtensions.WALinuxAgent__2.1.0</Uri>
+            </Uris>
+        </Plugin>
+        <Plugin>
+            <Version>9.9.9.10</Version>
+            <Uris>
+                <Uri>http://mock-goal-state/ga-manifests/OSTCExtensions.WALinuxAgent__9.9.9.10</Uri>
+            </Uris>
+        </Plugin>
+        <Plugin>
+            <Version>99999.0.0.0</Version>
+        </Plugin>
+    </Plugins>
+</PluginVersionManifest>
+

--- a/tests/ga/test_agent_update_handler.py
+++ b/tests/ga/test_agent_update_handler.py
@@ -447,7 +447,7 @@ class TestAgentUpdate(UpdateTestCase):
                 agent_update_handler.run(GoalState(agent_update_handler._protocol.client, GoalStateProperties.ExtensionsGoalState), True)
             self._assert_update_discovered_from_agent_manifest(mock_telemetry, version="99999.0.0.0")
             self.assertEqual(1, len([kwarg['message'] for _, kwarg in mock_telemetry.call_args_list if
-                                     "Self-update: failed to download version 99999.0.0.0, trying next largest version" in kwarg['message'] and kwarg[
+                                     "Self-update: failed to prepare version 99999.0.0.0 for update, trying next largest version" in kwarg['message'] and kwarg[
                                          'op'] == WALAEventOperation.AgentUpgrade]),
                                             "99999.0.0.0 download should have failed")
             self._assert_update_discovered_from_agent_manifest(mock_telemetry, version="9.9.9.10")
@@ -470,7 +470,7 @@ class TestAgentUpdate(UpdateTestCase):
                 agent_update_handler.run(GoalState(agent_update_handler._protocol.client, GoalStateProperties.ExtensionsGoalState), True)
                 self._assert_update_discovered_from_agent_manifest(mock_telemetry, version="99999.0.0.0")
                 self.assertEqual(1, len([kwarg['message'] for _, kwarg in mock_telemetry.call_args_list if
-                                         "Self-update: failed to download version 99999.0.0.0, trying next largest version" in kwarg['message'] and kwarg[
+                                         "Self-update: failed to prepare version 99999.0.0.0 for update, trying next largest version" in kwarg['message'] and kwarg[
                                              'op'] == WALAEventOperation.AgentUpgrade]),
                                                 "99999.0.0.0 download should have failed")
                 self._assert_update_discovered_from_agent_manifest(mock_telemetry, version="9.9.9.10")

--- a/tests/ga/test_agent_update_handler.py
+++ b/tests/ga/test_agent_update_handler.py
@@ -242,8 +242,7 @@ class TestAgentUpdate(UpdateTestCase):
         self.prepare_agents(count=1)
         data_file = DATA_FILE.copy()
         data_file['ext_conf'] = "wire/ext_conf.xml"
-        with self._get_agent_update_handler(test_data=data_file, autoupdate_frequency=10, protocol_get_error=True) as (
-        agent_update_handler, _):
+        with self._get_agent_update_handler(test_data=data_file, autoupdate_frequency=10, protocol_get_error=True) as (agent_update_handler, _):
             # making multiple agent update attempts
             goal_state = GoalState(agent_update_handler._protocol.client, GoalStateProperties.ExtensionsGoalState)
             agent_update_handler.run(goal_state, True)
@@ -251,8 +250,7 @@ class TestAgentUpdate(UpdateTestCase):
             agent_update_handler.run(goal_state, True)
 
             mock_wire_data = agent_update_handler._protocol.mock_wire_data
-            self.assertEqual(1, mock_wire_data.call_counts['manifest_of_ga.xml'],
-                             "Agent manifest should not be downloaded again")
+            self.assertEqual(1, mock_wire_data.call_counts['manifest_of_ga.xml'], "Agent manifest should not be downloaded again")
 
     def test_it_should_download_manifest_if_last_attempted_download_time_is_elapsed(self):
         self.prepare_agents(count=1)

--- a/tests/ga/test_agent_update_handler.py
+++ b/tests/ga/test_agent_update_handler.py
@@ -238,6 +238,22 @@ class TestAgentUpdate(UpdateTestCase):
             self._assert_agent_directories_exist_and_others_dont_exist(versions=[str(CURRENT_VERSION), "99999.0.0.0"])
             self._assert_agent_exit_process_telemetry_emitted(ustr(context.exception.reason))
 
+    def test_it_should_not_download_manifest_again_if_last_attempted_download_time_not_elapsed(self):
+        self.prepare_agents(count=1)
+        data_file = DATA_FILE.copy()
+        data_file['ext_conf'] = "wire/ext_conf.xml"
+        with self._get_agent_update_handler(test_data=data_file, autoupdate_frequency=10, protocol_get_error=True) as (
+        agent_update_handler, _):
+            # making multiple agent update attempts
+            goal_state = GoalState(agent_update_handler._protocol.client, GoalStateProperties.ExtensionsGoalState)
+            agent_update_handler.run(goal_state, True)
+            agent_update_handler.run(goal_state, True)
+            agent_update_handler.run(goal_state, True)
+
+            mock_wire_data = agent_update_handler._protocol.mock_wire_data
+            self.assertEqual(1, mock_wire_data.call_counts['manifest_of_ga.xml'],
+                             "Agent manifest should not be downloaded again")
+
     def test_it_should_download_manifest_if_last_attempted_download_time_is_elapsed(self):
         self.prepare_agents(count=1)
         data_file = DATA_FILE.copy()

--- a/tests/ga/test_agent_update_handler.py
+++ b/tests/ga/test_agent_update_handler.py
@@ -6,8 +6,8 @@ import time
 
 from azurelinuxagent.common import conf
 from azurelinuxagent.common.event import WALAEventOperation
-from azurelinuxagent.common.exception import AgentUpgradeExitException
-from azurelinuxagent.common.future import ustr, httpclient
+from azurelinuxagent.common.exception import AgentUpgradeExitException, ExtensionDownloadError
+from azurelinuxagent.common.future import ustr, httpclient, datetime_min_utc
 from azurelinuxagent.common.protocol.wire import GoalState, GoalStateProperties
 from azurelinuxagent.common.protocol.restapi import VMAgentUpdateStatuses
 from azurelinuxagent.common.protocol.util import ProtocolUtil
@@ -129,7 +129,7 @@ class TestAgentUpdate(UpdateTestCase):
             agent_update_handler.run(GoalState(agent_update_handler._protocol.client, GoalStateProperties.ExtensionsGoalState), True)
             self._assert_agent_directories_exist_and_others_dont_exist(versions=[str(CURRENT_VERSION)])
             self.assertEqual(0, len([kwarg['message'] for _, kwarg in mock_telemetry.call_args_list if
-                                     "requesting a new agent version" in kwarg['message'] and kwarg[
+                                     "requested by RSM in Goal state" in kwarg['message'] and kwarg[
                                          'op'] == WALAEventOperation.AgentUpgrade]), "should not check for rsm version")
 
     def test_it_should_update_to_largest_version_if_ga_versioning_disabled(self):
@@ -145,20 +145,27 @@ class TestAgentUpdate(UpdateTestCase):
             self._assert_agent_directories_exist_and_others_dont_exist(versions=[str(CURRENT_VERSION), "99999.0.0.0"])
             self._assert_agent_exit_process_telemetry_emitted(ustr(context.exception.reason))
 
-    def test_it_should_not_update_to_largest_version_if_manifest_download_time_not_elapsed(self):
+    def test_it_should_not_self_update_if_manifest_download_time_not_elapsed(self):
         self.prepare_agents(count=1)
 
         data_file = DATA_FILE.copy()
         data_file["ga_manifest"] = "wire/ga_manifest_no_uris.xml"
         with self._get_agent_update_handler(test_data=data_file, autoupdate_frequency=10) as (agent_update_handler, _):
+            mock_wire_data = agent_update_handler._protocol.mock_wire_data
+
+            # This run should attempt to download the manifest, but it will fail to download the agent since there are
+            # no package URIs in the manifest.
             agent_update_handler.run(GoalState(agent_update_handler._protocol.client, GoalStateProperties.ExtensionsGoalState), True)
-            self.assertFalse(os.path.exists(self.agent_dir("99999.0.0.0")),
-                             "New agent directory should not be found")
+            self._assert_agent_directories_exist_and_others_dont_exist(versions=[str(CURRENT_VERSION)])
+            self.assertEqual(1, mock_wire_data.call_counts['manifest_of_ga.xml'], "Agent manifest should have been downloaded once")
+
             agent_update_handler._protocol.mock_wire_data.set_ga_manifest("wire/ga_manifest.xml")
             agent_update_handler._protocol.mock_wire_data.set_incarnation(2)
+            # This run should not attempt to download the manifest, since the required time has not elapsed since last
+            # download attempt.
             agent_update_handler.run(GoalState(agent_update_handler._protocol.client, GoalStateProperties.ExtensionsGoalState), True)
-            self.assertFalse(os.path.exists(self.agent_dir("99999.0.0.0")),
-                             "New agent directory should not be found")
+            self._assert_agent_directories_exist_and_others_dont_exist(versions=[str(CURRENT_VERSION)])
+            self.assertEqual(1, mock_wire_data.call_counts['manifest_of_ga.xml'], "Agent manifest should not have been downloaded again")
 
     def test_it_should_not_do_self_update_if_update_time_is_not_elapsed(self):
         self.prepare_agents(count=1)
@@ -166,14 +173,22 @@ class TestAgentUpdate(UpdateTestCase):
         data_file = DATA_FILE.copy()
         data_file["ga_manifest"] = "wire/ga_manifest_no_uris.xml"
         with self._get_agent_update_handler(test_data=data_file, mock_random_update_time=False) as (agent_update_handler, _):
+            # This run should identify the update from the manifest and set a random time within the regular self-update
+            # frequency for the update.
+            self.assertEqual(datetime_min_utc, agent_update_handler._updater._next_update_time)
             agent_update_handler.run(GoalState(agent_update_handler._protocol.client, GoalStateProperties.ExtensionsGoalState), True)
-            self.assertFalse(os.path.exists(self.agent_dir("99999.0.0.0")),
-                             "New agent directory should not be found")
+            self._assert_agent_directories_exist_and_others_dont_exist(versions=[str(CURRENT_VERSION)])
+            next_update_time_after_first_run = agent_update_handler._updater._next_update_time
+            self.assertNotEqual(datetime_min_utc, next_update_time_after_first_run)
+
             agent_update_handler._protocol.mock_wire_data.set_ga_manifest("wire/ga_manifest.xml")
             agent_update_handler._protocol.mock_wire_data.set_incarnation(2)
+            # This run should identify the update from the manifest but should not update since the random update time
+            # is not elapsed yet. It should not set another random update time since the update is already identified
+            # in the last agent_update_handler run
             agent_update_handler.run(GoalState(agent_update_handler._protocol.client, GoalStateProperties.ExtensionsGoalState), True)
-            self.assertFalse(os.path.exists(self.agent_dir("99999.0.0.0")),
-                             "New agent directory should not be found")
+            self._assert_agent_directories_exist_and_others_dont_exist(versions=[str(CURRENT_VERSION)])
+            self.assertEqual(agent_update_handler._updater._next_update_time, next_update_time_after_first_run)
 
     def test_it_should_update_to_largest_version_after_time_window_elapsed(self):
         self.prepare_agents(count=1)
@@ -184,13 +199,20 @@ class TestAgentUpdate(UpdateTestCase):
             with patch("azurelinuxagent.common.conf.get_self_update_regular_frequency", return_value=1):
                 with self._get_agent_update_handler(test_data=data_file, mock_random_update_time=False) as (agent_update_handler, mock_telemetry):
                     with self.assertRaises(AgentUpgradeExitException) as context:
+                        # This run should identify the update from the manifest and set a random time within the regular
+                        # self-update frequency for the update.
+                        self.assertEqual(datetime_min_utc, agent_update_handler._updater._next_update_time)
                         agent_update_handler.run(GoalState(agent_update_handler._protocol.client, GoalStateProperties.ExtensionsGoalState), True)
-                        self.assertFalse(os.path.exists(self.agent_dir("99999.0.0.0")),
-                                         "New agent directory should not be found")
+                        self._assert_agent_directories_exist_and_others_dont_exist(versions=[str(CURRENT_VERSION)])
+                        next_update_time_after_first_run = agent_update_handler._updater._next_update_time
+                        self.assertNotEqual(datetime_min_utc, next_update_time_after_first_run)
+
                         agent_update_handler._protocol.mock_wire_data.set_ga_manifest("wire/ga_manifest.xml")
                         agent_update_handler._protocol.mock_wire_data.set_incarnation(2)
                         # sleeping for update window to elapse
                         time.sleep(0.1)
+                        # This run should do the update since the required time has elapsed since the update was
+                        # identified
                         agent_update_handler.run(GoalState(agent_update_handler._protocol.client, GoalStateProperties.ExtensionsGoalState), True)
                     self._assert_update_discovered_from_agent_manifest(mock_telemetry, inc=2, version="99999.0.0.0")
                     self._assert_agent_directories_exist_and_others_dont_exist(versions=[str(CURRENT_VERSION), "99999.0.0.0"])
@@ -204,7 +226,7 @@ class TestAgentUpdate(UpdateTestCase):
             agent_update_handler.run(GoalState(agent_update_handler._protocol.client, GoalStateProperties.ExtensionsGoalState), True)
             self._assert_agent_directories_exist_and_others_dont_exist(versions=[str(CURRENT_VERSION)])
 
-    def test_it_should_update_to_largest_version_if_rsm_version_not_available(self):
+    def test_it_should_self_update_to_largest_version_if_goal_state_does_not_have_rsm_fields(self):
         self.prepare_agents(count=1)
 
         data_file = DATA_FILE.copy()
@@ -215,20 +237,6 @@ class TestAgentUpdate(UpdateTestCase):
             self._assert_update_discovered_from_agent_manifest(mock_telemetry, version="99999.0.0.0")
             self._assert_agent_directories_exist_and_others_dont_exist(versions=[str(CURRENT_VERSION), "99999.0.0.0"])
             self._assert_agent_exit_process_telemetry_emitted(ustr(context.exception.reason))
-
-    def test_it_should_not_download_manifest_again_if_last_attempted_download_time_not_elapsed(self):
-        self.prepare_agents(count=1)
-        data_file = DATA_FILE.copy()
-        data_file['ext_conf'] = "wire/ext_conf.xml"
-        with self._get_agent_update_handler(test_data=data_file, autoupdate_frequency=10, protocol_get_error=True) as (agent_update_handler, _):
-            # making multiple agent update attempts
-            goal_state = GoalState(agent_update_handler._protocol.client, GoalStateProperties.ExtensionsGoalState)
-            agent_update_handler.run(goal_state, True)
-            agent_update_handler.run(goal_state, True)
-            agent_update_handler.run(goal_state, True)
-
-            mock_wire_data = agent_update_handler._protocol.mock_wire_data
-            self.assertEqual(1, mock_wire_data.call_counts['manifest_of_ga.xml'], "Agent manifest should not be downloaded again")
 
     def test_it_should_download_manifest_if_last_attempted_download_time_is_elapsed(self):
         self.prepare_agents(count=1)
@@ -259,11 +267,14 @@ class TestAgentUpdate(UpdateTestCase):
             agent_update_handler._protocol.mock_wire_data.set_incarnation(2)
             agent_update_handler._protocol.client.update_goal_state()
             agent_update_handler.run(GoalState(agent_update_handler._protocol.client, GoalStateProperties.ExtensionsGoalState), True)
+            self.assertEqual(1, len([kwarg['message'] for _, kwarg in mock_telemetry.call_args_list if
+                                     "VM enabled for RSM updates, switching to RSM update mode" in kwarg['message'] and kwarg[
+                                         'op'] == WALAEventOperation.AgentUpgrade]), "rsm mode should be used for update")
             self.assertEqual(0, len([kwarg['message'] for _, kwarg in mock_telemetry.call_args_list if
-                                     "requesting a new agent version" in kwarg['message'] and kwarg[
+                                     "requested by RSM in Goal state" in kwarg['message'] and kwarg[
                                          'op'] == WALAEventOperation.AgentUpgrade]), "rsm version should be same as current version")
-            self.assertFalse(os.path.exists(self.agent_dir("99999.0.0.0")),
-                             "New agent directory should not be found")
+            self.assertEqual(20, self.agent_count(), "There should not be any additional agent directories after running update handler")
+            self.assertFalse(os.path.exists(self.agent_dir("99999.0.0.0")), "Agent directories shouldn't have been modified")
 
     def test_it_should_upgrade_agent_if_rsm_version_is_available_greater_than_current_version(self):
         data_file = DATA_FILE.copy()
@@ -319,7 +330,7 @@ class TestAgentUpdate(UpdateTestCase):
             agent_update_handler._protocol.mock_wire_data.set_incarnation(2)
             agent_update_handler._protocol.client.update_goal_state()
             agent_update_handler.run(GoalState(agent_update_handler._protocol.client, GoalStateProperties.ExtensionsGoalState), True)
-            self.assertFalse(os.path.exists(self.agent_dir(downgrade_version)),"New agent directory should not be found")
+            self.assertFalse(os.path.exists(self.agent_dir(downgrade_version)), "New agent directory should not be found")
             self.assertEqual(1, len([kwarg['message'] for _, kwarg in mock_telemetry.call_args_list if
                                      "downgrade {0} is not allowed to update from {1}".format(downgrade_version, from_version) in kwarg['message'] and kwarg[
                                          'op'] == WALAEventOperation.AgentUpgrade]), "downgrade should not be allowed")
@@ -338,13 +349,19 @@ class TestAgentUpdate(UpdateTestCase):
 
         downgrade_version = "2.5.0"
 
-        with self._get_agent_update_handler(test_data=data_file) as (agent_update_handler, _):
+        with self._get_agent_update_handler(test_data=data_file) as (agent_update_handler, mock_telemetry):
             agent_update_handler._protocol.mock_wire_data.set_version_in_agent_family(downgrade_version)
             agent_update_handler._protocol.mock_wire_data.set_incarnation(2)
             agent_update_handler._protocol.client.update_goal_state()
             agent_update_handler.run(GoalState(agent_update_handler._protocol.client, GoalStateProperties.ExtensionsGoalState), True)
-            self.assertFalse(os.path.exists(self.agent_dir(downgrade_version)),
-                             "New agent directory should not be found")
+            self.assertFalse(os.path.exists(self.agent_dir(downgrade_version)), "New agent directory should not be found")
+            self.assertEqual(1, len([kwarg['message'] for _, kwarg in mock_telemetry.call_args_list if
+                                     "downgrade {0} is not allowed to update from {1}".format(downgrade_version, None) in kwarg['message'] and kwarg[
+                                         'op'] == WALAEventOperation.AgentUpgrade]), "downgrade should not be allowed")
+            vm_agent_update_status = agent_update_handler.get_vmagent_update_status()
+            self.assertEqual(1, vm_agent_update_status.code)
+            self.assertEqual(VMAgentUpdateStatuses.Error, vm_agent_update_status.status)
+            self.assertIn("downgrade {0} is not allowed to update from {1}".format(downgrade_version, None), vm_agent_update_status.message)
 
     def test_it_should_not_do_rsm_update_if_gs_not_updated_in_next_attempt(self):
         self.prepare_agents(count=1)
@@ -356,14 +373,16 @@ class TestAgentUpdate(UpdateTestCase):
             agent_update_handler._protocol.mock_wire_data.set_incarnation(2)
             agent_update_handler._protocol.client.update_goal_state()
             goal_state = GoalState(agent_update_handler._protocol.client, GoalStateProperties.ExtensionsGoalState)
+            # This run should fail to update because package for the version is not found in the manifest
             agent_update_handler.run(goal_state, True)
-
             self._assert_agent_rsm_version_in_goal_state(mock_telemetry, inc=2, version=version)
             self._assert_no_agent_package_telemetry_emitted(mock_telemetry, version=version)
-            # Now we shouldn't check for download if update not allowed(GS not updated).This run should not add new logs
+
+            # Now we shouldn't check for download if update not allowed(GS not updated). This run should not add new
+            # logs
             agent_update_handler.run(goal_state, False)
             self._assert_agent_rsm_version_in_goal_state(mock_telemetry, inc=2, version=version)
-            self._assert_no_agent_package_telemetry_emitted(mock_telemetry, version=version)
+            self._assert_no_agent_package_telemetry_emitted(mock_telemetry, version=version)    # Checks that this telemetry was only emitted once (i.e., not emitted again in the second run)
 
     def test_it_should_not_downgrade_below_daemon_version(self):
         data_file = DATA_FILE.copy()
@@ -390,8 +409,7 @@ class TestAgentUpdate(UpdateTestCase):
             self.assertEqual(VMAgentUpdateStatuses.Error, vm_agent_update_status.status)
             self.assertIn("new version {0} is below than daemon version".format(downgrade_version), vm_agent_update_status.message)
 
-
-    def test_it_should_update_to_largest_version_if_vm_not_enabled_for_rsm_upgrades(self):
+    def test_it_should_self_update_to_largest_version_if_vm_not_enabled_for_rsm_upgrades(self):
         self.prepare_agents(count=1)
 
         data_file = DATA_FILE.copy()
@@ -403,13 +421,59 @@ class TestAgentUpdate(UpdateTestCase):
             self._assert_agent_directories_exist_and_others_dont_exist(versions=[str(CURRENT_VERSION), "99999.0.0.0"])
             self._assert_agent_exit_process_telemetry_emitted(ustr(context.exception.reason))
 
+    def test_it_should_self_update_to_next_largest_version_if_largest_download_fails(self):
+        self.prepare_agents(count=1)
+
+        data_file = DATA_FILE.copy()
+        data_file['ext_conf'] = "wire/ext_conf_vm_not_enabled_for_rsm_upgrades.xml"
+        data_file["ga_manifest"] = "wire/ga_manifest_no_uris_for_largest.xml"
+
+        with self._get_agent_update_handler(test_data=data_file) as (agent_update_handler, mock_telemetry):
+            with self.assertRaises(AgentUpgradeExitException) as context:
+                agent_update_handler.run(GoalState(agent_update_handler._protocol.client, GoalStateProperties.ExtensionsGoalState), True)
+            self._assert_update_discovered_from_agent_manifest(mock_telemetry, version="99999.0.0.0")
+            self.assertEqual(1, len([kwarg['message'] for _, kwarg in mock_telemetry.call_args_list if
+                                     "Self-update: failed to download version 99999.0.0.0, trying next largest version" in kwarg['message'] and kwarg[
+                                         'op'] == WALAEventOperation.AgentUpgrade]),
+                                            "99999.0.0.0 download should have failed")
+            self._assert_update_discovered_from_agent_manifest(mock_telemetry, version="9.9.9.10")
+            self._assert_agent_directories_exist_and_others_dont_exist(versions=[str(CURRENT_VERSION), "9.9.9.10"])
+            self._assert_agent_exit_process_telemetry_emitted(ustr(context.exception.reason))
+
+    def test_it_should_only_attempt_to_download_versions_greater_than_current(self):
+        self.prepare_agents(count=1)
+
+        data_file = DATA_FILE.copy()
+        data_file['ext_conf'] = "wire/ext_conf_vm_not_enabled_for_rsm_upgrades.xml"
+        data_file["ga_manifest"] = "wire/ga_manifest_no_uris.xml"
+
+        def download_side_effect(*args, **_):
+            package_version = args[0].version
+            raise ExtensionDownloadError("Failed to download WALinuxAgent-{0} from all URIs".format(package_version))
+
+        with self._get_agent_update_handler(test_data=data_file) as (agent_update_handler, mock_telemetry):
+            with patch("azurelinuxagent.ga.ga_version_updater.GAVersionUpdater.download_new_agent_pkg", side_effect=download_side_effect) as mock_download_new_agent:
+                agent_update_handler.run(GoalState(agent_update_handler._protocol.client, GoalStateProperties.ExtensionsGoalState), True)
+                self._assert_update_discovered_from_agent_manifest(mock_telemetry, version="99999.0.0.0")
+                self.assertEqual(1, len([kwarg['message'] for _, kwarg in mock_telemetry.call_args_list if
+                                         "Self-update: failed to download version 99999.0.0.0, trying next largest version" in kwarg['message'] and kwarg[
+                                             'op'] == WALAEventOperation.AgentUpgrade]),
+                                                "99999.0.0.0 download should have failed")
+                self._assert_update_discovered_from_agent_manifest(mock_telemetry, version="9.9.9.10")
+                self.assertEqual(1, len([kwarg['message'] for _, kwarg in mock_telemetry.call_args_list if
+                                         "[SelfUpdate] Unable to update Agent: [ExtensionDownloadError] Failed to download WALinuxAgent-9.9.9.10 from all URIs" in kwarg['message'] and kwarg[
+                                             'op'] == WALAEventOperation.AgentUpgrade]),
+                                                "9.9.9.10 download should have failed and been raised as error")
+                self._assert_agent_directories_exist_and_others_dont_exist(versions=[str(CURRENT_VERSION)])
+                self.assertEqual(2, mock_download_new_agent.call_count)
+
     def test_it_should_not_update_to_version_if_version_not_from_rsm(self):
         self.prepare_agents(count=1)
         data_file = DATA_FILE.copy()
         data_file["ext_conf"] = "wire/ext_conf_version_not_from_rsm.xml"
         downgrade_version = "2.5.0"
 
-        with self._get_agent_update_handler(test_data=data_file) as (agent_update_handler, _):
+        with self._get_agent_update_handler(test_data=data_file) as (agent_update_handler, mock_telemetry):
             agent_update_handler._protocol.mock_wire_data.set_version_in_agent_family(downgrade_version)
             agent_update_handler._protocol.mock_wire_data.set_incarnation(2)
             agent_update_handler._protocol.client.update_goal_state()
@@ -418,6 +482,10 @@ class TestAgentUpdate(UpdateTestCase):
                 versions=[str(CURRENT_VERSION)])
             self.assertFalse(os.path.exists(self.agent_dir(downgrade_version)),
                              "New agent directory should not be found")
+            self.assertEqual(1, len([kwarg['message'] for _, kwarg in mock_telemetry.call_args_list if
+                                     "VM enabled for RSM updates, switching to RSM update mode" in kwarg['message'] and kwarg[
+                                         'op'] == WALAEventOperation.AgentUpgrade]),
+                                            "rsm mode should be used for update")
 
     def test_handles_if_rsm_version_not_found_in_pkgs_to_download(self):
         data_file = DATA_FILE.copy()
@@ -440,6 +508,10 @@ class TestAgentUpdate(UpdateTestCase):
                              "New agent directory should not be found")
 
             self._assert_no_agent_package_telemetry_emitted(mock_telemetry, version=version)
+            self.assertEqual(1, len([kwarg['message'] for _, kwarg in mock_telemetry.call_args_list if
+                                     "VM enabled for RSM updates, switching to RSM update mode" in kwarg['message'] and kwarg[
+                                         'op'] == WALAEventOperation.AgentUpgrade]),
+                                            "rsm mode should be used for update")
 
     def test_handles_missing_agent_family(self):
         data_file = DATA_FILE.copy()
@@ -461,7 +533,7 @@ class TestAgentUpdate(UpdateTestCase):
                                          'message'] and kwarg[
                                          'op'] == WALAEventOperation.AgentUpgrade]), "Agent manifest should not be in GS")
 
-            # making multiple agent update attempts and assert only one time logged
+            # making multiple agent update attempts and assert only one time logged (only the first run since it was a new goal state)
             agent_update_handler.run(goal_state, False)
             agent_update_handler.run(GoalState(agent_update_handler._protocol.client, GoalStateProperties.ExtensionsGoalState), False)
 
@@ -525,6 +597,7 @@ class TestAgentUpdate(UpdateTestCase):
         data_file["ext_conf"] = "wire/ext_conf_rsm_version.xml"
 
         with self._get_agent_update_handler(test_data=data_file, protocol_get_error=True) as (agent_update_handler, _):
+            # This run should fail to update because of download error and report error status
             agent_update_handler.run(GoalState(agent_update_handler._protocol.client, GoalStateProperties.ExtensionsGoalState), True)
             vm_agent_update_status = agent_update_handler.get_vmagent_update_status()
             self.assertEqual(VMAgentUpdateStatuses.Error, vm_agent_update_status.status)
@@ -537,6 +610,7 @@ class TestAgentUpdate(UpdateTestCase):
             agent_update_handler._protocol.mock_wire_data.set_version_in_agent_family(
                 str(CURRENT_VERSION))
             agent_update_handler._protocol.mock_wire_data.set_incarnation(2)
+            # This run should not produce any error status since the version requested in the GS is the current version
             agent_update_handler.run(GoalState(agent_update_handler._protocol.client, GoalStateProperties.ExtensionsGoalState), True)
             vm_agent_update_status = agent_update_handler.get_vmagent_update_status()
             self.assertEqual(VMAgentUpdateStatuses.Success, vm_agent_update_status.status)
@@ -554,7 +628,7 @@ class TestAgentUpdate(UpdateTestCase):
             self.assertEqual(1, vm_agent_update_status.code)
             self.assertIn("missing version property. So, skipping agent update", vm_agent_update_status.message)
 
-    def test_it_should_not_log_same_error_next_hours(self):
+    def test_it_should_not_log_same_error_if_gs_not_updated(self):
         data_file = DATA_FILE.copy()
         data_file["ext_conf"] = "wire/ext_conf_missing_family.xml"
 
@@ -564,22 +638,25 @@ class TestAgentUpdate(UpdateTestCase):
 
         with self._get_agent_update_handler(test_data=data_file) as (agent_update_handler, mock_telemetry):
             goal_state = GoalState(agent_update_handler._protocol.client, GoalStateProperties.ExtensionsGoalState)
+            # This run should fail to update because there are no manifest uris in the goal state
             agent_update_handler.run(goal_state, True)
 
             self.assertFalse(os.path.exists(self.agent_dir("99999.0.0.0")),
                              "New agent directory should not be found")
 
-        self.assertEqual(1, len([kwarg['message'] for _, kwarg in mock_telemetry.call_args_list if
-                                 "No manifest links found for agent family" in kwarg[
-                                     'message'] and kwarg[
-                                     'op'] == WALAEventOperation.AgentUpgrade]), "Agent manifest should not be in GS")
+            self.assertEqual(1, len([kwarg['message'] for _, kwarg in mock_telemetry.call_args_list if
+                                     "No manifest links found for agent family" in kwarg[
+                                         'message'] and kwarg[
+                                         'op'] == WALAEventOperation.AgentUpgrade]), "Agent manifest should not be in GS")
 
-        agent_update_handler.run(goal_state, True)
+            # This run should fail to update because there are no manifest uris in the goal state, but it should not
+            # emit the event again since the goal state has not been updated
+            agent_update_handler.run(goal_state, False)
 
-        self.assertEqual(1, len([kwarg['message'] for _, kwarg in mock_telemetry.call_args_list if
-                                 "No manifest links found for agent family" in kwarg[
-                                     'message'] and kwarg[
-                                     'op'] == WALAEventOperation.AgentUpgrade]), "Agent manifest should not be in GS")
+            self.assertEqual(1, len([kwarg['message'] for _, kwarg in mock_telemetry.call_args_list if
+                                     "No manifest links found for agent family" in kwarg[
+                                         'message'] and kwarg[
+                                         'op'] == WALAEventOperation.AgentUpgrade]), "Agent manifest should not be in GS")
 
     def test_it_should_save_rsm_state_of_the_most_recent_goal_state(self):
         data_file = DATA_FILE.copy()
@@ -587,6 +664,7 @@ class TestAgentUpdate(UpdateTestCase):
 
         with self._get_agent_update_handler(test_data=data_file) as (agent_update_handler, _):
             with self.assertRaises(AgentUpgradeExitException):
+                # This run should use rsm update mode and save rsm state file
                 agent_update_handler.run(GoalState(agent_update_handler._protocol.client, GoalStateProperties.ExtensionsGoalState), True)
 
             state_file = os.path.join(conf.get_lib_dir(), RSM_UPDATE_STATE_FILE)
@@ -596,6 +674,7 @@ class TestAgentUpdate(UpdateTestCase):
             agent_update_handler._protocol.mock_wire_data.set_extension_config_is_vm_enabled_for_rsm_upgrades("False")
             agent_update_handler._protocol.mock_wire_data.set_incarnation(2)
             with self.assertRaises(AgentUpgradeExitException):
+                # This run should use self-update mode and remove rsm state file
                 agent_update_handler.run(GoalState(agent_update_handler._protocol.client, GoalStateProperties.ExtensionsGoalState), True)
 
             self.assertFalse(os.path.exists(state_file), "The rsm file should be removed (file: {0})".format(state_file))
@@ -651,7 +730,7 @@ class TestAgentUpdate(UpdateTestCase):
                                          'op'] == WALAEventOperation.AgentUpgrade]),
                              "Update is not allowed after 3 attempts")
 
-    def test_it_should_fail_the_update_if_agent_pkg_is_invalid(self):
+    def test_it_should_fail_the_update_if_agent_pkg_is_missing_manifest(self):
         agent_uri = 'https://foo.blob.core.windows.net/bar/OSTCExtensions.WALinuxAgent__9.9.9.10'
 
         def http_get_handler(uri, *_, **__):
@@ -704,3 +783,7 @@ class TestAgentUpdate(UpdateTestCase):
             self._assert_agent_rsm_version_in_goal_state(mock_telemetry, version="9.9.9.10")
             self._assert_agent_directories_exist_and_others_dont_exist(versions=["9.9.9.10", str(CURRENT_VERSION)])
             self._assert_agent_exit_process_telemetry_emitted(ustr(context.exception.reason))
+            self.assertEqual(1, len([kwarg['message'] for _, kwarg in mock_telemetry.call_args_list if
+                                     "VM enabled for RSM updates, switching to RSM update mode" in kwarg['message'] and kwarg[
+                                         'op'] == WALAEventOperation.AgentUpgrade]),
+                                            "rsm mode should be used for update")


### PR DESCRIPTION
…alidation failures

<!-- DO NOT DELETE THIS TEMPLATE -->
<!--
Please add an informative description that covers that changes made by the pull request.
-->
## Description
Today the self-update agent only attempts to download and validate the package of the latest version in the manifest. If there's any issues downloading that version, or validating the package, the agent quits the update attempt. 

This PR updates the agent so that it attempts the next highest version in the manifest on those download/validation errors. If that version fails, it will try the next and so on until there are no more versions in the manifest greater than the current version. 
The idea is to prevent the agent from getting stuck on the baked-in version in the case of transient download/validation errors.
The agent does not try next highest version in case of blacklisting failures (only transient download/validation errors).

The PR also makes improvements to the existing agent update handler unit tests.

Issue # <!-- if any -->
---
<!--
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->
### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).
---
<!--
This checklist is used to track contributions from distro maintainers.
-->
### Distro maintenance information, if applicable
- [ ] This is a contribution from a distro maintainer
- [ ] The changes in this PR have been taken as a downstream patch (Note: it is not recommended to patch the agent without upstream review and approval)
