### PR TITLE
Update diskSizeGB for higher image size distros

### DIFF
--- a/tests_e2e/orchestrator/lib/agent_test_suite_combinator.py
+++ b/tests_e2e/orchestrator/lib/agent_test_suite_combinator.py
@@ -259,8 +259,9 @@ class AgentTestSuitesCombinator(Combinator):
                                     test_suite_info=test_suite_info)
                             shared_environments[env_name] = env
 
+                    vm_tags = env["vm_tags"]
+                    vm_tags["image_name"] = image_name # used in the update_arm_template hook to apply image-specific customizations in the ARM template
                     if test_suite_info.template != '':
-                        vm_tags = env["vm_tags"]
                         if "templates" not in vm_tags:
                             vm_tags["templates"] = test_suite_info.template
                         else:

--- a/tests_e2e/orchestrator/lib/update_arm_template_hook.py
+++ b/tests_e2e/orchestrator/lib/update_arm_template_hook.py
@@ -55,19 +55,23 @@ class UpdateArmTemplateHook:
             network_security_rule.add_allow_ssh_rule(allow_ssh)
 
         #
-        # Remove diskSizeGB from OS disk functions to avoid errors when the specified
-        # size is smaller than the VM image's disk size.
+        # Update diskSizeGB from OS disk functions to avoid errors when the specified
+        # size is smaller than the VM image's disk size for rhel_82 and rhel_75 distros.
         # TODO: Remove this workaround after LISA fixing the default size issue in their template
         #
-        for func_group in template.get("functions", []):
-            members = func_group.get("members", {})
+        image_name = vm_tags.get("image_name", "")
+        if any(name in image_name.lower() for name in ("rhel-8.2", "rhel-7.5")):
             for func_name in ("getOSImage", "getEphemeralOSImage"):
-                func_def = members.get(func_name)
-                if func_def is not None:
-                    output_value = func_def.get("output", {}).get("value", {})
+                try:
+                    output_value = UpdateArmTemplate.get_function_output(
+                        UpdateArmTemplate.get_lisa_function(template, func_name)
+                    )
                     if "diskSizeGB" in output_value:
-                        log.info("******** Waagent: Removing diskSizeGB in %s, which is set by the LISA template", func_name)
-                        del output_value["diskSizeGB"]
+                        log.info("******** Waagent: Updating diskSizeGB in %s to 64GB", func_name)
+                        output_value["diskSizeGB"] = 64
+                except Exception as e:
+                    log.info("Error while updating diskSizeGB in %s. Error: %s", func_name, str(e))
+
 
         #
         # Apply any template customizations provided by the tests.

--- a/tests_e2e/orchestrator/lib/update_arm_template_hook.py
+++ b/tests_e2e/orchestrator/lib/update_arm_template_hook.py
@@ -55,6 +55,21 @@ class UpdateArmTemplateHook:
             network_security_rule.add_allow_ssh_rule(allow_ssh)
 
         #
+        # Remove diskSizeGB from OS disk functions to avoid errors when the specified
+        # size is smaller than the VM image's disk size.
+        # TODO: Remove this workaround after LISA fixing the default size issue in their template
+        #
+        for func_group in template.get("functions", []):
+            members = func_group.get("members", {})
+            for func_name in ("getOSImage", "getEphemeralOSImage"):
+                func_def = members.get(func_name)
+                if func_def is not None:
+                    output_value = func_def.get("output", {}).get("value", {})
+                    if "diskSizeGB" in output_value:
+                        log.info("******** Waagent: Removing diskSizeGB in %s, which set by LISA template", func_name)
+                        del output_value["diskSizeGB"]
+
+        #
         # Apply any template customizations provided by the tests.
         #
         # The "templates" tag is a comma-separated list of the template customizations provided by the tests

--- a/tests_e2e/orchestrator/lib/update_arm_template_hook.py
+++ b/tests_e2e/orchestrator/lib/update_arm_template_hook.py
@@ -59,8 +59,8 @@ class UpdateArmTemplateHook:
         # size is smaller than the VM image's disk size for rhel_82 and rhel_75 distros.
         # TODO: Remove this workaround after LISA fixing the default size issue in their template
         #
-        image_name = vm_tags.get("image_name", "")
-        if any(name in image_name.lower() for name in ("rhel-8.2", "rhel-7.5")):
+        image_name = vm_tags.get("image_name", "").lower()
+        if image_name in ("rhel-8.2", "rhel-7.5"):
             for func_name in ("getOSImage", "getEphemeralOSImage"):
                 try:
                     output_value = UpdateArmTemplate.get_function_output(

--- a/tests_e2e/orchestrator/lib/update_arm_template_hook.py
+++ b/tests_e2e/orchestrator/lib/update_arm_template_hook.py
@@ -66,7 +66,7 @@ class UpdateArmTemplateHook:
                 if func_def is not None:
                     output_value = func_def.get("output", {}).get("value", {})
                     if "diskSizeGB" in output_value:
-                        log.info("******** Waagent: Removing diskSizeGB in %s, which set by LISA template", func_name)
+                        log.info("******** Waagent: Removing diskSizeGB in %s, which is set by the LISA template", func_name)
                         del output_value["diskSizeGB"]
 
         #


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->
<!--
Please add an informative description that covers that changes made by the pull request.
-->
## Description

Fixing
```
	  "error": {
	    "code": "OperationNotAllowed",
	    "message": "The specified disk size 30 GB is smaller than the size of the corresponding disk in the VM image: 64 GB. This is not allowed. Please choose equal or greater size or do not specify an explicit size.",
	    "target": "osDisk.diskSizeGB"
	  }
```

Issue # <!-- if any -->
---
<!--
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->
### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).
---
<!--
This checklist is used to track contributions from distro maintainers.
-->
### Distro maintenance information, if applicable
- [ ] This is a contribution from a distro maintainer
- [ ] The changes in this PR have been taken as a downstream patch (Note: it is not recommended to patch the agent without upstream review and approval)
