### PR TITLE
Enable fips e2e test suite in Mooncake

### DIFF
--- a/tests_e2e/test_suites/fips.yml
+++ b/tests_e2e/test_suites/fips.yml
@@ -12,8 +12,10 @@ name: "FIPS"
 tests:
   - source: "fips/fips.py"
 images:
-  - "ubuntu_pro_fips_2204" # FIPS is pre-enabled on these "fips" images.
-  - "ubuntu_pro_2404" # Enabling FIPS on Ubuntu requires the "pro" client to be enabled. There is not an Ubuntu 24 image which comes with FIPS pre-enabled, since it is not certified for FIPS yet, but we can enable FIPS manually on these pro VMs.
+  - "ubuntu_pro_fips_2204"        # FIPS is pre-enabled on these "fips" images.
+  - "ubuntu_pro_2404"             # Enabling FIPS on Ubuntu requires the "pro" client to be enabled. There is not an Ubuntu 24 image which comes with FIPS pre-enabled, since it is not certified for FIPS yet, but we can enable FIPS manually on these pro VMs.
+  - "ubuntu_pro_fips_2204_china"  # China cloud has different urns for ubuntu pro images, so we include those here as well.
+  - "ubuntu_pro_2404_china"       # China cloud has different urns for ubuntu pro images, so we include those here as well.
   - "oracle_95"
   - "rhel_95"
 
@@ -32,6 +34,12 @@ locations:
 skip_on_images:
   - "AzureChinaCloud:oracle_95"
   - "AzureChinaCloud:rhel_95"
+  - "AzureChinaCloud:ubuntu_pro_fips_2204"          # We use a different ubuntu pro image in China cloud, so we skip this one.
+  - "AzureChinaCloud:ubuntu_pro_2404"               # We use a different ubuntu pro image in China cloud, so we skip this one.
+  - "AzureCloud:ubuntu_pro_fips_2204_china"         # We use a different ubuntu pro image in Public cloud, so we skip this one.
+  - "AzureCloud:ubuntu_pro_2404_china"              # We use a different ubuntu pro image in Public cloud, so we skip this one.
+  - "AzureUSGovernment:ubuntu_pro_fips_2204_china"  # We use a different ubuntu pro image in USGov cloud, so we skip this one.
+  - "AzureUSGovernment:ubuntu_pro_2404_china"       # We use a different ubuntu pro image in USGov cloud, so we skip this one.
 
 #
 # The test VM could be shared with other test suites, but we want to ensure there is a mix of FIPS and non-FIPS environments in the test run,

--- a/tests_e2e/test_suites/fips.yml
+++ b/tests_e2e/test_suites/fips.yml
@@ -18,19 +18,20 @@ images:
   - "rhel_95"
 
 #
-# The test uses a keyvault located on westus2.
+# The test uses keyvaults in each of our test subscriptions. Those keyvaults are located in AzureCloud:westus2,
+# AzureUSGovernment:usgovarizona, and AzureChinaCloud:chinanorth2
 #
 locations:
   - "AzureCloud:westus2"
+  - "AzureUSGovernment:usgovarizona"
+  - "AzureChinaCloud:chinanorth2"
 
 #
-# Support for FIPS 140-3 has been deployed AzureChinaCloud, but none of the images which this suite runs on are
-# available in China cloud (oracle_95 and rhel_95 are not available in China cloud, and our China test subscription
-# does not have access to the ubuntu pro images).
-# TODO: Once the China test sub has access to Ubuntu PRO images, we should run this suite in China cloud.
+# The oracle_95 and rhel_95 images are not available in China cloud, so we skip the suite on those images.
 #
-skip_on_clouds:
-  - "AzureChinaCloud"
+skip_on_images:
+  - "AzureChinaCloud:oracle_95"
+  - "AzureChinaCloud:rhel_95"
 
 #
 # The test VM could be shared with other test suites, but we want to ensure there is a mix of FIPS and non-FIPS environments in the test run,

--- a/tests_e2e/test_suites/fips.yml
+++ b/tests_e2e/test_suites/fips.yml
@@ -30,16 +30,18 @@ locations:
 
 #
 # The oracle_95 and rhel_95 images are not available in China cloud, so we skip the suite on those images.
+# Additionally, there are two different urns for each Ubuntu Pro image because different clouds have different urns. We
+#   skip the images that are not available in each cloud.
 #
 skip_on_images:
   - "AzureChinaCloud:oracle_95"
   - "AzureChinaCloud:rhel_95"
-  - "AzureChinaCloud:ubuntu_pro_fips_2204"          # We use a different ubuntu pro image in China cloud, so we skip this one.
-  - "AzureChinaCloud:ubuntu_pro_2404"               # We use a different ubuntu pro image in China cloud, so we skip this one.
-  - "AzureCloud:ubuntu_pro_fips_2204_china"         # We use a different ubuntu pro image in Public cloud, so we skip this one.
-  - "AzureCloud:ubuntu_pro_2404_china"              # We use a different ubuntu pro image in Public cloud, so we skip this one.
-  - "AzureUSGovernment:ubuntu_pro_fips_2204_china"  # We use a different ubuntu pro image in USGov cloud, so we skip this one.
-  - "AzureUSGovernment:ubuntu_pro_2404_china"       # We use a different ubuntu pro image in USGov cloud, so we skip this one.
+  - "AzureChinaCloud:ubuntu_pro_fips_2204"
+  - "AzureChinaCloud:ubuntu_pro_2404"
+  - "AzureCloud:ubuntu_pro_fips_2204_china"
+  - "AzureCloud:ubuntu_pro_2404_china"
+  - "AzureUSGovernment:ubuntu_pro_fips_2204_china"
+  - "AzureUSGovernment:ubuntu_pro_2404_china"
 
 #
 # The test VM could be shared with other test suites, but we want to ensure there is a mix of FIPS and non-FIPS environments in the test run,

--- a/tests_e2e/test_suites/images.yml
+++ b/tests_e2e/test_suites/images.yml
@@ -357,6 +357,12 @@ images:
       urn: "Canonical:0001-com-ubuntu-pro-microsoft:pro-fips-22_04:latest"
       locations:
          AzureChinaCloud: []
+   ubuntu_pro_fips_2204_china:
+      # The ubuntu_pro_fips_2204 urn above is not available in China cloud, so we use a different urn for that cloud.
+      urn: "Canonical:ubuntu-22_04-lts:ubuntu-pro-fips:latest"
+      locations:
+         AzureCloud: []
+         AzureUSGovernment: []
    ubuntu_2204_arm64:
       urn: "Canonical:0001-com-ubuntu-server-jammy:22_04-lts-arm64:latest"
       vm_sizes:
@@ -371,6 +377,12 @@ images:
       urn: "Canonical:0001-com-ubuntu-pro-microsoft:pro-24_04:latest"
       locations:
          AzureChinaCloud: []
+   ubuntu_pro_2404_china:
+      # The ubuntu_pro_2404 urn above is not available in China cloud, so we use a different urn for that cloud.
+      urn: "Canonical:ubuntu-24_04-lts:ubuntu-pro:latest"
+      locations:
+         AzureCloud: []
+         AzureUSGovernment: []
    ubuntu_2404_arm64:
       urn: "Canonical:ubuntu-24_04-lts:server-arm64:latest"
       vm_sizes:

--- a/tests_e2e/tests/fips/fips.py
+++ b/tests_e2e/tests/fips/fips.py
@@ -211,7 +211,7 @@ class Fips(AgentVmTest):
                 },
                 'AzureChinaCloud': {
                     'source_vault': f"/subscriptions/{self._context.vm.subscription}/resourceGroups/waagent-tests/providers/Microsoft.KeyVault/vaults/waagenttests",
-                    'certificate_url': 'https://waagenttests.vault.azure.cn/certificates/rsa-cert/a1a6047c02d84d2da5300fec70b0d070'
+                    'certificate_url': 'https://waagenttests.vault.azure.cn/secrets/rsa-cert/a1a6047c02d84d2da5300fec70b0d070'
                 }
             }
             certificate = certificates_by_cloud[self._context.vm.cloud]

--- a/tests_e2e/tests/fips/fips.py
+++ b/tests_e2e/tests/fips/fips.py
@@ -209,6 +209,10 @@ class Fips(AgentVmTest):
                     'source_vault': f"/subscriptions/{self._context.vm.subscription}/resourceGroups/waagent-tests/providers/Microsoft.KeyVault/vaults/waagenttests",
                     'certificate_url': 'https://waagenttests.vault.usgovcloudapi.net/secrets/rsa-cert/100dd15190f2485fa200ab948afc1d2e'
                 },
+                'AzureChinaCloud': {
+                    'source_vault': f"/subscriptions/{self._context.vm.subscription}/resourceGroups/waagent-tests/providers/Microsoft.KeyVault/vaults/waagenttests",
+                    'certificate_url': 'https://waagenttests.vault.azure.cn/certificates/rsa-cert/a1a6047c02d84d2da5300fec70b0d070'
+                }
             }
             certificate = certificates_by_cloud[self._context.vm.cloud]
 


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->
<!--
Please add an informative description that covers that changes made by the pull request.
-->
## Description
This PR enables the FIPS e2e test suite on Ubuntu Pro images in Mooncake. oracle_95 and rhel_95 are still not available in Mooncake, so the suite only runs on Ubuntu in China. 

Note that Canonical publishes the pro images under different urns in Mooncake than Public/Fairfax so there are different urn definitions for Public/Fairfax and Mooncake.

Issue # <!-- if any -->
---
<!--
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->
### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).
---
<!--
This checklist is used to track contributions from distro maintainers.
-->
### Distro maintenance information, if applicable
- [ ] This is a contribution from a distro maintainer
- [ ] The changes in this PR have been taken as a downstream patch (Note: it is not recommended to patch the agent without upstream review and approval)
