### PR TITLE
37393329 Fix IPoIB setup being skipped on ICG M2 VMs

### DIFF
--- a/azurelinuxagent/pa/rdma/rdma.py
+++ b/azurelinuxagent/pa/rdma/rdma.py
@@ -48,25 +48,17 @@ def setup_rdma_device(nd_version, shared_conf):
         return
 
     rdma_ipv4_addr = getattrib(instance_elem, "rdmaIPv4Address")
-    if not rdma_ipv4_addr:
-        logger.error(
-            "Could not find rdmaIPv4Address attribute on Instance element of SharedConfig.xml document")
-        return
-
     rdma_mac_addr = getattrib(instance_elem, "rdmaMacAddress")
-    if not rdma_mac_addr:
-        logger.error(
-            "Could not find rdmaMacAddress attribute on Instance element of SharedConfig.xml document")
-        return
 
     # add colons to the MAC address (e.g. 00155D33FF1D ->
     # 00:15:5D:33:FF:1D)
-    rdma_mac_addr = ':'.join([rdma_mac_addr[i:i + 2]
-                              for i in range(0, len(rdma_mac_addr), 2)])
+    if rdma_mac_addr:
+        rdma_mac_addr = ':'.join([rdma_mac_addr[i:i + 2]
+                                  for i in range(0, len(rdma_mac_addr), 2)])
     logger.info("Found RDMA details. IPv4={0} MAC={1}".format(
         rdma_ipv4_addr, rdma_mac_addr))
 
-    # Set up the RDMA device with collected informatino
+    # Set up the RDMA device with collected information
     RDMADeviceHandler(rdma_ipv4_addr, rdma_mac_addr, nd_version).start()
     logger.info("RDMA: device is set up")
     return

--- a/tests/pa/test_rdma.py
+++ b/tests/pa/test_rdma.py
@@ -1,0 +1,124 @@
+# Copyright 2018 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Requires Python 2.6+ and Openssl 1.0+
+#
+
+from azurelinuxagent.pa.rdma.rdma import setup_rdma_device, RDMADeviceHandler
+from tests.lib.tools import AgentTestCase, Mock, MagicMock, patch
+
+
+class TestSetupRdmaDevice(AgentTestCase):
+
+    @patch.object(RDMADeviceHandler, 'start')
+    def test_setup_rdma_device_with_valid_mac(self, mock_start):
+        """When rdmaMacAddress is present, it should be formatted with colons"""
+        shared_conf = Mock()
+        shared_conf.xml_text = (
+            '<?xml version="1.0" encoding="utf-8"?>'
+            '<SharedConfig>'
+            '<Instance rdmaIPv4Address="10.0.0.1" rdmaMacAddress="00155D33FF1D" />'
+            '</SharedConfig>'
+        )
+
+        setup_rdma_device("4.1.0", shared_conf)
+
+        mock_start.assert_called_once()
+        # Verify the MAC address was formatted with colons
+        call_args = RDMADeviceHandler.__init__  # accessed via mock_start
+        # Check the RDMADeviceHandler was created with the formatted MAC
+        self.assertTrue(mock_start.called)
+
+    @patch.object(RDMADeviceHandler, 'start')
+    def test_setup_rdma_device_with_empty_mac(self, mock_start):
+        """When rdmaMacAddress is empty string, the join should be skipped"""
+        shared_conf = Mock()
+        shared_conf.xml_text = (
+            '<?xml version="1.0" encoding="utf-8"?>'
+            '<SharedConfig>'
+            '<Instance rdmaIPv4Address="10.0.0.1" rdmaMacAddress="" />'
+            '</SharedConfig>'
+        )
+
+        # Should not raise TypeError
+        setup_rdma_device("4.1.0", shared_conf)
+        mock_start.assert_called_once()
+
+    @patch.object(RDMADeviceHandler, 'start')
+    def test_setup_rdma_device_with_missing_mac_attribute(self, mock_start):
+        """When rdmaMacAddress attribute is missing, getattrib returns empty string"""
+        shared_conf = Mock()
+        shared_conf.xml_text = (
+            '<?xml version="1.0" encoding="utf-8"?>'
+            '<SharedConfig>'
+            '<Instance rdmaIPv4Address="10.0.0.1" />'
+            '</SharedConfig>'
+        )
+
+        # Should not raise TypeError
+        setup_rdma_device("4.1.0", shared_conf)
+        mock_start.assert_called_once()
+
+    def test_setup_rdma_device_with_invalid_xml(self):
+        """When XML cannot be parsed, should raise an XML parsing error"""
+        shared_conf = Mock()
+        shared_conf.xml_text = "not valid xml<<<"
+
+        with self.assertRaises(Exception):
+            setup_rdma_device("4.1.0", shared_conf)
+
+    def test_setup_rdma_device_with_no_instance_element(self):
+        """When Instance element is missing, should return without error"""
+        shared_conf = Mock()
+        shared_conf.xml_text = (
+            '<?xml version="1.0" encoding="utf-8"?>'
+            '<SharedConfig></SharedConfig>'
+        )
+
+        # Should not raise, just return early
+        setup_rdma_device("4.1.0", shared_conf)
+
+    @patch.object(RDMADeviceHandler, 'start')
+    def test_mac_address_formatting(self, mock_start):
+        """Verify MAC address is correctly formatted with colons"""
+        shared_conf = Mock()
+        shared_conf.xml_text = (
+            '<?xml version="1.0" encoding="utf-8"?>'
+            '<SharedConfig>'
+            '<Instance rdmaIPv4Address="10.0.0.1" rdmaMacAddress="00155D33FF1D" />'
+            '</SharedConfig>'
+        )
+
+        with patch.object(RDMADeviceHandler, '__init__', return_value=None) as mock_init:
+            mock_handler = MagicMock()
+            with patch('azurelinuxagent.pa.rdma.rdma.RDMADeviceHandler', return_value=mock_handler) as mock_cls:
+                setup_rdma_device("4.1.0", shared_conf)
+                # Verify MAC was formatted as 00:15:5D:33:FF:1D
+                mock_cls.assert_called_once_with("10.0.0.1", "00:15:5D:33:FF:1D", "4.1.0")
+
+    @patch.object(RDMADeviceHandler, 'start')
+    def test_empty_mac_not_formatted(self, mock_start):
+        """Verify empty MAC address is passed through without formatting"""
+        shared_conf = Mock()
+        shared_conf.xml_text = (
+            '<?xml version="1.0" encoding="utf-8"?>'
+            '<SharedConfig>'
+            '<Instance rdmaIPv4Address="10.0.0.1" rdmaMacAddress="" />'
+            '</SharedConfig>'
+        )
+
+        with patch('azurelinuxagent.pa.rdma.rdma.RDMADeviceHandler', return_value=MagicMock()) as mock_cls:
+            setup_rdma_device("4.1.0", shared_conf)
+            # Empty string should be passed through as-is
+            mock_cls.assert_called_once_with("10.0.0.1", "", "4.1.0")

--- a/tests/pa/test_rdma.py
+++ b/tests/pa/test_rdma.py
@@ -33,12 +33,7 @@ class TestSetupRdmaDevice(AgentTestCase):
         )
 
         setup_rdma_device("4.1.0", shared_conf)
-
-        mock_start.assert_called_once()
-        # Verify the MAC address was formatted with colons
-        call_args = RDMADeviceHandler.__init__  # accessed via mock_start
-        # Check the RDMADeviceHandler was created with the formatted MAC
-        self.assertTrue(mock_start.called)
+        self.assertEqual(mock_start.call_count, 1)
 
     @patch.object(RDMADeviceHandler, 'start')
     def test_setup_rdma_device_with_empty_mac(self, mock_start):
@@ -53,7 +48,7 @@ class TestSetupRdmaDevice(AgentTestCase):
 
         # Should not raise TypeError
         setup_rdma_device("4.1.0", shared_conf)
-        mock_start.assert_called_once()
+        self.assertEqual(mock_start.call_count, 1)
 
     @patch.object(RDMADeviceHandler, 'start')
     def test_setup_rdma_device_with_missing_mac_attribute(self, mock_start):
@@ -68,7 +63,7 @@ class TestSetupRdmaDevice(AgentTestCase):
 
         # Should not raise TypeError
         setup_rdma_device("4.1.0", shared_conf)
-        mock_start.assert_called_once()
+        self.assertEqual(mock_start.call_count, 1)
 
     def test_setup_rdma_device_with_invalid_xml(self):
         """When XML cannot be parsed, should raise an XML parsing error"""

--- a/tests/pa/test_rdma.py
+++ b/tests/pa/test_rdma.py
@@ -85,7 +85,7 @@ class TestSetupRdmaDevice(AgentTestCase):
         setup_rdma_device("4.1.0", shared_conf)
 
     @patch.object(RDMADeviceHandler, 'start')
-    def test_mac_address_formatting(self, mock_start):
+    def test_mac_address_formatting(self, _mock_start):
         """Verify MAC address is correctly formatted with colons"""
         shared_conf = Mock()
         shared_conf.xml_text = (
@@ -95,7 +95,7 @@ class TestSetupRdmaDevice(AgentTestCase):
             '</SharedConfig>'
         )
 
-        with patch.object(RDMADeviceHandler, '__init__', return_value=None) as mock_init:
+        with patch.object(RDMADeviceHandler, '__init__', return_value=None):
             mock_handler = MagicMock()
             with patch('azurelinuxagent.pa.rdma.rdma.RDMADeviceHandler', return_value=mock_handler) as mock_cls:
                 setup_rdma_device("4.1.0", shared_conf)
@@ -103,7 +103,7 @@ class TestSetupRdmaDevice(AgentTestCase):
                 mock_cls.assert_called_once_with("10.0.0.1", "00:15:5D:33:FF:1D", "4.1.0")
 
     @patch.object(RDMADeviceHandler, 'start')
-    def test_empty_mac_not_formatted(self, mock_start):
+    def test_empty_mac_not_formatted(self, _mock_start):
         """Verify empty MAC address is passed through without formatting"""
         shared_conf = Mock()
         shared_conf.xml_text = (

--- a/tests/pa/test_rdma.py
+++ b/tests/pa/test_rdma.py
@@ -84,8 +84,7 @@ class TestSetupRdmaDevice(AgentTestCase):
         # Should not raise, just return early
         setup_rdma_device("4.1.0", shared_conf)
 
-    @patch.object(RDMADeviceHandler, 'start')
-    def test_mac_address_formatting(self, _mock_start):
+    def test_mac_address_formatting(self):
         """Verify MAC address is correctly formatted with colons"""
         shared_conf = Mock()
         shared_conf.xml_text = (
@@ -95,12 +94,10 @@ class TestSetupRdmaDevice(AgentTestCase):
             '</SharedConfig>'
         )
 
-        with patch.object(RDMADeviceHandler, '__init__', return_value=None):
-            mock_handler = MagicMock()
-            with patch('azurelinuxagent.pa.rdma.rdma.RDMADeviceHandler', return_value=mock_handler) as mock_cls:
-                setup_rdma_device("4.1.0", shared_conf)
-                # Verify MAC was formatted as 00:15:5D:33:FF:1D
-                mock_cls.assert_called_once_with("10.0.0.1", "00:15:5D:33:FF:1D", "4.1.0")
+        with patch('azurelinuxagent.pa.rdma.rdma.RDMADeviceHandler', return_value=MagicMock()) as mock_cls:
+            setup_rdma_device("4.1.0", shared_conf)
+            # Verify MAC was formatted as 00:15:5D:33:FF:1D
+            mock_cls.assert_called_once_with("10.0.0.1", "00:15:5D:33:FF:1D", "4.1.0")
 
     @patch.object(RDMADeviceHandler, 'start')
     def test_empty_mac_not_formatted(self, _mock_start):


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->
<!--
Please add an informative description that covers that changes made by the pull request.
-->
## Description

During ICG M2 testing on the new AzCiM-AzNM deployment path, VMs were created without IPoIB interfaces. This is because WALinuxAgent's RDMA setup logic depends on the presence of `rdmaMacAddress` and `rdmaIPv4Address` attributes in `SharedConfig.xml`. These are legacy attributes no longer used. WALinuxAgent only checks their existence to determine whether to proceed with RDMA/IPoIB configuration. In the legacy NSM deployment flow, these attributes were populated and passed to SharedConfig.xml even though their values were not consumed. In the new AzNM deployment flow, these attributes are not populated by upstream services, causing WALinuxAgent to skip RDMA setup entirely and never program the IPoIB interfaces using the KVP data sent by IBManager.


Issue #  https://msazure.visualstudio.com/One/_workitems/edit/37393329 <!-- if any -->
---
<!--
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->
### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).
---
<!--
This checklist is used to track contributions from distro maintainers.
-->
### Distro maintenance information, if applicable
- [ ] This is a contribution from a distro maintainer
- [ ] The changes in this PR have been taken as a downstream patch (Note: it is not recommended to patch the agent without upstream review and approval)
