### PR TITLE
Add support for constrained extension policy 

### DIFF
--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -852,6 +852,9 @@ class ExtHandlersHandler(object):
             extension_is_signed = ext_handler_i.signature_validated
             self._policy_engine.check_extension_policy(ext_handler_i.ext_handler.name, extension_is_signed)
 
+            # Create runtime policy file for extension before enabling
+            self._policy_engine.create_runtime_policy_file(ext_handler_i)
+
             ext_handler_i.ensure_consistent_data_for_mc()
             ext_handler_i.update_settings(extension)
 

--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -42,7 +42,7 @@ from azurelinuxagent.common.agent_supported_feature import get_agent_supported_f
 from azurelinuxagent.common.utils.textutil import redact_sas_token
 from azurelinuxagent.ga.cgroupconfigurator import CGroupConfigurator
 from azurelinuxagent.ga.policy.policy_engine import ExtensionPolicyEngine, ExtensionDisallowedError, \
-    ExtensionSignaturePolicyError
+    ExtensionSignaturePolicyError, ExtensionRuntimePolicyError
 from azurelinuxagent.common.datacontract import get_properties, set_properties
 from azurelinuxagent.common.errorstate import ErrorState
 from azurelinuxagent.common.event import add_event, elapsed_milliseconds, WALAEventOperation, \
@@ -730,6 +730,13 @@ class ExtHandlersHandler(object):
             ).format(operation, ext_handler_i.ext_handler.name, conf.get_policy_file_path())
             self.__handle_ext_disallowed_error(ext_handler_i, error_code, report_op=WALAEventOperation.ExtensionSignaturePolicy, message=msg,
                                                extension=extension)
+        except ExtensionRuntimePolicyError as error:
+            operation, error_code = _EXT_DISALLOWED_ERROR_MAP.get(ext_handler_i.ext_handler.state)
+            msg = (
+                "Extension will not be processed: {0}"
+            ).format(ustr(error))
+            self.__handle_ext_disallowed_error(ext_handler_i, error_code, report_op=WALAEventOperation.ExtensionPolicy, message=msg,
+                                               extension=extension)
         except PackageValidationError as error:
             code = ExtensionErrorCodes.PluginInstallProcessingFailed   # Signature validation is only done during extension install
             self.__handle_ext_disallowed_error(ext_handler_i, code, report_op=error.operation,
@@ -828,6 +835,9 @@ class ExtHandlersHandler(object):
             self._policy_engine.check_extension_policy(ext_handler_i.ext_handler.name, extension_is_signed)
 
             self.__setup_new_handler(ext_handler_i, extension, self.__should_ignore_signature_validation_errors(ext_handler_i))
+
+            # Create runtime policy file for extension before enabling
+            self._policy_engine.create_runtime_policy_file(ext_handler_i)
 
             if old_ext_handler_i is None:
                 ext_handler_i.install(extension=extension)
@@ -2439,6 +2449,9 @@ class ExtHandlerInstance(object):
     def get_log_dir(self):
         return os.path.join(conf.get_ext_log_dir(), self.ext_handler.name)
 
+    def get_runtime_policy_file(self):
+        return os.path.join(self.get_conf_dir(), 'waagent_runtime_policy.json')
+
     @staticmethod
     def _read_status_file(ext_status_file):
         err_count = 0
@@ -2555,6 +2568,10 @@ class HandlerManifest(object):
 
     def supports_multiple_extensions(self):
         value = self.data['handlerManifest'].get('supportsMultipleExtensions', False)
+        return self._parse_boolean_value(value, default_val=False)
+    
+    def supports_policy(self):
+        value = self.data['handlerManifest'].get('supportsPolicy', False)
         return self._parse_boolean_value(value, default_val=False)
 
     def get_resource_limits(self):

--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -731,7 +731,7 @@ class ExtHandlersHandler(object):
             self.__handle_ext_disallowed_error(ext_handler_i, error_code, report_op=WALAEventOperation.ExtensionSignaturePolicy, message=msg,
                                                extension=extension)
         except ExtensionRuntimePolicyError as error:
-            operation, error_code = _EXT_DISALLOWED_ERROR_MAP.get(ext_handler_i.ext_handler.state)
+            _, error_code = _EXT_DISALLOWED_ERROR_MAP.get(ext_handler_i.ext_handler.state)
             msg = (
                 "Extension will not be processed: {0}"
             ).format(ustr(error))
@@ -2572,7 +2572,7 @@ class HandlerManifest(object):
     def supports_multiple_extensions(self):
         value = self.data['handlerManifest'].get('supportsMultipleExtensions', False)
         return self._parse_boolean_value(value, default_val=False)
-    
+
     def supports_policy(self):
         value = self.data['handlerManifest'].get('supportsPolicy', False)
         return self._parse_boolean_value(value, default_val=False)

--- a/azurelinuxagent/ga/policy/policy_engine.py
+++ b/azurelinuxagent/ga/policy/policy_engine.py
@@ -26,6 +26,7 @@ from azurelinuxagent.common.exception import AgentError
 from azurelinuxagent.common.protocol.extensions_goal_state_from_vm_settings import _CaseFoldedDict
 from azurelinuxagent.common.utils.flexible_version import FlexibleVersion
 from azurelinuxagent.ga.confidential_vm_info import ConfidentialVMInfo
+from azurelinuxagent.common.utils import fileutil
 
 
 # Default policy values to be used when customer does not specify these attributes in the policy file.
@@ -76,6 +77,12 @@ class ExtensionDisallowedError(PolicyError):
     """
     def __init__(self):
         super(ExtensionDisallowedError, self).__init__()
+
+
+class ExtensionRuntimePolicyError(PolicyError):
+    """
+    Any error related to extension-specific runtime policy.
+    """
 
 
 class _PolicyEngine(object):
@@ -407,3 +414,38 @@ class ExtensionPolicyEngine(_PolicyEngine):
         enforce_signature = self.should_enforce_signature_validation(extension_name)
         if enforce_signature and not extension_is_signed:
             raise ExtensionSignaturePolicyError() # Caller sets message and error code, based on requested extension operation
+
+    def get_runtime_policy(self, extension_name):
+        """
+        Return runtime policy for the extension if specified. If not, return None.
+        """
+        individual_policy = self._policy.get("extensionPolicies").get("extensions").get(extension_name)
+        return individual_policy.get("runtimePolicy") if individual_policy is not None else None
+
+    def create_runtime_policy_file(self, ext_handler_i):
+        """
+        Create the runtime policy file for the extension. The extension manifest includes a "supportsPolicy" attribute
+        indicating whether the extension supports runtime policy enforcement.
+
+        - If supportsPolicy is True: write the extension's runtime policy if present, otherwise write an empty JSON object.
+        - If supportsPolicy is False or missing but runtime policy is specified for the extension, raise an error.
+        - if supportsPolicy is False and runtime policy is not specified, do not create a file.
+        """
+        if not self._policy_enforcement_enabled:
+            return
+
+        runtime_policy_file_path = ext_handler_i.get_runtime_policy_file()
+        supports_policy = ext_handler_i.load_manifest().supports_policy()
+        runtime_policy = self.get_runtime_policy(ext_handler_i.ext_handler.name)
+
+        if supports_policy:
+            data_to_write = runtime_policy if runtime_policy is not None else {}
+            try:
+                fileutil.write_file(runtime_policy_file_path, json.dumps(data_to_write))
+            except IOError as e:
+                raise ExtensionRuntimePolicyError("Failed to save runtime policy file: {0}. Error: {1}".format(runtime_policy_file_path, e))
+        elif not supports_policy and runtime_policy is not None:
+            raise ExtensionRuntimePolicyError(
+                "Runtime policy is specified for extension '{0}', but this extension does not support policy enforcement."
+                "To continue, remove the entry '{0}.runtimePolicy' from the policy file ({1}).".format(ext_handler_i.ext_handler.name, conf.get_policy_file_path())
+            )

--- a/azurelinuxagent/ga/policy/policy_engine.py
+++ b/azurelinuxagent/ga/policy/policy_engine.py
@@ -427,9 +427,12 @@ class ExtensionPolicyEngine(_PolicyEngine):
         Create the runtime policy file for the extension. The extension manifest includes a "supportsPolicy" attribute
         indicating whether the extension supports runtime policy enforcement.
 
-        - If supportsPolicy is True: write the extension's runtime policy if present, otherwise write an empty JSON object.
-        - If supportsPolicy is False or missing but runtime policy is specified for the extension, raise an error.
-        - if supportsPolicy is False and runtime policy is not specified, do not create a file.
+        | supportsPolicy | runtimePolicy specified | Result                              |
+        |----------------|-------------------------|-------------------------------------|
+        | True           | Yes                     | Write runtimePolicy to file         |
+        | True           | No                      | Write {} to file                    |
+        | False          | Yes                     | Raise ExtensionRuntimePolicyError   |
+        | False          | No                      | Do nothing                          |
         """
         if not self._policy_enforcement_enabled:
             return

--- a/azurelinuxagent/ga/policy/policy_engine.py
+++ b/azurelinuxagent/ga/policy/policy_engine.py
@@ -419,7 +419,13 @@ class ExtensionPolicyEngine(_PolicyEngine):
         """
         Return runtime policy for the extension if specified. If not, return None.
         """
-        individual_policy = self._policy.get("extensionPolicies").get("extensions").get(extension_name)
+        extension_policies = self._policy.get("extensionPolicies")
+        if extension_policies is None:
+            return None
+        extensions = extension_policies.get("extensions")
+        if extensions is None:
+            return None
+        individual_policy = extensions.get(extension_name)
         return individual_policy.get("runtimePolicy") if individual_policy is not None else None
 
     def create_runtime_policy_file(self, ext_handler_i):
@@ -447,8 +453,8 @@ class ExtensionPolicyEngine(_PolicyEngine):
                 fileutil.write_file(runtime_policy_file_path, json.dumps(data_to_write))
             except IOError as e:
                 raise ExtensionRuntimePolicyError("Failed to save runtime policy file: {0}. Error: {1}".format(runtime_policy_file_path, e))
-        elif not supports_policy and runtime_policy is not None:
+        elif runtime_policy is not None:
             raise ExtensionRuntimePolicyError(
-                "Runtime policy is specified for extension '{0}', but this extension does not support policy enforcement."
+                "Runtime policy is specified for extension '{0}', but this extension does not support policy enforcement. "
                 "To continue, remove the entry '{0}.runtimePolicy' from the policy file ({1}).".format(ext_handler_i.ext_handler.name, conf.get_policy_file_path())
             )

--- a/tests/ga/test_extension.py
+++ b/tests/ga/test_extension.py
@@ -3550,6 +3550,11 @@ class TestExtensionPolicy(TestExtensionBase):
         self.patch_is_cvm.start()
         self.maxDiff = None     # When long error messages don't match, display the entire diff.
 
+        test_ext = Extension(name='OSTCExtensions.ExampleHandlerLinux')
+        test_ext.version = "1.0.0"
+        ext_handler_i = ExtHandlerInstance(ext_handler=test_ext, protocol=WireProtocol("1.2.3.4"))
+        self.runtime_policy_path = ext_handler_i.get_runtime_policy_file()
+
     def tearDown(self):
         patch.stopall()
         AgentTestCase.tearDown(self)
@@ -3867,6 +3872,87 @@ class TestExtensionPolicy(TestExtensionBase):
             self.assertTrue(os.path.exists(file_path), "Policy file was not copied to history folder")
             with open(file_path, mode='r') as f:
                 self.assertEqual(policy, json.load(f))
+
+    def test_should_create_runtime_policy_file_before_enabling(self):
+        # If "runtimePolicy" is specified in policy file, and "supportsPolicy" is true in handler manifest, create runtime policy file.
+        policy = {
+            "policyVersion": "0.1.0",
+            "extensionPolicies": {
+                "extensions": {
+                    "OSTCExtensions.ExampleHandlerLinux": {
+                        "runtimePolicy": {
+                            "allowDirectScripts": False
+                        }
+                    }
+                }
+            }
+        }
+
+        with patch("azurelinuxagent.ga.exthandlers.HandlerManifest.supports_policy", return_value=True):
+            self._test_policy_case(policy=policy, op=ExtensionRequestedState.Enabled, expected_status_code=0,
+                                   expected_handler_status='Ready', expected_ext_count=1)
+            self.assertTrue(os.path.exists(self.runtime_policy_path), "Runtime policy file was not created")
+            with open(self.runtime_policy_path, mode='r') as f:
+                expected_policy = {
+                    "allowDirectScripts": False
+                }
+                self.assertEqual(expected_policy, json.load(f))
+
+    def test_should_create_empty_runtime_policy_file_if_not_specified(self):
+        # If "runtimePolicy" is not specified in policy file, and "supportsPolicy" is true in handler manifest, create empty runtime policy file.
+        policy = {
+            "policyVersion": "0.1.0",
+            "extensionPolicies": {
+                "extensions": {
+                    "OSTCExtensions.ExampleHandlerLinux": {}
+                }
+            }
+        }
+
+        with patch("azurelinuxagent.ga.exthandlers.HandlerManifest.supports_policy", return_value=True):
+            self._test_policy_case(policy=policy, op=ExtensionRequestedState.Enabled, expected_status_code=0,
+                                   expected_handler_status='Ready', expected_ext_count=1)
+            self.assertTrue(os.path.exists(self.runtime_policy_path), "Runtime policy file was not created")
+            with open(self.runtime_policy_path, mode='r') as f:
+                expected_policy = {}
+                self.assertEqual(expected_policy, json.load(f))
+
+    def test_enable_should_fail_if_supportsPolicy_false_but_runtime_policy_specified(self):
+        # If "runtimePolicy" is specified in policy file, and "supportsPolicy" is false in handler manifest, fail extension.
+        policy = {
+            "policyVersion": "0.1.0",
+            "extensionPolicies": {
+                "extensions": {
+                    "OSTCExtensions.ExampleHandlerLinux": {
+                        "runtimePolicy": {
+                            "allowDirectScripts": False
+                        }
+                    }
+                }
+            }
+        }
+
+        with patch("azurelinuxagent.ga.exthandlers.HandlerManifest.supports_policy", return_value=False):
+            self._test_policy_case(policy=policy, op=ExtensionRequestedState.Enabled,
+                                   expected_status_code=ExtensionErrorCodes.PluginEnableProcessingFailed,
+                                   expected_handler_status='NotReady', expected_ext_count=1)
+            self.assertFalse(os.path.exists(self.runtime_policy_path), "Runtime policy file should not have been created")
+
+    def test_should_not_create_runtime_policy_file(self):
+        # If "runtimePolicy" is not specified in policy file, and "supportsPolicy" is false in handler manifest, do not create runtime policy file.
+        policy = {
+            "policyVersion": "0.1.0",
+            "extensionPolicies": {
+                "extensions": {
+                    "OSTCExtensions.ExampleHandlerLinux": {}
+                }
+            }
+        }
+
+        with patch("azurelinuxagent.ga.exthandlers.HandlerManifest.supports_policy", return_value=False):
+            self._test_policy_case(policy=policy, op=ExtensionRequestedState.Enabled, expected_status_code=0,
+                                   expected_handler_status='Ready', expected_ext_count=1)
+            self.assertFalse(os.path.exists(self.runtime_policy_path), "Runtime policy file should not have been created")
 
 
 class _TestSignatureValidationBase(TestExtensionBase):

--- a/tests/ga/test_extension.py
+++ b/tests/ga/test_extension.py
@@ -3550,10 +3550,7 @@ class TestExtensionPolicy(TestExtensionBase):
         self.patch_is_cvm.start()
         self.maxDiff = None     # When long error messages don't match, display the entire diff.
 
-        test_ext = Extension(name='OSTCExtensions.ExampleHandlerLinux')
-        test_ext.version = "1.0.0"
-        ext_handler_i = ExtHandlerInstance(ext_handler=test_ext, protocol=WireProtocol("1.2.3.4"))
-        self.runtime_policy_path = ext_handler_i.get_runtime_policy_file()
+        self.runtime_policy_path = os.path.join(conf.get_lib_dir(), "OSTCExtensions.ExampleHandlerLinux-1.0.0", "config", "waagent_runtime_policy.json")
 
     def tearDown(self):
         patch.stopall()
@@ -3933,12 +3930,14 @@ class TestExtensionPolicy(TestExtensionBase):
         }
 
         with patch("azurelinuxagent.ga.exthandlers.HandlerManifest.supports_policy", return_value=False):
+            expected_msg = "Runtime policy is specified for extension 'OSTCExtensions.ExampleHandlerLinux', but this extension does not support policy enforcement."
             self._test_policy_case(policy=policy, op=ExtensionRequestedState.Enabled,
                                    expected_status_code=ExtensionErrorCodes.PluginEnableProcessingFailed,
-                                   expected_handler_status='NotReady', expected_ext_count=1)
+                                   expected_handler_status='NotReady', expected_ext_count=1,
+                                   expected_status_msg=expected_msg)
             self.assertFalse(os.path.exists(self.runtime_policy_path), "Runtime policy file should not have been created")
 
-    def test_should_not_create_runtime_policy_file(self):
+    def test_should_not_create_runtime_policy_file_if_supportsPolicy_false_and_not_specified(self):
         # If "runtimePolicy" is not specified in policy file, and "supportsPolicy" is false in handler manifest, do not create runtime policy file.
         policy = {
             "policyVersion": "0.1.0",

--- a/tests/ga/test_extension.py
+++ b/tests/ga/test_extension.py
@@ -3954,6 +3954,60 @@ class TestExtensionPolicy(TestExtensionBase):
                                    expected_handler_status='Ready', expected_ext_count=1)
             self.assertFalse(os.path.exists(self.runtime_policy_path), "Runtime policy file should not have been created")
 
+    def test_should_create_runtime_policy_file_on_each_enable(self):
+        # Runtime policy file should be created fresh on each enable, not just the first one.
+        # This ensures that if the policy changes between enables, the extension gets the updated policy.
+        initial_policy = {
+            "policyVersion": "0.1.0",
+            "extensionPolicies": {
+                "extensions": {
+                    "OSTCExtensions.ExampleHandlerLinux": {
+                        "runtimePolicy": {
+                            "allowDirectScripts": False
+                        }
+                    }
+                }
+            }
+        }
+
+        updated_policy = {
+            "policyVersion": "0.1.0",
+            "extensionPolicies": {
+                "extensions": {
+                    "OSTCExtensions.ExampleHandlerLinux": {
+                        "runtimePolicy": {
+                            "allowDirectScripts": True,
+                            "maxExecutionTime": 300
+                        }
+                    }
+                }
+            }
+        }
+
+        with mock_wire_protocol(wire_protocol_data.DATA_FILE) as protocol:
+            protocol.aggregate_status = None
+            protocol.report_vm_status = MagicMock()
+            exthandlers_handler = get_exthandlers_handler(protocol)
+
+            with patch("azurelinuxagent.ga.exthandlers.HandlerManifest.supports_policy", return_value=True):
+                # First enable - initial policy
+                self._create_policy_file(initial_policy)
+                exthandlers_handler.run()
+
+                self.assertTrue(os.path.exists(self.runtime_policy_path), "Runtime policy file was not created on first enable")
+                with open(self.runtime_policy_path, mode='r') as f:
+                    self.assertEqual({"allowDirectScripts": False}, json.load(f), "Runtime policy file content does not match initial policy")
+
+                # Second enable - updated policy (extension already installed)
+                self._create_policy_file(updated_policy)
+                protocol.mock_wire_data.set_incarnation(2)
+                protocol.client.update_goal_state()
+                exthandlers_handler.run()
+
+                self.assertTrue(os.path.exists(self.runtime_policy_path), "Runtime policy file was not created on second enable")
+                with open(self.runtime_policy_path, mode='r') as f:
+                    self.assertEqual({"allowDirectScripts": True, "maxExecutionTime": 300}, json.load(f), "Runtime policy file was not updated on second enable")
+
 
 class _TestSignatureValidationBase(TestExtensionBase):
     def setUp(self):

--- a/tests/ga/test_policy_engine.py
+++ b/tests/ga/test_policy_engine.py
@@ -59,6 +59,18 @@ class _TestPolicyBase(AgentTestCase):
                 policy_file.write(policy)
             policy_file.flush()
 
+    def _create_mock_ext_handler_i(self, supports_policy, runtime_policy_path=None):
+        """
+        Create a mock ExtHandlerInstance with the specified supportsPolicy value and runtime policy file path.
+        """
+        if runtime_policy_path is None:
+            runtime_policy_path = os.path.join(self.tmp_dir, "waagent_runtime_policy.json")
+        mock_ext_handler_i = MagicMock()
+        mock_ext_handler_i.get_runtime_policy_file.return_value = runtime_policy_path
+        mock_ext_handler_i.load_manifest.return_value.supports_policy.return_value = supports_policy
+        mock_ext_handler_i.ext_handler.name = TEST_EXTENSION_NAME
+        return mock_ext_handler_i
+
     def _run_test_cases_should_fail_to_parse(self, cases, assert_msg):
         """
         Cases should be a list of policies.
@@ -663,11 +675,8 @@ class TestExtensionPolicyEngine(_TestPolicyBase):
         engine = ExtensionPolicyEngine()
         engine.update_policy(self.goal_state_history)
 
-        runtime_policy_path = os.path.join(self.tmp_dir, "waagent_runtime_policy.json")
-        mock_ext_handler_i = MagicMock()
-        mock_ext_handler_i.get_runtime_policy_file.return_value = runtime_policy_path
-        mock_ext_handler_i.load_manifest.return_value.supports_policy.return_value = True
-        mock_ext_handler_i.ext_handler.name = TEST_EXTENSION_NAME
+        mock_ext_handler_i = self._create_mock_ext_handler_i(supports_policy=True)
+        runtime_policy_path = mock_ext_handler_i.get_runtime_policy_file()
 
         engine.create_runtime_policy_file(mock_ext_handler_i)
 
@@ -692,11 +701,8 @@ class TestExtensionPolicyEngine(_TestPolicyBase):
         engine = ExtensionPolicyEngine()
         engine.update_policy(self.goal_state_history)
 
-        runtime_policy_path = os.path.join(self.tmp_dir, "waagent_runtime_policy.json")
-        mock_ext_handler_i = MagicMock()
-        mock_ext_handler_i.get_runtime_policy_file.return_value = runtime_policy_path
-        mock_ext_handler_i.load_manifest.return_value.supports_policy.return_value = True
-        mock_ext_handler_i.ext_handler.name = TEST_EXTENSION_NAME
+        mock_ext_handler_i = self._create_mock_ext_handler_i(supports_policy=True)
+        runtime_policy_path = mock_ext_handler_i.get_runtime_policy_file()
 
         engine.create_runtime_policy_file(mock_ext_handler_i)
 
@@ -724,11 +730,8 @@ class TestExtensionPolicyEngine(_TestPolicyBase):
         engine = ExtensionPolicyEngine()
         engine.update_policy(self.goal_state_history)
 
-        runtime_policy_path = os.path.join(self.tmp_dir, "waagent_runtime_policy.json")
-        mock_ext_handler_i = MagicMock()
-        mock_ext_handler_i.get_runtime_policy_file.return_value = runtime_policy_path
-        mock_ext_handler_i.load_manifest.return_value.supports_policy.return_value = False
-        mock_ext_handler_i.ext_handler.name = TEST_EXTENSION_NAME
+        mock_ext_handler_i = self._create_mock_ext_handler_i(supports_policy=False)
+        runtime_policy_path = mock_ext_handler_i.get_runtime_policy_file()
 
         with self.assertRaises(ExtensionRuntimePolicyError):
             engine.create_runtime_policy_file(mock_ext_handler_i)
@@ -751,11 +754,8 @@ class TestExtensionPolicyEngine(_TestPolicyBase):
         engine = ExtensionPolicyEngine()
         engine.update_policy(self.goal_state_history)
 
-        runtime_policy_path = os.path.join(self.tmp_dir, "waagent_runtime_policy.json")
-        mock_ext_handler_i = MagicMock()
-        mock_ext_handler_i.get_runtime_policy_file.return_value = runtime_policy_path
-        mock_ext_handler_i.load_manifest.return_value.supports_policy.return_value = False
-        mock_ext_handler_i.ext_handler.name = TEST_EXTENSION_NAME
+        mock_ext_handler_i = self._create_mock_ext_handler_i(supports_policy=False)
+        runtime_policy_path = mock_ext_handler_i.get_runtime_policy_file()
 
         engine.create_runtime_policy_file(mock_ext_handler_i)
 
@@ -780,10 +780,8 @@ class TestExtensionPolicyEngine(_TestPolicyBase):
         engine = ExtensionPolicyEngine()
         engine.update_policy(self.goal_state_history)
 
-        mock_ext_handler_i = MagicMock()
-        mock_ext_handler_i.get_runtime_policy_file.return_value = "/nonexistent/path/waagent_runtime_policy.json"
-        mock_ext_handler_i.load_manifest.return_value.supports_policy.return_value = True
-        mock_ext_handler_i.ext_handler.name = TEST_EXTENSION_NAME
+        mock_ext_handler_i = self._create_mock_ext_handler_i(supports_policy=True,
+                                                              runtime_policy_path="/nonexistent/path/waagent_runtime_policy.json")
 
         with self.assertRaises(ExtensionRuntimePolicyError):
             engine.create_runtime_policy_file(mock_ext_handler_i)

--- a/tests/ga/test_policy_engine.py
+++ b/tests/ga/test_policy_engine.py
@@ -19,7 +19,7 @@ import json
 import os
 
 from azurelinuxagent.ga.policy.policy_engine import ExtensionPolicyEngine, InvalidPolicyError, \
-    _PolicyEngine, _DEFAULT_ALLOW_LISTED_EXTENSIONS_ONLY, _DEFAULT_SIGNATURE_REQUIRED
+    _PolicyEngine, _DEFAULT_ALLOW_LISTED_EXTENSIONS_ONLY, _DEFAULT_SIGNATURE_REQUIRED, ExtensionRuntimePolicyError
 from tests.lib.tools import AgentTestCase, MagicMock, patch
 
 TEST_EXTENSION_NAME = "Microsoft.Azure.ActiveDirectory.AADSSHLoginForLinux"
@@ -577,3 +577,213 @@ class TestExtensionPolicyEngine(_TestPolicyBase):
                             msg="Extension should have been found in allowlist regardless of extension name case.")
             self.assertTrue(should_enforce_signature,
                             msg="Individual signatureRequired policy should have been found and used, regardless of extension name case.")
+
+    def test_get_runtime_policy_should_return_policy_if_specified(self):
+        """
+        If runtimePolicy is specified for the extension, get_runtime_policy() should return it.
+        """
+        runtime_policy = {"allowDirectScripts": False}
+        policy = {
+            "policyVersion": "0.1.0",
+            "extensionPolicies": {
+                "extensions": {
+                    TEST_EXTENSION_NAME: {
+                        "runtimePolicy": runtime_policy
+                    }
+                }
+            }
+        }
+        self._create_policy_file(policy)
+        engine = ExtensionPolicyEngine()
+        engine.update_policy(self.goal_state_history)
+        result = engine.get_runtime_policy(TEST_EXTENSION_NAME)
+        self.assertEqual(runtime_policy, result, msg="get_runtime_policy() should return the runtimePolicy dict.")
+
+    def test_get_runtime_policy_should_return_none_if_not_specified(self):
+        """
+        If runtimePolicy is not specified for the extension, get_runtime_policy() should return None.
+        """
+        policy = {
+            "policyVersion": "0.1.0",
+            "extensionPolicies": {
+                "extensions": {
+                    TEST_EXTENSION_NAME: {}
+                }
+            }
+        }
+        self._create_policy_file(policy)
+        engine = ExtensionPolicyEngine()
+        engine.update_policy(self.goal_state_history)
+        result = engine.get_runtime_policy(TEST_EXTENSION_NAME)
+        self.assertIsNone(result, msg="get_runtime_policy() should return None when runtimePolicy not specified.")
+
+    def test_get_runtime_policy_should_return_none_if_extension_not_in_policy(self):
+        """
+        If extension is not in policy at all, get_runtime_policy() should return None.
+        """
+        policy = {
+            "policyVersion": "0.1.0",
+            "extensionPolicies": {
+                "extensions": {}
+            }
+        }
+        self._create_policy_file(policy)
+        engine = ExtensionPolicyEngine()
+        engine.update_policy(self.goal_state_history)
+        result = engine.get_runtime_policy(TEST_EXTENSION_NAME)
+        self.assertIsNone(result, msg="get_runtime_policy() should return None when extension not in policy.")
+
+    def test_create_runtime_policy_file_should_do_nothing_if_policy_enforcement_disabled(self):
+        """
+        If policy enforcement is disabled, create_runtime_policy_file() should do nothing.
+        """
+        # No policy file - enforcement is disabled
+        engine = ExtensionPolicyEngine()
+        mock_ext_handler_i = MagicMock()
+        # Should not raise, should not call any methods on ext_handler_i
+        engine.create_runtime_policy_file(mock_ext_handler_i)
+        mock_ext_handler_i.get_runtime_policy_file.assert_not_called()
+
+    def test_create_runtime_policy_file_should_write_policy_if_supports_policy_true_and_runtime_policy_specified(self):
+        """
+        If supportsPolicy is true and runtimePolicy is specified, create_runtime_policy_file() should write the policy to file.
+        """
+        runtime_policy = {"allowDirectScripts": False}
+        policy = {
+            "policyVersion": "0.1.0",
+            "extensionPolicies": {
+                "extensions": {
+                    TEST_EXTENSION_NAME: {
+                        "runtimePolicy": runtime_policy
+                    }
+                }
+            }
+        }
+        self._create_policy_file(policy)
+        engine = ExtensionPolicyEngine()
+        engine.update_policy(self.goal_state_history)
+
+        runtime_policy_path = os.path.join(self.tmp_dir, "waagent_runtime_policy.json")
+        mock_ext_handler_i = MagicMock()
+        mock_ext_handler_i.get_runtime_policy_file.return_value = runtime_policy_path
+        mock_ext_handler_i.load_manifest.return_value.supports_policy.return_value = True
+        mock_ext_handler_i.ext_handler.name = TEST_EXTENSION_NAME
+
+        engine.create_runtime_policy_file(mock_ext_handler_i)
+
+        self.assertTrue(os.path.exists(runtime_policy_path), "Runtime policy file should have been created.")
+        with open(runtime_policy_path, 'r') as f:
+            written_policy = json.load(f)
+        self.assertEqual(runtime_policy, written_policy, "Written policy should match the runtimePolicy.")
+
+    def test_create_runtime_policy_file_should_write_empty_json_if_supports_policy_true_and_runtime_policy_not_specified(self):
+        """
+        If supportsPolicy is true but runtimePolicy is not specified, create_runtime_policy_file() should write {} to file.
+        """
+        policy = {
+            "policyVersion": "0.1.0",
+            "extensionPolicies": {
+                "extensions": {
+                    TEST_EXTENSION_NAME: {}
+                }
+            }
+        }
+        self._create_policy_file(policy)
+        engine = ExtensionPolicyEngine()
+        engine.update_policy(self.goal_state_history)
+
+        runtime_policy_path = os.path.join(self.tmp_dir, "waagent_runtime_policy.json")
+        mock_ext_handler_i = MagicMock()
+        mock_ext_handler_i.get_runtime_policy_file.return_value = runtime_policy_path
+        mock_ext_handler_i.load_manifest.return_value.supports_policy.return_value = True
+        mock_ext_handler_i.ext_handler.name = TEST_EXTENSION_NAME
+
+        engine.create_runtime_policy_file(mock_ext_handler_i)
+
+        self.assertTrue(os.path.exists(runtime_policy_path), "Runtime policy file should have been created.")
+        with open(runtime_policy_path, 'r') as f:
+            written_policy = json.load(f)
+        self.assertEqual({}, written_policy, "Written policy should be empty JSON object.")
+
+    def test_create_runtime_policy_file_should_raise_error_if_supports_policy_false_and_runtime_policy_specified(self):
+        """
+        If supportsPolicy is false but runtimePolicy is specified, create_runtime_policy_file() should raise ExtensionRuntimePolicyError.
+        """
+        runtime_policy = {"allowDirectScripts": False}
+        policy = {
+            "policyVersion": "0.1.0",
+            "extensionPolicies": {
+                "extensions": {
+                    TEST_EXTENSION_NAME: {
+                        "runtimePolicy": runtime_policy
+                    }
+                }
+            }
+        }
+        self._create_policy_file(policy)
+        engine = ExtensionPolicyEngine()
+        engine.update_policy(self.goal_state_history)
+
+        runtime_policy_path = os.path.join(self.tmp_dir, "waagent_runtime_policy.json")
+        mock_ext_handler_i = MagicMock()
+        mock_ext_handler_i.get_runtime_policy_file.return_value = runtime_policy_path
+        mock_ext_handler_i.load_manifest.return_value.supports_policy.return_value = False
+        mock_ext_handler_i.ext_handler.name = TEST_EXTENSION_NAME
+
+        with self.assertRaises(ExtensionRuntimePolicyError):
+            engine.create_runtime_policy_file(mock_ext_handler_i)
+
+        self.assertFalse(os.path.exists(runtime_policy_path), "Runtime policy file should not have been created.")
+
+    def test_create_runtime_policy_file_should_not_create_file_if_supports_policy_false_and_runtime_policy_not_specified(self):
+        """
+        If supportsPolicy is false and runtimePolicy is not specified, create_runtime_policy_file() should do nothing.
+        """
+        policy = {
+            "policyVersion": "0.1.0",
+            "extensionPolicies": {
+                "extensions": {
+                    TEST_EXTENSION_NAME: {}
+                }
+            }
+        }
+        self._create_policy_file(policy)
+        engine = ExtensionPolicyEngine()
+        engine.update_policy(self.goal_state_history)
+
+        runtime_policy_path = os.path.join(self.tmp_dir, "waagent_runtime_policy.json")
+        mock_ext_handler_i = MagicMock()
+        mock_ext_handler_i.get_runtime_policy_file.return_value = runtime_policy_path
+        mock_ext_handler_i.load_manifest.return_value.supports_policy.return_value = False
+        mock_ext_handler_i.ext_handler.name = TEST_EXTENSION_NAME
+
+        engine.create_runtime_policy_file(mock_ext_handler_i)
+
+        self.assertFalse(os.path.exists(runtime_policy_path), "Runtime policy file should not have been created.")
+
+    def test_create_runtime_policy_file_should_raise_error_on_ioerror(self):
+        """
+        If writing the runtime policy file fails with IOError, create_runtime_policy_file() should raise ExtensionRuntimePolicyError.
+        """
+        runtime_policy = {"allowDirectScripts": False}
+        policy = {
+            "policyVersion": "0.1.0",
+            "extensionPolicies": {
+                "extensions": {
+                    TEST_EXTENSION_NAME: {
+                        "runtimePolicy": runtime_policy
+                    }
+                }
+            }
+        }
+        self._create_policy_file(policy)
+        engine = ExtensionPolicyEngine()
+        engine.update_policy(self.goal_state_history)
+
+        mock_ext_handler_i = MagicMock()
+        mock_ext_handler_i.get_runtime_policy_file.return_value = "/nonexistent/path/waagent_runtime_policy.json"
+        mock_ext_handler_i.load_manifest.return_value.supports_policy.return_value = True
+        mock_ext_handler_i.ext_handler.name = TEST_EXTENSION_NAME
+
+        with self.assertRaises(ExtensionRuntimePolicyError):
+            engine.create_runtime_policy_file(mock_ext_handler_i)


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->
<!--
Please add an informative description that covers that changes made by the pull request.
-->
## Description

Issue # <!-- if any -->
---
This PR adds support for constrained extension (runtime) policy. If "runtimePolicy" is specified for an extension in the policy file, and the extension supports runtime policy, the agent writes this policy to a file in the extension's config directory. 

Behavior: 
- If "supportsPolicy" is true in the extension handler manifest:
  - If runtime policy is specified in "waagent_policy.json", agent will create a policy file "waagent_runtime_policy.json" in the config directory before enabling extension
    - Full path: /var/lib/waagent/<extname-extversion>/config/waagent_runtime_policy.json
  - If runtime policy is not specified, create a policy file with an empty json object.
- If "supportsPolicy is false in the extension handler manifest:
  - If runtime policy is specified in "waagent_policy.json", fail the extension.
  - If runtime policy is not specified, do not create waagent_runtime_policy.json file and continue with extension processing. 

<!--
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->
### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).
---
<!--
This checklist is used to track contributions from distro maintainers.
-->
### Distro maintenance information, if applicable
- [ ] This is a contribution from a distro maintainer
- [ ] The changes in this PR have been taken as a downstream patch (Note: it is not recommended to patch the agent without upstream review and approval)
