### PR TITLE
ExtPolicy test should own VM until optimized

### DIFF
--- a/tests_e2e/test_suites/ext_policy.yml
+++ b/tests_e2e/test_suites/ext_policy.yml
@@ -5,7 +5,6 @@
 name: "ExtensionPolicy"
 tests:
   - "ext_policy/ext_policy.py"
-  - "ext_policy/constrained_ext.py"
 images:
   - "random(endorsed,10)" # TODO: Remove randomization and run on all endorsed images once the test suite is optimized to reduce runtime.
   - "cvm-endorsed"

--- a/tests_e2e/test_suites/ext_policy.yml
+++ b/tests_e2e/test_suites/ext_policy.yml
@@ -1,14 +1,15 @@
 #
 # The test suite verifies that disallowed extensions are not processed, but the agent should still report status.
 #
-# TODO: This test suite takes ~30 minutes to run. This should be optimized to reduce impact to pipeline run times.
+# TODO: This test suite takes 30+ minutes to run. This should be optimized to reduce impact to pipeline run times.
 name: "ExtensionPolicy"
 tests:
   - "ext_policy/ext_policy.py"
+  - "ext_policy/constrained_ext.py"
 images:
   - "random(endorsed,10)" # TODO: Remove randomization and run on all endorsed images once the test suite is optimized to reduce runtime.
   - "cvm-endorsed"
-owns_vm: false
+owns_vm: true   # This test owns the VM because it is causing environment timeouts when shared with other tests. TODO: Remove this once the test suite is optimized to reduce runtime and can run on all endorsed images.
 skip_on_images:
   # TODO: The ConfigurationforLinux-1.26.109 extension is failing on Debian 11 in China cloud only; skip this image until the issue in the extension is fixed
   - "AzureChinaCloud:debian_11"


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->
<!--
Please add an informative description that covers that changes made by the pull request.
-->
## Description
This PR updates the ext_policy test suite to own its VM. This is because we are seeing environment timeouts due ExtPolicy test taking 30+ minutes to run, not leaving enough time for the other suites on the VM to complete. 

This test needs to be optimized so that it can share a VM again, reflected by TODO in comments 

Issue # <!-- if any -->
---
<!--
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->
### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).
---
<!--
This checklist is used to track contributions from distro maintainers.
-->
### Distro maintenance information, if applicable
- [ ] This is a contribution from a distro maintainer
- [ ] The changes in this PR have been taken as a downstream patch (Note: it is not recommended to patch the agent without upstream review and approval)
