### PR TITLE
Undo disk size workaround for rhel images

### DIFF
--- a/tests_e2e/orchestrator/lib/agent_test_suite_combinator.py
+++ b/tests_e2e/orchestrator/lib/agent_test_suite_combinator.py
@@ -265,7 +265,6 @@ class AgentTestSuitesCombinator(Combinator):
                             shared_environments[env_name] = env
 
                     vm_tags = env["vm_tags"]
-                    vm_tags["image_name"] = image_name # used in the update_arm_template hook to apply image-specific customizations in the ARM template
                     if test_suite_info.template != '':
                         if "templates" not in vm_tags:
                             vm_tags["templates"] = test_suite_info.template

--- a/tests_e2e/orchestrator/lib/update_arm_template_hook.py
+++ b/tests_e2e/orchestrator/lib/update_arm_template_hook.py
@@ -55,25 +55,6 @@ class UpdateArmTemplateHook:
             network_security_rule.add_allow_ssh_rule(allow_ssh)
 
         #
-        # Update diskSizeGB from OS disk functions to avoid errors when the specified
-        # size is smaller than the VM image's disk size for rhel_82 and rhel_75 distros.
-        # TODO: Remove this workaround after LISA fixing the default size issue in their template
-        #
-        image_name = vm_tags.get("image_name", "").lower()
-        if image_name in ("rhel-8.2", "rhel-7.5"):
-            for func_name in ("getOSImage", "getEphemeralOSImage"):
-                try:
-                    output_value = UpdateArmTemplate.get_function_output(
-                        UpdateArmTemplate.get_lisa_function(template, func_name)
-                    )
-                    if "diskSizeGB" in output_value:
-                        log.info("******** Waagent: Updating diskSizeGB in %s to 64GB", func_name)
-                        output_value["diskSizeGB"] = 64
-                except Exception as e:
-                    log.info("Error while updating diskSizeGB in %s. Error: %s", func_name, str(e))
-
-
-        #
         # Apply any template customizations provided by the tests.
         #
         # The "templates" tag is a comma-separated list of the template customizations provided by the tests


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->
<!--
Please add an informative description that covers that changes made by the pull request.
-->
## Description
We added a workaround for Rhel 7.5/8.2 disk size deployment failures in this pull request: https://github.com/Azure/WALinuxAgent/pull/3601/changes

Now that we are using the lisa commit with fix for disk size, this workaround is no longer necessary. Removing it in this PR

Issue # <!-- if any -->
---
<!--
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->
### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).
---
<!--
This checklist is used to track contributions from distro maintainers.
-->
### Distro maintenance information, if applicable
- [ ] This is a contribution from a distro maintainer
- [ ] The changes in this PR have been taken as a downstream patch (Note: it is not recommended to patch the agent without upstream review and approval)
