### PR TITLE
Cleaning up telemetry for Agent errors

### DIFF
--- a/azurelinuxagent/ga/cgroupapi.py
+++ b/azurelinuxagent/ga/cgroupapi.py
@@ -849,7 +849,7 @@ class CgroupV2(Cgroup):
             if expected_relative_path is not None:
                 expected_path = os.path.join(self._root_cgroup_path, expected_relative_path)
                 if self._cgroup_path != expected_path:
-                    log_cgroup_warning(
+                    log_cgroup_info(
                         "The {0} cgroup is not mounted at the expected path; will not track. Actual cgroup path:[{1}] Expected:[{2}]".format(
                             self._cgroup_name, self._cgroup_path, expected_path))
                     continue

--- a/azurelinuxagent/ga/cgroupapi.py
+++ b/azurelinuxagent/ga/cgroupapi.py
@@ -774,7 +774,7 @@ class CgroupV1(Cgroup):
             if expected_relative_path is not None:
                 expected_path = os.path.join(controller_mountpoint, expected_relative_path)
                 if controller_path != expected_path:
-                    log_cgroup_warning("The {0} controller is not mounted at the expected path for the {1} cgroup; will not track. Actual cgroup path:[{2}] Expected:[{3}]".format(supported_controller_name, self._cgroup_name, controller_path, expected_path))
+                    log_cgroup_info("The {0} controller is not mounted at the expected path for the {1} cgroup; will not track. Actual cgroup path:[{2}] Expected:[{3}]".format(supported_controller_name, self._cgroup_name, controller_path, expected_path))
                     continue
 
             if supported_controller_name == self.CPU_CONTROLLER:

--- a/azurelinuxagent/ga/collect_logs.py
+++ b/azurelinuxagent/ga/collect_logs.py
@@ -57,22 +57,17 @@ def is_log_collection_allowed():
     supported_python = PY_VERSION_MINOR >= 6 if PY_VERSION_MAJOR == 2 else PY_VERSION_MAJOR == 3
     is_allowed = conf_enabled and (cgroups_enabled or cgroup_v2_resource_limiting_enabled) and supported_python
 
-    msg = "Checking if log collection is allowed at this time [{0}]. All three conditions must be met: " \
+    msg = "Log collection {0} supported. All three conditions must be met: " \
           "1. configuration enabled [{1}], " \
           "2. cgroups v1 enabled [{2}] OR cgroups v2 is in use and v2 resource limiting configuration enabled [{3}], " \
-          "3. python supported: [{4}]".format(is_allowed,
-                                              conf_enabled,
-                                              cgroups_enabled,
-                                              cgroup_v2_resource_limiting_enabled,
-                                              supported_python)
+          "3. python supported: [{4}]".format(
+            "is" if is_allowed else "is not",
+            conf_enabled,
+            cgroups_enabled,
+            cgroup_v2_resource_limiting_enabled,
+            supported_python)
     logger.info(msg)
-    add_event(
-        name=AGENT_NAME,
-        version=CURRENT_VERSION,
-        op=WALAEventOperation.LogCollection,
-        is_success=is_allowed,
-        message=msg,
-        log_event=False)
+    add_event(op=WALAEventOperation.LogCollection, message=msg)
 
     return is_allowed
 

--- a/azurelinuxagent/ga/env.py
+++ b/azurelinuxagent/ga/env.py
@@ -118,7 +118,7 @@ class EnableFirewall(PeriodicOperation):
     def __init__(self, wire_server_address):
         super(EnableFirewall, self).__init__(conf.get_enable_firewall_period())
         self._wire_server_address = wire_server_address
-        self._is_first_iteration = True # The firewall may not be setup on service start (e.g. new VMs); we issue some messages as INFO the first time, then as WARNING/ERROR for subsequent iterations
+        self._is_first_iteration = True  # The firewall may not be setup on service start (e.g. new VMs); we issue some messages as INFO the first time, then as WARNING/ERROR for subsequent iterations
         self._firewall_manager = None  # initialized on demand in the _operation method
         self._firewall_state = FirewallState.OK  # Initialized to OK to prevent turning on verbose mode on the initial invocation of _operation(). It is properly initialized as soon as we do the first check of the firewall.
         #

--- a/azurelinuxagent/ga/env.py
+++ b/azurelinuxagent/ga/env.py
@@ -118,6 +118,7 @@ class EnableFirewall(PeriodicOperation):
     def __init__(self, wire_server_address):
         super(EnableFirewall, self).__init__(conf.get_enable_firewall_period())
         self._wire_server_address = wire_server_address
+        self._is_first_iteration = True # The firewall may not be setup on service start (e.g. new VMs); we issue some messages as INFO the first time, then as WARNING/ERROR for subsequent iterations
         self._firewall_manager = None  # initialized on demand in the _operation method
         self._firewall_state = FirewallState.OK  # Initialized to OK to prevent turning on verbose mode on the initial invocation of _operation(). It is properly initialized as soon as we do the first check of the firewall.
         #
@@ -157,14 +158,14 @@ class EnableFirewall(PeriodicOperation):
                     self._emit_event(event.info, WALAEventOperation.Firewall, "The firewall is configured correctly. Current state:\n{0}", self._firewall_manager.get_state())
                     return
                 self._update_firewall_state(FirewallState.NotSet)
-                self._emit_event(event.warn, WALAEventOperation.Firewall, "The firewall has not been setup. Will set it up.")
+                self._emit_event(event.info if self._is_first_iteration else event.warn, WALAEventOperation.Firewall, "The firewall has not been setup. Will set it up.")
             except IptablesInconsistencyError as e:
                 self._update_firewall_state(FirewallState.Inconsistent)
                 self._emit_event(event.warn, WALAEventOperation.FirewallInconsistency, "The results returned by iptables are inconsistent, will not change the current state of the firewall: {0}", ustr(e))
                 return
             except FirewallStateError as e:
                 self._update_firewall_state(FirewallState.Invalid)
-                self._emit_event(event.warn, WALAEventOperation.ResetFirewall, "The firewall is not configured correctly. {0}. Will reset it. Current state:\n{1}", ustr(e), self._firewall_manager.get_state())
+                self._emit_event(event.info if self._is_first_iteration else event.warn, WALAEventOperation.ResetFirewall, "The firewall is not configured correctly. {0}. Will reset it. Current state:\n{1}", ustr(e), self._firewall_manager.get_state())
                 self._firewall_manager.remove()
 
             self._firewall_manager.setup()
@@ -180,6 +181,8 @@ class EnableFirewall(PeriodicOperation):
             if self._should_report:
                 self._report_count += 1
                 self._period_report_count += 1
+            self._is_first_iteration = False
+
 
     def _emit_event(self, event_function, operation, message, *args):
         if self._should_report:

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -781,7 +781,8 @@ class UpdateHandler(object):
             # There may be a race condition in which the child exited after the above check for None and send_signal(); ignore it.
             if error.errno != errno.ESRCH:  # "no such process" 
                 raise
-            logger.info(u"The {0} child process no longer existed when forwarding signal {1}, continuing the service shutdown process.", CURRENT_AGENT, signum)
+            message = u"The {0} child process no longer existed when forwarding signal {1}; continuing the service shutdown process.".format(CURRENT_AGENT, signum)
+            logger.info(u"{0}", message)
             add_event(op=WALAEventOperation.Enable, message=message)
 
         if self.signal_handler not in (None, signal.SIG_IGN, signal.SIG_DFL):

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -771,8 +771,8 @@ class UpdateHandler(object):
             return
 
         child_agent_name = self.child_agent.name if self.child_agent is not None else CURRENT_AGENT
-        message = u"Agent {0} forwarding signal {1} to {2}\n".format(CURRENT_AGENT, signum, child_agent_name)
-        logger.info(u"{0}", message)
+        message = u"Agent {0} forwarding signal {1} to {2}...".format(CURRENT_AGENT, signum, child_agent_name)
+        logger.info(u"{0}\n", message)
         add_event(op=WALAEventOperation.Enable, message=message)
 
         try:

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -18,6 +18,7 @@
 # Requires Python 2.6+ and Openssl 1.0+
 #
 import glob
+import errno
 import os
 import platform
 import re
@@ -769,13 +770,19 @@ class UpdateHandler(object):
         if self.child_process is None:
             return
 
-        logger.info(
-            u"Agent {0} forwarding signal {1} to {2}\n",
-            CURRENT_AGENT,
-            signum,
-            self.child_agent.name if self.child_agent is not None else CURRENT_AGENT)
+        child_agent_name = self.child_agent.name if self.child_agent is not None else CURRENT_AGENT
+        message = u"Agent {0} forwarding signal {1} to {2}\n".format(CURRENT_AGENT, signum, child_agent_name)
+        logger.info(u"{0}", message)
+        add_event(op=WALAEventOperation.Enable, message=message)
 
-        self.child_process.send_signal(signum)
+        try:
+            self.child_process.send_signal(signum)
+        except OSError as error:
+            # There may be a race condition in which the child exited after the above check for None and send_signal(); ignore it.
+            if error.errno != errno.ESRCH:  # "no such process" 
+                raise
+            logger.info(u"The {0} child process no longer existed when forwarding signal {1}, continuing the service shutdown process.", CURRENT_AGENT, signum)
+            add_event(op=WALAEventOperation.Enable, message=message)
 
         if self.signal_handler not in (None, signal.SIG_IGN, signal.SIG_DFL):
             self.signal_handler(signum, frame)

--- a/tests_e2e/tests/lib/agent_log.py
+++ b/tests_e2e/tests/lib/agent_log.py
@@ -463,14 +463,6 @@ class AgentLog(object):
             {
                 'message': r"(?s)Disabling resource usage monitoring. Reason: Failed to start.*using systemd-run, will try invoking the extension directly. Error: \[SystemdRunError\].* (Message recipient disconnected from message bus without replying|Connection reset by peer|Remote peer disconnected|Transport endpoint is not connected)",
             },
-            #
-            # If agent is not mounted at the expected path, we log this message in v2 machines. This is not an error.
-            # 2025-03-03T09:19:03.145557Z INFO ExtHandler ExtHandler [CGW] The walinuxagent.service cgroup is not mounted at the expected path; will not track. Actual cgroup path:[/sys/fs/cgroup/system.slice/walinuxagent.service] Expected:[/sys/fs/cgroup/azure.slice/walinuxagent.service]
-            # 2025-03-12T22:03:04.095141Z INFO ExtHandler ExtHandler [CGW] The cpu,cpuacct controller is not mounted at the expected path for the walinuxagent.service cgroup; will not track. Actual cgroup path:[/sys/fs/cgroup/cpu,cpuacct/system.slice/walinuxagent.service] Expected:[/sys/fs/cgroup/cpu,cpuacct/azure.slice/walinuxagent.service]
-            #
-            {
-                'message': r"(The walinuxagent.service cgroup is not mounted at the expected path|controller is not mounted at the expected path for the walinuxagent.service cgroup); will not track. Actual cgroup path:\[.*\] Expected:\[.*\]",
-            },
             # Timing issue when the CGroup has been deleted/reset quota by the time we are fetching the values
             # from it. We would see IOError with file entry not found (ERRNO: 2).
             # 2025-08-28T18:46:06.813016Z WARNING MonitorHandler ExtHandler [PERIODIC] Could not collect metrics for cgroup azuremonitor-coreagent. Error : [CGroupsException] Failed to read cpu.stat: Cannot find throttled_usec


### PR DESCRIPTION
Initial cleanup of the telemetry tracked by the "Agent Errors" deployment query.

There will be additional PRs for clean up that requires more complex code changes.

Most of the changes in this PR simply change warnings/errors to infos. I also added a couple of events to the code that starts the extension handler.