### PR TITLE
Update lisa commit for disk size issue in deployments

### DIFF
--- a/tests_e2e/orchestrator/docker/Dockerfile
+++ b/tests_e2e/orchestrator/docker/Dockerfile
@@ -71,7 +71,7 @@ RUN \
     cd $HOME                                                                                                  && \
     git clone https://github.com/microsoft/lisa.git                                                           && \
     cd lisa                                                                                                   && \
-    git checkout eeceb48b1343023424075ba986044d63a8a1d326                                                     && \
+    git checkout 608ceb37ffcdf44b991301dc86e1600f8df230e5                                                     && \
                                                                                                                  \
     python3 -m pip install --upgrade pip                                                                      && \
     python3 -m pip install --editable .[azure,libvirt] --config-settings editable_mode=compat                 && \

--- a/tests_e2e/orchestrator/docker/Dockerfile
+++ b/tests_e2e/orchestrator/docker/Dockerfile
@@ -89,8 +89,8 @@ RUN \
     #                                                                                                            \
     # Download Pypy to a known location, from which it will be installed to the test VMs.                        \
     #                                                                                                            \
-    wget https://dcrdata.blob.core.windows.net/python/pypy3.7-x64.tar.bz2 -O /tmp/pypy3.7-x64.tar.bz2         && \
-    wget https://dcrdata.blob.core.windows.net/python/pypy3.7-arm64.tar.bz2 -O /tmp/pypy3.7-arm64.tar.bz2     && \
+    wget https://pythonenv.blob.core.windows.net/e2e/pypy3.7-x64.tar.bz2 -O /tmp/pypy3.7-x64.tar.bz2         && \
+    wget https://pythonenv.blob.core.windows.net/e2e/pypy3.7-arm64.tar.bz2 -O /tmp/pypy3.7-arm64.tar.bz2     && \
                                                                                                                  \
     #                                                                                                            \
     # Install pudb, which can be useful to debug issues in the image                                             \


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->
<!--
Please add an informative description that covers that changes made by the pull request.
-->
## Description
Our daily runs started to see deployment failures due to OS image size being larger than disk size: 
```
no available environment
deployment failed. LisaException: OperationNotAllowed: The specified disk size 30 GB is smaller than the size of the corresponding disk in the VM image: 49 GB. This is not allowed. Please choose equal or greater size or do not specify an explicit size.
```
This was happening for Oracle 9.5

Lisa folks committed a fix for this to dynamically increase disk size when necessary: https://github.com/microsoft/lisa/commit/608ceb37ffcdf44b991301dc86e1600f8df230e5

This PR updates our dockerfile to use this commit, and also updates the dockerfile to use the new pythonenv container for pypy


Issue # <!-- if any -->
---
<!--
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->
### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).
---
<!--
This checklist is used to track contributions from distro maintainers.
-->
### Distro maintenance information, if applicable
- [ ] This is a contribution from a distro maintainer
- [ ] The changes in this PR have been taken as a downstream patch (Note: it is not recommended to patch the agent without upstream review and approval)
