### PR TITLE
Rhel 7.5 and 8.2 is no longer available in Gov cloud

### DIFF
--- a/tests_e2e/test_suites/images.yml
+++ b/tests_e2e/test_suites/images.yml
@@ -260,6 +260,7 @@ images:
       urn: "RedHat:RHEL:7.5:latest"
       locations:
          AzureChinaCloud: []
+         AzureUSGovernment: []
    rhel_79:
       urn: "RedHat:RHEL:7_9:latest"
       locations:
@@ -268,6 +269,7 @@ images:
       urn: "RedHat:RHEL:8.2:latest"
       locations:
          AzureChinaCloud: []
+         AzureUSGovernment: []
       vm_sizes:
       # Previously one user reported agent hang on this VM size for redhat 7+ but not observed in rhel 8. So I'm using same vm size to test agent cgroups scenario for rhel 8 to make sure we don't see any issue in automation.
          - "Standard_B2s"


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->
<!--
Please add an informative description that covers that changes made by the pull request.
-->
## Description
We are seeing consistently Rhel 7.5/8.2 deployment failures in Gov cloud runs:

`deployment failed. LisaException: InvalidParameter: The following list of images referenced from the deployment template are not found: Publisher: redhat, Offer: rhel, Sku: 7.5, Version: latest. Please refer to https://docs.microsoft.com/en-us/azure/virtual-machines/windows/cli-ps-findimage for instructions on finding available images.`

`deployment failed. LisaException: InvalidParameter: The following list of images referenced from the deployment template are not found: Publisher: redhat, Offer: rhel, Sku: 8.2, Version: latest. Please refer to https://docs.microsoft.com/en-us/azure/virtual-machines/windows/cli-ps-findimage for instructions on finding available images.`

Removing them from the run as they are no longer available.

Issue # <!-- if any -->
---
<!--
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->
### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).
---
<!--
This checklist is used to track contributions from distro maintainers.
-->
### Distro maintenance information, if applicable
- [ ] This is a contribution from a distro maintainer
- [ ] The changes in this PR have been taken as a downstream patch (Note: it is not recommended to patch the agent without upstream review and approval)
