### PR TITLE
Skip CentOS 8.2 on the tests for cgroups

### DIFF
--- a/tests_e2e/test_suites/agent_cgroups.yml
+++ b/tests_e2e/test_suites/agent_cgroups.yml
@@ -14,5 +14,4 @@ images:
   - "ubuntu_2510"
 owns_vm: true
 skip_on_images: # AMA extension used in agent_cgroups_process_check, and it is not supported on these images
-  - "centos_82"
   - "rhel_95_arm64"

--- a/tests_e2e/test_suites/images.yml
+++ b/tests_e2e/test_suites/images.yml
@@ -53,7 +53,8 @@ image-sets:
    # As of today agent only support and enabled resource governance feature on following distros
    cgroups-endorsed:
       - "azure-linux_3"
-      - "centos_82"
+      # TODO: Microsoft.Azure.Monitor.AzureMonitorLinuxAgent does not support these CentOS 8.2 since version 1.43. We need to reconsider the use of this extension on the tests for cgroups. In the meanwhile, we are skipping that distro from the test run.
+      # - "centos_82"
       - "rhel_82"
       - "rhel_95"
       - "rhel_95_arm64"


### PR DESCRIPTION
Microsoft.Azure.Monitor.AzureMonitorLinuxAgent does not support CentOS 8.2 since version 1.43, and the cgroups tests depend on that extension.