### PR TITLE
Http_request should retry IOError 'timeout' when fast_on_timeout is False

### DIFF
--- a/azurelinuxagent/common/utils/restutil.py
+++ b/azurelinuxagent/common/utils/restutil.py
@@ -529,7 +529,7 @@ def http_request(method,
             # If the error was an IOError and fail_fast_on_timeout is True, check if the error message contains
             # "timed out" or "timeout" and break the loop to fail fast in the case of no outbound connection on the VM.
             # Otherwise, continue with the retries.
-            if fail_fast_on_timeout and "timed out" in ustr(e) or "timeout" in ustr(e):
+            if fail_fast_on_timeout and ("timed out" in ustr(e) or "timeout" in ustr(e)):
                 break
             continue
 

--- a/tests/common/utils/test_rest_util.py
+++ b/tests/common/utils/test_rest_util.py
@@ -685,6 +685,17 @@ class TestHttpOperations(AgentTestCase):
         self.assertRaises(HttpError, restutil.http_get, "https://foo.bar", fail_fast_on_timeout=True)
         self.assertEqual(1, _http_request.call_count)
 
+    @patch("azurelinuxagent.common.utils.restutil._http_request")
+    def test_http_request_fails_fast_for_timeout_ioerror(self, _http_request):
+        ioerror = IOError("timeout")
+
+        _http_request.side_effect = [
+            ioerror
+        ]
+
+        self.assertRaises(HttpError, restutil.http_get, "https://foo.bar", fail_fast_on_timeout=True)
+        self.assertEqual(1, _http_request.call_count)
+
     @patch("time.sleep")
     @patch("azurelinuxagent.common.utils.restutil._http_request")
     def test_http_request_retries_for_non_timed_out_ioerror(self, _http_request, _sleep):
@@ -697,6 +708,49 @@ class TestHttpOperations(AgentTestCase):
         ]
 
         restutil.http_get("https://foo.bar", fail_fast_on_timeout=True)
+        self.assertEqual(2, _http_request.call_count)
+        self.assertEqual(1, _sleep.call_count)
+
+    @patch("time.sleep")
+    @patch("azurelinuxagent.common.utils.restutil._http_request")
+    def test_http_request_retries_timed_out_ioerror_when_fail_fast_disabled(self, _http_request, _sleep):
+        ioerror = IOError("timed out")
+
+        _http_request.side_effect = [
+            ioerror,
+            Mock(status=httpclient.OK)
+        ]
+
+        restutil.http_get("https://foo.bar", fail_fast_on_timeout=False)
+        self.assertEqual(2, _http_request.call_count)
+        self.assertEqual(1, _sleep.call_count)
+
+    @patch("time.sleep")
+    @patch("azurelinuxagent.common.utils.restutil._http_request")
+    def test_http_request_retries_timeout_ioerror_when_fail_fast_disabled(self, _http_request, _sleep):
+        ioerror = IOError("timeout")
+
+        _http_request.side_effect = [
+            ioerror,
+            Mock(status=httpclient.OK)
+        ]
+
+        restutil.http_get("https://foo.bar", fail_fast_on_timeout=False)
+        self.assertEqual(2, _http_request.call_count)
+        self.assertEqual(1, _sleep.call_count)
+
+    @patch("time.sleep")
+    @patch("azurelinuxagent.common.utils.restutil._http_request")
+    def test_http_request_retries_non_timed_out_ioerror_when_fail_fast_disabled(self, _http_request, _sleep):
+        ioerror = IOError()
+        ioerror.errno = 42
+
+        _http_request.side_effect = [
+            ioerror,
+            Mock(status=httpclient.OK)
+        ]
+
+        restutil.http_get("https://foo.bar", fail_fast_on_timeout=False)
         self.assertEqual(2, _http_request.call_count)
         self.assertEqual(1, _sleep.call_count)
 


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->
<!--
Please add an informative description that covers that changes made by the pull request.
-->
## Description
In previous PR #3561 we updated the retry strategy for artifact downloads so that http_request would fail fast and skip remaining retries if download failed with IOError 'timed out' or 'timeout' and fail_fast_on_timeout is True. The intention of this change was to fail fast only on IOError 'timed out'/'timeout' on the Direct artifact download channel so that we could fallback to HGAP immediately. This was meant to help TDPR for customers with outbound access disabled. 

Due to operator precedence, the  fail_fast_on_timeout retry check introduced in that PR `fail_fast_on_timeout and "timed out" in ustr(e) or "timeout" in ustr(e)`  is evaluated as `(fail_fast_on_timeout and "timed out" in ustr(e)) or ("timeout" in ustr(e))` which would cause any IOError whose message contained "timeout" to abort the retry loop even when fail-fast was disabled.

We have not identified any actual impact from this bug. We cannot find evidence that IOError 'timeout' is even a valid exception string for the python IOError, and telemetry further shows we only see IOError 'timed out', so we have not seen any actual instances of this bug being hit in the fleet. 

This PR fixes the condition for correctness. 


Issue # <!-- if any -->
---
<!--
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->
### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).
---
<!--
This checklist is used to track contributions from distro maintainers.
-->
### Distro maintenance information, if applicable
- [ ] This is a contribution from a distro maintainer
- [ ] The changes in this PR have been taken as a downstream patch (Note: it is not recommended to patch the agent without upstream review and approval)
