### PR TITLE
Disable agent_update_with_signature test suite

### DIFF
--- a/tests_e2e/orchestrator/runbook.yml
+++ b/tests_e2e/orchestrator/runbook.yml
@@ -44,7 +44,10 @@ variable:
       - agent_persist_firewall
       - agent_status
       - agent_update
-      - agent_update_with_signature
+#      Disabling agent_update_with_signature test suite. The changes in CRP to include the agent signatures in the goal
+#      state were disabled due to concerns with svd size for uniform scalesets. Once CRP re-enables the agent signatures
+#      in the goal state, we can re-enable this test suite.
+#      - agent_update_with_signature
       - ext_cgroups
       - ext_policy
       - ext_policy_with_dependencies


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->
<!--
Please add an informative description that covers that changes made by the pull request.
-->
## Description
CRP disabled agent signature consumption due to concerns with svd size for uniform VMSS. Disable the e2e test until signature consumption is re-enabled in canary

Issue # <!-- if any -->
---
<!--
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->
### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).
---
<!--
This checklist is used to track contributions from distro maintainers.
-->
### Distro maintenance information, if applicable
- [ ] This is a contribution from a distro maintainer
- [ ] The changes in this PR have been taken as a downstream patch (Note: it is not recommended to patch the agent without upstream review and approval)
