### PR TITLE
Update debian_11_arm64 sku in e2e runs

### DIFF
--- a/tests_e2e/test_suites/images.yml
+++ b/tests_e2e/test_suites/images.yml
@@ -42,7 +42,6 @@ image-sets:
 
    # Endorsed distros (ARM64) that are tested on the daily runs
    endorsed-arm64:
-      - "debian_11_arm64"
       - "flatcar_arm64"
       - "mariner_2_arm64"
       - "azure-linux_3_arm64"
@@ -202,14 +201,6 @@ images:
    debian_8: "credativ:Debian:8:latest"
    debian_10: "Debian:debian-10:10:latest"
    debian_11: "Debian:debian-11:11:latest"
-   debian_11_arm64:
-      urn: "Debian:debian-11:11-backports-arm64:latest"
-      vm_sizes:
-         # See comment above wrt VM sizes for ARM64 machines
-         - "Standard_B2pls_v2"
-      locations:
-         AzureUSGovernment: []
-         AzureChinaCloud: []
    flatcar:
       urn: "kinvolk:flatcar-container-linux-free:stable:latest"
       locations:

--- a/tests_e2e/test_suites/images.yml
+++ b/tests_e2e/test_suites/images.yml
@@ -42,6 +42,7 @@ image-sets:
 
    # Endorsed distros (ARM64) that are tested on the daily runs
    endorsed-arm64:
+      - "debian_11_arm64"
       - "flatcar_arm64"
       - "mariner_2_arm64"
       - "azure-linux_3_arm64"
@@ -201,6 +202,14 @@ images:
    debian_8: "credativ:Debian:8:latest"
    debian_10: "Debian:debian-10:10:latest"
    debian_11: "Debian:debian-11:11:latest"
+   debian_11_arm64:
+      urn: "Debian:debian-11:11-backports-arm64-v2:latest"
+      vm_sizes:
+         # See comment above wrt VM sizes for ARM64 machines
+         - "Standard_B2pls_v2"
+      locations:
+         AzureUSGovernment: []
+         AzureChinaCloud: []
    flatcar:
       urn: "kinvolk:flatcar-container-linux-free:stable:latest"
       locations:


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->
<!--
Please add an informative description that covers that changes made by the pull request.
-->
## Description
We are getting deployment errors for debian 11 arm64:
deployment failed. LisaException: InvalidParameter: The following list of images referenced from the deployment template are not found: Publisher: debian, Offer: debian-11, Sku: 11-backports-arm64, Version: latest. Please refer to https://docs.microsoft.com/en-us/azure/virtual-machines/windows/cli-ps-findimage for instructions on finding available images.

This PR updates to the new sku (discovered via cli)

Issue # <!-- if any -->
---
<!--
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->
### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).
---
<!--
This checklist is used to track contributions from distro maintainers.
-->
### Distro maintenance information, if applicable
- [ ] This is a contribution from a distro maintainer
- [ ] The changes in this PR have been taken as a downstream patch (Note: it is not recommended to patch the agent without upstream review and approval)
