### PR TITLE
Fix unit tests for publishing lower agent versions

### DIFF
--- a/tests/data/wire/ga_manifest.xml
+++ b/tests/data/wire/ga_manifest.xml
@@ -20,6 +20,9 @@
             </Uris>
         </Plugin>
         <Plugin>
+            <Version>1.5.0</Version><Uris><Uri>http://mock-goal-state/ga-manifests/OSTCExtensions.WALinuxAgent__1.5.0</Uri></Uris>
+        </Plugin>
+        <Plugin>
             <Version>2.0.0</Version><Uris><Uri>http://mock-goal-state/ga-manifests/OSTCExtensions.WALinuxAgent__2.0.0</Uri></Uris>
         </Plugin>
         <Plugin>

--- a/tests/ga/test_agent_update_handler.py
+++ b/tests/ga/test_agent_update_handler.py
@@ -12,6 +12,7 @@ from azurelinuxagent.common.future import ustr, httpclient, datetime_min_utc
 from azurelinuxagent.common.protocol.wire import GoalState, GoalStateProperties
 from azurelinuxagent.common.protocol.restapi import VMAgentUpdateStatuses
 from azurelinuxagent.common.protocol.util import ProtocolUtil
+from azurelinuxagent.common.utils.flexible_version import FlexibleVersion
 from azurelinuxagent.common.version import CURRENT_VERSION, AGENT_NAME
 from azurelinuxagent.ga.agent_update_handler import get_agent_update_handler
 from azurelinuxagent.ga.guestagent import GuestAgent, INITIAL_UPDATE_STATE_FILE, RSM_UPDATE_STATE_FILE
@@ -320,7 +321,7 @@ class TestAgentUpdate(UpdateTestCase):
         self.prepare_agents()
         self.assertEqual(20, self.agent_count(), "Agent directories not set properly")
 
-        downgrade_version = "2.5.0"
+        downgrade_version = "1.5.0"
 
         with self._get_agent_update_handler(test_data=data_file) as (agent_update_handler, mock_telemetry):
             agent_update_handler._protocol.mock_wire_data.set_version_in_agent_family(downgrade_version)
@@ -342,7 +343,7 @@ class TestAgentUpdate(UpdateTestCase):
         self.prepare_agents()
         self.assertEqual(20, self.agent_count(), "Agent directories not set properly")
 
-        downgrade_version = "2.5.0"
+        downgrade_version = "1.5.0"
         from_version = "3.0.0"
 
         with self._get_agent_update_handler(test_data=data_file) as (agent_update_handler, mock_telemetry):
@@ -368,7 +369,7 @@ class TestAgentUpdate(UpdateTestCase):
         self.prepare_agents()
         self.assertEqual(20, self.agent_count(), "Agent directories not set properly")
 
-        downgrade_version = "2.5.0"
+        downgrade_version = "1.5.0"
 
         with self._get_agent_update_handler(test_data=data_file) as (agent_update_handler, mock_telemetry):
             agent_update_handler._protocol.mock_wire_data.set_version_in_agent_family(downgrade_version)
@@ -472,27 +473,41 @@ class TestAgentUpdate(UpdateTestCase):
             package_version = args[0].version
             raise ExtensionDownloadError("Failed to download WALinuxAgent-{0} from all URIs".format(package_version))
 
+        # Versions in ga_manifest_no_uris.xml that are greater than CURRENT_VERSION should each be attempted,
+        # in descending order. All earlier attempts should emit "trying next largest version", and the final
+        # (smallest) attempt should emit the terminal "[SelfUpdate] Unable to update Agent" error.
+        all_manifest_versions = ["1.0.0", "1.1.0", "1.2.0", "2.0.0", "2.1.0", "9.9.9.10", "99999.0.0.0"]
+        candidates = sorted(
+            [v for v in all_manifest_versions if FlexibleVersion(v) > CURRENT_VERSION],
+            key=FlexibleVersion, reverse=True)
+        self.assertGreaterEqual(len(candidates), 2, "Test requires at least 2 candidate versions greater than current")
+        last_candidate = candidates[-1]
+
         with self._get_agent_update_handler(test_data=data_file) as (agent_update_handler, mock_telemetry):
             with patch("azurelinuxagent.ga.ga_version_updater.GAVersionUpdater.download_new_agent_pkg", side_effect=download_side_effect) as mock_download_new_agent:
                 agent_update_handler.run(GoalState(agent_update_handler._protocol.client, GoalStateProperties.ExtensionsGoalState), True)
                 self._assert_update_discovered_from_agent_manifest(mock_telemetry, version="99999.0.0.0")
+                # All non-terminal candidates should emit "trying next largest version"
+                for version in candidates[:-1]:
+                    self.assertEqual(1, len([kwarg['message'] for _, kwarg in mock_telemetry.call_args_list if
+                                             "Self-update: failed to prepare version {0} for update, trying next largest version".format(version) in kwarg['message'] and kwarg[
+                                                 'op'] == WALAEventOperation.AgentUpgrade]),
+                                                    "{0} download should have failed".format(version))
+                    self._assert_update_discovered_from_agent_manifest(mock_telemetry, version=version)
+                # The last (smallest) candidate should fail with the terminal error
+                self._assert_update_discovered_from_agent_manifest(mock_telemetry, version=last_candidate)
                 self.assertEqual(1, len([kwarg['message'] for _, kwarg in mock_telemetry.call_args_list if
-                                         "Self-update: failed to prepare version 99999.0.0.0 for update, trying next largest version" in kwarg['message'] and kwarg[
+                                         "[SelfUpdate] Unable to update Agent: [ExtensionDownloadError] Failed to download WALinuxAgent-{0} from all URIs".format(last_candidate) in kwarg['message'] and kwarg[
                                              'op'] == WALAEventOperation.AgentUpgrade]),
-                                                "99999.0.0.0 download should have failed")
-                self._assert_update_discovered_from_agent_manifest(mock_telemetry, version="9.9.9.10")
-                self.assertEqual(1, len([kwarg['message'] for _, kwarg in mock_telemetry.call_args_list if
-                                         "[SelfUpdate] Unable to update Agent: [ExtensionDownloadError] Failed to download WALinuxAgent-9.9.9.10 from all URIs" in kwarg['message'] and kwarg[
-                                             'op'] == WALAEventOperation.AgentUpgrade]),
-                                                "9.9.9.10 download should have failed and been raised as error")
+                                                "{0} download should have failed and been raised as error".format(last_candidate))
                 self._assert_agent_directories_exist_and_others_dont_exist(versions=[str(CURRENT_VERSION)])
-                self.assertEqual(2, mock_download_new_agent.call_count)
+                self.assertEqual(len(candidates), mock_download_new_agent.call_count)
 
     def test_it_should_not_update_to_version_if_version_not_from_rsm(self):
         self.prepare_agents(count=1)
         data_file = DATA_FILE.copy()
         data_file["ext_conf"] = "wire/ext_conf_version_not_from_rsm.xml"
-        downgrade_version = "2.5.0"
+        downgrade_version = "1.5.0"
 
         with self._get_agent_update_handler(test_data=data_file) as (agent_update_handler, mock_telemetry):
             agent_update_handler._protocol.mock_wire_data.set_version_in_agent_family(downgrade_version)

--- a/tests/ga/test_update.py
+++ b/tests/ga/test_update.py
@@ -1795,7 +1795,7 @@ class TestAgentUpgrade(UpdateTestCase):
 
     def test_it_should_mark_current_agent_as_bad_version_on_downgrade(self):
         no_of_iterations = 100
-        downgrade_version = "2.5.0"
+        downgrade_version = "1.5.0"
 
         self.prepare_agents(count=1)
         self.assertTrue(os.path.exists(self.agent_dir(CURRENT_VERSION)))


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->
<!--
Please add an informative description that covers that changes made by the pull request.
-->
## Description
Some RSM unit tests have a requirement that the agent version is greater than 2.5.0

We need to publish multiple agent versions < 2.5.0 for e2e testing: 1.6.0.0, 2.3.17.0, 2.3.17.1

This PR updates the unit tests so that they will run/pass as expecting when agent version is greater than 1.5

Issue # <!-- if any -->
---
<!--
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->
### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).
---
<!--
This checklist is used to track contributions from distro maintainers.
-->
### Distro maintenance information, if applicable
- [ ] This is a contribution from a distro maintainer
- [ ] The changes in this PR have been taken as a downstream patch (Note: it is not recommended to patch the agent without upstream review and approval)
