### PR TITLE
Remove .mrseq state file in disable operation for multi config scenario

### DIFF
--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -2392,8 +2392,9 @@ class ExtHandlerInstance(object):
     def __remove_extension_state_files(self, extension):
         self.logger.info("Removing states files for disabled extension: {0}".format(extension.name))
         try:
-            # MultiConfig: Remove all config/<extName>.*.settings, status/<extName>.*.status and config/<extName>.HandlerState files
+            # MultiConfig: Remove all <extName>.mrseq, config/<extName>.*.settings, status/<extName>.*.status and config/<extName>.HandlerState files
             files_to_delete = [
+                os.path.join(self.get_base_dir(), "{0}.mrseq".format(extension.name)),
                 os.path.join(self.get_conf_dir(), "{0}.*.settings".format(extension.name)),
                 os.path.join(self.get_status_dir(), "{0}.*.status".format(extension.name)),
                 os.path.join(self.get_conf_dir(), self.__get_handler_state_file_name(extension))

--- a/tests_e2e/test_suites/multi_config_ext.yml
+++ b/tests_e2e/test_suites/multi_config_ext.yml
@@ -7,6 +7,3 @@ tests:
   - "multi_config_ext/multi_config_ext.py"
 images:
   - "endorsed"
-# TODO: This test has been failing due to issues in the RC2 extension on AzureCloud. Re-enable once the extension has been fixed.
-skip_on_clouds:
-  - "AzureCloud"

--- a/tests_e2e/tests/multi_config_ext/multi_config_ext.py
+++ b/tests_e2e/tests/multi_config_ext/multi_config_ext.py
@@ -161,6 +161,29 @@ class MultiConfigExt(AgentVmTest):
         self.enable_and_assert_test_cases(cases_to_enable=sc_test_cases, cases_to_assert=sc_test_cases,
                                           delete_extensions=True)
 
+        # Enable multiple instances of RCv2, verify, disable one of them, verify, re-enable the disabled instance, verify, and delete all extensions
+        log.info("")
+        log.info("Add multiple instances of RCv2 to the VM...")
+        rc_test_case_1: Dict[str, MultiConfigExt.TestCase] = {
+            "MCExt7": MultiConfigExt.TestCase(
+                VirtualMachineRunCommandClient(self._context.vm, VmExtensionIds.RunCommandHandler,
+                                              resource_name="MCExt7"), mc_settings)}
+        self.enable_and_assert_test_cases(cases_to_enable=rc_test_case_1, cases_to_assert=rc_test_case_1)
+
+        rc_test_case_2: Dict[str, MultiConfigExt.TestCase] = {
+            "MCExt8": MultiConfigExt.TestCase(
+                VirtualMachineRunCommandClient(self._context.vm, VmExtensionIds.RunCommandHandler,
+                                              resource_name="MCExt8"), mc_settings)}
+        self.enable_and_assert_test_cases(cases_to_enable=rc_test_case_2, cases_to_assert=rc_test_case_2, delete_extensions=True)
+
+        log.info("")
+        log.info("Re-add deleted extension to the VM...")
+        self.enable_and_assert_test_cases(cases_to_enable=rc_test_case_2, cases_to_assert=rc_test_case_2)
+
+        log.info("")
+        log.info("Cleanup all extensions from the VM...")
+        self.delete_extensions(rc_test_case_1 | rc_test_case_2)
+
 
 if __name__ == "__main__":
     MultiConfigExt.run_from_command_line()

--- a/tests_e2e/tests/multi_config_ext/multi_config_ext.py
+++ b/tests_e2e/tests/multi_config_ext/multi_config_ext.py
@@ -161,7 +161,8 @@ class MultiConfigExt(AgentVmTest):
         self.enable_and_assert_test_cases(cases_to_enable=sc_test_cases, cases_to_assert=sc_test_cases,
                                           delete_extensions=True)
 
-        # Enable multiple instances of RCv2, verify, disable one of them, verify, re-enable the disabled instance, verify, and delete all extensions
+        # Enable multiple instances of RCv2, verify, delete one of them, verify the remaining instance, re-add the deleted
+        # instance, verify again, and delete all extensions
         log.info("")
         log.info("Add multiple instances of RCv2 to the VM...")
         rc_test_case_1: Dict[str, MultiConfigExt.TestCase] = {
@@ -174,15 +175,24 @@ class MultiConfigExt(AgentVmTest):
             "MCExt8": MultiConfigExt.TestCase(
                 VirtualMachineRunCommandClient(self._context.vm, VmExtensionIds.RunCommandHandler,
                                               resource_name="MCExt8"), mc_settings)}
-        self.enable_and_assert_test_cases(cases_to_enable=rc_test_case_2, cases_to_assert=rc_test_case_2, delete_extensions=True)
+        all_rc_test_cases: Dict[str, MultiConfigExt.TestCase] = {**rc_test_case_1, **rc_test_case_2}
+        self.enable_and_assert_test_cases(cases_to_enable=rc_test_case_2, cases_to_assert=all_rc_test_cases)
+
+        log.info("")
+        log.info("Delete one RCv2 extension from the VM...")
+        self.delete_extensions(rc_test_case_2)
+
+        log.info("")
+        log.info("Verify the remaining RCv2 extension is still healthy...")
+        self.enable_and_assert_test_cases(cases_to_enable={}, cases_to_assert=rc_test_case_1)
 
         log.info("")
         log.info("Re-add deleted extension to the VM...")
-        self.enable_and_assert_test_cases(cases_to_enable=rc_test_case_2, cases_to_assert=rc_test_case_2)
+        self.enable_and_assert_test_cases(cases_to_enable=rc_test_case_2, cases_to_assert=all_rc_test_cases)
 
         log.info("")
         log.info("Cleanup all extensions from the VM...")
-        self.delete_extensions(rc_test_case_1 | rc_test_case_2)
+        self.delete_extensions(all_rc_test_cases)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->
<!--
Please add an informative description that covers that changes made by the pull request.
-->
## Description

Re-enabling the extension after deletion fails because the agent does not clean up the mrseq state file created by the extension during the disable operation for RunCommand v2.

 
Issue # <!-- if any -->
---
<!--
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->
### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).
---
<!--
This checklist is used to track contributions from distro maintainers.
-->
### Distro maintenance information, if applicable
- [ ] This is a contribution from a distro maintainer
- [ ] The changes in this PR have been taken as a downstream patch (Note: it is not recommended to patch the agent without upstream review and approval)
