### PR TITLE
Update CVM Skus to Standard_DC2as_v6

### DIFF
--- a/tests_e2e/test_suites/images.yml
+++ b/tests_e2e/test_suites/images.yml
@@ -172,10 +172,10 @@ images:
       urn: "microsoftcblmariner azure-linux-3 azure-linux-3-cvm latest"
       security_type: "ConfidentialVM"
       vm_sizes:
-         - "Standard_DC2ads_v5" # TODO: The sku for this image should be updated to 'Standard_DC2as_v6' once we have capacity for it in our test subs, since it is available in more regions
+         - "Standard_DC2as_v6"
       locations:
-         AzureCloud: ["westeurope", "eastus2euap"] # The 'Standard_DC2ads_v5' SKU is currently only available in a limited set of regions.
-         AzureUSGovernment: []                     # TODO: We don't have the required quota for CVM VMs in our Gov subscription, remove this once we do.
+         AzureCloud: ["westus2", "westcentralus", "southcentralus", "eastus2euap"] # If additional regions are required, we will need to request additional capacity for 'Standard DCasv6 Family vCPUs' in our Public test sub.
+         AzureUSGovernment: ["usgovarizona"]       # If additional regions are required, we will need to request additional capacity for 'Standard DCasv6 Family vCPUs' in our Gov test sub.
          AzureChinaCloud: []                       # TODO: China cloud does not have CVM support yet. Remove this once CVM is available in China cloud.
    azure-linux_4:
       urn: "microsoftazurelinux:azurelinux-4:4:latest"
@@ -313,28 +313,28 @@ images:
       urn: "RedHat rhel-cvm 9_4_cvm latest"
       security_type: "ConfidentialVM"
       vm_sizes:
-         - "Standard_DC2ads_v5" # TODO: The sku for this image should be updated to 'Standard_DC2as_v6' once we have capacity for it in our test subs, since it is available in more regions
+         - "Standard_DC2as_v6"
       locations:
-         AzureCloud: ["westeurope", "eastus2euap"] # The 'Standard_DC2ads_v5' SKU is currently only available in a limited set of regions.
-         AzureUSGovernment: []                     # TODO: We don't have the required quota for CVM VMs in our Gov subscription, remove this once we do.
+         AzureCloud: ["westus2", "westcentralus", "southcentralus", "eastus2euap"] # If additional regions are required, we will need to request additional capacity for 'Standard DCasv6 Family vCPUs' in our Public test sub.
+         AzureUSGovernment: ["usgovarizona"]       # If additional regions are required, we will need to request additional capacity for 'Standard DCasv6 Family vCPUs' in our Gov test sub.
          AzureChinaCloud: []                       # TODO: China cloud does not have CVM support yet. Remove this once CVM is available in China cloud.
    rhel_95_cvm:
       urn: "RedHat rhel-cvm 9_5_cvm latest"
       security_type: "ConfidentialVM"
       vm_sizes:
-         - "Standard_DC2ads_v5" # TODO: The sku for this image should be updated to 'Standard_DC2as_v6' once we have capacity for it in our test subs, since it is available in more regions
+         - "Standard_DC2as_v6"
       locations:
-         AzureCloud: ["westeurope", "eastus2euap"] # The 'Standard_DC2ads_v5' SKU is currently only available in a limited set of regions.
-         AzureUSGovernment: []                     # TODO: We don't have the required quota for CVM VMs in our Gov subscription, remove this once we do.
+         AzureCloud: ["westus2", "westcentralus", "southcentralus", "eastus2euap"] # If additional regions are required, we will need to request additional capacity for 'Standard DCasv6 Family vCPUs' in our Public test sub.
+         AzureUSGovernment: ["usgovarizona"]       # If additional regions are required, we will need to request additional capacity for 'Standard DCasv6 Family vCPUs' in our Gov test sub.
          AzureChinaCloud: []                       # TODO: China cloud does not have CVM support yet. Remove this once CVM is available in China cloud.
    rhel_10_cvm:
       urn: "RedHat:rhel-cvm:10_2_cvm:latest"
       security_type: "ConfidentialVM"
       vm_sizes:
-         - "Standard_DC2ads_v5" # TODO: The sku for this image should be updated to 'Standard_DC2as_v6' once we have capacity for it in our test subs, since it is available in more regions
+         - "Standard_DC2as_v6"
       locations:
-         AzureCloud: ["westeurope", "eastus2euap"] # The 'Standard_DC2ads_v5' SKU is currently only available in a limited set of regions.
-         AzureUSGovernment: []                     # TODO: We don't have the required quota for CVM VMs in our Gov subscription, remove this once we do.
+         AzureCloud: ["westus2", "westcentralus", "southcentralus", "eastus2euap"] # If additional regions are required, we will need to request additional capacity for 'Standard DCasv6 Family vCPUs' in our Public test sub.
+         AzureUSGovernment: ["usgovarizona"]       # If additional regions are required, we will need to request additional capacity for 'Standard DCasv6 Family vCPUs' in our Gov test sub.
          AzureChinaCloud: []                       # TODO: China cloud does not have CVM support yet. Remove this once CVM is available in China cloud.
    rocky_9:
       urn: "ciq:rocky-community-editions:rocky-community-9:latest"
@@ -345,10 +345,10 @@ images:
       urn: "ciq:rocky-lts:ciqrl94lts-cvm:latest"
       security_type: "ConfidentialVM"
       vm_sizes:
-         - "Standard_DC2ads_v5" # TODO: The sku for this image should be updated to 'Standard_DC2as_v6' once we have capacity for it in our test subs, since it is available in more regions
+         - "Standard_DC2as_v6"
       locations:
-         AzureCloud: ["westeurope", "eastus2euap"] # The 'Standard_DC2ads_v5' SKU is currently only available in a limited set of regions.
-         AzureUSGovernment: []                     # TODO: We don't have the required quota for CVM VMs in our Gov subscription, remove this once we do.
+         AzureCloud: ["westus2", "westcentralus", "southcentralus", "eastus2euap"] # If additional regions are required, we will need to request additional capacity for 'Standard DCasv6 Family vCPUs' in our Public test sub.
+         AzureUSGovernment: ["usgovarizona"]       # If additional regions are required, we will need to request additional capacity for 'Standard DCasv6 Family vCPUs' in our Gov test sub.
          AzureChinaCloud: []                       # TODO: China cloud does not have CVM support yet. Remove this once CVM is available in China cloud.
    suse_12:
       urn: "SUSE:sles-12-sp5:gen1:latest"
@@ -392,27 +392,27 @@ images:
       urn: "Canonical 0001-com-ubuntu-confidential-vm-focal 20_04-lts-cvm latest"
       security_type: "ConfidentialVM"
       vm_sizes:
-         - "Standard_DC2ads_v5" # TODO: The sku for this image should be updated to 'Standard_DC2as_v6' once we have capacity for it in our test subs, since it is available in more regions
+         - "Standard_DC2as_v6"
       locations:
-         AzureCloud: ["westeurope", "eastus2euap"] # The 'Standard_DC2ads_v5' SKU is currently only available in a limited set of regions.
-         AzureUSGovernment: []                     # TODO: We don't have the required quota for CVM VMs in our Gov subscription, remove this once we do.
+         AzureCloud: ["westus2", "westcentralus", "southcentralus", "eastus2euap"] # If additional regions are required, we will need to request additional capacity for 'Standard DCasv6 Family vCPUs' in our Public test sub.
+         AzureUSGovernment: ["usgovarizona"]       # If additional regions are required, we will need to request additional capacity for 'Standard DCasv6 Family vCPUs' in our Gov test sub.
          AzureChinaCloud: []                       # TODO: China cloud does not have CVM support yet. Remove this once CVM is available in China cloud.
    ubuntu_2204_cvm:
       urn: "Canonical 0001-com-ubuntu-confidential-vm-jammy 22_04-lts-cvm latest"
       security_type: "ConfidentialVM"
       vm_sizes:
-         - "Standard_DC2ads_v5" # TODO: The sku for this image should be updated to 'Standard_DC2as_v6' once we have capacity for it in our test subs, since it is available in more regions
+         - "Standard_DC2as_v6"
       locations:
-         AzureCloud: ["westeurope", "eastus2euap"] # The 'Standard_DC2ads_v5' SKU is currently only available in a limited set of regions.
-         AzureUSGovernment: []                     # TODO: We don't have the required quota for CVM VMs in our Gov subscription, remove this once we do.
+         AzureCloud: ["westus2", "westcentralus", "southcentralus", "eastus2euap"] # If additional regions are required, we will need to request additional capacity for 'Standard DCasv6 Family vCPUs' in our Public test sub.
+         AzureUSGovernment: ["usgovarizona"]       # If additional regions are required, we will need to request additional capacity for 'Standard DCasv6 Family vCPUs' in our Gov test sub.
          AzureChinaCloud: []                       # TODO: China cloud does not have CVM support yet. Remove this once CVM is available in China cloud.
    ubuntu_2404_cvm:
       urn: "Canonical ubuntu-24_04-lts cvm latest"
       security_type: "ConfidentialVM"
       vm_sizes:
-         - "Standard_DC2ads_v5" # TODO: The sku for this image should be updated to 'Standard_DC2as_v6' once we have capacity for it in our test subs, since it is available in more regions
+         - "Standard_DC2as_v6"
       locations:
-         AzureCloud: ["westeurope", "eastus2euap"] # The 'Standard_DC2ads_v5' SKU is currently only available in a limited set of regions.
-         AzureUSGovernment: []                     # TODO: We don't have the required quota for CVM VMs in our Gov subscription, remove this once we do.
+         AzureCloud: ["westus2", "westcentralus", "southcentralus", "eastus2euap"] # If additional regions are required, we will need to request additional capacity for 'Standard DCasv6 Family vCPUs' in our Public test sub.
+         AzureUSGovernment: ["usgovarizona"]       # If additional regions are required, we will need to request additional capacity for 'Standard DCasv6 Family vCPUs' in our Gov test sub.
          AzureChinaCloud: []                       # TODO: China cloud does not have CVM support yet. Remove this once CVM is available in China cloud.
    ubuntu_2510: "Canonical:ubuntu-25_10:server:latest"

--- a/tests_e2e/test_suites/images.yml
+++ b/tests_e2e/test_suites/images.yml
@@ -175,7 +175,7 @@ images:
          - "Standard_DC2as_v6"
       locations:
          AzureCloud: ["westus2", "westcentralus", "southcentralus", "eastus2euap"] # If additional regions are required, we will need to request additional capacity for 'Standard DCasv6 Family vCPUs' in our Public test sub.
-         AzureUSGovernment: ["usgovarizona"]       # If additional regions are required, we will need to request additional capacity for 'Standard DCasv6 Family vCPUs' in our Gov test sub.
+         AzureUSGovernment: []                     # TODO: This image is not available in Gov cloud. Update this once the image is available in Gov cloud.
          AzureChinaCloud: []                       # TODO: China cloud does not have CVM support yet. Remove this once CVM is available in China cloud.
    azure-linux_4:
       urn: "microsoftazurelinux:azurelinux-4:4:latest"


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->
<!--
Please add an informative description that covers that changes made by the pull request.
-->
## Description
The recommended SKU for CVMs is Standard_DC2as_v6. Updating all CVM image definitions in images.yml to use this sku instead of the previous v5 SKU. 

Note our test subscriptions were allow-listed for the v6 SKU and we were granted capacity in a limited number of regions. The regions which we have capacity for in each cloud are listed in each image definition. China cloud still does not have CVM availability. 

Getting VM deployment failures for the azlinux3 CVM image in Gov cloud, so marking that image as unavailable in Gov cloud: The following list of images referenced from the deployment template are not found: Publisher: microsoftcblmariner, Offer: azure-linux-3, Sku: azure-linux-3-cvm, Version: latest. Please refer to https://docs.microsoft.com/en-us/azure/virtual-machines/windows/cli-ps-findimage for instructions on finding available images.

Issue # <!-- if any -->
---
<!--
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->
### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).
---
<!--
This checklist is used to track contributions from distro maintainers.
-->
### Distro maintenance information, if applicable
- [ ] This is a contribution from a distro maintainer
- [ ] The changes in this PR have been taken as a downstream patch (Note: it is not recommended to patch the agent without upstream review and approval)
