### PR TITLE
Http_request retry loop should only break on IOError timeout when fai…

### DIFF
--- a/azurelinuxagent/common/utils/restutil.py
+++ b/azurelinuxagent/common/utils/restutil.py
@@ -529,7 +529,7 @@ def http_request(method,
             # If the error was an IOError and fail_fast_on_timeout is True, check if the error message contains
             # "timed out" or "timeout" and break the loop to fail fast in the case of no outbound connection on the VM.
             # Otherwise, continue with the retries.
-            if fail_fast_on_timeout and "timed out" in ustr(e) or "timeout" in ustr(e):
+            if fail_fast_on_timeout and ("timed out" in ustr(e) or "timeout" in ustr(e)):
                 break
             continue
 

--- a/tests/common/utils/test_rest_util.py
+++ b/tests/common/utils/test_rest_util.py
@@ -685,6 +685,17 @@ class TestHttpOperations(AgentTestCase):
         self.assertRaises(HttpError, restutil.http_get, "https://foo.bar", fail_fast_on_timeout=True)
         self.assertEqual(1, _http_request.call_count)
 
+    @patch("azurelinuxagent.common.utils.restutil._http_request")
+    def test_http_request_fails_fast_for_timeout_ioerror(self, _http_request):
+        ioerror = IOError("timeout")
+
+        _http_request.side_effect = [
+            ioerror
+        ]
+
+        self.assertRaises(HttpError, restutil.http_get, "https://foo.bar", fail_fast_on_timeout=True)
+        self.assertEqual(1, _http_request.call_count)
+
     @patch("time.sleep")
     @patch("azurelinuxagent.common.utils.restutil._http_request")
     def test_http_request_retries_for_non_timed_out_ioerror(self, _http_request, _sleep):
@@ -697,6 +708,49 @@ class TestHttpOperations(AgentTestCase):
         ]
 
         restutil.http_get("https://foo.bar", fail_fast_on_timeout=True)
+        self.assertEqual(2, _http_request.call_count)
+        self.assertEqual(1, _sleep.call_count)
+
+    @patch("time.sleep")
+    @patch("azurelinuxagent.common.utils.restutil._http_request")
+    def test_http_request_retries_timed_out_ioerror_when_fail_fast_disabled(self, _http_request, _sleep):
+        ioerror = IOError("timed out")
+
+        _http_request.side_effect = [
+            ioerror,
+            Mock(status=httpclient.OK)
+        ]
+
+        restutil.http_get("https://foo.bar", fail_fast_on_timeout=False)
+        self.assertEqual(2, _http_request.call_count)
+        self.assertEqual(1, _sleep.call_count)
+
+    @patch("time.sleep")
+    @patch("azurelinuxagent.common.utils.restutil._http_request")
+    def test_http_request_retries_timeout_ioerror_when_fail_fast_disabled(self, _http_request, _sleep):
+        ioerror = IOError("timeout")
+
+        _http_request.side_effect = [
+            ioerror,
+            Mock(status=httpclient.OK)
+        ]
+
+        restutil.http_get("https://foo.bar", fail_fast_on_timeout=False)
+        self.assertEqual(2, _http_request.call_count)
+        self.assertEqual(1, _sleep.call_count)
+
+    @patch("time.sleep")
+    @patch("azurelinuxagent.common.utils.restutil._http_request")
+    def test_http_request_retries_non_timed_out_ioerror_when_fail_fast_disabled(self, _http_request, _sleep):
+        ioerror = IOError()
+        ioerror.errno = 42
+
+        _http_request.side_effect = [
+            ioerror,
+            Mock(status=httpclient.OK)
+        ]
+
+        restutil.http_get("https://foo.bar", fail_fast_on_timeout=False)
         self.assertEqual(2, _http_request.call_count)
         self.assertEqual(1, _sleep.call_count)
 


### PR DESCRIPTION
…l_fast_on_timeout is True (#3644)

(cherry picked from commit 07356f776315603a5248a6c899e22c1919163b9d)

<!-- DO NOT DELETE THIS TEMPLATE -->
<!--
Please add an informative description that covers that changes made by the pull request.
-->
## Description

Issue # <!-- if any -->
---
<!--
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->
### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).
---
<!--
This checklist is used to track contributions from distro maintainers.
-->
### Distro maintenance information, if applicable
- [ ] This is a contribution from a distro maintainer
- [ ] The changes in this PR have been taken as a downstream patch (Note: it is not recommended to patch the agent without upstream review and approval)
