### PR TITLE
Skip suse 12 on tests that depend on Microsoft.Azure.Monitor.AzureMon…

### DIFF
--- a/tests_e2e/test_suites/ext_policy.yml
+++ b/tests_e2e/test_suites/ext_policy.yml
@@ -17,3 +17,4 @@ skip_on_images:
   # The test depends on Microsoft.Azure.Monitor.AzureMonitorLinuxAgent, which does not support these distros since version 1.43
   - "centos_79"
   - "centos_82"
+  - "suse_12"

--- a/tests_e2e/test_suites/ext_policy_with_dependencies.yml
+++ b/tests_e2e/test_suites/ext_policy_with_dependencies.yml
@@ -20,6 +20,7 @@ skip_on_images:
   # The test depends on Microsoft.Azure.Monitor.AzureMonitorLinuxAgent, which does not support these distros since version 1.43
   - "centos_79"
   - "centos_82"
+  - "suse_12"
 
 # TODO: The current deployment of VmAccess 1.5.22 prevents the extension from uninstalling; enable this test when the issue is fixed
 skip_on_clouds:

--- a/tests_e2e/test_suites/ext_sequencing.yml
+++ b/tests_e2e/test_suites/ext_sequencing.yml
@@ -19,6 +19,7 @@ skip_on_images:
   # The test depends on Microsoft.Azure.Monitor.AzureMonitorLinuxAgent, which does not support these distros since version 1.43
   - "centos_79"
   - "centos_82"
+  - "suse_12"
 
 # TODO: The current deployment of VmAccess 1.5.22 prevents the extension from uninstalling; enable this test when the issue is fixed
 skip_on_clouds:


### PR DESCRIPTION
…itorLinuxAgent

<!-- DO NOT DELETE THIS TEMPLATE -->
<!--
Please add an informative description that covers that changes made by the pull request.
-->
## Description
AzureMonitorLinuxAgent stopped supporting suse 12 on version 1.43.

Skipping those distros on tests that depend on this extension. We already made this change for centos: #3632 

Issue # <!-- if any -->
---
<!--
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->
### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).
---
<!--
This checklist is used to track contributions from distro maintainers.
-->
### Distro maintenance information, if applicable
- [ ] This is a contribution from a distro maintainer
- [ ] The changes in this PR have been taken as a downstream patch (Note: it is not recommended to patch the agent without upstream review and approval)
