### PR TITLE
Skip CentOS 7.9 and 8.2 on tests that depend on Microsoft.Azure.Monitor.AzureMonitorLinuxAgent

### DIFF
--- a/tests_e2e/test_suites/agent_cgroups.yml
+++ b/tests_e2e/test_suites/agent_cgroups.yml
@@ -14,4 +14,5 @@ images:
   - "ubuntu_2510"
 owns_vm: true
 skip_on_images: # AMA extension used in agent_cgroups_process_check, and it is not supported on these images
+  - "centos_82"
   - "rhel_95_arm64"

--- a/tests_e2e/test_suites/ext_policy.yml
+++ b/tests_e2e/test_suites/ext_policy.yml
@@ -10,4 +10,5 @@ images:
   - "cvm-endorsed"
 owns_vm: false
 skip_on_images:
+  - "centos_79" # The test depends on Microsoft.Azure.Monitor.AzureMonitorLinuxAgent, which does not support these distros since version 1.43
   - "AzureChinaCloud:debian_11" # The ConfigurationforLinux-1.26.109 extension is failing on Debian 11 in China cloud only; skip this image until the issue in the extension is fixed

--- a/tests_e2e/test_suites/ext_policy.yml
+++ b/tests_e2e/test_suites/ext_policy.yml
@@ -10,5 +10,8 @@ images:
   - "cvm-endorsed"
 owns_vm: false
 skip_on_images:
-  - "centos_79" # The test depends on Microsoft.Azure.Monitor.AzureMonitorLinuxAgent, which does not support these distros since version 1.43
-  - "AzureChinaCloud:debian_11" # The ConfigurationforLinux-1.26.109 extension is failing on Debian 11 in China cloud only; skip this image until the issue in the extension is fixed
+  # The test depends on Microsoft.Azure.Monitor.AzureMonitorLinuxAgent, which does not support these distros since version 1.43
+  - "centos_79"
+  - "centos_82"
+  # TODO: The ConfigurationforLinux-1.26.109 extension is failing on Debian 11 in China cloud only; skip this image until the issue in the extension is fixed
+  - "AzureChinaCloud:debian_11"

--- a/tests_e2e/test_suites/ext_policy_with_dependencies.yml
+++ b/tests_e2e/test_suites/ext_policy_with_dependencies.yml
@@ -10,11 +10,14 @@ images:
 executes_on_scale_set: true
 owns_vm: false
 
-# TODO: Currently AlmaLinux is not available for scale sets; enable this image when it is available.
 skip_on_images:
+  # TODO: Currently AlmaLinux is not available for scale sets; enable this image when it is available.
   - "alma_8"
   - "alma_9"
   - "alma_10"
+  # The test depends on Microsoft.Azure.Monitor.AzureMonitorLinuxAgent, which does not support these distros since version 1.43
+  - "centos_79"
+  - "centos_82"
 
 # TODO: The current deployment of VmAccess 1.5.22 prevents the extension from uninstalling; enable this test when the issue is fixed
 skip_on_clouds:

--- a/tests_e2e/test_suites/ext_sequencing.yml
+++ b/tests_e2e/test_suites/ext_sequencing.yml
@@ -9,11 +9,14 @@ images: "endorsed"
 # This scenario is executed on instances of a scaleset created by the agent test suite.
 executes_on_scale_set: true
 
-# TODO: Currently AlmaLinux is not available for scale sets; enable this image when it is available.
 skip_on_images:
+  # TODO: Currently AlmaLinux is not available for scale sets; enable this image when it is available.
   - "alma_8"
   - "alma_9"
   - "alma_10"
+  # The test depends on Microsoft.Azure.Monitor.AzureMonitorLinuxAgent, which does not support these distros since version 1.43
+  - "centos_79"
+  - "centos_82"
 
 # TODO: The current deployment of VmAccess 1.5.22 prevents the extension from uninstalling; enable this test when the issue is fixed
 skip_on_clouds:


### PR DESCRIPTION
AzureMonitorLinuxAgent stopped supporting CentOS 7.9 and 8.2 on version 1.43.

Skipping those distros on tests that depend on this extension
.