### PR TITLE
Move signature validation tests to production region

### DIFF
--- a/tests_e2e/test_suites/ext_signature_validation.yml
+++ b/tests_e2e/test_suites/ext_signature_validation.yml
@@ -6,9 +6,8 @@ tests:
   - "ext_signature_validation/ext_signature_validation.py"
 # Extension signature is sent by CRP only for CVMs, so this test suite should run exclusively on CVMs.
 images: "cvm-endorsed"
-# This test needs to run in a canary region until all extensions being tested are published with signature in all prod regions.
 # Extension signatures are currently only available in the public cloud, so we skip this test on other clouds.
-locations: "AzureCloud:eastus2euap"
+locations: "AzureCloud:westeurope"
 skip_on_clouds:
   - "AzureChinaCloud"
   - "AzureUSGovernment"

--- a/tests_e2e/tests/ext_signature_validation/ext_signature_validation.py
+++ b/tests_e2e/tests/ext_signature_validation/ext_signature_validation.py
@@ -251,16 +251,16 @@ class ExtSignatureValidation(AgentVmTest):
             None
         )
 
-        # VmAccess 1.5 (signed, single-config) and ApplicationHealthLinux 2.0 (signed, no-config)
-        # are additional extensions used to stress test signature validation by including multiple
-        # signed extensions in a single goal state.
-        vmaccess_id_1_5 = VmExtensionIdentifier(publisher='Microsoft.OSTCExtensions.Edp', ext_type='VMAccessForLinux', version="1.5")
-        vm_access_signed = ExtSignatureValidation._TestCase(
-            VirtualMachineExtensionClient(self._context.vm, vmaccess_id_1_5),
-            settings = None,
-            protected_settings={'username': 'testuser'}
-        )
-        # TODO: Uncomment when ApplicationHealthLinux signature issues are resolved (see Test case 6)
+        # TODO: Uncomment when ApplicationHealthLinux and VmAccess signature issues are resolved (see Test case 6)
+        # # VmAccess 1.5 (signed, single-config) and ApplicationHealthLinux 2.0 (signed, no-config)
+        # # are additional extensions used to stress test signature validation by including multiple
+        # # signed extensions in a single goal state.
+        # vmaccess_id_1_5 = VmExtensionIdentifier(publisher='Microsoft.OSTCExtensions.Edp', ext_type='VMAccessForLinux', version="1.5")
+        # vm_access_signed = ExtSignatureValidation._TestCase(
+        #     VirtualMachineExtensionClient(self._context.vm, vmaccess_id_1_5),
+        #     settings = None,
+        #     protected_settings={'username': 'testuser'}
+        # )
         # ahl_id_2_0 = VmExtensionIdentifier(publisher='Microsoft.ManagedServices.Edp', ext_type='ApplicationHealthLinux', version="2.0")
         # application_health_signed = ExtSignatureValidation._TestCase(
         #     VirtualMachineExtensionClient(self._context.vm, ahl_id_2_0),
@@ -326,12 +326,12 @@ class ExtSignatureValidation(AgentVmTest):
         # TODO: Add test cases for package published with invalid signature and invalid manifest signingInfo, when
         # PIR allows for publication of invalid packages.
 
-        log.info("")
-        log.info("*** Test case 6: should enable multiple signed extensions in single goal state")
-        # RunCommand v2 is excluded here since it should be deployed only via VirtualMachineRunCommandClient, not ARM template.
-        # ApplicationHealthLinux is temporarily excluded due to intermittent missing signature issue in certain prod regions.
-        ext_to_enable = [custom_script_signed, vm_access_signed] # TODO: Add application_health_signed back to this list once the intermittent signature issue is resolved.
-        self._should_enable_multiple_signed_extensions(ext_to_enable)
+        # TODO: VmAccess and ApplicationHealthLinux extensions are facing issues where the signature is intermittently missing in certain prod regions. Once the issue is resolved, re-enable this test case.
+        # log.info("")
+        # log.info("*** Test case 6: should enable multiple signed extensions in single goal state")
+        # # RunCommand v2 is excluded here since it should be deployed only via VirtualMachineRunCommandClient, not ARM template.
+        # ext_to_enable = [custom_script_signed, vm_access_signed, application_health_signed]
+        # self._should_enable_multiple_signed_extensions(ext_to_enable)
 
         # This set of test cases will test behavior when signature is validated AND enforced. Unsigned extensions should fail.
         try:

--- a/tests_e2e/tests/ext_signature_validation/ext_signature_validation.py
+++ b/tests_e2e/tests/ext_signature_validation/ext_signature_validation.py
@@ -260,11 +260,12 @@ class ExtSignatureValidation(AgentVmTest):
             settings = None,
             protected_settings={'username': 'testuser'}
         )
-        ahl_id_2_0 = VmExtensionIdentifier(publisher='Microsoft.ManagedServices.Edp', ext_type='ApplicationHealthLinux', version="2.0")
-        application_health_signed = ExtSignatureValidation._TestCase(
-            VirtualMachineExtensionClient(self._context.vm, ahl_id_2_0),
-            None
-        )
+        # TODO: Uncomment when ApplicationHealthLinux signature issues are resolved (see Test case 6)
+        # ahl_id_2_0 = VmExtensionIdentifier(publisher='Microsoft.ManagedServices.Edp', ext_type='ApplicationHealthLinux', version="2.0")
+        # application_health_signed = ExtSignatureValidation._TestCase(
+        #     VirtualMachineExtensionClient(self._context.vm, ahl_id_2_0),
+        #     None
+        # )
 
         # Delete any existing extensions on the VM to ensure a clean test setup.
         # Signature validation occurs only during download, so extensions must be removed
@@ -328,7 +329,8 @@ class ExtSignatureValidation(AgentVmTest):
         log.info("")
         log.info("*** Test case 6: should enable multiple signed extensions in single goal state")
         # RunCommand v2 is excluded here since it should be deployed only via VirtualMachineRunCommandClient, not ARM template.
-        ext_to_enable = [custom_script_signed, vm_access_signed, application_health_signed]
+        # ApplicationHealthLinux is temporarily excluded due to intermittent missing signature issue in certain prod regions.
+        ext_to_enable = [custom_script_signed, vm_access_signed] # TODO: Add application_health_signed back to this list once the intermittent signature issue is resolved.
         self._should_enable_multiple_signed_extensions(ext_to_enable)
 
         # This set of test cases will test behavior when signature is validated AND enforced. Unsigned extensions should fail.


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->
<!--
Please add an informative description that covers that changes made by the pull request.
-->
## Description

Issue # <!-- if any -->
---
<!--
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->
This PR moves the CVM signature validation tests from canary to a production region (westeurope) to avoid deployment failures caused by capacity constraints in canary. Some of the extensions covered by these tests have known issues in production regions where they are not yet signed. As a temporary workaround, the affected test cases have been disabled and marked with a TODO to re-enable them once the signing issue is resolved.

### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).
---
<!--
This checklist is used to track contributions from distro maintainers.
-->
### Distro maintenance information, if applicable
- [ ] This is a contribution from a distro maintainer
- [ ] The changes in this PR have been taken as a downstream patch (Note: it is not recommended to patch the agent without upstream review and approval)
