### PR TITLE
Remove CentOS 8.2 from test suite

### DIFF
--- a/tests_e2e/test_suites/firewalld.yml
+++ b/tests_e2e/test_suites/firewalld.yml
@@ -5,6 +5,5 @@ name: "Firewalld"
 tests:
   - "firewalld/boot_conflicts.py"
 images:
-  - "centos_82"
   - "oracle_95"
   - "rhel_95"


### PR DESCRIPTION
The CentOS 8.2 repository mirrors needed to install firewalld are no longer available. Although we could have the test use the vault repositories instead, Oracle Linux and RHEL already provide enough coverage for this test, so removing CentOS.