### PR TITLE
Disable signature validation in common test setup

### DIFF
--- a/tests_e2e/orchestrator/lib/agent_test_suite.py
+++ b/tests_e2e/orchestrator/lib/agent_test_suite.py
@@ -477,11 +477,6 @@ class AgentTestSuite(LisaTestSuite):
             log.info('Installing tools on the test node')
             log.info(ssh_client.run_command("~/bin/install-tools"))
 
-            # Update waagent.conf on test node
-            log.info("Updating conf file on test node: setting 'Debug.EnableSignatureValidation' to true")
-            command = "update-waagent-conf Debug.EnableSignatureValidation=y"
-            log.info("%s\n%s", command, ssh_client.run_command(command, use_sudo=True))
-
             if self._is_vhd:
                 log.info("Using a VHD; will not install the Test Agent.")
             elif not install_test_agent:

--- a/tests_e2e/orchestrator/runbook.yml
+++ b/tests_e2e/orchestrator/runbook.yml
@@ -51,7 +51,6 @@ variable:
 #      - ext_policy
 #      - ext_policy_with_dependencies
       - ext_sequencing
-      - ext_signature_validation
       - ext_telemetry_pipeline
       - ext_update
       - extensions_disabled


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->
<!--
Please add an informative description that covers that changes made by the pull request.
-->
## Description

Issue # <!-- if any -->
---
This PR disables the Debug.EnableSignatureValidation configuration flag in test runs for the next release branch.

Currently, Debug.EnableSignatureValidation is set to true in all daily tests so the validation code path is regularly exercised. In the upcoming release, this flag will default to false. To keep tests consistent with release behavior, we are removing the code in the common test setup that forces the flag on. Signature validation tests are also removed from the runbook since they are no longer applicable in this context.
<!--
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->
### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).
---
<!--
This checklist is used to track contributions from distro maintainers.
-->
### Distro maintenance information, if applicable
- [ ] This is a contribution from a distro maintainer
- [ ] The changes in this PR have been taken as a downstream patch (Note: it is not recommended to patch the agent without upstream review and approval)
