### PR TITLE
Ignore warn msg 'usage of legacy autoupdate flag' in e2e tests

### DIFF
--- a/tests_e2e/tests/lib/agent_log.py
+++ b/tests_e2e/tests/lib/agent_log.py
@@ -350,7 +350,7 @@ class AgentLog(object):
 
             # 2026-06-08T05:26:22.944493Z WARNING Daemon Daemon The legacy AutoUpdate.Enabled configuration is also used, but it is ignored in favor of the new configuration (AutoUpdate.UpdateToLatestVersion).
             {
-                'message': r"The legacy AutoUpdate.Enabled configuration is also used, but it is ignored in favor of the new configuration \(AutoUpdate.UpdateToLatestVersion\)",
+                'message': r"The legacy AutoUpdate\.Enabled configuration is also used, but it is ignored in favor of the new configuration \(AutoUpdate\.UpdateToLatestVersion\)",
                 'if': lambda r: r.prefix == 'Daemon' and r.thread == 'Daemon'
             },
             #

--- a/tests_e2e/tests/lib/agent_log.py
+++ b/tests_e2e/tests/lib/agent_log.py
@@ -347,6 +347,12 @@ class AgentLog(object):
                 'message': r"AutoUpdate.Enabled property is \*\*Deprecated\*\* now but it's set to different value from AutoUpdate.UpdateToLatestVersion",
                 'if': lambda r: r.prefix == 'ExtHandler' and r.thread == 'ExtHandler'
             },
+
+            # 2026-06-08T05:26:22.944493Z WARNING Daemon Daemon The legacy AutoUpdate.Enabled configuration is also used, but it is ignored in favor of the new configuration (AutoUpdate.UpdateToLatestVersion).
+            {
+                'message': r"The legacy AutoUpdate.Enabled configuration is also used, but it is ignored in favor of the new configuration \(AutoUpdate.UpdateToLatestVersion\)",
+                'if': lambda r: r.prefix == 'Daemon' and r.thread == 'Daemon'
+            },
             #
             # Some distros are running older agents, which do not add the DNS rule
             #


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->
<!--
Please add an informative description that covers that changes made by the pull request.
-->
## Description

In E2E tests, we use the legacy flag, so the warning message is expected in checklog errors. Therefore, we are ignoring it.

Issue # <!-- if any -->
---
<!--
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->
### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).
---
<!--
This checklist is used to track contributions from distro maintainers.
-->
### Distro maintenance information, if applicable
- [ ] This is a contribution from a distro maintainer
- [ ] The changes in this PR have been taken as a downstream patch (Note: it is not recommended to patch the agent without upstream review and approval)
