### PR TITLE
fix: replace deprecated logger.warn() with logger.warning()

### DIFF
--- a/azurelinuxagent/agent.py
+++ b/azurelinuxagent/agent.py
@@ -288,7 +288,7 @@ class Agent(object):
                     event.add_event(op=event.WALAEventOperation.LogCollection, message=msg, log_event=False)
                 except Exception as e:
                     msg = "An error occurred while reporting log collector resource usage summary: {0}".format(ustr(e))
-                    logger.warn(msg)
+                    logger.warning(msg)
                     event.add_event(op=event.WALAEventOperation.LogCollection, is_success=False, message=msg, log_event=False)
 
         except Exception as e:

--- a/azurelinuxagent/common/datacontract.py
+++ b/azurelinuxagent/common/datacontract.py
@@ -52,7 +52,7 @@ def set_properties(name, obj, data):
             try:
                 prob = getattr(obj, prob_name)
             except AttributeError:
-                logger.warn("Unknown property: {0}", prob_full_name)
+                logger.warning("Unknown property: {0}", prob_full_name)
                 continue
             prob = set_properties(prob_full_name, prob, prob_val)
             setattr(obj, prob_name, prob)

--- a/azurelinuxagent/common/dhcp.py
+++ b/azurelinuxagent/common/dhcp.py
@@ -96,7 +96,7 @@ class DhcpHandler(object):
                 route_exists = True
                 logger.info("Route to {0} exists".format(KNOWN_WIRESERVER_IP))
             else:
-                logger.warn("No route exists to {0}".format(KNOWN_WIRESERVER_IP))
+                logger.warning("No route exists to {0}".format(KNOWN_WIRESERVER_IP))
         except Exception as e:
             logger.error(
                 "Could not determine whether route exists to {0}: {1}".format(
@@ -144,7 +144,7 @@ class DhcpHandler(object):
                 validate_dhcp_resp(request, response)
                 return response
             except DhcpError as e:
-                logger.warn("Failed to send DHCP request: {0}", e)
+                logger.warning("Failed to send DHCP request: {0}", e)
             time.sleep(duration)
         return None
 

--- a/azurelinuxagent/common/event.py
+++ b/azurelinuxagent/common/event.py
@@ -194,7 +194,7 @@ class EventStatus(object):
                 with open(self._path, 'r') as f:
                     self._status = json.load(f)
         except Exception as e:
-            logger.warn("Exception occurred loading event status: {0}".format(e))
+            logger.warning("Exception occurred loading event status: {0}".format(e))
             self._status = {}
 
     def _save(self):
@@ -202,7 +202,7 @@ class EventStatus(object):
             with open(self._path, 'w') as f:
                 json.dump(self._status, f)
         except Exception as e:
-            logger.warn("Exception occurred saving event status: {0}".format(e))
+            logger.warning("Exception occurred saving event status: {0}".format(e))
 
 
 __event_status__ = EventStatus()
@@ -420,7 +420,7 @@ class EventLogger(object):
         try:
             return osutil.get_total_mem()
         except OSUtilError as e:
-            logger.warn("Failed to get RAM info; will be missing from telemetry: {0}", ustr(e))
+            logger.warning("Failed to get RAM info; will be missing from telemetry: {0}", ustr(e))
         return 0
 
     @staticmethod
@@ -428,7 +428,7 @@ class EventLogger(object):
         try:
             return osutil.get_processor_cores()
         except OSUtilError as e:
-            logger.warn("Failed to get Processors info; will be missing from telemetry: {0}", ustr(e))
+            logger.warning("Failed to get Processors info; will be missing from telemetry: {0}", ustr(e))
         return 0
 
     def initialize_vminfo_common_parameters(self, protocol):
@@ -446,7 +446,7 @@ class EventLogger(object):
             parameters[CommonTelemetryEventSchema.RoleName].value = vminfo.roleName
             parameters[CommonTelemetryEventSchema.RoleInstanceName].value = vminfo.roleInstanceName
         except Exception as e:
-            logger.warn("Failed to get VM info from goal state; will be missing from telemetry: {0}", ustr(e))
+            logger.warning("Failed to get VM info from goal state; will be missing from telemetry: {0}", ustr(e))
 
         try:
             imds_client = get_imds_client()
@@ -457,11 +457,11 @@ class EventLogger(object):
             parameters[CommonTelemetryEventSchema.VMId].value = imds_info.vmId
             parameters[CommonTelemetryEventSchema.ImageOrigin].value = int(imds_info.image_origin)
         except Exception as e:
-            logger.warn("Failed to get IMDS info; will be missing from telemetry: {0}", ustr(e))
+            logger.warning("Failed to get IMDS info; will be missing from telemetry: {0}", ustr(e))
 
     def save_event(self, data):
         if self.event_dir is None:
-            logger.warn("Cannot save event -- Event reporter is not initialized.")
+            logger.warning("Cannot save event -- Event reporter is not initialized.")
             return
 
         try:
@@ -695,7 +695,7 @@ def report_metric(category, counter, instance, value, log_event=False, reporter=
     :param EventLogger reporter: The EventLogger instance to which metric events should be sent
     """
     if reporter.event_dir is None:
-        logger.warn("Cannot report metric event -- Event reporter is not initialized.")
+        logger.warning("Cannot report metric event -- Event reporter is not initialized.")
         message = "Metric {0}/{1} [{2}] = {3}".format(category, counter, instance, value)
         _log_event(AGENT_NAME, "METRIC", message, 0)
         return
@@ -718,7 +718,7 @@ def add_event(name=AGENT_NAME, op=WALAEventOperation.Unknown, is_success=True, d
     :param flush: if true, flush the event immediately to the wire server
     """
     if reporter.event_dir is None:
-        logger.warn("Cannot add event -- Event reporter is not initialized.")
+        logger.warning("Cannot add event -- Event reporter is not initialized.")
         _log_event(name, op, message, duration, is_success=is_success)
         return
 
@@ -741,7 +741,7 @@ def warn(op, fmt, *args):
     """
     Creates a telemetry event and logs the message as WARNING.
     """
-    logger.warn(fmt, *args)
+    logger.warning(fmt, *args)
     add_event(op=op, message="[WARNING] " + fmt.format(*args), is_success=False, log_event=False)
 
 
@@ -765,7 +765,7 @@ class LogEvent(object):
         add_event(op=op, message=fmt.format(*args), is_success=True)
 
     def warn(self, op, fmt, *args):
-        self._logger.warn(fmt, *args)
+        self._logger.warning(fmt, *args)
         add_event(op=op, message="[WARNING] " + fmt.format(*args), is_success=False, log_event=False)
 
     def error(self, op, fmt, *args):
@@ -794,7 +794,7 @@ def add_log_event(level, message, forced=False, reporter=__event_logger__):
 def add_periodic(delta, name, op=WALAEventOperation.Unknown, is_success=True, duration=0, version=str(CURRENT_VERSION),
                  message="", log_event=True, force=False, reporter=__event_logger__):
     if reporter.event_dir is None:
-        logger.warn("Cannot add periodic event -- Event reporter is not initialized.")
+        logger.warning("Cannot add periodic event -- Event reporter is not initialized.")
         _log_event(name, op, message, duration, is_success=is_success)
         return
 

--- a/azurelinuxagent/common/logger.py
+++ b/azurelinuxagent/common/logger.py
@@ -95,7 +95,7 @@ class Logger(object):
             Assuming a logger with two appenders - FileAppender and TelemetryAppender. Here is an example of
             how using appender_lock flag can help.
 
-            logger.warn("foo")
+            logger.warning("foo")
                 |- log.warn() (azurelinuxagent.common.logger.Logger.warn)
                     |- log() (azurelinuxagent.common.logger.Logger.log)
                         |- FileAppender.appender_lock is currently False not log_appender.appender_lock is True

--- a/azurelinuxagent/common/osutil/bigip.py
+++ b/azurelinuxagent/common/osutil/bigip.py
@@ -257,7 +257,7 @@ class BigIpOSUtil(DefaultOSUtil):
         :param chk_err: Whether or not to check for errors raised by the eject
                         command
         """
-        logger.warn("Eject is not supported on this platform")
+        logger.warning("Eject is not supported on this platform")
 
     def get_first_if(self):
         """Return the interface name, and ip addr of the management interface.
@@ -287,7 +287,7 @@ class BigIpOSUtil(DefaultOSUtil):
         ret = fcntl.ioctl(sock.fileno(), 0x8912, param)
         retsize = (struct.unpack('iL', ret)[0])
         if retsize == (expected * struct_size):
-            logger.warn(('SIOCGIFCONF returned more than {0} up '
+            logger.warning(('SIOCGIFCONF returned more than {0} up '
                          'network interfaces.'), expected)
 
         sock = array_to_bytes(buff)

--- a/azurelinuxagent/common/osutil/chainguard.py
+++ b/azurelinuxagent/common/osutil/chainguard.py
@@ -51,12 +51,12 @@ class ChainguardOSUtil(DefaultOSUtil):
                 shellutil.run_command(["systemctl", "restart", "systemd-networkd"])
 
             except shellutil.CommandError as cmd_err:
-                logger.warn("failed to restart systemd-networkd: return code {1}".format(cmd_err.returncode))
+                logger.warning("failed to restart systemd-networkd: return code {1}".format(cmd_err.returncode))
                 if attempt < retry_limit:
                     logger.info("retrying in {0} seconds".format(wait))
                     time.sleep(wait)
                 else:
-                    logger.warn("exceeded restart retries")
+                    logger.warning("exceeded restart retries")
 
     def is_dhcp_available(self):
         return True

--- a/azurelinuxagent/common/osutil/default.py
+++ b/azurelinuxagent/common/osutil/default.py
@@ -136,7 +136,7 @@ class DefaultOSUtil(object):
         try:
             return platform.machine()
         except Exception as e:
-            logger.warn("Unable to determine cpu architecture: {0}", ustr(e))
+            logger.warning("Unable to determine cpu architecture: {0}", ustr(e))
             return "unknown"
 
     @staticmethod
@@ -480,7 +480,7 @@ class DefaultOSUtil(object):
                 logger.info("Successfully mounted dvd")
                 return
             else:
-                logger.warn(
+                logger.warning(
                     "Mounting dvd failed [retry {0}/{1}, sleeping {2} sec]",
                     retry,
                     max_retry - 1,
@@ -519,7 +519,7 @@ class DefaultOSUtil(object):
         try:
             self.load_atapiix_mod()
         except Exception as e:
-            logger.warn("Could not load ATAPI driver: {0}".format(e))
+            logger.warning("Could not load ATAPI driver: {0}".format(e))
 
     def load_atapiix_mod(self):
         if self.is_atapiix_mod_loaded():
@@ -590,7 +590,7 @@ class DefaultOSUtil(object):
             if os.path.isfile(dest):
                 os.remove(dest)
             if os.path.isfile(src):
-                logger.warn("Move rules file {0} to {1}", file_name, dest)
+                logger.warning("Move rules file {0} to {1}", file_name, dest)
                 shutil.move(src, dest)
 
     def restore_rules_files(self, rules_files=None):
@@ -603,7 +603,7 @@ class DefaultOSUtil(object):
             if os.path.isfile(dest):
                 continue
             if os.path.isfile(src):
-                logger.warn("Move rules file {0} to {1}", filename, dest)
+                logger.warning("Move rules file {0} to {1}", filename, dest)
                 shutil.move(src, dest)
 
     def get_mac_addr(self):
@@ -655,7 +655,7 @@ class DefaultOSUtil(object):
         sock.close()
 
         if retsize == array_size:
-            logger.warn(('SIOCGIFCONF returned more than {0} up '
+            logger.warning(('SIOCGIFCONF returned more than {0} up '
                          'network interfaces.'), expected)
 
         ifconf_buff = array_to_bytes(buff)
@@ -793,10 +793,10 @@ class DefaultOSUtil(object):
             if not self.disable_route_warning:
                 with open('/proc/net/route') as routing_table_fh:
                     routing_table_text = routing_table_fh.read()
-                    logger.warn('Could not determine primary interface, '
+                    logger.warning('Could not determine primary interface, '
                                 'please ensure /proc/net/route is correct')
-                    logger.warn('Contents of /proc/net/route:\n{0}'.format(routing_table_text))
-                    logger.warn('Primary interface examination will retry silently')
+                    logger.warning('Contents of /proc/net/route:\n{0}'.format(routing_table_text))
+                    logger.warning('Primary interface examination will retry silently')
                     self.disable_route_warning = True
         else:
             logger.info('Primary interface is [{0}]'.format(primary_interface))
@@ -906,7 +906,7 @@ class DefaultOSUtil(object):
                     return False
             return True
         except CommandError as e:
-            logger.warn("Cannot get the routing table. {0} failed: {1}", ustr(route_cmd), ustr(e))
+            logger.warning("Cannot get the routing table. {0} failed: {1}", ustr(route_cmd), ustr(e))
             return False
 
     def get_if_name(self):
@@ -1016,12 +1016,12 @@ class DefaultOSUtil(object):
             return_code = shellutil.run("ifdown {0} && ifup {0}".format(ifname), expected_errors=[1] if attempt < retries else [])
             if return_code == 0:
                 return
-            logger.warn("failed to restart {0}: return code {1}".format(ifname, return_code))
+            logger.warning("failed to restart {0}: return code {1}".format(ifname, return_code))
             if attempt < retry_limit:
                 logger.info("retrying in {0} seconds".format(wait))
                 time.sleep(wait)
             else:
-                logger.warn("exceeded restart retries")
+                logger.warning("exceeded restart retries")
 
     def check_and_recover_nic_state(self, ifname):
         # TODO: This should be implemented for all distros where we reset the network during publishing hostname. Currently it is only implemented in RedhatOSUtil.
@@ -1131,7 +1131,7 @@ class DefaultOSUtil(object):
                                     device = d.split(':')[1]
                                     return device
         except (OSError, IOError) as exc:
-            logger.warn('Error getting device for {0} or {1}: {2}', gen1_device_prefix, gen2_device_id, ustr(exc))
+            logger.warning('Error getting device for {0} or {1}: {2}', gen1_device_prefix, gen2_device_id, ustr(exc))
         return None
 
     def device_for_ide_port(self, port_id):
@@ -1194,7 +1194,7 @@ class DefaultOSUtil(object):
                 if "hostname" in hostname_info:
                     return hostname_info["hostname"]
         except Exception as exception:
-            logger.warn("Error retrieving hostname: {0}", ustr(exception))
+            logger.warning("Error retrieving hostname: {0}", ustr(exception))
         return None
 
     def del_account(self, username):
@@ -1246,7 +1246,7 @@ class DefaultOSUtil(object):
         try:
             results = fileutil.read_file('/proc/stat')
         except (OSError, IOError) as ex:
-            logger.warn("Couldn't read /proc/stat: {0}".format(ex.strerror))
+            logger.warning("Couldn't read /proc/stat: {0}".format(ex.strerror))
             raise
 
         return results

--- a/azurelinuxagent/common/osutil/factory.py
+++ b/azurelinuxagent/common/osutil/factory.py
@@ -158,5 +158,5 @@ def _get_osutil(distro_name, distro_code_name, distro_version, distro_full_name)
     if distro_name == "fedora":
         return FedoraOSUtil()
 
-    logger.warn("Unable to load distro implementation for {0}. Using default distro implementation instead.", distro_name)
+    logger.warning("Unable to load distro implementation for {0}. Using default distro implementation instead.", distro_name)
     return DefaultOSUtil()

--- a/azurelinuxagent/common/osutil/fedora.py
+++ b/azurelinuxagent/common/osutil/fedora.py
@@ -48,12 +48,12 @@ class FedoraOSUtil(DefaultOSUtil):
             return_code = shellutil.run("ip link set {0} down && ip link set {0} up".format(ifname))
             if return_code == 0:
                 return
-            logger.warn("failed to restart {0}: return code {1}".format(ifname, return_code))
+            logger.warning("failed to restart {0}: return code {1}".format(ifname, return_code))
             if attempt < retry_limit:
                 logger.info("retrying in {0} seconds".format(wait))
                 time.sleep(wait)
             else:
-                logger.warn("exceeded restart retries")
+                logger.warning("exceeded restart retries")
 
     def restart_ssh_service(self):
         shellutil.run('systemctl restart sshd')

--- a/azurelinuxagent/common/osutil/freebsd.py
+++ b/azurelinuxagent/common/osutil/freebsd.py
@@ -56,7 +56,7 @@ class FreeBSDOSUtil(DefaultOSUtil):
         """
         userentry = self.get_userentry(username)
         if userentry is not None:
-            logger.warn("User {0} already exists, skip useradd", username)
+            logger.warning("User {0} already exists, skip useradd", username)
             return
         if expiration is not None:
             cmd = ["pw", "useradd", username, "-e", expiration, "-m"]
@@ -377,9 +377,9 @@ class FreeBSDOSUtil(DefaultOSUtil):
         if primary_interface is None:
             primary_interface = ''
             if not self.disable_route_warning:
-                logger.warn('Could not determine primary interface, '
+                logger.warning('Could not determine primary interface, '
                             'please ensure routes are correct')
-                logger.warn('Primary interface examination will retry silently')
+                logger.warning('Primary interface examination will retry silently')
                 self.disable_route_warning = True
         else:
             logger.info('Primary interface is [{0}]'.format(primary_interface))

--- a/azurelinuxagent/common/osutil/gaia.py
+++ b/azurelinuxagent/common/osutil/gaia.py
@@ -59,7 +59,7 @@ class GaiaOSUtil(DefaultOSUtil):
         return ret, out
 
     def useradd(self, username, expiration=None, comment=None):
-        logger.warn('useradd is not supported on GAiA')
+        logger.warning('useradd is not supported on GAiA')
 
     def chpasswd(self, username, password, crypt_id=6, salt_len=10):
         logger.info('chpasswd')
@@ -147,7 +147,7 @@ class GaiaOSUtil(DefaultOSUtil):
             username, (path, thumbprint, value))
 
     def eject_dvd(self, chk_err=True):
-        logger.warn('eject is not supported on GAiA')
+        logger.warning('eject is not supported on GAiA')
 
     def mount(self, device, mount_point, option=None, chk_err=True):
         if not option:
@@ -196,13 +196,13 @@ class GaiaOSUtil(DefaultOSUtil):
         return ret
 
     def set_hostname(self, hostname):
-        logger.warn('set_hostname is ignored on GAiA')
+        logger.warning('set_hostname is ignored on GAiA')
 
     def set_dhcp_hostname(self, hostname):
-        logger.warn('set_dhcp_hostname is ignored on GAiA')
+        logger.warning('set_dhcp_hostname is ignored on GAiA')
 
     def publish_hostname(self, hostname, recover_nic=False):
-        logger.warn('publish_hostname is ignored on GAiA')
+        logger.warning('publish_hostname is ignored on GAiA')
 
     def del_account(self, username):
-        logger.warn('del_account is ignored on GAiA')
+        logger.warning('del_account is ignored on GAiA')

--- a/azurelinuxagent/common/osutil/iosxe.py
+++ b/azurelinuxagent/common/osutil/iosxe.py
@@ -55,7 +55,7 @@ class IosxeOSUtil(DefaultOSUtil):
         try:
             shellutil.run_command(hostnamectl_cmd)
         except Exception as e:
-            logger.warn("[{0}] failed with error: {1}, attempting fallback".format(' '.join(hostnamectl_cmd), ustr(e)))
+            logger.warning("[{0}] failed with error: {1}, attempting fallback".format(' '.join(hostnamectl_cmd), ustr(e)))
             DefaultOSUtil.set_hostname(self, hostname)
 
     def publish_hostname(self, hostname, recover_nic=False):

--- a/azurelinuxagent/common/osutil/nsbsd.py
+++ b/azurelinuxagent/common/osutil/nsbsd.py
@@ -83,13 +83,13 @@ class NSBSDOSUtil(FreeBSDOSUtil):
         """
         Create user account with 'username'
         """
-        logger.warn("User creation disabled")
+        logger.warning("User creation disabled")
 
     def del_account(self, username):
-        logger.warn("User deletion disabled")
+        logger.warning("User deletion disabled")
 
     def conf_sudoer(self, username, nopasswd=False, remove=False):
-        logger.warn("Sudo is not enabled")
+        logger.warning("Sudo is not enabled")
 
     def chpasswd(self, username, password, crypt_id=6, salt_len=10):
         self._run_command_raising_OSUtilError(["/usr/Firewall/sbin/fwpasswd", "-p", password],
@@ -110,7 +110,7 @@ class NSBSDOSUtil(FreeBSDOSUtil):
                                                    ["/usr/Firewall/.ssh/authorized_keys", thumbprint, value])
 
     def del_root_password(self):
-        logger.warn("Root password deletion disabled")
+        logger.warning("Root password deletion disabled")
 
     def start_dhcp_service(self):
         shellutil.run("/usr/Firewall/sbin/nstart dhclient", chk_err=False)

--- a/azurelinuxagent/common/osutil/openbsd.py
+++ b/azurelinuxagent/common/osutil/openbsd.py
@@ -259,7 +259,7 @@ class OpenBSDOSUtil(DefaultOSUtil):
                 if existing is not None:
                     logger.info("{0} is mounted at {1}", dvd_device, existing)
                     return
-                logger.warn("Mount DVD failed: retry={0}, ret={1}", retry,
+                logger.warning("Mount DVD failed: retry={0}, ret={1}", retry,
                             retcode)
                 time.sleep(sleep_time)
         if chk_err:

--- a/azurelinuxagent/common/osutil/openwrt.py
+++ b/azurelinuxagent/common/osutil/openwrt.py
@@ -36,7 +36,7 @@ class OpenWRTOSUtil(DefaultOSUtil):
     _ip_command_output = re.compile(r'^\d+:\s+(\w+):\s+(.*)$')
 
     def eject_dvd(self, chk_err=True):
-        logger.warn('eject is not supported on OpenWRT')
+        logger.warning('eject is not supported on OpenWRT')
 
     def useradd(self, username, expiration=None, comment=None):
         """
@@ -130,7 +130,7 @@ class OpenWRTOSUtil(DefaultOSUtil):
         if os.path.exists("/etc/init.d/sshd"):
             return shellutil.run("/etc/init.d/sshd restart", chk_err=True)
         else:
-            logger.warn("sshd service does not exists")
+            logger.warning("sshd service does not exists")
 
     def stop_agent_service(self):
         return shellutil.run("/etc/init.d/{0} stop".format(self.service_name), chk_err=True)

--- a/azurelinuxagent/common/osutil/redhat.py
+++ b/azurelinuxagent/common/osutil/redhat.py
@@ -126,7 +126,7 @@ class RedhatOSUtil(Redhat6xOSUtil):
         try:
             shellutil.run_command(hostnamectl_cmd, log_error=False)
         except shellutil.CommandError:
-            logger.warn("[{0}] failed, attempting fallback".format(' '.join(hostnamectl_cmd)))
+            logger.warning("[{0}] failed, attempting fallback".format(' '.join(hostnamectl_cmd)))
             DefaultOSUtil.set_hostname(self, hostname)
 
     def get_nm_controlled(self, ifname):
@@ -145,9 +145,9 @@ class RedhatOSUtil(Redhat6xOSUtil):
             # Log warning for any other exit code.
             # NM_CONTROLLED=y by default if not specified.
             if e.returncode != 1:
-                logger.warn("[{0}] failed: {1}.\nAgent will continue to publish hostname without NetworkManager restart".format(' '.join(nm_controlled_cmd), e))
+                logger.warning("[{0}] failed: {1}.\nAgent will continue to publish hostname without NetworkManager restart".format(' '.join(nm_controlled_cmd), e))
         except Exception as e:
-            logger.warn("Unexpected error while retrieving value of NM_CONTROLLED in {0}: {1}.\nAgent will continue to publish hostname without NetworkManager restart".format(filepath, e))
+            logger.warning("Unexpected error while retrieving value of NM_CONTROLLED in {0}: {1}.\nAgent will continue to publish hostname without NetworkManager restart".format(filepath, e))
 
         return True
 
@@ -160,24 +160,24 @@ class RedhatOSUtil(Redhat6xOSUtil):
         nic_general_state_cmd = ['nmcli', '-g', 'general.state', 'device', 'show', ifname]
         if not os.path.isfile(filepath):
             msg = "Unable to determine primary network interface {0} state, because state file does not exist: {1}".format(ifname, filepath)
-            logger.warn(msg)
+            logger.warning(msg)
             raise Exception(msg)
 
         try:
             nic_oper_state = fileutil.read_file(filepath).rstrip().lower()
             nic_general_state = shellutil.run_command(nic_general_state_cmd, log_error=True).rstrip().lower()
             if nic_oper_state != "up":
-                logger.warn("The primary network interface {0} operational state is '{1}'.".format(ifname, nic_oper_state))
+                logger.warning("The primary network interface {0} operational state is '{1}'.".format(ifname, nic_oper_state))
             else:
                 logger.info("The primary network interface {0} operational state is '{1}'.".format(ifname, nic_oper_state))
             if nic_general_state != "100 (connected)":
-                logger.warn("The primary network interface {0} general state is '{1}'.".format(ifname, nic_general_state))
+                logger.warning("The primary network interface {0} general state is '{1}'.".format(ifname, nic_general_state))
             else:
                 logger.info("The primary network interface {0} general state is '{1}'.".format(ifname, nic_general_state))
             return nic_oper_state, nic_general_state
         except Exception as e:
             msg = "Unexpected error while determining the primary network interface state: {0}".format(e)
-            logger.warn(msg)
+            logger.warning(msg)
             raise Exception(msg)
 
     def check_and_recover_nic_state(self, ifname):
@@ -200,7 +200,7 @@ class RedhatOSUtil(Redhat6xOSUtil):
             # down, disconnected, up, or connected
             if nic_operstate != "up" or nic_general_state != "100 (connected)":
                 msg = "Network Manager restart failed to bring network interface {0} into 'up' and 'connected' state".format(ifname)
-                logger.warn(msg)
+                logger.warning(msg)
                 raise Exception(msg)
             else:
                 logger.info("Network Manager restart successfully brought the network interface {0} into 'up' and 'connected' state".format(ifname))
@@ -279,12 +279,12 @@ class RedhatOSModernUtil(RedhatOSUtil):
             return_code = shellutil.run("ip link set {0} down && ip link set {0} up".format(ifname))
             if return_code == 0:
                 return
-            logger.warn("failed to restart {0}: return code {1}".format(ifname, return_code))
+            logger.warning("failed to restart {0}: return code {1}".format(ifname, return_code))
             if attempt < retry_limit:
                 logger.info("retrying in {0} seconds".format(wait))
                 time.sleep(wait)
             else:
-                logger.warn("exceeded restart retries")
+                logger.warning("exceeded restart retries")
 
     def check_and_recover_nic_state(self, ifname):
         # TODO: Implement and test a way to recover the network interface for RedhatOSModernUtil

--- a/azurelinuxagent/common/osutil/suse.py
+++ b/azurelinuxagent/common/osutil/suse.py
@@ -92,7 +92,7 @@ class SUSEOSUtil(SUSE11OSUtil):
                     logger.info("retrying in {0} seconds".format(wait))
                     time.sleep(wait)
                 else:
-                    logger.warn("exceeded restart retries")
+                    logger.warning("exceeded restart retries")
 
     @staticmethod
     def get_systemd_unit_file_install_path():

--- a/azurelinuxagent/common/osutil/ubuntu.py
+++ b/azurelinuxagent/common/osutil/ubuntu.py
@@ -106,12 +106,12 @@ class Ubuntu18OSUtil(Ubuntu16OSUtil):
                 shellutil.run_command(["systemctl", "restart", "systemd-networkd"])
 
             except shellutil.CommandError as cmd_err:
-                logger.warn("failed to restart systemd-networkd: return code {1}".format(cmd_err.returncode))
+                logger.warning("failed to restart systemd-networkd: return code {1}".format(cmd_err.returncode))
                 if attempt < retry_limit:
                     logger.info("retrying in {0} seconds".format(wait))
                     time.sleep(wait)
                 else:
-                    logger.warn("exceeded restart retries")
+                    logger.warning("exceeded restart retries")
 
     def get_dhcp_pid(self):
         return self._get_dhcp_pid(["pidof", "systemd-networkd"])
@@ -173,12 +173,12 @@ class UbuntuOSUtil(Ubuntu16OSUtil):
             return_code = shellutil.run("ip link set {0} down && ip link set {0} up".format(ifname))
             if return_code == 0:
                 return
-            logger.warn("failed to restart {0}: return code {1}".format(ifname, return_code))
+            logger.warning("failed to restart {0}: return code {1}".format(ifname, return_code))
             if attempt < retry_limit:
                 logger.info("retrying in {0} seconds".format(wait))
                 time.sleep(wait)
             else:
-                logger.warn("exceeded restart retries")
+                logger.warning("exceeded restart retries")
 
 
 class UbuntuSnappyOSUtil(Ubuntu14OSUtil):

--- a/azurelinuxagent/common/protocol/extensions_goal_state_from_extensions_config.py
+++ b/azurelinuxagent/common/protocol/extensions_goal_state_from_extensions_config.py
@@ -105,7 +105,7 @@ class ExtensionsGoalStateFromExtensionsConfig(ExtensionsGoalState):
             add_event(op=WALAEventOperation.ArtifactsProfileBlob, message=message, is_success=True, log_event=False)
 
         def log_warning(message):
-            logger.warn(message)
+            logger.warning(message)
             add_event(op=WALAEventOperation.ArtifactsProfileBlob, message=message, is_success=False, log_event=False)
 
         artifacts_profile_blob = gettext(artifacts_profile_blob_xml_node)
@@ -429,7 +429,7 @@ class ExtensionsGoalStateFromExtensionsConfig(ExtensionsGoalState):
             try:
                 depends_on_level = int(getattrib(depends_on_node, "dependencyLevel"))
             except (ValueError, TypeError):
-                logger.warn("Could not parse dependencyLevel for handler {0}. Setting it to 0".format(name))
+                logger.warning("Could not parse dependencyLevel for handler {0}. Setting it to 0".format(name))
                 depends_on_level = 0
         return depends_on_level
 

--- a/azurelinuxagent/common/protocol/extensions_goal_state_from_vm_settings.py
+++ b/azurelinuxagent/common/protocol/extensions_goal_state_from_vm_settings.py
@@ -529,7 +529,7 @@ class ExtensionsGoalStateFromVmSettings(ExtensionsGoalState):
             if length > 1:
                 raise Exception('dependsOn should be an array with exactly one item for single-config extensions ({0}) (got {1})'.format(extension.name, depends_on))
             if length == 0:
-                logger.warn('dependsOn is an empty array for extension {0}; setting the dependency level to 0'.format(extension.name))
+                logger.warning('dependsOn is an empty array for extension {0}; setting the dependency level to 0'.format(extension.name))
                 dependency_level = 0
             else:
                 dependency_level = depends_on[0]['dependencyLevel']
@@ -538,7 +538,7 @@ class ExtensionsGoalStateFromVmSettings(ExtensionsGoalState):
                     # TODO: Consider removing this check and its telemetry after a few releases if we do not receive any telemetry indicating
                     #       that dependsOnExtension is actually missing from the vmSettings
                     message = 'Missing dependsOnExtension on extension {0}'.format(extension.name)
-                    logger.warn(message)
+                    logger.warning(message)
                     add_event(WALAEventOperation.ProvisionAfterExtensions, message=message, is_success=False, log_event=False)
                 else:
                     message = '{0} depends on {1}'.format(extension.name, depends_on_extension)
@@ -546,7 +546,7 @@ class ExtensionsGoalStateFromVmSettings(ExtensionsGoalState):
                     add_event(WALAEventOperation.ProvisionAfterExtensions, message=message, is_success=True, log_event=False)
             if len(extension.settings) == 0:
                 message = 'Extension {0} does not have any settings. Will ignore dependency (dependency level: {1})'.format(extension.name, dependency_level)
-                logger.warn(message)
+                logger.warning(message)
                 add_event(WALAEventOperation.ProvisionAfterExtensions, message=message, is_success=False, log_event=False)
             else:
                 extension.settings[0].dependencyLevel = dependency_level

--- a/azurelinuxagent/common/protocol/goal_state.py
+++ b/azurelinuxagent/common/protocol/goal_state.py
@@ -324,7 +324,7 @@ class GoalState(object):
                 except Exception as e:
                     message = "Unable to download certificates. Goal state processing will continue, some " \
                               "extensions requiring certificates may fail. Error: {0}".format(ustr(e))
-                    self.logger.warn(message)
+                    self.logger.warning(message)
                     add_event(op=WALAEventOperation.GoalState, is_success=False, message=message)
 
     def _restore_wire_server_goal_state(self, incarnation, xml_text, xml_doc, vm_settings_support_stopped_error):
@@ -462,7 +462,7 @@ class GoalState(object):
                 try:
                     fileutil.write_file(shared_config_file, xml_text)
                 except Exception as e:
-                    logger.warn("Failed to save {0}: {1}".format(shared_config, e))
+                    logger.warning("Failed to save {0}: {1}".format(shared_config, e))
 
             certs = EmptyCertificates()
             certs_uri = findtext(xml_doc, "Certificates")
@@ -491,7 +491,7 @@ class GoalState(object):
             return extensions_config
 
         except Exception as exception:
-            self.logger.warn("Fetching the goal state failed: {0}", ustr(exception))
+            self.logger.warning("Fetching the goal state failed: {0}", ustr(exception))
             raise ProtocolError(msg="Error fetching goal state", inner=exception)
         finally:
             message = 'Fetch goal state from WireServer completed'

--- a/azurelinuxagent/common/protocol/healthservice.py
+++ b/azurelinuxagent/common/protocol/healthservice.py
@@ -155,7 +155,7 @@ class HealthService(object):
             restutil.http_post(self.endpoint, self.as_json, headers={'Content-Type': 'application/json'})
             logger.verbose('HealthService: Reported observations to {0}: {1}', self.endpoint, self.as_json)
         except HttpError as e:
-            logger.warn("HealthService: could not report observations: {0}", ustr(e))
+            logger.warning("HealthService: could not report observations: {0}", ustr(e))
         finally:
             # report any failures via telemetry
             self._report_failures()

--- a/azurelinuxagent/common/protocol/hostplugin.py
+++ b/azurelinuxagent/common/protocol/hostplugin.py
@@ -428,7 +428,7 @@ class HostPluginProtocol(object):
                 with open(HostPluginProtocol._get_fast_track_state_file(), "w") as file_:
                     json.dump({"timestamp": timestamp}, file_)
         except Exception as e:
-            logger.warn("Error updating the Fast Track state ({0}): {1}", HostPluginProtocol._get_fast_track_state_file(), ustr(e))
+            logger.warning("Error updating the Fast Track state ({0}): {1}", HostPluginProtocol._get_fast_track_state_file(), ustr(e))
 
     @staticmethod
     def clear_fast_track_state():
@@ -437,7 +437,7 @@ class HostPluginProtocol(object):
                 if os.path.exists(HostPluginProtocol._get_fast_track_state_file()):
                     os.remove(HostPluginProtocol._get_fast_track_state_file())
         except Exception as e:
-            logger.warn("Error clearing the current state for Fast Track ({0}): {1}", HostPluginProtocol._get_fast_track_state_file(),
+            logger.warning("Error clearing the current state for Fast Track ({0}): {1}", HostPluginProtocol._get_fast_track_state_file(),
                         ustr(e))
 
     @staticmethod
@@ -455,7 +455,7 @@ class HostPluginProtocol(object):
                 with open(state_file, "r") as file_:
                     return json.load(file_)["timestamp"]
             except Exception as e:
-                logger.warn("Can't retrieve the timestamp for the most recent Fast Track goal state ({0}), will assume the current time. Error: {1}", state_file, ustr(e))
+                logger.warning("Can't retrieve the timestamp for the most recent Fast Track goal state ({0}), will assume the current time. Error: {1}", state_file, ustr(e))
             return timeutil.create_utc_timestamp(datetime.datetime.now(UTC))
 
     def fetch_vm_settings(self, force_update=False):
@@ -475,7 +475,7 @@ class HostPluginProtocol(object):
                 if self._supports_vm_settings:
                     # The most recent goal state was delivered using FastTrack, and suddenly the HostGAPlugin does not support the vmSettings API anymore.
                     # This can happen if, for example, the VM is migrated across host nodes that are running different versions of the HostGAPlugin.
-                    logger.warn("The HostGAPlugin stopped supporting the vmSettings API. If there is a pending FastTrack goal state, it will not be executed.")
+                    logger.warning("The HostGAPlugin stopped supporting the vmSettings API. If there is a pending FastTrack goal state, it will not be executed.")
                     add_event(op=WALAEventOperation.VmSettings, message="[VmSettingsSupportStopped] HostGAPlugin: {0}".format(self._version), is_success=False, log_event=False)
                     raise VmSettingsSupportStopped(self._fast_track_timestamp)
                 else:

--- a/azurelinuxagent/common/protocol/metadata_server_migration_util.py
+++ b/azurelinuxagent/common/protocol/metadata_server_migration_util.py
@@ -130,13 +130,13 @@ def _get_firewall_will_wait():
         output = shellutil.run_command(_get_iptables_version_command())
     except Exception as e:
         msg = "Unable to determine version of iptables: {0}".format(ustr(e))
-        logger.warn(msg)
+        logger.warning(msg)
         raise Exception(msg)
 
     m = _IPTABLES_VERSION_PATTERN.match(output)
     if m is None:
         msg = "iptables did not return version information: {0}".format(output)
-        logger.warn(msg)
+        logger.warning(msg)
         raise Exception(msg)
 
     wait = "-w" \

--- a/azurelinuxagent/common/protocol/ovfenv.py
+++ b/azurelinuxagent/common/protocol/ovfenv.py
@@ -76,7 +76,7 @@ class OvfEnv(object):
         _validate_ovf(version, "Version not found")
 
         if version > OVF_VERSION:
-            logger.warn("Newer provisioning configuration detected. "
+            logger.warning("Newer provisioning configuration detected. "
                         "Please consider updating waagent")
         
         conf_set = find(section, "LinuxProvisioningConfigurationSet", 

--- a/azurelinuxagent/common/protocol/util.py
+++ b/azurelinuxagent/common/protocol/util.py
@@ -110,7 +110,7 @@ class ProtocolUtil(SingletonPerThread):
             self.osutil.umount_dvd()
             self.osutil.eject_dvd()
         except OSUtilError as e:
-            logger.warn(ustr(e))
+            logger.warning(ustr(e))
 
     def get_ovf_env(self):
         """

--- a/azurelinuxagent/common/protocol/wire.py
+++ b/azurelinuxagent/common/protocol/wire.py
@@ -728,13 +728,13 @@ class WireClient(object):
                 try:
                     shutil.rmtree(target_directory)
                 except Exception as rmtree_exception:
-                    logger.warn("Cannot delete {0}: {1}", target_directory, ustr(rmtree_exception))
+                    logger.warning("Cannot delete {0}: {1}", target_directory, ustr(rmtree_exception))
             raise
         finally:
             try:
                 os.remove(target_file)
             except Exception as exception:
-                logger.warn("Cannot delete {0}: {1}", target_file, ustr(exception))
+                logger.warning("Cannot delete {0}: {1}", target_file, ustr(exception))
 
     def stream(self, uri, destination, headers=None, use_proxy=None):
         """
@@ -758,7 +758,7 @@ class WireClient(object):
                 try:
                     os.remove(destination)
                 except Exception as exception:
-                    logger.warn("Can't delete {0}: {1}", destination, ustr(exception))
+                    logger.warning("Can't delete {0}: {1}", destination, ustr(exception))
             raise
 
     def fetch(self, uri, headers=None, use_proxy=None, decode=True, retry_codes=None, ok_codes=None):
@@ -790,7 +790,7 @@ class WireClient(object):
             if restutil.request_failed(resp, ok_codes=ok_codes):
                 error_response = restutil.read_response_error(resp)
                 msg = "Fetch failed from [{0}]: {1}".format(uri, error_response)
-                logger.warn(msg)
+                logger.warning(msg)
 
                 if host_plugin is not None:
                     host_plugin.report_fetch_health(uri,
@@ -804,7 +804,7 @@ class WireClient(object):
 
         except (HttpError, ProtocolError, IOError) as error:
             msg = "Fetch failed: {0}".format(error)
-            logger.warn(msg)
+            logger.warning(msg)
             report_event(op=WALAEventOperation.HttpGet, is_success=False, message=msg, log_event=False)
             raise
 
@@ -1146,7 +1146,7 @@ class WireClient(object):
                 events_per_provider[event.providerId] += 1
 
             except Exception as error:
-                logger.warn("Unexpected error when generating Events:{0}", textutil.format_exception(error))
+                logger.warning("Unexpected error when generating Events:{0}", textutil.format_exception(error))
 
         # Send out all events left in buffer.
         for provider_id in list(buf.keys()):

--- a/azurelinuxagent/common/utils/archive.py
+++ b/azurelinuxagent/common/utils/archive.py
@@ -162,7 +162,7 @@ class StateArchiver(object):
                 fileutil.mkdir(self._source, mode=0o700)
             except IOError as exception:
                 if exception.errno != errno.EEXIST:
-                    logger.warn("{0} : {1}", self._source, exception.strerror)
+                    logger.warning("{0} : {1}", self._source, exception.strerror)
 
     @staticmethod
     def purge_legacy_goal_state_history():
@@ -180,7 +180,7 @@ class StateArchiver(object):
                     try:
                         os.remove(full_path)
                     except Exception as e:
-                        logger.warn("Cannot delete legacy history file '{0}': {1}".format(full_path, e))
+                        logger.warning("Cannot delete legacy history file '{0}': {1}".format(full_path, e))
                     break
 
     def archive(self):
@@ -239,7 +239,7 @@ class GoalStateHistory(object):
         except Exception as e:
             if not self._errors:  # report only 1 error per directory
                 self._errors = True
-                logger.warn("Failed to save {0} to the goal state history: {1} [no additional errors saving the goal state will be reported]".format(file_name, e))
+                logger.warning("Failed to save {0} to the goal state history: {1} [no additional errors saving the goal state will be reported]".format(file_name, e))
 
     _purge_error_count = 0
 
@@ -274,9 +274,9 @@ class GoalStateHistory(object):
         except Exception as e:
             GoalStateHistory._purge_error_count += 1
             if GoalStateHistory._purge_error_count < 5:
-                logger.warn("Failed to clean up the goal state history directory: {0}".format(e))
+                logger.warning("Failed to clean up the goal state history directory: {0}".format(e))
             elif GoalStateHistory._purge_error_count == 5:
-                logger.warn("Failed to clean up the goal state history directory [will stop reporting these errors]: {0}".format(e))
+                logger.warning("Failed to clean up the goal state history directory [will stop reporting these errors]: {0}".format(e))
 
 
     @staticmethod
@@ -290,7 +290,7 @@ class GoalStateHistory(object):
             with open(placeholder, "w") as handle:
                 handle.write("<xml>empty placeholder file</xml>")
         except Exception as e:
-            logger.warn("Failed to save placeholder file ({0}): {1}".format(_PLACEHOLDER_FILE_NAME, e))
+            logger.warning("Failed to save placeholder file ({0}): {1}".format(_PLACEHOLDER_FILE_NAME, e))
 
     def save_goal_state(self, text):
         self.save(text, _GOAL_STATE_FILE_NAME)

--- a/azurelinuxagent/common/utils/restutil.py
+++ b/azurelinuxagent/common/utils/restutil.py
@@ -399,7 +399,7 @@ def http_request(method,
 
         secure = False
         if not SECURE_WARNING_EMITTED:
-            logger.warn("Python does not include SSL support")
+            logger.warning("Python does not include SSL support")
             SECURE_WARNING_EMITTED = True
 
     # If httplib module doesn't support HTTPS tunnelling,
@@ -414,7 +414,7 @@ def http_request(method,
 
         secure = False
         if not SECURE_WARNING_EMITTED:
-            logger.warn("Python does not support HTTPS tunnelling")
+            logger.warning("Python does not support HTTPS tunnelling")
             SECURE_WARNING_EMITTED = True
 
     msg = ''
@@ -677,5 +677,5 @@ def read_response_error(resp):
             result = textutil.replace_non_ascii(result)
 
         except Exception as e:
-            logger.warn(textutil.format_exception(e))
+            logger.warning(textutil.format_exception(e))
     return result

--- a/azurelinuxagent/daemon/main.py
+++ b/azurelinuxagent/daemon/main.py
@@ -85,7 +85,7 @@ class DaemonHandler(object):
                 err_msg = textutil.format_exception(e)
                 add_event(name=AGENT_NAME, is_success=False, message=ustr(err_msg),
                           op=WALAEventOperation.UnhandledError)
-                logger.warn("Daemon ended with exception -- Sleep 15 seconds and restart daemon")
+                logger.warning("Daemon ended with exception -- Sleep 15 seconds and restart daemon")
                 time.sleep(15)
 
     def check_pid(self):
@@ -105,8 +105,8 @@ class DaemonHandler(object):
         agent_disabled_file_path = conf.get_disable_agent_file_path()
         if os.path.exists(agent_disabled_file_path):
             import threading
-            logger.warn("Disabling the guest agent by sleeping forever; to re-enable, remove {0} and restart".format(agent_disabled_file_path))
-            logger.warn("To enable VM extensions, also ensure that the VM's osProfile.allowExtensionOperations property is set to true.")
+            logger.warning("Disabling the guest agent by sleeping forever; to re-enable, remove {0} and restart".format(agent_disabled_file_path))
+            logger.warning("To enable VM extensions, also ensure that the VM's osProfile.allowExtensionOperations property is set to true.")
             self.running = False
             disable_event = threading.Event()
             disable_event.wait()

--- a/azurelinuxagent/daemon/resourcedisk/default.py
+++ b/azurelinuxagent/daemon/resourcedisk/default.py
@@ -72,7 +72,7 @@ class ResourceDiskHandler(object):
             try:
                 fileutil.write_file(warning_file, DATA_LOSS_WARNING)
             except IOError as e:
-                logger.warn("Failed to write data loss warning:{0}", e)
+                logger.warning("Failed to write data loss warning:{0}", e)
             return mount_point
         except ResourceDiskError as e:
             logger.error("Failed to mount resource disk {0}", e)
@@ -184,21 +184,21 @@ class ResourceDiskHandler(object):
         ret, output = shellutil.run_get_output(mount_string, chk_err=False)
         # if the exit code is 32, then the resource disk can be already mounted
         if ret == 32 and output.find("is already mounted") != -1:
-            logger.warn("Could not mount resource disk: {0}", output)
+            logger.warning("Could not mount resource disk: {0}", output)
         elif ret != 0:
             # Some kernels seem to issue an async partition re-read after a
             # 'parted' command invocation. This causes mount to fail if the
             # partition re-read is not complete by the time mount is
             # attempted. Seen in CentOS 7.2. Force a sequential re-read of
             # the partition and try mounting.
-            logger.warn("Failed to mount resource disk. "
+            logger.warning("Failed to mount resource disk. "
                         "Retry mounting after re-reading partition info.")
 
             self.reread_partition_table(device)
 
             ret, output = shellutil.run_get_output(mount_string, chk_err=False)
             if ret:
-                logger.warn("Failed to mount resource disk. "
+                logger.warning("Failed to mount resource disk. "
                             "Attempting to format and retry mount. [{0}]",
                             output)
 

--- a/azurelinuxagent/daemon/resourcedisk/openwrt.py
+++ b/azurelinuxagent/daemon/resourcedisk/openwrt.py
@@ -37,7 +37,7 @@ class OpenWRTResourceDiskHandler(ResourceDiskHandler):
     def reread_partition_table(self, device):
         ret, output = shellutil.run_get_output("hdparm -z {0}".format(device), chk_err=False)  # pylint: disable=W0612
         if ret != 0:
-            logger.warn("Failed refresh the partition table.")
+            logger.warning("Failed refresh the partition table.")
 
     def mount_resource_disk(self, mount_point):
         device = self.osutil.device_for_ide_port(1)
@@ -101,7 +101,7 @@ class OpenWRTResourceDiskHandler(ResourceDiskHandler):
             raise ResourceDiskError("Partition was not created [{0}]".format(partition))
 
         if os.path.ismount(mount_point):
-            logger.warn("Disk is already mounted on {0}", mount_point)
+            logger.warning("Disk is already mounted on {0}", mount_point)
         else:
             # Some kernels seem to issue an async partition re-read after a
             # command invocation. This causes mount to fail if the
@@ -115,7 +115,7 @@ class OpenWRTResourceDiskHandler(ResourceDiskHandler):
             logger.info("Mount resource disk [{0}]", mount_string)
             ret, output = shellutil.run_get_output(mount_string)
             if ret:
-                logger.warn("Failed to mount resource disk. "
+                logger.warning("Failed to mount resource disk. "
                             "Attempting to format and retry mount. [{0}]",
                             output)
 

--- a/azurelinuxagent/ga/agent_update_handler.py
+++ b/azurelinuxagent/ga/agent_update_handler.py
@@ -214,7 +214,7 @@ class AgentUpdateHandler(object):
                 error_msg = "Unable to update Agent: {0}".format(textutil.format_exception(err))
             if log_error:
                 error_msg = "[{0}]{1}".format(self.get_current_update_mode(), error_msg)
-                logger.warn(error_msg)
+                logger.warning(error_msg)
                 add_event(op=WALAEventOperation.AgentUpgrade, is_success=False, message=error_msg, log_event=False)
             self._last_attempted_update_error_msg = error_msg
 
@@ -240,6 +240,6 @@ class AgentUpdateHandler(object):
                 return VMAgentUpdateStatus(expected_version=str(CURRENT_VERSION), status=status, code=code, message=self._last_attempted_update_error_msg)
         except Exception as err:
             msg = "Unable to report agent update status: {0}".format(textutil.format_exception(err))
-            logger.warn(msg)
+            logger.warning(msg)
             add_event(op=WALAEventOperation.AgentUpgrade, is_success=False, message=msg, log_event=True)
         return None

--- a/azurelinuxagent/ga/cgroupconfigurator.py
+++ b/azurelinuxagent/ga/cgroupconfigurator.py
@@ -358,7 +358,7 @@ class CGroupConfigurator(object):
                         self._reset_cpu_quota(systemd.get_agent_unit_name())
 
             except Exception as err:
-                logger.warn("Error while resetting the quotas: {0}".format(err))
+                logger.warning("Error while resetting the quotas: {0}".format(err))
 
         @staticmethod
         def _enable_accounting(unit_name):

--- a/azurelinuxagent/ga/collect_logs.py
+++ b/azurelinuxagent/ga/collect_logs.py
@@ -267,7 +267,7 @@ class CollectLogsHandler(ThreadHandlerInterface):
             success = True
         except Exception as e:
             msg = "Failed to upload logs. Error: {0}".format(ustr(e))
-            logger.warn(msg)
+            logger.warning(msg)
         finally:
             add_event(
                 name=AGENT_NAME,

--- a/azurelinuxagent/ga/collect_telemetry_events.py
+++ b/azurelinuxagent/ga/collect_telemetry_events.py
@@ -101,7 +101,7 @@ class _ProcessExtensionEvents(PeriodicOperation):
     def _operation(self):
 
         if self._send_telemetry_events_handler.stopped():
-            logger.warn("{0} service is not running, skipping current iteration".format(
+            logger.warning("{0} service is not running, skipping current iteration".format(
                 self._send_telemetry_events_handler.get_thread_name()))
             return
 
@@ -163,7 +163,7 @@ class _ProcessExtensionEvents(PeriodicOperation):
             msg = "Skipping file: {0} as its size is {1:.2f} Mb > Max size allowed {2:.1f} Mb".format(
                 event_file_path, convert_to_mb(event_file_size),
                 convert_to_mb(self._EXTENSION_EVENT_FILE_MAX_SIZE))
-            logger.warn(msg)
+            logger.warning(msg)
             add_log_event(level=logger.LogLevel.WARNING, message=msg, forced=True)
             return False
         return True
@@ -203,7 +203,7 @@ class _ProcessExtensionEvents(PeriodicOperation):
                     if captured_extension_events_count >= self._MAX_NUMBER_OF_EVENTS_PER_EXTENSION_PER_PERIOD:
                         msg = "Reached max count for the extension: {0}; Max Limit: {1}. Skipping the rest.".format(
                             handler_name, self._MAX_NUMBER_OF_EVENTS_PER_EXTENSION_PER_PERIOD)
-                        logger.warn(msg)
+                        logger.warning(msg)
                         add_log_event(level=logger.LogLevel.WARNING, message=msg, forced=True)
                         break
                 except ServiceStoppedError:
@@ -214,7 +214,7 @@ class _ProcessExtensionEvents(PeriodicOperation):
                 except Exception as error:
                     msg = "Failed to process event file {0}:{1}".format(event_file,
                                                                               textutil.format_exception(error))
-                    logger.warn(msg)
+                    logger.warning(msg)
                     add_log_event(level=logger.LogLevel.WARNING, message=msg, forced=True)
                 finally:
                     # Todo: We should delete files after ensuring that we sent the data to Wireserver successfully
@@ -226,7 +226,7 @@ class _ProcessExtensionEvents(PeriodicOperation):
             if dropped_events_with_error_count:
                 msg = "Dropped events for Extension: {0}; Details:\n\t{1}".format(handler_name, '\n\t'.join(
                     ["Reason: {0}; Dropped Count: {1}".format(k, v) for k, v in dropped_events_with_error_count.items()]))
-                logger.warn(msg)
+                logger.warning(msg)
                 add_log_event(level=logger.LogLevel.WARNING, message=msg, forced=True)
 
             if captured_extension_events_count > 0:
@@ -311,7 +311,7 @@ class _ProcessExtensionEvents(PeriodicOperation):
                         ustr(stopped_error)))
                 raise
             except Exception as error:
-                logger.warn("Unable to parse and transmit event, error: {0}".format(error))
+                logger.warning("Unable to parse and transmit event, error: {0}".format(error))
 
             if captured_events_count >= self._MAX_NUMBER_OF_EVENTS_PER_EXTENSION_PER_PERIOD:
                 break
@@ -433,7 +433,7 @@ class _CollectAndEnqueueEvents(PeriodicOperation):
         """
         try:
             if self._send_telemetry_events_handler.stopped():
-                logger.warn("{0} service is not running, skipping iteration.".format(
+                logger.warning("{0} service is not running, skipping iteration.".format(
                     self._send_telemetry_events_handler.get_thread_name()))
                 return
             self.process_events()
@@ -627,7 +627,7 @@ class CollectTelemetryEventsHandler(ThreadHandlerInterface):
                     periodic_op.run()
 
             except Exception as error:
-                logger.warn(
+                logger.warning(
                     "An error occurred in the Telemetry Extension thread main loop; will skip the current iteration.\n{0}",
                     ustr(error))
             finally:

--- a/azurelinuxagent/ga/env.py
+++ b/azurelinuxagent/ga/env.py
@@ -90,7 +90,7 @@ class MonitorDhcpClientRestart(PeriodicOperation):
             pid = sorted(self.osutil.get_dhcp_pid())
 
             if len(pid) == 0 and self.dhcp_warning_enabled:
-                logger.warn("Dhcp client is not running.")
+                logger.warning("Dhcp client is not running.")
         except Exception as exception:
             if self.dhcp_warning_enabled:
                 logger.error("Failed to get the PID of the DHCP client: {0}", ustr(exception))

--- a/azurelinuxagent/ga/extensionprocessutil.py
+++ b/azurelinuxagent/ga/extensionprocessutil.py
@@ -127,12 +127,12 @@ def _check_noexec():
                 flags = columns[3]
                 if agent_dir.startswith(mount_point) and "noexec" in flags:
                     message = "The noexec flag is set on {0}. This can prevent extensions from executing.".format(mount_point)
-                    logger.warn(message)
+                    logger.warning(message)
                     add_event(op=WALAEventOperation.NoExec, is_success=False, message=message)
                     return mount_point
     except Exception as e:
         message = "Error while checking the noexec flag: {0}".format(e)
-        logger.warn(message)
+        logger.warning(message)
         if _COLLECT_NOEXEC_ERRORS:
             _COLLECT_NOEXEC_ERRORS = False
             add_event(op=WALAEventOperation.NoExec, is_success=False, log_event=False, message="Error while checking the noexec flag: {0}".format(e))
@@ -212,6 +212,6 @@ def get_cpu_throttled_time(cpu_controller):
         try:
             throttled_time = cpu_controller.get_cpu_throttled_time(read_previous_throttled_time=False)
         except Exception as e:
-            logger.warn("Failed to get cpu throttled time for the extension: {0}", ustr(e))
+            logger.warning("Failed to get cpu throttled time for the extension: {0}", ustr(e))
 
     return throttled_time

--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -245,7 +245,7 @@ def migrate_handler_state():
                     try:
                         shutil.move(from_path, to_path)
                     except Exception as e:
-                        logger.warn(
+                        logger.warning(
                             "Exception occurred migrating {0} {1} file: {2}",
                             handler,
                             file,
@@ -254,7 +254,7 @@ def migrate_handler_state():
     try:
         shutil.rmtree(handler_state_path)
     except Exception as e:
-        logger.warn("Exception occurred removing {0}: {1}", handler_state_path, str(e))
+        logger.warning("Exception occurred removing {0}: {1}", handler_state_path, str(e))
     return
 
 
@@ -373,7 +373,7 @@ class ExtHandlersHandler(object):
             unsupported_features = self.__get_unsupported_features()
             if any(unsupported_features):
                 msg = "Failing GS {0} as Unsupported features found: {1}".format(goal_state_id, ', '.join(unsupported_features))
-                logger.warn(msg)
+                logger.warning(msg)
                 self.__gs_aggregate_status = GoalStateAggregateStatus(status=GoalStateStatus.Failed, seq_no=svd_sequence_number,
                                                                       code=GoalStateAggregateStatusCodes.GoalStateUnsupportedRequiredFeatures,
                                                                       message=msg)
@@ -391,7 +391,7 @@ class ExtHandlersHandler(object):
             self.__gs_aggregate_status = GoalStateAggregateStatus(status=GoalStateStatus.Failed, seq_no=svd_sequence_number,
                                                                   code=GoalStateAggregateStatusCodes.GoalStateUnknownFailure,
                                                                   message=msg)
-            logger.warn(msg)
+            logger.warning(msg)
             add_event(op=WALAEventOperation.ExtensionProcessing,
                       is_success=False,
                       message=msg,
@@ -451,7 +451,7 @@ class ExtHandlersHandler(object):
                 os.remove(pkg)
                 logger.verbose("Removed orphaned extension package {0}".format(pkg))
             except OSError as e:
-                logger.warn("Failed to remove orphaned package {0}: {1}".format(pkg, e.strerror))
+                logger.warning("Failed to remove orphaned package {0}: {1}".format(pkg, e.strerror))
 
         # Finally, remove the directories and packages of the orphaned handlers, i.e. Any extension directory that
         # is still in the FileSystem but not in the GoalState
@@ -463,7 +463,7 @@ class ExtHandlersHandler(object):
                     os.remove(pkg)
                     logger.verbose("Removed extension package {0}".format(pkg))
                 except OSError as e:
-                    logger.warn("Failed to remove extension package {0}: {1}".format(pkg, e.strerror))
+                    logger.warning("Failed to remove extension package {0}: {1}".format(pkg, e.strerror))
 
     def _extensions_on_hold(self):
         if conf.get_enable_overprovisioning():
@@ -606,7 +606,7 @@ class ExtHandlersHandler(object):
                     self.wait_for_handler_completion(handler_i, wait_until, extension=extension)
 
                 except Exception as error:
-                    logger.warn(
+                    logger.warning(
                         "Dependent extension {0} failed or timed out, will skip processing the rest of the extensions".format(
                             extension_full_name))
                     depends_on_err_msg = ustr(error)
@@ -1000,7 +1000,7 @@ class ExtHandlersHandler(object):
             except Exception as error:
                 # Log error once per goal state
                 if goal_state_changed:
-                    logger.warn("Can't fetch ExtHandler from path: {0}; Error: {1}".format(path, ustr(error)))
+                    logger.warning("Can't fetch ExtHandler from path: {0}; Error: {1}".format(path, ustr(error)))
 
         return handlers_to_report
 
@@ -1065,7 +1065,7 @@ class ExtHandlersHandler(object):
 
         except Exception as error:
             msg = u"Failed to report status: {0}".format(textutil.format_exception(error))
-            logger.warn(msg)
+            logger.warning(msg)
             add_event(AGENT_NAME,
                       version=CURRENT_VERSION,
                       op=WALAEventOperation.ReportStatus,
@@ -1222,7 +1222,7 @@ class ExtHandlerInstance(object):
                     if is_file_not_found_error(cleanup_exception):
                         logger.info("File '{0}' does not exist.", f)
                     else:
-                        logger.warn("Exception occurred while attempting to remove file '{0}': {1}", f,
+                        logger.warning("Exception occurred while attempting to remove file '{0}': {1}", f,
                                     cleanup_exception)
 
     def decide_version(self, target_state, extension, gs_activity_id):
@@ -1263,7 +1263,7 @@ class ExtHandlerInstance(object):
             if installed_pkg is None:
                 msg = "Failed to find installed version: {0} of Handler: {1}  in handler manifest to uninstall.".format(
                     installed_version, self.ext_handler.name)
-                self.logger.warn(msg)
+                self.logger.warning(msg)
             self.pkg = installed_pkg
             self.ext_handler.version = str(installed_version) \
                 if installed_version is not None else None
@@ -1731,7 +1731,7 @@ class ExtHandlerInstance(object):
         except IOError as e:
             message = "Failed to remove extension handler directory: {0}".format(e)
             self.report_event(message=message, is_success=False)
-            self.logger.warn(message)
+            self.logger.warning(message)
 
     def update(self, handler_version=None, disable_exit_codes=None, updating_from_version=None, extension=None):
         # For Handler level operations, extension just specifies the settings that initiated the update.
@@ -1969,7 +1969,7 @@ class ExtHandlerInstance(object):
         # Since this code is called on a loop, logging as a warning only on goal state change, else logging it
         # as verbose
         if goal_state_changed:
-            logger.warn(log_msg)
+            logger.warning(log_msg)
             add_event(name=self.get_extension_full_name(extension), version=self.ext_handler.version,
                       op=op, message=event_msg, is_success=False, log_event=False)
         else:
@@ -2273,7 +2273,7 @@ class ExtHandlerInstance(object):
             extension_name = self.get_extension_full_name(extension)
             message = "Failed to remove extension state files for {0}: {1}".format(extension_name, ustr(error))
             self.report_event(name=extension_name, message=message, is_success=False, log_event=False)
-            self.logger.warn(message)
+            self.logger.warning(message)
 
     def set_handler_status(self, status=ExtHandlerStatusValue.not_ready, message="", code=0):
         state_dir = self.get_conf_dir()

--- a/azurelinuxagent/ga/firewall_manager.py
+++ b/azurelinuxagent/ga/firewall_manager.py
@@ -128,7 +128,7 @@ class FirewallManager(object):
             return shellutil.run_command(self._get_state_command())
         except Exception as e:
             message = "Failed to get the current state of the firewall rules: {0}".format(ustr(e))
-            logger.warn("Listing firewall rules failed: {0}".format(ustr(e)))
+            logger.warning("Listing firewall rules failed: {0}".format(ustr(e)))
             return message
 
     def _get_state_command(self):

--- a/azurelinuxagent/ga/ga_version_updater.py
+++ b/azurelinuxagent/ga/ga_version_updater.py
@@ -123,7 +123,7 @@ class GAVersionUpdater(object):
                 if os.path.isdir(agent_dir):
                     shutil.rmtree(agent_dir, ignore_errors=True)
             except Exception as err:
-                logger.warn("Unable to delete Agent directory: {0}".format(err))
+                logger.warning("Unable to delete Agent directory: {0}".format(err))
             raise AgentUpdateError("Downloaded agent package: {0} is missing agent handler manifest file: {1}".format(agent_name, agent_handler_manifest_file))
 
     def download_and_get_new_agent(self, protocol, agent_family, goal_state):
@@ -180,4 +180,4 @@ class GAVersionUpdater(object):
                         logger.info(u"Purging outdated Agent directory {0}", agent_path)
                         shutil.rmtree(agent_path)
             except Exception as e:
-                logger.warn(u"Purging {0} raised exception: {1}", agent_path, ustr(e))
+                logger.warning(u"Purging {0} raised exception: {1}", agent_path, ustr(e))

--- a/azurelinuxagent/ga/guestagent.py
+++ b/azurelinuxagent/ga/guestagent.py
@@ -63,7 +63,7 @@ class GuestAgent(object):
                 if os.path.isdir(self.get_agent_dir()):
                     shutil.rmtree(self.get_agent_dir(), ignore_errors=True)
             except Exception as err:
-                logger.warn("Unable to delete Agent files: {0}".format(err))
+                logger.warning("Unable to delete Agent files: {0}".format(err))
             msg = u"Agent {0} install failed with exception:".format(
                 self.name)
             detailed_msg = '{0} {1}'.format(msg, textutil.format_exception(e))
@@ -137,14 +137,14 @@ class GuestAgent(object):
                 msg = u"Agent {0} is permanently disabled".format(self.name)
                 report_func(WALAEventOperation.AgentDisabled, msg)
         except Exception as e:
-            logger.warn(u"Agent {0} failed recording error state: {1}", self.name, ustr(e))
+            logger.warning(u"Agent {0} failed recording error state: {1}", self.name, ustr(e))
 
     def inc_update_attempt_count(self):
         try:
             self.update_attempt_data.inc_count()
             self.update_attempt_data.save()
         except Exception as e:
-            logger.warn(u"Agent {0} failed recording update attempt: {1}", self.name, ustr(e))
+            logger.warning(u"Agent {0} failed recording update attempt: {1}", self.name, ustr(e))
 
     def get_update_attempt_count(self):
         return self.update_attempt_data.count
@@ -159,7 +159,7 @@ class GuestAgent(object):
             self.error.load()
             logger.verbose(u"Agent {0} error state: {1}", self.name, ustr(self.error))
         except Exception as e:
-            logger.warn(u"Agent {0} failed loading error state: {1}", self.name, ustr(e))
+            logger.warning(u"Agent {0} failed loading error state: {1}", self.name, ustr(e))
 
     def _load_manifest(self):
         path = self.get_agent_manifest_path()
@@ -242,7 +242,7 @@ class GuestAgentError(object):
             except Exception as error:
                 # The error.json file is only supposed to be written only by the agent.
                 # If for whatever reason the file is malformed, just delete it to reset state of the errors.
-                logger.warn(
+                logger.warning(
                     "Ran into error when trying to load error file {0}, deleting it to clean state. Error: {1}".format(
                         self.path, textutil.format_exception(error)))
                 try:
@@ -306,7 +306,7 @@ class GuestAgentUpdateAttempt(object):
             except Exception as error:
                 # The update_attempt.json file is only supposed to be written only by the agent.
                 # If for whatever reason the file is malformed, just delete it to reset state of the errors.
-                logger.warn(
+                logger.warning(
                     "Ran into error when trying to load error file {0}, deleting it to clean state. Error: {1}".format(
                         self.path, textutil.format_exception(error)))
                 try:
@@ -349,7 +349,7 @@ class GuestAgentUpdateUtil(object):
                 pass
         except Exception as e:
             msg = "Error creating the initial update state file ({0}): {1}".format(GuestAgentUpdateUtil.get_initial_update_state_file(), ustr(e))
-            logger.warn(msg)
+            logger.warning(msg)
             add_event(op=WALAEventOperation.AgentUpgrade, message=msg, log_event=False)
 
     @staticmethod
@@ -376,7 +376,7 @@ class GuestAgentUpdateUtil(object):
                 pass
         except Exception as e:
             msg = "Error creating the RSM state file ({0}): {1}".format(GuestAgentUpdateUtil.get_rsm_update_state_file(), ustr(e))
-            logger.warn(msg)
+            logger.warning(msg)
             add_event(op=WALAEventOperation.AgentUpgrade, message=msg, log_event=False)
 
     @staticmethod
@@ -389,7 +389,7 @@ class GuestAgentUpdateUtil(object):
                 os.remove(GuestAgentUpdateUtil.get_rsm_update_state_file())
         except Exception as e:
             msg = "Error removing the RSM state file ({0}): {1}".format(GuestAgentUpdateUtil.get_rsm_update_state_file(), ustr(e))
-            logger.warn(msg)
+            logger.warning(msg)
             add_event(op=WALAEventOperation.AgentUpgrade, message=msg, log_event=False)
 
     @staticmethod

--- a/azurelinuxagent/ga/monitor.py
+++ b/azurelinuxagent/ga/monitor.py
@@ -140,7 +140,7 @@ class ReportNetworkConfigurationChanges(PeriodicOperation):
             if network_interfaces != '':
                 logger.info("Network interfaces:\n{0}", network_interfaces)
         except Exception as exception:
-            logger.warn("Error fetching the network configuration: {0}", ustr(exception))
+            logger.warning("Error fetching the network configuration: {0}", ustr(exception))
 
     def _operation(self):
         raw_route_list = self.osutil.read_route_table()

--- a/azurelinuxagent/ga/periodic_operation.py
+++ b/azurelinuxagent/ga/periodic_operation.py
@@ -51,7 +51,7 @@ class PeriodicOperation(object):
         except Exception as e:
             warning = "Error in {0}: {1} --- [NOTE: Will not log the same error for the next hour]".format(self._name, ustr(e))
             if warning != self._last_warning or self._last_warning_time is None or datetime.datetime.now(UTC) >= self._last_warning_time + self._LOG_WARNING_PERIOD:
-                logger.warn(warning)
+                logger.warning(warning)
                 self._last_warning_time = datetime.datetime.now(UTC)
                 self._last_warning = warning
 

--- a/azurelinuxagent/ga/persist_firewall_rules.py
+++ b/azurelinuxagent/ga/persist_firewall_rules.py
@@ -188,7 +188,7 @@ if __name__ == '__main__':
                 try:
                     fileutil.rm_files(old_service_file_path)
                 except Exception as error:
-                    logger.warn("Unable to delete old service in image mode {0}: {1}".format(self._network_setup_service_name, ustr(error)))
+                    logger.warning("Unable to delete old service in image mode {0}: {1}".format(self._network_setup_service_name, ustr(error)))
 
         self.__setup_binary_file()
 
@@ -218,7 +218,7 @@ if __name__ == '__main__':
                                                               py_path=sys.executable))
             logger.info("Successfully updated the Binary file {0} for firewall setup".format(binary_file_path))
         except Exception:
-            logger.warn(
+            logger.warning(
                 "Unable to setup binary file, removing the service unit file {0} to ensure its not run on system reboot".format(
                     self.get_service_file_path()))
             self.__remove_file_without_raising(binary_file_path)
@@ -256,7 +256,7 @@ if __name__ == '__main__':
             try:
                 os.remove(file_path)
             except Exception as error:
-                logger.warn("Unable to delete file: {0}; Error: {1}".format(file_path, ustr(error)))
+                logger.warning("Unable to delete file: {0}; Error: {1}".format(file_path, ustr(error)))
 
     def __verify_network_setup_service_failed(self):
         # Check if the agent-network-setup.service failed in its last run
@@ -287,11 +287,11 @@ if __name__ == '__main__':
         except CommandError as error:
             msg = "Unable to fetch service logs, Command: {0} failed with ExitCode: {1}\nStdout: {2}\nStderr: {3}".format(
                 ' '.join(cmd), error.returncode, error.stdout, error.stderr)
-            logger.warn(msg)
+            logger.warning(msg)
         except Exception as e:
             msg = "Ran into unexpected error when getting logs for {0} service. Error: {1}".format(
                 self._network_setup_service_name, textutil.format_exception(e))
-            logger.warn(msg)
+            logger.warning(msg)
 
         # Log service status and logs if we can fetch them from journalctl and send it to Kusto,
         # else just log the error of the failure of fetching logs

--- a/azurelinuxagent/ga/rsm_version_updater.py
+++ b/azurelinuxagent/ga/rsm_version_updater.py
@@ -136,7 +136,7 @@ class RSMVersionUpdater(GAVersionUpdater):
                 add_event(op=WALAEventOperation.AgentUpgrade, message=msg, log_event=False)
                 current_agent.mark_failure(is_fatal=True, reason=msg, report_func=event.info)
             except StopIteration:
-                logger.warn(
+                logger.warning(
                     "Could not find a matching agent with current version {0} to blacklist, skipping it".format(
                         CURRENT_VERSION))
         else:

--- a/azurelinuxagent/ga/signature_validation_util.py
+++ b/azurelinuxagent/ga/signature_validation_util.py
@@ -129,7 +129,7 @@ def _report_validation_event(op, level, message, name, version, duration):
         is_success = False
     elif level == logger.LogLevel.WARNING:
         message = "{0}\nThis failure can be safely ignored; will continue processing the package.".format(message)
-        logger.warn(message)
+        logger.warning(message)
         event_msg = "[WARNING] {0}".format(message)
         is_success = False
     else:

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -202,7 +202,7 @@ class UpdateHandler(object):
         both_auto_updates_used = conf.is_present("AutoUpdate.Enabled") and conf.is_present("AutoUpdate.UpdateToLatestVersion")
         if both_auto_updates_used:
             msg = u"The legacy AutoUpdate.Enabled configuration is also used, but it is ignored in favor of the new configuration (AutoUpdate.UpdateToLatestVersion)."
-            logger.warn(msg)
+            logger.warning(msg)
             add_event(
                 AGENT_NAME,
                 version=CURRENT_VERSION,
@@ -288,14 +288,14 @@ class UpdateHandler(object):
                             agent_name,
                             agent_cmd,
                             ret)
-                        logger.warn(msg)
+                        logger.warning(msg)
 
             else:
                 msg = u"Agent {0} launched with command '{1}' failed with return code: {2}".format(
                     agent_name,
                     agent_cmd,
                     ret)
-                logger.warn(msg)
+                logger.warning(msg)
                 add_event(
                     AGENT_NAME,
                     version=agent_version,
@@ -309,7 +309,7 @@ class UpdateHandler(object):
                 msg = u"Agent {0} launched with command '{1}' failed with exception: \n".format(
                     agent_name,
                     agent_cmd)
-                logger.warn(msg)
+                logger.warning(msg)
                 detailed_message = '{0} {1}'.format(msg, textutil.format_exception(e))
                 add_event(
                     AGENT_NAME,
@@ -433,8 +433,8 @@ class UpdateHandler(object):
         except Exception as error:
             msg = u"Agent {0} failed with exception: {1}".format(CURRENT_AGENT, ustr(error))
             self._set_sentinel(msg=msg)
-            logger.warn(msg)
-            logger.warn(textutil.format_exception(error))
+            logger.warning(msg)
+            logger.warning(textutil.format_exception(error))
             sys.exit(1)
             # additional return here because sys.exit is mocked in unit tests
             return  # pylint: disable=unreachable
@@ -521,7 +521,7 @@ class UpdateHandler(object):
         # Check that all the threads are still running
         for thread_handler in all_thread_handlers:
             if thread_handler.keep_alive() and not thread_handler.is_alive():
-                logger.warn("{0} thread died, restarting".format(thread_handler.get_thread_name()))
+                logger.warning("{0} thread died, restarting".format(thread_handler.get_thread_name()))
                 thread_handler.start()
 
     def _try_update_goal_state(self, protocol):
@@ -640,7 +640,7 @@ class UpdateHandler(object):
             if self._processing_new_extensions_goal_state():
                 if not self._extensions_summary.converged:
                     message = "A new goal state was received, but not all the extensions in the previous goal state have completed: {0}".format(self._extensions_summary)
-                    logger.warn(message)
+                    logger.warning(message)
                     add_event(op=WALAEventOperation.GoalState, message=message, is_success=False, log_event=False)
                     if self._is_initial_goal_state:
                         self._on_initial_goal_state_completed(self._extensions_summary)
@@ -672,14 +672,14 @@ class UpdateHandler(object):
             archiver = StateArchiver(conf.get_lib_dir())
             archiver.archive()
         except Exception as exception:
-            logger.warn("Error cleaning up the goal state history: {0}", ustr(exception))
+            logger.warning("Error cleaning up the goal state history: {0}", ustr(exception))
 
     @staticmethod
     def _cleanup_legacy_goal_state_history():
         try:
             StateArchiver.purge_legacy_goal_state_history()
         except Exception as exception:
-            logger.warn("Error removing legacy history files: {0}", ustr(exception))
+            logger.warning("Error removing legacy history files: {0}", ustr(exception))
 
     def _report_status(self, exthandlers_handler, agent_update_handler):
         # report_ext_handlers_status does its own error handling and returns None if an error occurred
@@ -716,7 +716,7 @@ class UpdateHandler(object):
             if self._report_status_last_failed_goal_state != self._goal_state.extensions_goal_state.id:
                 self._report_status_last_failed_goal_state = self._goal_state.extensions_goal_state.id
                 msg = u"Error logging the goal state summary: {0}".format(textutil.format_exception(error))
-                logger.warn(msg)
+                logger.warning(msg)
                 add_event(op=WALAEventOperation.GoalState, is_success=False, message=msg)
 
     def _on_initial_goal_state_completed(self, extensions_summary):
@@ -830,7 +830,7 @@ class UpdateHandler(object):
 
             if conf.is_present("AutoUpdate.Enabled") and conf.get_autoupdate_enabled() != conf.get_auto_update_to_latest_version():
                 msg = "AutoUpdate.Enabled property is **Deprecated** now but it's set to different value from AutoUpdate.UpdateToLatestVersion. Please consider removing it if added by mistake"
-                logger.warn(msg)
+                logger.warning(msg)
                 add_event(AGENT_NAME, op=WALAEventOperation.ConfigurationChange, message=msg)
 
             if conf.enable_firewall():
@@ -848,7 +848,7 @@ class UpdateHandler(object):
             log_if_agent_versioning_feature_disabled()
 
         except Exception as e:
-            logger.warn("Failed to log changes in configuration: {0}", ustr(e))
+            logger.warning("Failed to log changes in configuration: {0}", ustr(e))
 
     def _ensure_no_orphans(self, orphan_wait_interval=ORPHAN_WAIT_INTERVAL):
         pid_files, ignored = self._write_pid_file()  # pylint: disable=W0612
@@ -860,7 +860,7 @@ class UpdateHandler(object):
                 while self.osutil.check_pid_alive(pid):
                     wait_interval -= ORPHAN_POLL_INTERVAL
                     if wait_interval <= 0:
-                        logger.warn(
+                        logger.warning(
                             u"{0} forcibly terminated orphan process {1}",
                             CURRENT_AGENT,
                             pid)
@@ -876,7 +876,7 @@ class UpdateHandler(object):
                 os.remove(pid_file)
 
             except Exception as e:
-                logger.warn(
+                logger.warning(
                     u"Exception occurred waiting for orphan agent to terminate: {0}",
                     ustr(e))
         return
@@ -932,7 +932,7 @@ class UpdateHandler(object):
             self._set_and_sort_agents(self._load_agents())
             self._filter_blacklisted_agents()
         except Exception as e:
-            logger.warn(u"Exception occurred loading available agents: {0}", ustr(e))
+            logger.warning(u"Exception occurred loading available agents: {0}", ustr(e))
         return
 
     def _get_pid_parts(self):
@@ -1002,7 +1002,7 @@ class UpdateHandler(object):
                         logger.info(u"Purging outdated Agent directory {0}", agent_path)
                         shutil.rmtree(agent_path)
             except Exception as e:
-                logger.warn(u"Purging {0} raised exception: {1}", agent_path, ustr(e))
+                logger.warning(u"Purging {0} raised exception: {1}", agent_path, ustr(e))
         return
 
     def _set_and_sort_agents(self, agents=None):
@@ -1018,7 +1018,7 @@ class UpdateHandler(object):
                 self._sentinel_file_path(),
                 "[{0}] [{1}]".format(agent, msg))
         except Exception as e:
-            logger.warn(
+            logger.warning(
                 u"Exception writing sentinel file {0}: {1}",
                 self._sentinel_file_path(),
                 str(e))
@@ -1042,7 +1042,7 @@ class UpdateHandler(object):
         try:
             os.remove(self._sentinel_file_path())
         except Exception as e:
-            logger.warn(
+            logger.warning(
                 u"Exception removing sentinel file {0}: {1}",
                 self._sentinel_file_path(),
                 str(e))
@@ -1064,7 +1064,7 @@ class UpdateHandler(object):
             logger.info(u"{0} running as process {1}", CURRENT_AGENT, ustr(os.getpid()))
         except Exception as e:
             pid_file = None
-            logger.warn(
+            logger.warning(
                 u"Expection writing goal state agent {0} pid to {1}: {2}",
                 CURRENT_AGENT,
                 pid_file,
@@ -1116,7 +1116,7 @@ class UpdateHandler(object):
             if self._check_memory_usage_last_error_report == datetime_min_utc or (self._check_memory_usage_last_error_report + timedelta(hours=6)) > datetime.now(UTC):
                 self._check_memory_usage_last_error_report = datetime.now(UTC)
                 msg = "Error checking the agent's memory usage: {0} --- [NOTE: Will not log the same error for the 6 hours]".format(ustr(exception))
-                logger.warn(msg)
+                logger.warning(msg)
                 add_event(AGENT_NAME, op=WALAEventOperation.AgentMemory, is_success=False, message=msg)
 
     @staticmethod
@@ -1141,7 +1141,7 @@ class UpdateHandler(object):
                     if etp_enabled and not(os.path.exists(events_dir)):
                         fileutil.mkdir(events_dir, mode=0o700)
             except Exception as e:
-                logger.warn(
+                logger.warning(
                     "Unable to re-create HandlerEnvironment file on service startup. Error: {0}".format(ustr(e)))
                 continue
 
@@ -1153,7 +1153,7 @@ class UpdateHandler(object):
                 for ext_dir in extension_event_dirs:
                     shutil.rmtree(ext_dir, ignore_errors=True)
         except Exception as e:
-            logger.warn("Error when trying to delete existing Extension events directory. Error: {0}".format(ustr(e)))
+            logger.warning("Error when trying to delete existing Extension events directory. Error: {0}".format(ustr(e)))
 
     @staticmethod
     def _initialize_firewall(wire_server_address):

--- a/azurelinuxagent/pa/provision/cloudinit.py
+++ b/azurelinuxagent/pa/provision/cloudinit.py
@@ -95,7 +95,7 @@ class CloudInitProvisionHandler(ProvisionHandler):
                                                     max_retry - retry,
                                                     sleep_time))
                         if not cloud_init_is_enabled():
-                            logger.warn("cloud-init does not appear to be enabled")
+                            logger.warning("cloud-init does not appear to be enabled")
                         logging_interval = min(logging_interval * 2, max_logging_interval)
                     time.sleep(sleep_time)
         raise ProvisionError("Giving up, ovf-env.xml was not copied to {0} "
@@ -118,7 +118,7 @@ class CloudInitProvisionHandler(ProvisionHandler):
                     logger.info("Thumbprint obtained from : {0}".format(path))
                     return thumbprint
                 except ProvisionError:
-                    logger.warn("Could not get thumbprint from {0}".format(path))
+                    logger.warning("Could not get thumbprint from {0}".format(path))
             if retry < max_retry - 1:
                 if retry % logging_interval == 0:
                     logger.info("Waiting for ssh host key be generated at {0} "
@@ -127,7 +127,7 @@ class CloudInitProvisionHandler(ProvisionHandler):
                                                         max_retry - retry,
                                                         sleep_time))
                     if not cloud_init_is_enabled():
-                        logger.warn("cloud-init does not appear to be running")
+                        logger.warning("cloud-init does not appear to be running")
                     logging_interval = min(logging_interval * 2, max_logging_interval)
                 time.sleep(sleep_time)
         raise ProvisionError("Giving up, ssh host key was not found at {0} "

--- a/azurelinuxagent/pa/provision/default.py
+++ b/azurelinuxagent/pa/provision/default.py
@@ -175,7 +175,7 @@ class ProvisionHandler(object):
                 msg = "VM is provisioned, but the VM unique identifier has changed. This indicates the VM may be " \
                       "created from an image that was not properly deprovisioned or generalized, which can result in " \
                       "unexpected behavior from the guest agent -- clearing cached state"
-                logger.warn(msg)
+                logger.warning(msg)
                 self.report_event(msg)
                 from azurelinuxagent.pa.deprovision \
                     import get_deprovision_handler
@@ -194,7 +194,7 @@ class ProvisionHandler(object):
 
     @staticmethod
     def write_agent_disabled():
-        logger.warn("Disabling guest agent in accordance with ovf-env.xml")
+        logger.warning("Disabling guest agent in accordance with ovf-env.xml")
         fileutil.write_file(conf.get_disable_agent_file_path(), '')
 
     def handle_provision_guest_agent(self, provision_guest_agent):

--- a/azurelinuxagent/pa/rdma/rdma.py
+++ b/azurelinuxagent/pa/rdma/rdma.py
@@ -256,7 +256,7 @@ class RDMADeviceHandler(object):
             else:
                 logger.info("RDMA: hv_network_direct driver version not present, assuming 4.0.x or older.")
         else:
-            logger.warn("RDMA: failed to get module info on hv_network_direct.")
+            logger.warning("RDMA: failed to get module info on hv_network_direct.")
 
         if not skip_rdma_device:
             RDMADeviceHandler.wait_rdma_device(

--- a/tests/common/test_logger.py
+++ b/tests/common/test_logger.py
@@ -414,7 +414,7 @@ class TestLogger(AgentTestCase):
         logger.add_logger_appender(logger.AppenderType.TELEMETRY, logger.LogLevel.WARNING, path=add_log_event)
         logger.set_prefix(prefix)
 
-        logger.warn('Test Log - Warning')
+        logger.warning('Test Log - Warning')
 
         event_files = os.listdir(__event_logger__.event_dir)
         self.assertEqual(1, len(event_files))
@@ -438,7 +438,7 @@ class TestLogger(AgentTestCase):
         logger.add_logger_appender(logger.AppenderType.TELEMETRY, logger.LogLevel.WARNING, path=add_log_event)
 
         for i in range(MAX_NUMBER_OF_EVENTS):
-            logger.warn('Test Log - {0} - 1 - Warning'.format(i))
+            logger.warning('Test Log - {0} - 1 - Warning'.format(i))
 
         exception_caught = False
 
@@ -448,7 +448,7 @@ class TestLogger(AgentTestCase):
         # The description of the fix is given in the comments @ azurelinuxagent.common.logger.Logger#log.write_log.
         try:
             for i in range(10):
-                logger.warn('Test Log - {0} - 2 - Warning'.format(i))
+                logger.warning('Test Log - {0} - 2 - Warning'.format(i))
         except RuntimeError:
             exception_caught = True
 
@@ -474,7 +474,7 @@ class TestLogger(AgentTestCase):
         # 1000 events into the events dir, and then drop the remaining events. It should not generate the RuntimeError
         try:
             for i in range(0, no_of_log_statements):
-                logger.warn('Test Log - {0} - 1 - Warning'.format(i))
+                logger.warning('Test Log - {0} - 1 - Warning'.format(i))
         except RuntimeError:
             exception_caught = True
 
@@ -526,7 +526,7 @@ class TestAppender(AgentTestCase):
 
         logger.verbose("test-verbose")
         logger.info("test-info")
-        logger.warn("test-warn")
+        logger.warning("test-warn")
         logger.error("test-error")
 
         # Validating Console and File logs
@@ -555,7 +555,7 @@ class TestAppender(AgentTestCase):
             self.assertEqual(0, len(logcontent))
 
         # As console has a mode of w, it'll always only have 1 line only.
-        logger.warn("test-warn")
+        logger.warning("test-warn")
         with open(self.log_file) as logfile:
             logcontent = logfile.readlines()
             self.assertEqual(1, len(logcontent))
@@ -572,7 +572,7 @@ class TestAppender(AgentTestCase):
         logger.add_logger_appender(logger.AppenderType.FILE, logger.LogLevel.INFO, path=self.log_file)
         logger.verbose("test-verbose")
         logger.info("test-info")
-        logger.warn("test-warn")
+        logger.warning("test-warn")
         logger.error("test-error")
 
         with open(self.log_file) as logfile:
@@ -589,7 +589,7 @@ class TestAppender(AgentTestCase):
         logger.add_logger_appender(logger.AppenderType.TELEMETRY, logger.LogLevel.WARNING, path=add_log_event)
         logger.verbose("test-verbose")
         logger.info("test-info")
-        logger.warn("test-warn")
+        logger.warning("test-warn")
         logger.error("test-error")
 
         self.assertEqual(2, mock_add_log_event.call_count)
@@ -599,7 +599,7 @@ class TestAppender(AgentTestCase):
         logger.add_logger_appender(logger.AppenderType.STDOUT, logger.LogLevel.ERROR)
         logger.verbose("test-verbose")
         logger.info("test-info")
-        logger.warn("test-warn")
+        logger.warning("test-warn")
         logger.error("test-error")
 
         # Validating only test-error gets logged and not others.


### PR DESCRIPTION
Replaces all instances of deprecated `logger.warn()` with `logger.warning()` to resolve Python 3.13+ deprecation warnings.