### PR TITLE
Re-add CentOS 8.2 to cgroups test

### DIFF
--- a/tests_e2e/test_suites/agent_cgroups.yml
+++ b/tests_e2e/test_suites/agent_cgroups.yml
@@ -14,5 +14,4 @@ images:
   - "ubuntu_2510"
 owns_vm: true
 skip_on_images: # AMA extension used in agent_cgroups_process_check, and it is not supported on these images
-  - "centos_82"
   - "rhel_95_arm64"


### PR DESCRIPTION
#3632 removed CentOS 8.2 from the agent_cgroups test suite. It is still needed. Re-adding.