### PR TITLE
Adding support for constrained extensions

### DIFF
--- a/azurelinuxagent/ga/exthandlers.py
+++ b/azurelinuxagent/ga/exthandlers.py
@@ -42,7 +42,7 @@ from azurelinuxagent.common.agent_supported_feature import get_agent_supported_f
 from azurelinuxagent.common.utils.textutil import redact_sas_token
 from azurelinuxagent.ga.cgroupconfigurator import CGroupConfigurator
 from azurelinuxagent.ga.policy.policy_engine import ExtensionPolicyEngine, ExtensionDisallowedError, \
-    ExtensionSignaturePolicyError, ExtensionUnsignedError, ExtensionSignatureNotValidatedError
+    ExtensionSignaturePolicyError, ExtensionUnsignedError, ExtensionSignatureNotValidatedError, ExtensionRuntimePolicyError
 from azurelinuxagent.common.datacontract import get_properties, set_properties
 from azurelinuxagent.common.errorstate import ErrorState
 from azurelinuxagent.common.event import add_event, elapsed_milliseconds, WALAEventOperation, \
@@ -730,6 +730,13 @@ class ExtHandlersHandler(object):
             ).format(operation, ext_handler_i.ext_handler.name, conf.get_policy_file_path())
             self.__handle_ext_disallowed_error(ext_handler_i, error_code, report_op=WALAEventOperation.ExtensionSignaturePolicy, message=msg,
                                                extension=extension)
+        except ExtensionRuntimePolicyError as error:
+            _, error_code = _EXT_DISALLOWED_ERROR_MAP.get(ext_handler_i.ext_handler.state)
+            msg = (
+                "Extension will not be processed: {0}"
+            ).format(ustr(error))
+            self.__handle_ext_disallowed_error(ext_handler_i, error_code, report_op=WALAEventOperation.ExtensionPolicy, message=msg,
+                                                extension=extension)
         except ExtensionSignatureNotValidatedError:
             operation, error_code = _EXT_DISALLOWED_ERROR_MAP.get(ext_handler_i.ext_handler.state)
             msg = (
@@ -842,6 +849,9 @@ class ExtHandlersHandler(object):
                 raise ExtensionUnsignedError()
 
             self.__setup_new_handler(ext_handler_i, extension, self.__should_ignore_ext_signature_validation_errors(ext_handler_i))
+            # The runtime policy file should be created, updated, or removed before each install/enable to ensure that
+            # the latest changes to the policy file (if any) are applied.
+            self.__update_extension_runtime_policy(ext_handler_i)
 
             if old_ext_handler_i is None:
                 ext_handler_i.install(extension=extension)
@@ -877,8 +887,29 @@ class ExtHandlersHandler(object):
 
             ext_handler_i.ensure_consistent_data_for_mc()
             ext_handler_i.update_settings(extension)
+            # The runtime policy file should be created, updated, or removed before each install/enable to ensure that
+            # the latest changes to the policy file (if any) are applied.
+            self.__update_extension_runtime_policy(ext_handler_i)
 
         self.__handle_extension(ext_handler_i, extension, uninstall_exit_code)
+
+    def __update_extension_runtime_policy(self, ext_handler_i):
+        # This method synchronizes the extension runtime policy file with the current agent policy at
+        # /etc/waagent_policy.json. If policy enforcement is disabled, any stale runtime policy file is removed. If
+        # policy enforcement is enabled, the extension runtime policy file is created/updated only for extensions that
+        # support policy.
+        #
+        # If an extension runtime policy exists, but the extension does not support policy, an exception will be raised
+        # and caught in handle_ext_handler to prevent the extension from being processed and report the appropriate
+        # status for the extension. This ensures that the policy is not silently ignored.
+        if not self._policy_engine.policy_enforcement_enabled:
+            if ext_handler_i.runtime_policy_exists():
+                ext_handler_i.remove_runtime_policy()   # remove any stale runtime policy file for the extension
+            return
+
+        runtime_policy = self._policy_engine.get_extension_runtime_policy(ext_handler_i.ext_handler.name, ext_handler_i.supports_policy())
+        if runtime_policy is not None:
+            ext_handler_i.update_runtime_policy(runtime_policy) # Create or update the extension runtime policy file
 
     @staticmethod
     def __setup_new_handler(ext_handler_i, extension, ignore_signature_validation_errors):
@@ -2513,6 +2544,32 @@ class ExtHandlerInstance(object):
     def get_log_dir(self):
         return os.path.join(conf.get_ext_log_dir(), self.ext_handler.name)
 
+    def get_runtime_policy_file(self):
+        return os.path.join(self.get_conf_dir(), 'waagent_runtime_policy.json')
+
+    def runtime_policy_exists(self):
+        return os.path.isfile(self.get_runtime_policy_file())
+
+    def supports_policy(self):
+        return self.load_manifest().supports_policy()
+
+    def update_runtime_policy(self, runtime_policy):
+        runtime_policy_file = self.get_runtime_policy_file()
+        try:
+            fileutil.write_file(runtime_policy_file, json.dumps(runtime_policy))
+        except IOError as e:
+            raise ExtensionRuntimePolicyError(
+                "Failed to save extension runtime policy file: {0}. Error: {1}".format(runtime_policy_file, e))
+
+    def remove_runtime_policy(self):
+        runtime_policy_file = self.get_runtime_policy_file()
+        try:
+            fileutil.rm_files(runtime_policy_file)
+        except OSError as e:
+            if not is_file_not_found_error(e):
+                raise ExtensionRuntimePolicyError(
+                    "Failed to remove extension runtime policy file: {0}. Error: {1}".format(runtime_policy_file, e))
+
     @staticmethod
     def _read_status_file(ext_status_file):
         err_count = 0
@@ -2631,6 +2688,12 @@ class HandlerManifest(object):
         value = self.data['handlerManifest'].get('supportsMultipleExtensions', False)
         return self._parse_boolean_value(value, default_val=False)
 
+    def supports_policy(self):
+        value = self.data['handlerManifest'].get('supportsPolicy', False)
+        # For legacy properties in the manifest, we accept string booleans for backwards compatibility. Since this is a
+        # new boolean property we will not accept string. If the value is not a boolean, False will always be returned.
+        return value if isinstance(value, bool) else False
+
     def get_resource_limits(self):
         return ResourceLimits(self.data.get('resourceLimits', None))
 
@@ -2643,7 +2706,7 @@ class HandlerManifest(object):
         """
         Check that the specified keys in the handler manifest has boolean values.
         """
-        for key in ['reportHeartbeat', 'continueOnUpdateFailure', 'supportsMultipleExtensions']:
+        for key in ['reportHeartbeat', 'continueOnUpdateFailure', 'supportsMultipleExtensions', 'supportsPolicy']:
             value = self.data['handlerManifest'].get(key)
             if value is not None and not isinstance(value, bool):
                 msg = "In the handler manifest: '{0}' has a non-boolean value [{1}] for boolean type. Please change it to a boolean value.".format(key, value)

--- a/azurelinuxagent/ga/policy/policy_engine.py
+++ b/azurelinuxagent/ga/policy/policy_engine.py
@@ -97,6 +97,12 @@ class ExtensionDisallowedError(PolicyError):
         super(ExtensionDisallowedError, self).__init__()
 
 
+class ExtensionRuntimePolicyError(PolicyError):
+    """
+    Any error related to extension-specific runtime policy.
+    """
+
+
 class _PolicyEngine(object):
     """
     Implements base policy engine API.
@@ -443,3 +449,43 @@ class ExtensionPolicyEngine(_PolicyEngine):
         enforce_signature = self.should_enforce_signature_validation(extension_name)
         if enforce_signature and not extension_is_signed:
             raise ExtensionSignaturePolicyError() # Caller sets message and error code, based on requested extension operation
+
+    def get_extension_runtime_policy(self, extension_name, supports_policy):
+        """
+        Return the runtime policy contents for the extension, or None if no runtime policy file should be written.
+
+        No runtime policy file should be written in either of the following cases:
+            1. Policy enforcement is not enabled.
+            2. The extension does not support policy and no runtime policy is configured for the extension.
+
+        Otherwise, the agent should create or update the extension runtime policy file with the configured runtime policy,
+        or an empty dict if no runtime policy is configured. If a runtime policy is configured but the extension does not
+        support policy, raise an exception to prevent the extension from being processed. This ensures that the policy is
+        not silently ignored.
+
+        | Policy enforcement | supportsPolicy | runtimePolicy specified | Result                     |
+        |--------------------|----------------|-------------------------|----------------------------|
+        | Disabled           | Any            | Any                     | Return None                |
+        | Enabled            | True           | Yes                     | Return runtimePolicy       |
+        | Enabled            | True           | No                      | Return {}                  |
+        | Enabled            | False          | Yes                     | Raise runtime policy error |
+        | Enabled            | False          | No                      | Return None                |
+        """
+        if not self._policy_enforcement_enabled:
+            return None
+
+        extension_policies = self._policy.get("extensionPolicies")
+        extensions = extension_policies.get("extensions") if extension_policies is not None else None
+        individual_policy = extensions.get(extension_name) if extensions is not None else None
+        runtime_policy = individual_policy.get("runtimePolicy") if individual_policy is not None else None
+
+        if supports_policy:
+            return runtime_policy if runtime_policy is not None else {}
+
+        elif runtime_policy is not None:
+            raise ExtensionRuntimePolicyError(
+                "Runtime policy is specified for extension '{0}', but this extension does not support runtime policy enforcement. "
+                "To continue enabling the extension without runtime policy, remove the 'runtimePolicy' property for "
+                "extension '{0}' from the policy file ({1}).".format(extension_name, conf.get_policy_file_path()))
+
+        return None

--- a/tests/data/ext/handler_manifest/manifest_boolean_fields_false.json
+++ b/tests/data/ext/handler_manifest/manifest_boolean_fields_false.json
@@ -9,7 +9,8 @@
       "disableCommand": "disable_cmd",
       "reportHeartbeat": "false",
       "continueOnUpdateFailure": "false",
-      "supportsMultipleExtensions": "false"
+      "supportsMultipleExtensions": "false",
+      "supportsPolicy": "false"
     }
 }]
 

--- a/tests/data/ext/handler_manifest/manifest_boolean_fields_invalid.json
+++ b/tests/data/ext/handler_manifest/manifest_boolean_fields_invalid.json
@@ -9,7 +9,8 @@
       "disableCommand": "disable_cmd",
       "reportHeartbeat": "invalid",
       "continueOnUpdateFailure": "invalid",
-      "supportsMultipleExtensions": 1
+      "supportsMultipleExtensions": 1,
+      "supportsPolicy": 1
     }
 }]
 

--- a/tests/data/ext/handler_manifest/manifest_boolean_fields_strings.json
+++ b/tests/data/ext/handler_manifest/manifest_boolean_fields_strings.json
@@ -9,7 +9,8 @@
       "disableCommand": "disable_cmd",
       "reportHeartbeat": "true",
       "continueOnUpdateFailure": "true",
-      "supportsMultipleExtensions": "True"
+      "supportsMultipleExtensions": "True",
+      "supportsPolicy": "True"
     }
 }]
 

--- a/tests/data/ext/handler_manifest/valid_manifest.json
+++ b/tests/data/ext/handler_manifest/valid_manifest.json
@@ -9,7 +9,8 @@
       "disableCommand": "disable_cmd",
       "reportHeartbeat": true,
       "continueOnUpdateFailure": true,
-      "supportsMultipleExtensions": true
+      "supportsMultipleExtensions": true,
+      "supportsPolicy": true
     }
 }]
 

--- a/tests/ga/test_extension.py
+++ b/tests/ga/test_extension.py
@@ -48,7 +48,7 @@ from azurelinuxagent.common.utils.restutil import KNOWN_WIRESERVER_IP
 from azurelinuxagent.common.utils.archive import ARCHIVE_DIRECTORY_NAME
 from azurelinuxagent.ga.signing_certificate_util import write_signing_certificates
 
-from azurelinuxagent.ga.exthandlers import ExtHandlerInstance, ExtHandlersHandler, migrate_handler_state, \
+from azurelinuxagent.ga.exthandlers import ExtHandlerInstance, migrate_handler_state, \
     get_exthandlers_handler, ExtCommandEnvVariable, HandlerManifest, NOT_RUN, \
     ExtensionStatusValue, HANDLER_COMPLETE_NAME_PATTERN, HandlerEnvironment, GoalStateStatus, ExtHandlerState
 from azurelinuxagent.ga.policy.policy_engine import _PolicyEngine
@@ -3510,6 +3510,7 @@ class TestExtensionHandlerManifest(AgentTestCase):
             self.assertTrue(manifest.is_continue_on_update_failure())
             self.assertTrue(manifest.is_report_heartbeat())
             self.assertTrue(manifest.supports_multiple_extensions())
+            self.assertTrue(manifest.supports_policy())
 
     def test_handler_manifest_defaults(self):
         # Set only the required fields
@@ -3519,6 +3520,15 @@ class TestExtensionHandlerManifest(AgentTestCase):
             self.assertFalse(manifest.is_continue_on_update_failure())
             self.assertFalse(manifest.is_report_heartbeat())
             self.assertFalse(manifest.supports_multiple_extensions())
+            self.assertFalse(manifest.supports_policy())
+
+    def test_supports_policy_requires_boolean_value(self):
+        # Unlike legacy properties in extension manifest which allow string for bool type properties, the
+        # supportsPolicy property only allows boolean. Any non-boolean value should be treated as False.
+        self.assertTrue(HandlerManifest({"handlerManifest": {"supportsPolicy": True}}).supports_policy())
+        self.assertFalse(HandlerManifest({"handlerManifest": {"supportsPolicy": False}}).supports_policy())
+        self.assertFalse(HandlerManifest({"handlerManifest": {"supportsPolicy": "true"}}).supports_policy())
+        self.assertFalse(HandlerManifest({"handlerManifest": {"supportsPolicy": 1}}).supports_policy())
 
     def test_handler_manifest_boolean_fields(self):
         # Set the boolean fields to strings
@@ -3528,6 +3538,7 @@ class TestExtensionHandlerManifest(AgentTestCase):
             self.assertTrue(manifest.is_continue_on_update_failure())
             self.assertTrue(manifest.is_report_heartbeat())
             self.assertTrue(manifest.supports_multiple_extensions())
+            self.assertFalse(manifest.supports_policy())    # Unlike legacy manifest properties, non-bool values are not accepted for supportsPolicy so they should be evaluated to False
 
         # set the boolean fields to invalid values
         shutil.copyfile(os.path.join(data_dir, "ext", "handler_manifest", "manifest_boolean_fields_invalid.json"), self.test_file)
@@ -3536,6 +3547,7 @@ class TestExtensionHandlerManifest(AgentTestCase):
             self.assertFalse(manifest.is_continue_on_update_failure())
             self.assertFalse(manifest.is_report_heartbeat())
             self.assertFalse(manifest.supports_multiple_extensions())
+            self.assertFalse(manifest.supports_policy())
 
         # set the boolean fields to 'false' string
         shutil.copyfile(os.path.join(data_dir, "ext", "handler_manifest", "manifest_boolean_fields_false.json"), self.test_file)
@@ -3544,6 +3556,7 @@ class TestExtensionHandlerManifest(AgentTestCase):
             self.assertFalse(manifest.is_continue_on_update_failure())
             self.assertFalse(manifest.is_report_heartbeat())
             self.assertFalse(manifest.supports_multiple_extensions())
+            self.assertFalse(manifest.supports_policy())
 
     def test_report_msg_if_handler_manifest_contains_invalid_values(self):
         # Set the boolean fields to invalid values
@@ -3553,10 +3566,11 @@ class TestExtensionHandlerManifest(AgentTestCase):
                 manifest = self.ext_handler_instance.load_manifest()
                 manifest.report_invalid_boolean_properties("test_ext")
                 kw_messages = [kw for _, kw in mock_add_event.call_args_list if kw.get('op') == 'ExtensionHandlerManifest']
-                self.assertEqual(3, len(kw_messages))
+                self.assertEqual(4, len(kw_messages))
                 self.assertIn("'reportHeartbeat' has a non-boolean value", kw_messages[0]['message'])
                 self.assertIn("'continueOnUpdateFailure' has a non-boolean value", kw_messages[1]['message'])
                 self.assertIn("'supportsMultipleExtensions' has a non-boolean value", kw_messages[2]['message'])
+                self.assertIn("'supportsPolicy' has a non-boolean value", kw_messages[3]['message'])
 
 
 class TestExtensionPolicy(TestExtensionBase):
@@ -3576,6 +3590,8 @@ class TestExtensionPolicy(TestExtensionBase):
         self.patch_is_cvm = patch('azurelinuxagent.ga.confidential_vm_info.ConfidentialVMInfo.is_confidential_vm', return_value=True)
         self.patch_is_cvm.start()
         self.maxDiff = None     # When long error messages don't match, display the entire diff.
+
+        self.runtime_policy_path = os.path.join(conf.get_lib_dir(), "OSTCExtensions.ExampleHandlerLinux-1.0.0", "config", "waagent_runtime_policy.json")
 
     def tearDown(self):
         self.mock_sleep.stop()
@@ -3908,13 +3924,13 @@ class TestExtensionPolicy(TestExtensionBase):
             protocol.mock_wire_data.set_manifest_version("1.0.1")
             protocol.client.update_goal_state()
 
-            # Patch __setup_new_handler so the upgrade does not attempt actual signature validation
-            # of the new package (test fixtures do not have a real matching signature). The intent of
-            # this test is to verify that the OLD handler's policy check is enforced before any
-            # operation is invoked on the old handler.
-            with patch.object(ExtHandlersHandler, "_ExtHandlersHandler__setup_new_handler"):
-                exthandlers_handler.run()
-                exthandlers_handler.report_ext_handlers_status()
+            # Patch signature and manifest validation so the upgrade does not attempt actual validation of the new
+            # package (test fixtures do not have a real matching signature for this package). The intent of this test is
+            # to verify that the OLD handler's policy check is enforced before any operation is invoked on the old handler.
+            with patch("azurelinuxagent.common.protocol.wire.validate_signature"):
+                with patch("azurelinuxagent.ga.exthandlers.validate_extension_manifest_signing_info"):
+                    exthandlers_handler.run()
+                    exthandlers_handler.report_ext_handlers_status()
 
             expected_err_msg = "policy specifies that extension must be signed, but the installed extension's signature was not previously validated by the agent."
             self._assert_handler_status(protocol.report_vm_status, expected_status="NotReady", expected_ext_count=1,
@@ -4005,6 +4021,198 @@ class TestExtensionPolicy(TestExtensionBase):
             self.assertTrue(os.path.exists(file_path), "Policy file was not copied to history folder")
             with open(file_path, mode='r') as f:
                 self.assertEqual(policy, json.load(f))
+
+    def test_should_create_runtime_policy_file_before_enabling(self):
+        # If "runtimePolicy" is specified in policy file, and "supportsPolicy" is true in handler manifest, create runtime policy file.
+        policy = {
+            "policyVersion": "0.1.0",
+            "extensionPolicies": {
+                "extensions": {
+                    "OSTCExtensions.ExampleHandlerLinux": {
+                        "runtimePolicy": {
+                            "allowDirectScripts": False
+                        }
+                    }
+                }
+            }
+        }
+
+        with patch("azurelinuxagent.ga.exthandlers.HandlerManifest.supports_policy", return_value=True):
+            self._test_policy_case(policy=policy, op=ExtensionRequestedState.Enabled, expected_status_code=0,
+                                   expected_handler_status='Ready', expected_ext_count=1)
+            self.assertTrue(os.path.exists(self.runtime_policy_path), "Runtime policy file was not created")
+            with open(self.runtime_policy_path, mode='r') as f:
+                expected_policy = {
+                    "allowDirectScripts": False
+                }
+                self.assertEqual(expected_policy, json.load(f))
+
+    def test_should_create_empty_runtime_policy_file_if_not_specified(self):
+        # If "runtimePolicy" is not specified in policy file, and "supportsPolicy" is true in handler manifest, create empty runtime policy file.
+        policy = {
+            "policyVersion": "0.1.0",
+            "extensionPolicies": {
+                "extensions": {
+                    "OSTCExtensions.ExampleHandlerLinux": {}
+                }
+            }
+        }
+
+        with patch("azurelinuxagent.ga.exthandlers.HandlerManifest.supports_policy", return_value=True):
+            self._test_policy_case(policy=policy, op=ExtensionRequestedState.Enabled, expected_status_code=0,
+                                   expected_handler_status='Ready', expected_ext_count=1)
+            self.assertTrue(os.path.exists(self.runtime_policy_path), "Runtime policy file was not created")
+            with open(self.runtime_policy_path, mode='r') as f:
+                expected_policy = {}
+                self.assertEqual(expected_policy, json.load(f))
+
+    def test_should_create_empty_runtime_policy_file_if_extension_not_in_policy(self):
+        # If extension is not restricted in policy file, and "supportsPolicy" is true in handler manifest, create empty runtime policy file.
+        policy = {
+            "policyVersion": "0.1.0",
+            "extensionPolicies": {
+                "extensions": {}
+            }
+        }
+
+        with patch("azurelinuxagent.ga.exthandlers.HandlerManifest.supports_policy", return_value=True):
+            self._test_policy_case(policy=policy, op=ExtensionRequestedState.Enabled, expected_status_code=0,
+                                   expected_handler_status='Ready', expected_ext_count=1)
+            self.assertTrue(os.path.exists(self.runtime_policy_path), "Runtime policy file was not created")
+            with open(self.runtime_policy_path, mode='r') as f:
+                self.assertEqual({}, json.load(f))
+
+    def test_enable_should_fail_if_supportsPolicy_false_but_runtime_policy_specified(self):
+        # If "runtimePolicy" is specified in policy file, and "supportsPolicy" is false in handler manifest, fail extension.
+        policy = {
+            "policyVersion": "0.1.0",
+            "extensionPolicies": {
+                "extensions": {
+                    "OSTCExtensions.ExampleHandlerLinux": {
+                        "runtimePolicy": {
+                            "allowDirectScripts": False
+                        }
+                    }
+                }
+            }
+        }
+
+        with patch("azurelinuxagent.ga.exthandlers.HandlerManifest.supports_policy", return_value=False):
+            expected_msg = "Runtime policy is specified for extension 'OSTCExtensions.ExampleHandlerLinux', but this extension does not support runtime policy enforcement."
+            self._test_policy_case(policy=policy, op=ExtensionRequestedState.Enabled,
+                                   expected_status_code=ExtensionErrorCodes.PluginEnableProcessingFailed,
+                                   expected_handler_status='NotReady', expected_ext_count=1,
+                                   expected_status_msg=expected_msg)
+            self.assertFalse(os.path.exists(self.runtime_policy_path), "Runtime policy file should not have been created")
+
+    def test_should_not_create_runtime_policy_file_if_supportsPolicy_false_and_not_specified(self):
+        # If "runtimePolicy" is not specified in policy file, and "supportsPolicy" is false in handler manifest, do not create runtime policy file.
+        policy = {
+            "policyVersion": "0.1.0",
+            "extensionPolicies": {
+                "extensions": {
+                    "OSTCExtensions.ExampleHandlerLinux": {}
+                }
+            }
+        }
+
+        with patch("azurelinuxagent.ga.exthandlers.HandlerManifest.supports_policy", return_value=False):
+            self._test_policy_case(policy=policy, op=ExtensionRequestedState.Enabled, expected_status_code=0,
+                                   expected_handler_status='Ready', expected_ext_count=1)
+            self.assertFalse(os.path.exists(self.runtime_policy_path), "Runtime policy file should not have been created")
+
+    def test_should_not_check_supports_policy_or_create_runtime_policy_file_if_policy_enforcement_is_disabled(self):
+        # When no agent policy file exists, runtime policy processing should not inspect the extension manifest or
+        # create an extension runtime policy file.
+        with mock_wire_protocol(wire_protocol_data.DATA_FILE) as protocol:
+            exthandlers_handler = get_exthandlers_handler(protocol)
+
+            with patch.object(ExtHandlerInstance, "supports_policy") as supports_policy:
+                exthandlers_handler.run()
+
+            supports_policy.assert_not_called()
+            self.assertFalse(os.path.exists(self.runtime_policy_path))
+
+    def test_should_synchronize_runtime_policy_file_on_each_enable(self):
+        # Synchronize the runtime policy file on every enable so policy updates and removals are applied before the
+        # extension runs.
+        initial_policy_with_runtime_policy = {
+            "policyVersion": "0.1.0",
+            "extensionPolicies": {
+                "extensions": {
+                    "OSTCExtensions.ExampleHandlerLinux": {
+                        "runtimePolicy": {
+                            "allowDirectScripts": False
+                        }
+                    }
+                }
+            }
+        }
+
+        updated_policy_with_runtime_policy = {
+            "policyVersion": "0.1.0",
+            "extensionPolicies": {
+                "extensions": {
+                    "OSTCExtensions.ExampleHandlerLinux": {
+                        "runtimePolicy": {
+                            "allowDirectScripts": True,
+                            "maxExecutionTime": 300
+                        }
+                    }
+                }
+            }
+        }
+
+        updated_policy_without_runtime_policy = {
+            "policyVersion": "0.1.0",
+            "extensionPolicies": {
+                "extensions": {
+                    "OSTCExtensions.ExampleHandlerLinux": {}
+                }
+            }
+        }
+
+        with mock_wire_protocol(wire_protocol_data.DATA_FILE) as protocol:
+            protocol.aggregate_status = None
+            protocol.report_vm_status = MagicMock()
+            exthandlers_handler = get_exthandlers_handler(protocol)
+
+            with patch("azurelinuxagent.ga.exthandlers.HandlerManifest.supports_policy", return_value=True):
+                # First enable - initial policy
+                self._create_policy_file(initial_policy_with_runtime_policy)
+                exthandlers_handler.run()
+
+                self.assertTrue(os.path.exists(self.runtime_policy_path), "Runtime policy file was not created on first enable")
+                with open(self.runtime_policy_path, mode='r') as f:
+                    self.assertEqual({"allowDirectScripts": False}, json.load(f), "Runtime policy file content does not match initial policy")
+
+                # Second enable - updated policy (extension already installed)
+                self._create_policy_file(updated_policy_with_runtime_policy)
+                protocol.mock_wire_data.set_incarnation(2)
+                protocol.client.update_goal_state()
+                exthandlers_handler.run()
+
+                self.assertTrue(os.path.exists(self.runtime_policy_path), "Runtime policy file was not created on second enable")
+                with open(self.runtime_policy_path, mode='r') as f:
+                    self.assertEqual({"allowDirectScripts": True, "maxExecutionTime": 300}, json.load(f), "Runtime policy file was not updated on second enable")
+
+                # Third enable - runtime policy removed from the extension policy
+                self._create_policy_file(updated_policy_without_runtime_policy)
+                protocol.mock_wire_data.set_incarnation(3)
+                protocol.client.update_goal_state()
+                exthandlers_handler.run()
+
+                self.assertTrue(os.path.exists(self.runtime_policy_path), "Empty runtime policy file was not created")
+                with open(self.runtime_policy_path, mode='r') as f:
+                    self.assertEqual({}, json.load(f), "Removed runtime policy was not replaced with an empty object")
+
+                # Fourth enable - policy enforcement disabled
+                os.remove(self.policy_path)
+                protocol.mock_wire_data.set_incarnation(4)
+                protocol.client.update_goal_state()
+                exthandlers_handler.run()
+
+                self.assertFalse(os.path.exists(self.runtime_policy_path), "Stale runtime policy file was not removed")
 
 
 class _TestSignatureValidationBase(TestExtensionBase):

--- a/tests/ga/test_exthandlers_exthandlerinstance.py
+++ b/tests/ga/test_exthandlers_exthandlerinstance.py
@@ -1,12 +1,14 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the Apache License.
 
+import errno
 import os
 import shutil
 import sys
 
 from azurelinuxagent.common.protocol.restapi import Extension, ExtHandlerPackage
 from azurelinuxagent.ga.exthandlers import ExtHandlerInstance
+from azurelinuxagent.ga.policy.policy_engine import ExtensionRuntimePolicyError
 from tests.lib.tools import AgentTestCase, patch
 
 
@@ -30,6 +32,23 @@ class ExtHandlerInstanceTestCase(AgentTestCase):
     def tearDown(self):
         self.mock_get_base_dir.stop()
         super(ExtHandlerInstanceTestCase, self).tearDown()
+
+    def test_create_runtime_policy_file_should_raise_runtime_policy_error_on_ioerror(self):
+        # Return a path with a nonexistent parent directory to force fileutil.write_file() to raise IOError.
+        with patch.object(self.ext_handler_instance, "get_runtime_policy_file",
+                          return_value="/nonexistent/path/waagent_runtime_policy.json"):
+            with self.assertRaises(ExtensionRuntimePolicyError):
+                self.ext_handler_instance.update_runtime_policy({"allowDirectScripts": False})
+
+    def test_remove_runtime_policy_should_ignore_file_not_found_error(self):
+        file_not_found_error = OSError(errno.ENOENT, "mocked error")
+        with patch("azurelinuxagent.ga.exthandlers.fileutil.rm_files", side_effect=file_not_found_error):
+            self.ext_handler_instance.remove_runtime_policy()
+
+    def test_remove_runtime_policy_should_raise_runtime_policy_error_on_oserror(self):
+        with patch("azurelinuxagent.ga.exthandlers.fileutil.rm_files", side_effect=OSError(errno.EACCES, "mocked error")):
+            with self.assertRaises(ExtensionRuntimePolicyError):
+                self.ext_handler_instance.remove_runtime_policy()
 
     def test_rm_ext_handler_dir_should_remove_the_extension_packages(self):
         os.mkdir(self.extension_directory)
@@ -126,4 +145,3 @@ class ExtHandlerInstanceTestCase(AgentTestCase):
 
         args, kwargs = mock_report_event.call_args  # pylint: disable=unused-variable
         self.assertTrue("A mocked error" in kwargs["message"])
-

--- a/tests/ga/test_policy_engine.py
+++ b/tests/ga/test_policy_engine.py
@@ -19,7 +19,7 @@ import json
 import os
 
 from azurelinuxagent.ga.policy.policy_engine import ExtensionPolicyEngine, InvalidPolicyError, \
-    _PolicyEngine, _DEFAULT_ALLOW_LISTED_EXTENSIONS_ONLY, _DEFAULT_SIGNATURE_REQUIRED
+    _PolicyEngine, _DEFAULT_ALLOW_LISTED_EXTENSIONS_ONLY, _DEFAULT_SIGNATURE_REQUIRED, ExtensionRuntimePolicyError
 from tests.lib.tools import AgentTestCase, MagicMock, patch
 
 TEST_EXTENSION_NAME = "Microsoft.Azure.ActiveDirectory.AADSSHLoginForLinux"
@@ -573,10 +573,12 @@ class TestExtensionPolicyEngine(_TestPolicyBase):
 
     def test_extension_name_in_policy_should_be_case_insensitive(self):
         """
-        Extension name is allowed to be any case. Test that should_allow() and should_enforce_signature_validation() return expected
-        results, even when the extension name does not match the case of the name specified in policy.
+        Extension name is allowed to be any case. Test that should_allow(), should_enforce_signature_validation(), and
+        get_extension_runtime_policy() return expected results, even when the extension name does not match the case
+        of the name specified in policy.
         """
         ext_name_in_policy = "Microsoft.Azure.ActiveDirectory.AADSSHLoginForLinux"
+        ext_runtime_policy = {"allowDirectScripts": False}
         for ext_name_to_test in [
             "MicrOsoft.aZure.activedirectory.aaDsShloginFORlinux",
             "microsoft.azure.activedirectory.aadsshloginforlinux"
@@ -589,7 +591,8 @@ class TestExtensionPolicyEngine(_TestPolicyBase):
                         "signatureRequired": False,
                         "extensions": {
                             ext_name_in_policy: {
-                                "signatureRequired": True
+                                "signatureRequired": True,
+                                "runtimePolicy": ext_runtime_policy
                             }
                         }
                     }
@@ -600,7 +603,125 @@ class TestExtensionPolicyEngine(_TestPolicyBase):
             engine.update_policy(self.goal_state_history)
             should_allow = engine._should_allow_extension(ext_name_to_test)
             should_enforce_signature = engine.should_enforce_signature_validation(ext_name_to_test)
+            runtime_policy = engine.get_extension_runtime_policy(ext_name_to_test, True)
             self.assertTrue(should_allow,
                             msg="Extension should have been found in allowlist regardless of extension name case.")
             self.assertTrue(should_enforce_signature,
                             msg="Individual signatureRequired policy should have been found and used, regardless of extension name case.")
+            self.assertEqual(ext_runtime_policy, runtime_policy,
+                             msg="Runtime policy should have been returned, regardless of extension name case.")
+
+    def test_get_extension_runtime_policy_should_return_none_if_policy_enforcement_is_disabled(self):
+        engine = ExtensionPolicyEngine()
+        result = engine.get_extension_runtime_policy(TEST_EXTENSION_NAME, supports_policy=True)
+        self.assertIsNone(result)
+
+    def test_get_extension_runtime_policy_should_return_policy_if_specified_and_ext_supports_policy(self):
+        """
+        If runtimePolicy is specified for the extension, get_extension_runtime_policy() should return it.
+        """
+        runtime_policy = {"allowDirectScripts": False}
+        policy = {
+            "policyVersion": "0.1.0",
+            "extensionPolicies": {
+                "extensions": {
+                    TEST_EXTENSION_NAME: {
+                        "runtimePolicy": runtime_policy
+                    }
+                }
+            }
+        }
+        self._create_policy_file(policy)
+        engine = ExtensionPolicyEngine()
+        engine.update_policy(self.goal_state_history)
+        result = engine.get_extension_runtime_policy(TEST_EXTENSION_NAME, supports_policy=True)
+        self.assertEqual(runtime_policy, result, msg="get_extension_runtime_policy() should return the runtimePolicy dict.")
+
+    def test_get_extension_runtime_policy_should_return_empty_dict_if_not_specified_and_ext_supports_policy(self):
+        """
+        If runtimePolicy is not specified for an extension that supports policy, get_extension_runtime_policy() should return {}.
+        """
+        policy = {
+            "policyVersion": "0.1.0",
+            "extensionPolicies": {
+                "extensions": {
+                    TEST_EXTENSION_NAME: {}
+                }
+            }
+        }
+        self._create_policy_file(policy)
+        engine = ExtensionPolicyEngine()
+        engine.update_policy(self.goal_state_history)
+        result = engine.get_extension_runtime_policy(TEST_EXTENSION_NAME, supports_policy=True)
+        self.assertEqual({}, result, msg="get_extension_runtime_policy() should return an empty object when runtimePolicy is not specified.")
+
+    def test_get_extension_runtime_policy_should_return_empty_dict_if_extension_not_in_policy_and_ext_supports_policy(self):
+        """
+        If an extension that supports policy is not in the policy, get_extension_runtime_policy() should return {}.
+        """
+        policy = {
+            "policyVersion": "0.1.0",
+            "extensionPolicies": {
+                "extensions": {}
+            }
+        }
+        self._create_policy_file(policy)
+        engine = ExtensionPolicyEngine()
+        engine.update_policy(self.goal_state_history)
+        result = engine.get_extension_runtime_policy(TEST_EXTENSION_NAME, supports_policy=True)
+        self.assertEqual({}, result, msg="get_extension_runtime_policy() should return an empty object when extension is not in policy.")
+
+    def test_get_extension_runtime_policy_should_raise_if_ext_does_not_support_policy_and_policy_specified(self):
+        runtime_policy = {"allowDirectScripts": False}
+        policy = {
+            "policyVersion": "0.1.0",
+            "extensionPolicies": {
+                "extensions": {
+                    TEST_EXTENSION_NAME: {
+                        "runtimePolicy": runtime_policy
+                    }
+                }
+            }
+        }
+        self._create_policy_file(policy)
+        engine = ExtensionPolicyEngine()
+        engine.update_policy(self.goal_state_history)
+
+        with self.assertRaises(ExtensionRuntimePolicyError):
+            engine.get_extension_runtime_policy(TEST_EXTENSION_NAME, supports_policy=False)
+
+    def test_get_extension_runtime_policy_should_raise_if_ext_does_not_support_policy_and_empty_runtime_policy_specified(self):
+        runtime_policy = {}     # The agent has no knowledge of runtime_policy contents, so even an empty dict is considered as a provided policy
+        policy = {
+            "policyVersion": "0.1.0",
+            "extensionPolicies": {
+                "extensions": {
+                    TEST_EXTENSION_NAME: {
+                        "runtimePolicy": runtime_policy
+                    }
+                }
+            }
+        }
+        self._create_policy_file(policy)
+        engine = ExtensionPolicyEngine()
+        engine.update_policy(self.goal_state_history)
+
+        with self.assertRaises(ExtensionRuntimePolicyError):
+            engine.get_extension_runtime_policy(TEST_EXTENSION_NAME, supports_policy=False)
+
+    def test_get_extension_runtime_policy_should_return_none_if_extension_does_not_support_policy_and_none_is_specified(self):
+        policy = {
+            "policyVersion": "0.1.0",
+            "extensionPolicies": {
+                "extensions": {
+                    TEST_EXTENSION_NAME: {}
+                }
+            }
+        }
+        self._create_policy_file(policy)
+        engine = ExtensionPolicyEngine()
+        engine.update_policy(self.goal_state_history)
+
+        result = engine.get_extension_runtime_policy(TEST_EXTENSION_NAME, supports_policy=False)
+
+        self.assertIsNone(result)

--- a/tests_e2e/test_suites/ext_runtime_policy.yml
+++ b/tests_e2e/test_suites/ext_runtime_policy.yml
@@ -1,0 +1,13 @@
+#
+# The test suite verifies that the Agent passes runtime policy to policy-capable extensions.
+#
+name: "ExtensionRuntimePolicy"
+tests:
+  - "ext_runtime_policy/ext_runtime_policy.py"
+images:
+  - "random(endorsed,10)"
+#  - "cvm-endorsed"       # TODO: We only have capacity for the CVM images in eastus2euap, but Test CSE 2.8.0 is only available in centraluseuap. Move this test to eastus2euap once it is published to the second canary region
+locations: "AzureCloud:centraluseuap"   # Test CSE 2.8.0 is currently available only in centraluseuap.
+skip_on_clouds:
+  - "AzureChinaCloud"     # TODO: Remove the skip once the extension is published to China cloud
+  - "AzureUSGovernment"   # TODO: Remove the skip once the extension is published to Gov cloud

--- a/tests_e2e/test_suites/ext_runtime_policy.yml
+++ b/tests_e2e/test_suites/ext_runtime_policy.yml
@@ -10,6 +10,7 @@ images:
 locations: "AzureCloud:centraluseuap"   # Test CSE 2.8.0 is currently available only in centraluseuap.
 skip_on_images:
   - "centos_79"           # TODO: Test CSE 2.8.0 install fails due to golang issues on CentOS 7.9. Remove this once the issue is resolved.
+  - "rhel_79"             # TODO: Test CSE 2.8.0 install fails due to golang issues on RHEL 7.9. Remove this once the issue is resolved.
 skip_on_clouds:
   - "AzureChinaCloud"     # TODO: Remove the skip once the extension is published to China cloud
   - "AzureUSGovernment"   # TODO: Remove the skip once the extension is published to Gov cloud

--- a/tests_e2e/test_suites/ext_runtime_policy.yml
+++ b/tests_e2e/test_suites/ext_runtime_policy.yml
@@ -8,6 +8,8 @@ images:
   - "random(endorsed,10)"
 #  - "cvm-endorsed"       # TODO: We only have capacity for the CVM images in eastus2euap, but Test CSE 2.8.0 is only available in centraluseuap. Move this test to eastus2euap once it is published to the second canary region
 locations: "AzureCloud:centraluseuap"   # Test CSE 2.8.0 is currently available only in centraluseuap.
+skip_on_images:
+  - "centos_79"           # TODO: Test CSE 2.8.0 install fails due to golang issues on CentOS 7.9. Remove this once the issue is resolved.
 skip_on_clouds:
   - "AzureChinaCloud"     # TODO: Remove the skip once the extension is published to China cloud
   - "AzureUSGovernment"   # TODO: Remove the skip once the extension is published to Gov cloud

--- a/tests_e2e/tests/ext_runtime_policy/ext_runtime_policy.py
+++ b/tests_e2e/tests/ext_runtime_policy/ext_runtime_policy.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+
+# Microsoft Azure Linux Agent
+#
+# Copyright 2018 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import json
+import os
+import re
+import uuid
+from datetime import datetime
+from typing import Any, Dict, List
+
+from assertpy import assert_that, fail
+
+from azurelinuxagent.common.future import UTC
+
+from tests_e2e.tests.lib.agent_test import AgentVmTest
+from tests_e2e.tests.lib.agent_test_context import AgentVmTestContext
+from tests_e2e.tests.lib.logging import log
+from tests_e2e.tests.lib.ssh_client import SshClient
+from tests_e2e.tests.lib.virtual_machine_extension_client import VirtualMachineExtensionClient
+from tests_e2e.tests.lib.vm_extension_identifier import VmExtensionIdentifier
+
+
+class ExtRuntimePolicy(AgentVmTest):
+    """
+    Validates the runtime policy feature for VM extensions:
+
+    1. A policy-capable CSE receives a matching AllowedCommandToExecute policy and enables successfully.
+    2. The agent refreshes the policy before re-enable, causing CSE to reject a command that is no longer allowed.
+    3. Omitting runtimePolicy writes an empty policy, while removing the agent policy deletes the runtime policy file.
+    4. Production CSE 2.0, which does not declare supportsPolicy, is blocked when runtime policy is configured.
+    5. Production CSE 2.0, which does not declare supportsPolicy, is allowed when runtime policy is not configured.
+    """
+    _POLICY_FILE = "/etc/waagent_policy.json"
+    _UNSUPPORTED_EXTENSION_OUTPUT = "/tmp/unsupported-extension-executed"
+
+    def __init__(self, context: AgentVmTestContext):
+        super().__init__(context)
+        self._ssh_client: SshClient = self._context.create_ssh_client()
+
+    def _create_policy_file(self, policy):
+        """
+        Create policy json file and copy to /etc/waagent_policy.json on test machine.
+        """
+        unique_id = uuid.uuid4()
+        file_path = f"/tmp/waagent_policy_{unique_id}.json"
+        with open(file_path, mode="w") as policy_file:
+            json.dump(policy, policy_file, indent=4)
+            policy_file.flush()
+            log.info(f"Policy file contents: {json.dumps(policy, indent=4)}")
+
+            remote_path = "/tmp/waagent_policy.json"
+            local_path = policy_file.name
+            self._ssh_client.copy_to_node(local_path=local_path, remote_path=remote_path)
+            log.info("Copying policy file to test VM [%s]", self._context.vm.name)
+            self._ssh_client.run_command(f"mv {remote_path} {self._POLICY_FILE}", use_sudo=True)
+        os.remove(file_path)
+
+    def _set_runtime_policy(self, extension_name, runtime_policy=None):
+        """
+        Create an agent policy containing the given extension runtime policy. Pass None when the extension's
+        runtimePolicy property should not be created.
+        """
+        extension_policy = {}
+        if runtime_policy is not None:
+            extension_policy["runtimePolicy"] = runtime_policy
+
+        self._create_policy_file({
+            "policyVersion": "0.1.0",
+            "extensionPolicies": {
+                "allowListedExtensionsOnly": False,
+                "extensions": {
+                    extension_name: extension_policy
+                }
+            }
+        })
+
+    def _enable_cse(self, extension, timeout=None):
+        """
+        Enable CSE, using force_update=True to ensure the extension is processed again even if settings haven't changed.
+        """
+        arguments = {
+            "settings": {"commandToExecute": "echo 'Hello, world!'"},
+            "auto_upgrade_minor_version": True,
+            "force_update": True
+        }
+        if timeout is not None:
+            arguments["timeout"] = timeout
+        extension.enable(**arguments)
+
+    def _assert_runtime_policy_file_contents(self, runtime_policy_file_path, expected_policy):
+        """
+        Assert that the agent copied the expected extension policy into CSE's config directory.
+        """
+        actual_policy = json.loads(self._ssh_client.run_command(f"cat {runtime_policy_file_path}", use_sudo=True))
+        assert_that(actual_policy).described_as("Extension runtime policy").is_equal_to(expected_policy)
+
+    def _assert_cse_loaded_policy(self, after_timestamp, extension_name):
+        """
+        Assert that CSE loaded its extension policy after the given enable operation started.
+        """
+        command_execution_log = "/var/log/azure/{0}/CommandExecution.log".format(extension_name)
+        log_contents = self._ssh_client.run_command("cat {0}".format(command_execution_log), use_sudo=True)
+        expected_message = "successfully loaded extension policy settings"
+        matching_lines = []
+        for line in log_contents.splitlines():
+            timestamp_match = re.match(r"^time=(?P<timestamp>\S+)", line)
+            if timestamp_match is not None and expected_message in line:
+                timestamp = datetime.strptime(timestamp_match.group("timestamp"), "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=UTC)
+                if timestamp >= after_timestamp:
+                    matching_lines.append(line)
+
+        assert_that(matching_lines) \
+            .described_as(
+                "Expected CommandExecution.log to contain '{0}' after {1}. Log contents:\n{2}".format(
+                    expected_message,
+                    after_timestamp,
+                    log_contents)) \
+            .is_not_empty()
+
+    def run(self):
+        # TODO: Only the Test CSE Extension 2.8.0+ supports 'AllowedCommandToExecute' policy right now. Once the Prod CSE
+        #  Extension supports this policy, the publisher/type/version should be updated to use Prod
+        cse_supports_policy = VirtualMachineExtensionClient(
+            self._context.vm,
+            VmExtensionIdentifier(publisher="Microsoft.Azure.Extensions.Edp", ext_type="CustomScript", version="2.8"),
+            resource_name="CustomScriptRuntimePolicy")
+
+        # CSE 2.0 does not declare supportsPolicy and is used to validate that the agent does not attempt to use policy
+        # with an extension that does not support it.
+        cse_does_not_support_policy = VirtualMachineExtensionClient(
+            self._context.vm,
+            VmExtensionIdentifier(publisher="Microsoft.Azure.Extensions", ext_type="CustomScript", version="2.0"),
+            resource_name="UnsupportedCustomScriptRuntimePolicy")
+
+        try:
+            log.info("Enabling Debug.EnableExtensionPolicy in waagent.conf...")
+            self._ssh_client.run_command("update-waagent-conf Debug.EnableExtensionPolicy=y", use_sudo=True)
+            log.info("Debug.EnableExtensionPolicy successfully enabled")
+            log.info("")
+
+            log.info("***Test Case 1 - CSE which supports policy should successfully enable when the requested commandToExecute is allowed")
+            log.info("Creating agent policy which allows \"echo 'Hello, world!'\" command...")
+            allowed_command = "echo 'Hello, world!'"
+            cse_runtime_policy = {"AllowedCommandToExecute": [allowed_command]}
+            self._set_runtime_policy("{0}.{1}".format(cse_supports_policy.extension_id.publisher, cse_supports_policy.extension_id.type), cse_runtime_policy)
+            log.info("Successfully updated agent policy with allowed command. Policy file contents: \n{0}".format(json.loads(self._ssh_client.run_command("cat {0}".format(self._POLICY_FILE), use_sudo=True))))
+            log.info("")
+
+            log.info("Enabling CSE which supports policy...")
+            enable_timestamp = self._ssh_client.get_time().replace(microsecond=0) # CSE log timestamps have second precision, so discard microseconds before comparing
+            self._enable_cse(cse_supports_policy)
+            cse_supports_policy.assert_instance_view(expected_message="Hello, world!")
+            log.info("Successfully enabled CSE with the allowed command.")
+            log.info("")
+
+            log.info("Validating that CSE logs show the runtime policy was loaded successfully...")
+            cse_version = cse_supports_policy.get_instance_view().type_handler_version
+            runtime_policy_file_path = ("/var/lib/waagent/{0}.{1}-{2}/config/waagent_runtime_policy.json".format(
+                cse_supports_policy.extension_id.publisher,
+                cse_supports_policy.extension_id.type,
+                cse_version)
+            )
+            self._assert_cse_loaded_policy(enable_timestamp, "{0}.{1}".format(cse_supports_policy.extension_id.publisher, cse_supports_policy.extension_id.type))
+            log.info("Successfully validated the runtime policy was loaded by CSE.")
+            log.info("")
+
+            log.info("Validating that the runtime policy config file for the extension has the expected content...")
+            self._assert_runtime_policy_file_contents(runtime_policy_file_path, cse_runtime_policy)
+            log.info("Successfully validated the runtime policy config file has the expected content.")
+            log.info("")
+
+            log.info("***Test Case 2 - CSE which supports policy should fail to enable when the requested commandToExecute is not allowed")
+            log.info("Refreshing agent policy to allow only 'date' command in CSE runtime policy...")
+            cse_disallow_policy = {"AllowedCommandToExecute": ["date"]}
+            self._set_runtime_policy("{0}.{1}".format(cse_supports_policy.extension_id.publisher, cse_supports_policy.extension_id.type), cse_disallow_policy)
+            log.info("Successfully updated agent policy with allowed command. Policy file contents: \n{0}".format(json.loads(self._ssh_client.run_command("cat {0}".format(self._POLICY_FILE), use_sudo=True))))
+            log.info("")
+
+            log.info("Re-enabling CSE with \"echo 'Hello, world!'\" commandToExecute, which is expected to fail...")
+            enable_timestamp = self._ssh_client.get_time().replace(microsecond=0)
+            try:
+                self._enable_cse(cse_supports_policy, timeout=6 * 60)
+                fail("CSE enable should have failed because \"echo 'Hello, world!'\" is not in the runtime-policy allowlist")
+            except Exception as error:
+                expected_error = r"item is not in the allowlist"
+                assert_that(re.search(expected_error, str(error))) \
+                    .described_as("CSE enable error should contain '{0}', but the actual error was: {1}".format(expected_error,error)).is_not_none()
+            log.info("CSE failed to enable, as expected.")
+            log.info("")
+
+            log.info("Validating that CSE logs show the runtime policy was loaded successfully...")
+            self._assert_cse_loaded_policy(enable_timestamp, "{0}.{1}".format(cse_supports_policy.extension_id.publisher, cse_supports_policy.extension_id.type))
+            log.info("Successfully validated the runtime policy was loaded by CSE.")
+            log.info("")
+
+            log.info("Validating that the runtime policy config file for the extension has the expected content...")
+            self._assert_runtime_policy_file_contents(runtime_policy_file_path, cse_disallow_policy)
+            log.info("Successfully validated the runtime policy config file has the expected content.")
+            log.info("")
+
+            log.info("***Test Case 3 - CSE which supports policy should succeed when extension specific runtime policy is removed")
+            log.info("Refreshing agent policy to remove the runtime policy property for CSE...")
+            self._set_runtime_policy("{0}.{1}".format(cse_supports_policy.extension_id.publisher, cse_supports_policy.extension_id.type))
+            log.info("Successfully updated agent policy with allowed command. Policy file contents: \n{0}".format(json.loads(self._ssh_client.run_command("cat {0}".format(self._POLICY_FILE), use_sudo=True))))
+            log.info("")
+
+            log.info("Re-enabling CSE with \"echo 'Hello, world!'\" commandToExecute, which is expected to succeed...")
+            enable_timestamp = self._ssh_client.get_time().replace(microsecond=0)
+            self._enable_cse(cse_supports_policy)
+            cse_supports_policy.assert_instance_view(expected_message="Hello, world!")
+            log.info("Successfully enabled CSE after removing runtime policy.")
+            log.info("")
+
+            log.info("Validating that CSE logs show the runtime policy was loaded successfully...")
+            self._assert_cse_loaded_policy(enable_timestamp, "{0}.{1}".format(cse_supports_policy.extension_id.publisher, cse_supports_policy.extension_id.type))
+            log.info("Successfully validated the runtime policy was loaded by CSE.")
+            log.info("")
+
+            log.info("Validating that the runtime policy config file for the extension has the expected content...")
+            self._assert_runtime_policy_file_contents(runtime_policy_file_path, {})
+            log.info("Successfully validated the runtime policy config file has the expected content.")
+            log.info("")
+
+            log.info("***Test Case 4 - CSE which supports policy should succeed when the agent policy is removed")
+            log.info("Removing agent policy file...")
+            self._ssh_client.run_command(f"rm -f {self._POLICY_FILE}", use_sudo=True)
+            log.info("Successfully removed agent policy file.")
+            log.info("")
+
+            log.info("Re-enabling CSE with \"echo 'Hello, world!'\" commandToExecute, which is expected to succeed...")
+            self._enable_cse(cse_supports_policy)
+            cse_supports_policy.assert_instance_view(expected_message="Hello, world!")
+            log.info("Successfully enabled CSE after removing agent policy file.")
+
+            log.info("Validating that the runtime policy config file for the extension doesn't exist after removing policy file...")
+            self._ssh_client.run_command(f"test ! -e {runtime_policy_file_path}", use_sudo=True)
+            log.info("Successfully validated that the runtime policy config file for the extension doesn't exist after removing policy file.")
+            log.info("")
+
+            log.info("***Test Case 5 - Agent fails CSE request when runtime policy configured if this version of CSE doesn't support runtime policy")
+            log.info("Removing the policy-capable extension before testing an unsupported extension...")
+            cse_supports_policy.delete()
+            log.info("Successfully removed the version of CSE which supports runtime policy.")
+            log.info("")
+
+            command_to_create_file = "touch {0}".format(self._UNSUPPORTED_EXTENSION_OUTPUT)
+            log.info("Updating agent policy file to include a runtime policy for CSE which allows command '{0}'...".format(command_to_create_file))
+            self._set_runtime_policy("{0}.{1}".format(cse_does_not_support_policy.extension_id.publisher, cse_does_not_support_policy.extension_id.type), {"AllowedCommandToExecute": [command_to_create_file]})
+            log.info("Successfully updated agent policy with allowed command. Policy file contents: \n{0}".format(json.loads(self._ssh_client.run_command("cat {0}".format(self._POLICY_FILE), use_sudo=True))))
+            log.info("")
+
+            log.info("Enabling CSE which does not support policy, expected to fail...")
+            try:
+                cse_does_not_support_policy.enable(
+                    settings={"commandToExecute": command_to_create_file},
+                    auto_upgrade_minor_version=False,
+                    force_update=True,
+                    timeout=6 * 60)
+                fail("CSE enable should have failed because the extension does not support runtime policy")
+            except Exception as error:
+                expected_error = r"does not support runtime policy enforcement"
+                assert_that(re.search(expected_error, str(error))) \
+                    .described_as(
+                        "CSE enable error should contain '{0}', but the actual error was: {1}".format(
+                            expected_error,
+                            error)) \
+                    .is_not_none()
+            log.info("CSE failed to enable, as expected.")
+            log.info("")
+
+            cse_version = cse_does_not_support_policy.get_instance_view().type_handler_version
+            runtime_policy_file_path = ("/var/lib/waagent/{0}.{1}-{2}/config/waagent_runtime_policy.json".format(
+                cse_does_not_support_policy.extension_id.publisher,
+                cse_does_not_support_policy.extension_id.type,
+                cse_version)
+            )
+            log.info("Validating that the tmp file was not created, since the agent should have failed the extension before enable was called...")
+            self._ssh_client.run_command("test ! -e {0}".format(self._UNSUPPORTED_EXTENSION_OUTPUT), use_sudo=True)
+            log.info("Successfully validated that the tmp file was not created.")
+            log.info("")
+
+            log.info("Validating that the runtime policy config file for the extension doesn't exist when the extension does not support policy...")
+            self._ssh_client.run_command(f"test ! -e {runtime_policy_file_path}", use_sudo=True)
+            log.info("Successfully validated that the runtime policy config file for the extension doesn't exist when the extension doesn't support runtime policy.")
+            log.info("")
+
+            log.info("***Test Case 6 - CSE which doesn't support policy should successfully be enabled when no runtime policy is configured for the extension")
+            log.info("Verifying an extension that does not support policy is allowed without runtime policy")
+            self._set_runtime_policy("{0}.{1}".format(cse_does_not_support_policy.extension_id.publisher, cse_does_not_support_policy.extension_id.type))
+            log.info("Successfully updated agent policy to remove CSE runtime policy. Policy file contents: \n{0}".format(json.loads(self._ssh_client.run_command("cat {0}".format(self._POLICY_FILE), use_sudo=True))))
+            log.info("")
+
+            log.info("Re-enabling CSE, which is expected to succeed...")
+            cse_does_not_support_policy.enable(
+                settings={"commandToExecute": command_to_create_file},
+                auto_upgrade_minor_version=False,
+                force_update=True)
+            cse_does_not_support_policy.assert_instance_view()
+            log.info("Successfully enabled CSE after removing the CSE runtime policy.")
+
+            log.info("Validating that the tmp file was created when no runtime policy is configured for the extension...")
+            self._ssh_client.run_command("test -e {0}".format(self._UNSUPPORTED_EXTENSION_OUTPUT), use_sudo=True)
+            log.info("Successfully validated that the tmp file was created.")
+            log.info("")
+
+            log.info("Validating that the runtime policy config file for the extension doesn't exist when the extension does not support policy...")
+            self._ssh_client.run_command(f"test ! -e {runtime_policy_file_path}", use_sudo=True)
+            log.info("Successfully validated that the runtime policy config file for the extension doesn't exist when the extension doesn't support runtime policy.")
+            log.info("")
+
+            # TODO: Add multi-config coverage when an extension that supports runtime policy is available.
+        finally:
+            log.info("Cleaning up the runtime-policy E2E test...")
+
+            log.info("Removing the policy file and tmp file created by CSE...")
+            self._ssh_client.run_command("rm -f {0} {1}".format(self._POLICY_FILE, self._UNSUPPORTED_EXTENSION_OUTPUT), use_sudo=True)
+            log.info("Successfully cleaned up files.")
+
+            log.info("Removing extensions added by this test...")
+            extension_names = {item.name for item in self._context.vm.get_extensions().value}
+            for extension_to_remove in [cse_supports_policy, cse_does_not_support_policy]:
+                if extension_to_remove._resource_name in extension_names:
+                    extension_to_remove.delete()
+            log.info("Successfully removed extension.")
+
+    def get_ignore_error_rules(self) -> List[Dict[str, Any]]:
+        return [
+            # CSE is expected to have failures when it rejects the command due to policy.
+            {
+                "message": r"item is not in the allowlist"
+            },
+            {
+                "message": (
+                    r"name=Microsoft.Azure.Extensions.Edp.CustomScript, op=Enable, "
+                    r"message=\[ExtensionOperationError\] Non-zero exit code"
+                )
+            },
+            # Runtime policy on an unsupported extension is intentionally rejected by the agent.
+            {
+                "message": (
+                    r"Runtime policy is specified for extension .* "
+                    r"but this extension does not support runtime policy enforcement"
+                )
+            }
+        ]
+
+
+if __name__ == "__main__":
+    ExtRuntimePolicy.run_from_command_line()

--- a/tests_e2e/tests/ext_runtime_policy/ext_runtime_policy.py
+++ b/tests_e2e/tests/ext_runtime_policy/ext_runtime_policy.py
@@ -26,8 +26,6 @@ from typing import Any, Dict, List
 
 from assertpy import assert_that, fail
 
-from azurelinuxagent.common.future import UTC
-
 from tests_e2e.tests.lib.agent_test import AgentVmTest
 from tests_e2e.tests.lib.agent_test_context import AgentVmTestContext
 from tests_e2e.tests.lib.logging import log
@@ -121,7 +119,7 @@ class ExtRuntimePolicy(AgentVmTest):
         for line in log_contents.splitlines():
             timestamp_match = re.match(r"^time=(?P<timestamp>\S+)", line)
             if timestamp_match is not None and expected_message in line:
-                timestamp = datetime.strptime(timestamp_match.group("timestamp"), "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=UTC)
+                timestamp = datetime.fromisoformat(timestamp_match.group("timestamp").replace("Z", "+00:00"))
                 if timestamp >= after_timestamp:
                     matching_lines.append(line)
 


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->
<!--
Please add an informative description that covers that changes made by the pull request.
-->
## Description
This PR adds support for the constrained extensions feature. The constrained extensions feature allows users to specify extension specific runtime policy via the existing /etc/waagent_policy.json configuration.

Each extension defines their own runtime policy schema and declares support for policy in its manifest. At each enable, the agent creates the runtime_policy.json for the extension in its config directory if the extension supports policy. The contents of the runtime_policy.json are the extension specific configuration provided by the customer in waagent_policy.json. 

The extension is expected to pick up the policy from its config directory and apply it.

This PR introduces a new E2E test for the scenario which uses the CSE Test extension which supports policy. 

Issue # <!-- if any -->
---
<!--
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->
### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).
---
<!--
This checklist is used to track contributions from distro maintainers.
-->
### Distro maintenance information, if applicable
- [ ] This is a contribution from a distro maintainer
- [ ] The changes in this PR have been taken as a downstream patch (Note: it is not recommended to patch the agent without upstream review and approval)
