### PR TITLE
Lower downgrade_version for RSM unit tests

### DIFF
--- a/tests/ga/test_agent_update_handler.py
+++ b/tests/ga/test_agent_update_handler.py
@@ -313,7 +313,7 @@ class TestAgentUpdate(UpdateTestCase):
         self.prepare_agents()
         self.assertEqual(20, self.agent_count(), "Agent directories not set properly")
 
-        downgrade_version = "2.5.0"
+        downgrade_version = "2.0.0"
 
         with self._get_agent_update_handler(test_data=data_file) as (agent_update_handler, mock_telemetry):
             agent_update_handler._protocol.mock_wire_data.set_version_in_agent_family(downgrade_version)
@@ -335,8 +335,8 @@ class TestAgentUpdate(UpdateTestCase):
         self.prepare_agents()
         self.assertEqual(20, self.agent_count(), "Agent directories not set properly")
 
-        downgrade_version = "2.5.0"
-        from_version = "3.0.0"
+        downgrade_version = "2.0.0"
+        from_version = "2.5.0"
 
         with self._get_agent_update_handler(test_data=data_file) as (agent_update_handler, mock_telemetry):
             agent_update_handler._protocol.mock_wire_data.set_version_in_agent_family(downgrade_version)
@@ -361,7 +361,7 @@ class TestAgentUpdate(UpdateTestCase):
         self.prepare_agents()
         self.assertEqual(20, self.agent_count(), "Agent directories not set properly")
 
-        downgrade_version = "2.5.0"
+        downgrade_version = "2.0.0"
 
         with self._get_agent_update_handler(test_data=data_file) as (agent_update_handler, mock_telemetry):
             agent_update_handler._protocol.mock_wire_data.set_version_in_agent_family(downgrade_version)
@@ -485,7 +485,7 @@ class TestAgentUpdate(UpdateTestCase):
         self.prepare_agents(count=1)
         data_file = DATA_FILE.copy()
         data_file["ext_conf"] = "wire/ext_conf_version_not_from_rsm.xml"
-        downgrade_version = "2.5.0"
+        downgrade_version = "2.0.0"
 
         with self._get_agent_update_handler(test_data=data_file) as (agent_update_handler, mock_telemetry):
             agent_update_handler._protocol.mock_wire_data.set_version_in_agent_family(downgrade_version)

--- a/tests/ga/test_update.py
+++ b/tests/ga/test_update.py
@@ -1795,7 +1795,7 @@ class TestAgentUpgrade(UpdateTestCase):
 
     def test_it_should_mark_current_agent_as_bad_version_on_downgrade(self):
         no_of_iterations = 100
-        downgrade_version = "2.5.0"
+        downgrade_version = "2.0.0"
 
         self.prepare_agents(count=1)
         self.assertTrue(os.path.exists(self.agent_dir(CURRENT_VERSION)))


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->
<!--
Please add an informative description that covers that changes made by the pull request.
-->
## Description
I'm publishing a lower version of the Test agent to canary (2.3.16.0) for end to end signature validation testing. Some of the RSM downgrade unit tests are using requested version 2.5.0 which is greater than 2.3.16.0. As a result, these unit tests are failing on my release branch with version 2.3.16.0.

I'm opening this PR to lower the downgrade version in these unit tests so that it is less than the dummy release version. This change will not be cherry-picked to develop, it is only needed for this dummy release branch

Issue # <!-- if any -->
---
<!--
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->
### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).
---
<!--
This checklist is used to track contributions from distro maintainers.
-->
### Distro maintenance information, if applicable
- [ ] This is a contribution from a distro maintainer
- [ ] The changes in this PR have been taken as a downstream patch (Note: it is not recommended to patch the agent without upstream review and approval)
