### PR TITLE
Add ubuntu24 pro image to FIPS test and remove ubuntu22 pro

### DIFF
--- a/tests_e2e/test_suites/fips.yml
+++ b/tests_e2e/test_suites/fips.yml
@@ -3,7 +3,7 @@
 # cryptographic algorithms used by the Extensions pipeline (e.g. encryption of protected settings, creation of PFX packages, and communication
 # Agent<->Wireserver) are FIPS approved.
 #
-# This test suite focuses on FIPS 140-3 and uses Ubuntu 22 and RHEL 9 as the representative distros for this feature. Note that Azure Linux 3
+# This test suite focuses on FIPS 140-3 and uses Ubuntu 22/24 and RHEL 9 as the representative distros for this feature. Note that Azure Linux 3
 # is also FIPS 140-3 compliant, but, similarly to Windows, it takes a more permissive approach and deprecated cryptographic algorithms can still
 # be used. We do not include Azure Linux 3 in the images here, it is already included in the "endorsed" image set and runs as part of the other
 # test suites.
@@ -12,8 +12,8 @@ name: "FIPS"
 tests:
   - source: "fips/fips.py"
 images:
-  - "ubuntu_pro_2204" # Enabling FIPS on Ubuntu requires the "pro" client to be enabled; it is pre-enabled on these "pro" images.
   - "ubuntu_pro_fips_2204" # FIPS is pre-enabled on these "fips" images.
+  - "ubuntu_pro_2404" # Enabling FIPS on Ubuntu requires the "pro" client to be enabled. There is not an Ubuntu 24 image which comes with FIPS pre-enabled, since it is not certified for FIPS yet, but we can enable FIPS manually on these pro VMs.
   - "oracle_95"
   - "rhel_95"
 
@@ -33,8 +33,8 @@ skip_on_clouds:
 # The Ubuntu images required by the test are not available on AzureUSGovernment
 #
 skip_on_images:
-  - "AzureUSGovernment:ubuntu_pro_2204"
   - "AzureUSGovernment:ubuntu_pro_fips_2204"
+  - "AzureUSGovernment:ubuntu_pro_2404"
 
 #
 # The test VM could be shared with other test suites, but we want to ensure there is a mix of FIPS and non-FIPS environments in the test run,

--- a/tests_e2e/test_suites/fips.yml
+++ b/tests_e2e/test_suites/fips.yml
@@ -24,13 +24,17 @@ locations:
   - "AzureCloud:westus2"
 
 #
-# Support for FIPS 140-3 has not been deployed AzureChinaCloud.
+# Support for FIPS 140-3 has been deployed AzureChinaCloud, but none of the images which this suite runs on are
+# available in China cloud (oracle_95 and rhel_95 are not available in China cloud, and our China test subscription
+# does not have access to the ubuntu pro images).
+# TODO: Once the China test sub has access to Ubuntu PRO images, we should run this suite in China cloud.
 #
 skip_on_clouds:
   - "AzureChinaCloud"
 
 #
 # The Ubuntu images required by the test are not available on AzureUSGovernment
+# TODO: Remove these once the Gov test sub has access to Ubuntu PRO images.
 #
 skip_on_images:
   - "AzureUSGovernment:ubuntu_pro_fips_2204"

--- a/tests_e2e/test_suites/images.yml
+++ b/tests_e2e/test_suites/images.yml
@@ -359,11 +359,6 @@ images:
    ubuntu_1804: "Canonical:UbuntuServer:18.04-LTS:latest"
    ubuntu_2004: "Canonical:0001-com-ubuntu-server-focal:20_04-lts:latest"
    ubuntu_2204: "Canonical:0001-com-ubuntu-server-jammy:22_04-lts:latest"
-   ubuntu_pro_2204:
-      urn: "Canonical:0001-com-ubuntu-pro-microsoft:pro-22_04:latest"
-      locations:
-         AzureUSGovernment: []
-         AzureChinaCloud: []
    ubuntu_pro_fips_2204:
       urn: "Canonical:0001-com-ubuntu-pro-microsoft:pro-fips-22_04:latest"
       locations:
@@ -379,6 +374,11 @@ images:
          AzureUSGovernment: []
    ubuntu_2204_minimal: "Canonical:0001-com-ubuntu-minimal-jammy:minimal-22_04-lts-gen2:latest"
    ubuntu_2404: "Canonical:ubuntu-24_04-lts:server:latest"
+   ubuntu_pro_2404:
+      urn: "Canonical:0001-com-ubuntu-pro-microsoft:pro-24_04:latest"
+      locations:
+         AzureUSGovernment: []
+         AzureChinaCloud: []
    ubuntu_2404_arm64:
       urn: "Canonical:ubuntu-24_04-lts:server-arm64:latest"
       vm_sizes:

--- a/tests_e2e/tests/fips/fips.py
+++ b/tests_e2e/tests/fips/fips.py
@@ -46,8 +46,8 @@ class Fips(AgentVmTest):
         self._opt_in_to_fips()
         log.info("")
 
-        if self._distro.startswith("ubuntu_22"):
-            self._enable_fips_on_ubuntu_22()
+        if self._distro.startswith("ubuntu_22") or self._distro.startswith("ubuntu_24"):
+            self._enable_fips_on_ubuntu()
         elif Fips._is_red_hat_distro(self._distro):
             self._enable_fips_on_red_hat_distro()
         else:
@@ -131,11 +131,11 @@ class Fips(AgentVmTest):
         """
         return distro in ("rhel_95", "oracle_95")
 
-    def _enable_fips_on_ubuntu_22(self) -> None:
+    def _enable_fips_on_ubuntu(self) -> None:
         #
         # See https://ubuntu.com/tutorials/using-the-ubuntu-pro-client-to-enable-fips#4-enabling-fips-crypto-modules
         #
-        log.info("Enabling FIPS on Ubuntu 22...")
+        log.info("Enabling FIPS on Ubuntu...")
 
         # Skip this if FIPS is already enabled
         is_enabled_command = "test -f {0} && test $(cat {0}) = 1 && echo yes || true".format("/proc/sys/crypto/fips_enabled")
@@ -153,7 +153,7 @@ class Fips(AgentVmTest):
 
         enabled = self._ssh_client.run_command(is_enabled_command).rstrip()
         if enabled != "yes":
-            raise Exception("Failed to enable FIPS on Ubuntu 22; aborting test!!!!")
+            raise Exception("Failed to enable FIPS on Ubuntu; aborting test!!!!")
         log.info("FIPS was enabled successfully.")
 
     def _enable_fips_on_red_hat_distro(self) -> None:


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->
<!--
Please add an informative description that covers that changes made by the pull request.
-->
## Description
Canonical confirmed that walinuxagent 2.15.0.1 package hit the -updates pocket for Questing, Noble, and Jammy. I confirmed that the baked-in agent on Ubuntu 22 is now 2.15.0.1.

This PR removes the 'ubuntu_pro_2204' image from the FIPS e2e testing. We still test the 'ubuntu_pro_fips_2204' image, which comes with FIPS pre-enabled. The only reason we were testing both before is that we wanted to catch any issues with the old daemon **when FIPS is enabled after VM creation** (issues like the infinite loop on RHEL 9). Now that the image is updated with a version of the agent which supports FIPS, there is no need to test both ubuntu 22 images.

The PR also adds the 'ubuntu_pro_2404' image to the FIPS e2e testing. FIPS 140-3 is not yet certified on Ubuntu24, but it's in the process of getting certified so we are adding it to the test run in advance. I cannot find a ubuntu 24 pro image where fips is pre-enabled, likely because it is not yet certified, so we will use the regular ubuntu 24 pro image and enable fips after VM creation.

Issue # <!-- if any -->
---
<!--
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->
### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).
---
<!--
This checklist is used to track contributions from distro maintainers.
-->
### Distro maintenance information, if applicable
- [ ] This is a contribution from a distro maintainer
- [ ] The changes in this PR have been taken as a downstream patch (Note: it is not recommended to patch the agent without upstream review and approval)
