### PR TITLE
Change version to 2.3.16.0

### DIFF
--- a/azurelinuxagent/common/version.py
+++ b/azurelinuxagent/common/version.py
@@ -220,7 +220,7 @@ AGENT_LONG_NAME = "Azure Linux Agent"
 #
 #            When doing a release, be sure to use the actual agent version. Current agent version: 2.4.0.0
 #
-AGENT_VERSION = '2.15.2.0'
+AGENT_VERSION = '2.3.16.0'
 AGENT_LONG_VERSION = "{0}-{1}".format(AGENT_NAME, AGENT_VERSION)
 AGENT_DESCRIPTION = """
 The Azure Linux Agent supports the provisioning and running of Linux


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->
<!--
Please add an informative description that covers that changes made by the pull request.
-->
## Description
Change version to 2.3.16.0 for Test type release to Canary only.

The rsm_update.py end to end test performs agent downgrade and upgrade attempts to versions 2.3.15.0 and 2.3.15.1. Since the agent package signature validation feature is in development, we need to publish versions of the agent with signature for these rsm downgrade/upgrade scenarios. 

This branch will be used to publish 2.3.16.0 Test type to Canary for this test scenario

Issue # <!-- if any -->
---
<!--
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->
### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).
---
<!--
This checklist is used to track contributions from distro maintainers.
-->
### Distro maintenance information, if applicable
- [ ] This is a contribution from a distro maintainer
- [ ] The changes in this PR have been taken as a downstream patch (Note: it is not recommended to patch the agent without upstream review and approval)
