### PR TITLE
Remove oracle_75, oracle_79 and oracle_82 from e2e test matrix

### DIFF
--- a/tests_e2e/test_suites/images.yml
+++ b/tests_e2e/test_suites/images.yml
@@ -21,7 +21,6 @@ image-sets:
       - "debian_10"
       - "debian_11"
       - "flatcar"
-      - "oracle_79"
       - "oracle_810"
       - "oracle_95"
       - "oracle_10"
@@ -238,20 +237,6 @@ images:
          AzureChinaCloud: []
          AzureUSGovernment: []
    oracle_610: "Oracle:Oracle-Linux:6.10:latest" # Python 2.6.6; not in test run
-   oracle_75: # Python: 2.7.5; used for the recover_network_interface test
-      urn: "Oracle:Oracle-Linux:7.5:latest"
-      locations:
-         AzureChinaCloud: []
-         AzureUSGovernment: []
-   oracle_79: # Python: 2.7.5
-      urn: "Oracle:Oracle-Linux:ol79-gen2:latest"
-      locations:
-         AzureChinaCloud: []
-   oracle_82: # Python: 3.6.8; used for the recover_network_interface test
-      urn: "Oracle:Oracle-Linux:ol82-gen2:latest"
-      locations:
-         AzureChinaCloud: []
-         AzureUSGovernment: []
    oracle_810: # Python: 3.6.8
       urn: "Oracle:Oracle-Linux:ol810-lvm-gen2:latest"
       locations:

--- a/tests_e2e/test_suites/recover_network_interface.yml
+++ b/tests_e2e/test_suites/recover_network_interface.yml
@@ -11,6 +11,3 @@ images:
   - "centos_82"
   - "rhel_79"
   - "rhel_83"
-  - "oracle_75"
-  - "oracle_79"
-  - "oracle_82"


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->
<!--
Please add an informative description that covers that changes made by the pull request.
-->
## Description

Fixing images not available in marketplace

`Message: The following list of images referenced from the deployment template are not found: Publisher: Oracle, Offer: Oracle-Linux, Sku: ol79-gen2, Version: latest`

`Message: The following list of images referenced from the deployment template are not found: Publisher: oracle, Offer: oracle-linux, Sku: ol82-gen2, Version: latest.`

`Message: The following list of images referenced from the deployment template are not found: Publisher: oracle, Offer: oracle-linux, Sku: 7.5, Version: latest`

Issue # <!-- if any -->
---
<!--
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->
### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).
---
<!--
This checklist is used to track contributions from distro maintainers.
-->
### Distro maintenance information, if applicable
- [ ] This is a contribution from a distro maintainer
- [ ] The changes in this PR have been taken as a downstream patch (Note: it is not recommended to patch the agent without upstream review and approval)
