### PR TITLE
Check whether the Agent is in the expected Control Group

### DIFF
--- a/azurelinuxagent/ga/cgroupapi.py
+++ b/azurelinuxagent/ga/cgroupapi.py
@@ -715,9 +715,6 @@ class Cgroup(object):
     def get_controllers(self):
         """
         Cgroup version specific. Returns a list of the agent supported controllers which are mounted/enabled for the cgroup.
-
-        :param expected_relative_path: The expected relative path of the cgroup. If provided, only controllers mounted
-        at this expected path will be returned.
         """
         raise NotImplementedError()
 

--- a/azurelinuxagent/ga/cgroupapi.py
+++ b/azurelinuxagent/ga/cgroupapi.py
@@ -712,7 +712,7 @@ class Cgroup(object):
         """
         raise NotImplementedError()
 
-    def get_controllers(self, expected_relative_path=None):
+    def get_controllers(self):
         """
         Cgroup version specific. Returns a list of the agent supported controllers which are mounted/enabled for the cgroup.
 
@@ -754,7 +754,7 @@ class CgroupV1(Cgroup):
 
         return in_expected_slice
 
-    def get_controllers(self, expected_relative_path=None):
+    def get_controllers(self):
         controllers = []
 
         for supported_controller_name in self.get_supported_controller_names():
@@ -770,12 +770,6 @@ class CgroupV1(Cgroup):
             if controller_path is None:
                 log_cgroup_warning("{0} is not mounted for the {1} cgroup; will not track".format(supported_controller_name, self._cgroup_name))
                 continue
-
-            if expected_relative_path is not None:
-                expected_path = os.path.join(controller_mountpoint, expected_relative_path)
-                if controller_path != expected_path:
-                    log_cgroup_info("The {0} controller is not mounted at the expected path for the {1} cgroup; will not track. Actual cgroup path:[{2}] Expected:[{3}]".format(supported_controller_name, self._cgroup_name, controller_path, expected_path))
-                    continue
 
             if supported_controller_name == self.CPU_CONTROLLER:
                 controller = CpuControllerV1(self._cgroup_name, controller_path)
@@ -830,7 +824,7 @@ class CgroupV2(Cgroup):
 
         return True
 
-    def get_controllers(self, expected_relative_path=None):
+    def get_controllers(self):
         controllers = []
 
         for supported_controller_name in self.get_supported_controller_names():
@@ -845,14 +839,6 @@ class CgroupV2(Cgroup):
             if self._cgroup_path == "":
                 log_cgroup_warning("Cgroup path for {0} cannot be determined; will not track".format(self._cgroup_name))
                 continue
-
-            if expected_relative_path is not None:
-                expected_path = os.path.join(self._root_cgroup_path, expected_relative_path)
-                if self._cgroup_path != expected_path:
-                    log_cgroup_info(
-                        "The {0} cgroup is not mounted at the expected path; will not track. Actual cgroup path:[{1}] Expected:[{2}]".format(
-                            self._cgroup_name, self._cgroup_path, expected_path))
-                    continue
 
             if supported_controller_name == self.CPU_CONTROLLER:
                 controller = CpuControllerV2(self._cgroup_name, self._cgroup_path)

--- a/azurelinuxagent/ga/cgroupconfigurator.py
+++ b/azurelinuxagent/ga/cgroupconfigurator.py
@@ -139,18 +139,19 @@ class CGroupConfigurator(object):
                     self._reset_agent_cgroup_setup()
                     return
 
-                # We check the agent unit 'Slice' property before setting up azure.slice. This check is done first
-                # because the agent's Slice unit property will be 'azure.slice' if the slice drop-in file exists, even
-                # though systemd has not moved the agent to azure.slice yet. Systemd will only move the agent to
-                # azure.slice after a vm restart.
+                # PR #2015 introduced a check to disable cgroups when the Agent is not in the expected cgroup. Telemetry at the time indicated that in a small number of
+                # VMs the Agent was showing up directly under the root cgroup or system.slice. As we started moving the agent to its own slice, the check was eventually
+                # changed to use the Slice property as returned by systemctl show (PR #2160).
+                # Current telemetry doesn't reports any VMs where the Agent shows up in an unexpected Slice. The cgroups logic has had quite a few fixes since the original
+                # check was introduced, and very likely the issue causing the mismatch has been resolved. However, the check using the Slice property is not always accurate,
+                # for example when the dropin file that defines the slice has been created but the Agent service has not been restarted, so the Agent is still in the default
+                # slice.
+                # I am changing the check to use the ControlGroup property instead. Consider removing it after a few releases if telemetry does not show any VMs failing
+                # the check.
                 agent_unit_name = systemd.get_agent_unit_name()
-                try:
-                    agent_control_group = systemd.get_unit_property(agent_unit_name, "ControlGroup")
-                    if agent_control_group not in ("/{0}/{1}".format(AZURE_SLICE, agent_unit_name), "/system.slice/{0}".format(agent_unit_name)):
-                        log_cgroup_warning("The agent is within an unexpected control group: {0}".format(agent_control_group))
-                        return
-                except Exception as exception:
-                    log_cgroup_warning("Unable to verify the agent is in the expected control group; will skip this check: {0}".format(ustr(exception)))
+                agent_control_group = systemd.get_unit_property(agent_unit_name, "ControlGroup")
+                if agent_control_group not in ("/{0}/{1}".format(AZURE_SLICE, agent_unit_name), "/system.slice/{0}".format(agent_unit_name)):
+                    log_cgroup_warning("The agent is within an unexpected control group: {0}".format(agent_control_group))
                     return
 
                 # Before agent setup, cleanup the old agent setup (drop-in files) since new agent uses different approach(systemctl) to setup cgroups.

--- a/azurelinuxagent/ga/cgroupconfigurator.py
+++ b/azurelinuxagent/ga/cgroupconfigurator.py
@@ -144,9 +144,13 @@ class CGroupConfigurator(object):
                 # though systemd has not moved the agent to azure.slice yet. Systemd will only move the agent to
                 # azure.slice after a vm restart.
                 agent_unit_name = systemd.get_agent_unit_name()
-                agent_slice = systemd.get_unit_property(agent_unit_name, "Slice")
-                if agent_slice not in (AZURE_SLICE, "system.slice"):
-                    log_cgroup_warning("The agent is within an unexpected slice: {0}".format(agent_slice))
+                try:
+                    agent_control_group = systemd.get_unit_property(agent_unit_name, "ControlGroup")
+                    if agent_control_group not in ("/{0}/{1}".format(AZURE_SLICE, agent_unit_name), "/system.slice/{0}".format(agent_unit_name)):
+                        log_cgroup_warning("The agent is within an unexpected control group: {0}".format(agent_control_group))
+                        return
+                except Exception as exception:
+                    log_cgroup_warning("Unable to verify the agent is in the expected control group; will skip this check: {0}".format(ustr(exception)))
                     return
 
                 # Before agent setup, cleanup the old agent setup (drop-in files) since new agent uses different approach(systemctl) to setup cgroups.
@@ -168,13 +172,13 @@ class CGroupConfigurator(object):
                 # Get agent cgroup
                 self._agent_cgroup = self._cgroups_api.get_unit_cgroup(unit_name=agent_unit_name, cgroup_name=AGENT_NAME_TELEMETRY)
 
-                if conf.get_cgroup_disable_on_process_check_failure() and self._check_fails_if_processes_found_in_agent_cgroup_before_enable(agent_slice):
+                if conf.get_cgroup_disable_on_process_check_failure() and self._check_fails_if_processes_found_in_agent_cgroup_before_enable():
                     reason = "Found unexpected processes in the agent cgroup before agent enable cgroups."
                     self.disable(reason, DisableCgroups.ALL)
                     return
 
                 # Get controllers to track
-                agent_controllers = self._agent_cgroup.get_controllers(expected_relative_path=os.path.join(agent_slice, agent_unit_name))
+                agent_controllers = self._agent_cgroup.get_controllers()
                 if len(agent_controllers) > 0:
                     self.enable()
                     self._enable_accounting(agent_unit_name)
@@ -538,7 +542,7 @@ class CGroupConfigurator(object):
             except Exception as exception:
                 log_cgroup_warning('Failed to reset resource quota: {0}'.format(ustr(exception)))
 
-        def _check_fails_if_processes_found_in_agent_cgroup_before_enable(self, agent_slice):
+        def _check_fails_if_processes_found_in_agent_cgroup_before_enable(self):
             """
             This check ensures that before we enable the agent's cgroups, there are no unexpected processes in the agent's cgroup already.
 
@@ -547,8 +551,6 @@ class CGroupConfigurator(object):
             2. Disabled agent cgroups due to check_cgroups regular check. Once we disable the cgroups we don't run the extensions in it's own slice, so they will be in agent cgroups.
             3. When ext_hanlder restart and enable the cgroups again, already running processes from step 2 still be in agent cgroups. This may cause the extensions run with agent limit.
             """
-            if agent_slice not in (AZURE_SLICE, "system.slice"):
-                return False
             try:
                 log_cgroup_info("Checking for unexpected processes in the agent's cgroup before enabling cgroups")
                 self._check_processes_in_agent_cgroup(True)

--- a/azurelinuxagent/ga/cgroupconfigurator.py
+++ b/azurelinuxagent/ga/cgroupconfigurator.py
@@ -142,7 +142,7 @@ class CGroupConfigurator(object):
                 # PR #2015 introduced a check to disable cgroups when the Agent is not in the expected cgroup. Telemetry at the time indicated that in a small number of
                 # VMs the Agent was showing up directly under the root cgroup or system.slice. As we started moving the agent to its own slice, the check was eventually
                 # changed to use the Slice property as returned by systemctl show (PR #2160).
-                # Current telemetry doesn't reports any VMs where the Agent shows up in an unexpected Slice. The cgroups logic has had quite a few fixes since the original
+                # Current telemetry doesn't report any VMs where the Agent shows up in an unexpected Slice. The cgroups logic has had quite a few fixes since the original
                 # check was introduced, and very likely the issue causing the mismatch has been resolved. However, the check using the Slice property is not always accurate,
                 # for example when the dropin file that defines the slice has been created but the Agent service has not been restarted, so the Agent is still in the default
                 # slice.

--- a/tests/ga/test_cgroupapi.py
+++ b/tests/ga/test_cgroupapi.py
@@ -567,21 +567,6 @@ class CgroupsApiv1TestCase(AgentTestCase):
                 controllers = cgroup.get_controllers()
                 self.assertEqual(len(controllers), 0)
 
-    def test_get_controllers_returns_only_controllers_at_expected_path_v1(self):
-        with mock_cgroup_v1_environment(self.tmp_dir):
-            with patch('azurelinuxagent.ga.cgroupapi.SystemdCgroupApiv1._get_process_relative_controller_paths', return_value={'cpu,cpuacct': 'system.slice/walinuxagent.service', 'memory': 'unexpected/path'}):
-                cgroup = create_cgroup_api().get_process_cgroup(process_id="self", cgroup_name="walinuxagent")
-                controllers = cgroup.get_controllers(expected_relative_path="system.slice/walinuxagent.service")
-                self.assertEqual(len(controllers), 1)
-                self.assertIsInstance(controllers[0], CpuControllerV1)
-                self.assertEqual(controllers[0].name, "walinuxagent")
-                self.assertEqual(controllers[0].path, "/sys/fs/cgroup/cpu,cpuacct/system.slice/walinuxagent.service")
-
-            with patch('azurelinuxagent.ga.cgroupapi.SystemdCgroupApiv1._get_process_relative_controller_paths', return_value={'cpu,cpuacct': 'unexpected/path', 'memory': 'unexpected/path'}):
-                cgroup = create_cgroup_api().get_process_cgroup(process_id="self", cgroup_name="walinuxagent")
-                controllers = cgroup.get_controllers(expected_relative_path="system.slice/walinuxagent.service")
-                self.assertEqual(len(controllers), 0)
-
     def test_get_procs_path_returns_correct_path_v1(self):
         with mock_cgroup_v1_environment(self.tmp_dir):
             cgroup = create_cgroup_api().get_process_cgroup(process_id="self", cgroup_name="walinuxagent")
@@ -681,14 +666,6 @@ class CgroupsApiv2TestCase(AgentTestCase):
             with patch("azurelinuxagent.ga.cgroupapi.SystemdCgroupApiv2.get_process_cgroup", return_value=mock_cgroup_empty_path):
                 cgroup = create_cgroup_api().get_process_cgroup(process_id="self", cgroup_name="walinuxagent")
                 controllers = cgroup.get_controllers()
-                self.assertEqual(len(controllers), 0)
-
-    def test_get_controllers_returns_only_controllers_at_expected_path_v2(self):
-        with mock_cgroup_v2_environment(self.tmp_dir):
-            mock_cgroup_unexpected_path = CgroupV2(cgroup_name="test", root_cgroup_path="/sys/fs/cgroup", cgroup_path="/sys/fs/cgroup/unexpected/path", enabled_controllers=["cpu", "memory"])
-            with patch("azurelinuxagent.ga.cgroupapi.SystemdCgroupApiv2.get_process_cgroup", return_value=mock_cgroup_unexpected_path):
-                cgroup = create_cgroup_api().get_process_cgroup(process_id="self", cgroup_name="walinuxagent")
-                controllers = cgroup.get_controllers(expected_relative_path="system.slice/walinuxagent.service")
                 self.assertEqual(len(controllers), 0)
 
     def test_get_procs_path_returns_empty_if_root_cgroup_empty_v2(self):

--- a/tests/ga/test_cgroupconfigurator.py
+++ b/tests/ga/test_cgroupconfigurator.py
@@ -255,7 +255,7 @@ class CGroupConfiguratorSystemdTestCase(AgentTestCase):
     def test_agent_should_reset_cpu_quota_when_previously_set_and_agent_not_enabled_now(self):
         command_mocks = [
                  MockCommand(r"^systemctl show walinuxagent\.service --property ControlGroup$",
-                             '''ControlGroup=/azure.slice/walinuxagent.service
+                             '''ControlGroup=/system.slice
                              '''),
                  MockCommand(r"^systemctl show (.+) --property CPUQuotaPerSecUSec$",
                              '''CPUQuotaPerSecUSec=5ms


### PR DESCRIPTION
The check in Cgroup.get_controllers() to verify the Agent is in the expected cgroup is not needed, since CGroupConfigurator.initialize() already performs an equivalent check.

Both checks are incorrect under some conditions, though. The checks are based on the Slice property, which may not be updated if the drop-in file that defines the slice has been created, but the Agent service has not been restarted since. This can happen, for example, during Agent update, which creates a new process that executes the logic in CGroupConfigurator.initialize() again without a service restart.

I removed the check in Cgroup.get_controllers() and updated the check in CGroupConfigurator.initialize() to use the ControlGroup property instead.

Also, the motivation of the check may not be valid anymore and the check could be removed altogether after checking telemetry for a few releases. I added more details in the inline comments surrounding the code for the check.
