### PR TITLE
Add nftables fallback for missing iptables modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Waagent depends on some system packages in order to function properly:
 * Filesystem utilities: sfdisk, fdisk, mkfs, parted
 * Password tools: chpasswd, sudo
 * Text processing tools: sed, grep
-* Network tools: ip-route, iptables
+* Network tools: ip-route, iptables, nft (iptables or nft command line tools are required for firewall configuration)
 
 ## Installation
 

--- a/azurelinuxagent/agent.py
+++ b/azurelinuxagent/agent.py
@@ -312,7 +312,7 @@ class Agent(object):
             if isinstance(firewall_manager, IpTables):
                 try:
                     run_command(['systemctl', 'is-enabled', '--type=service', 'firewalld.service']).rstrip()
-                    logger.info("Firewalld is enabled. Will not setup the iptables firewall rules to avoid conflicts.")
+                    logger.info("Firewalld is enabled. Will not setup the firewall rules to avoid conflicts.")
                     sys.exit(0)
                 except CommandError:
                     # Differences across versions of systemd make hard to determine whether the command failed because firewalld is not installed

--- a/azurelinuxagent/agent.py
+++ b/azurelinuxagent/agent.py
@@ -307,18 +307,18 @@ class Agent(object):
         logger.info("Setting up firewall during boot. Endpoint: {0}", ustr(endpoint))
 
         try:
-            run_command(['systemctl', 'is-enabled', '--type=service', 'firewalld.service']).rstrip()
-            logger.info("Firewalld is enabled. Will not setup the firewall rules to avoid conflicts.")
-            sys.exit(0)
-        except CommandError:
-            # Differences across versions of systemd make hard to determine whether the command failed because firewalld is not installed
-            # or for another reason. Assume it is not installed and continue.
-            pass
-
-        try:
             firewall_manager = FirewallManager.create(endpoint)
             firewall_manager.verbose = True
             if isinstance(firewall_manager, IpTables):
+                try:
+                    run_command(['systemctl', 'is-enabled', '--type=service', 'firewalld.service']).rstrip()
+                    logger.info("Firewalld is enabled. Will not setup the iptables firewall rules to avoid conflicts.")
+                    sys.exit(0)
+                except CommandError:
+                    # Differences across versions of systemd make hard to determine whether the command failed because firewalld is not installed
+                    # or for another reason. Assume it is not installed and continue.
+                    pass
+
                 try:
                     #
                     # We execute "iptables -C -m conntrack" to force loading of the conntrack module with the intention of avoiding the

--- a/azurelinuxagent/ga/firewall_manager.py
+++ b/azurelinuxagent/ga/firewall_manager.py
@@ -86,21 +86,46 @@ class FirewallManager(object):
     @staticmethod
     def create(wire_server_address):
         """
-        Creates the appropriate FirewallManager implementation depending on the availability of the underlying command-line tools.
+        Creates the appropriate FirewallManager implementation depending on the availability of the underlying
+        command-line tools and the kernel modules required by iptables.
 
-        NOTE: Currently this method checks only for iptables and nftables, giving precedence to the former.
+        NOTE: Currently this method checks only for iptables and nft, giving precedence to the former. There are
+        some images (Rhel 10.2/Alma 10/Rocky 10), where iptables exists but the required modules (xt_owner and
+        xt_conntrack) to create the agent rules don't exist. This method now handles that case and cleans up the
+        remaining IpTables rules when we fall back to nft on those machines.
         """
         try:
-            manager = IpTables(wire_server_address)
-            event.info(WALAEventOperation.Firewall, "Using iptables [version {0}] to manage firewall rules", manager.version)
-            return manager
+            iptables_manager = IpTables(wire_server_address)
+
+            # Some distros (like RHEL 10.2) ship iptables but not the xt_owner and xt_conntrack kernel modules. As a
+            # result, the iptables commands to create the UID-based allow rule and conntrack-based drop rule will fail.
+            # In this case if nft is available, the agent should try to clean up the leftover iptables rules (since the
+            # DNS rule may exist) and fall back to nft for firewall management.
+            unresolved_modules = iptables_manager.get_unresolved_modules()
+            if len(unresolved_modules) > 0:
+                try:
+                    nftables_manager = NfTables(wire_server_address)
+                    event.warn(WALAEventOperation.Firewall, "Falling back to nftables because required iptables kernel modules are unresolved: {0}", unresolved_modules)
+
+                    try:
+                        iptables_manager.remove()
+                    except Exception as error:
+                        event.warn(WALAEventOperation.Firewall, "Unable to remove existing iptables rules while switching to nft: {0}", ustr(error))
+
+                    event.info(WALAEventOperation.Firewall, "Using nft [version {0}] to manage firewall rules", nftables_manager.version)
+                    return nftables_manager
+                except FirewallManagerNotAvailableError:
+                    event.warn(WALAEventOperation.Firewall, "Required iptables kernel modules are unresolved ({0}) and nft is not available, continuing with iptables as best effort", ", ".join(unresolved_modules))
+
+            event.info(WALAEventOperation.Firewall, "Using iptables [version {0}] to manage firewall rules", iptables_manager.version)
+            return iptables_manager
         except FirewallManagerNotAvailableError:
             pass
 
         try:
-            manager = NfTables(wire_server_address)
-            event.info(WALAEventOperation.Firewall, "Using nft [version {0}] to manage firewall rules", manager.version)
-            return manager
+            nftables_manager = NfTables(wire_server_address)
+            event.info(WALAEventOperation.Firewall, "Using nft [version {0}] to manage firewall rules", nftables_manager.version)
+            return nftables_manager
         except FirewallManagerNotAvailableError:
             pass
 
@@ -389,6 +414,31 @@ class IpTables(_FirewallManagerIndividualRules):
                     raise IptablesInconsistencyError(e.missing_rules, output_chain)
             raise
 
+    @staticmethod
+    def get_unresolved_modules():
+        """
+        Returns a list of the required iptables modules that modinfo cannot resolve. If modinfo is not available for
+        the check, returns an empty list because the modules cannot be confirmed as unresolved.
+
+        The list of modules this helper checks may not be exhaustive. It checks for the modules which are known to be
+        missing on the latest EL10 distros.
+        """
+        try:
+            shellutil.run_command(["modinfo", "--version"])
+        except Exception:
+            return []
+
+        unresolved_modules = []
+        for module_name in ["xt_owner", "xt_conntrack"]:
+            try:
+                shellutil.run_command(["modinfo", module_name])
+            except CommandError:
+                unresolved_modules.append(module_name)
+            except Exception:
+                pass
+
+        return unresolved_modules
+
     def load_conntrack(self):
         """
         Forces the conntrack module to be loaded by executing "iptables -C -m conntrack..."
@@ -450,7 +500,7 @@ class FirewallCmd(_FirewallManagerIndividualRules):
             self._version = shellutil.run_command(["firewall-cmd", "--version"]).strip()
         except Exception as exception:
             if isinstance(exception, OSError) and exception.errno == errno.ENOENT:  # pylint: disable=no-member
-                raise FirewallManagerNotAvailableError("nft is not available")
+                raise FirewallManagerNotAvailableError("firewall-cmd is not available")
             self._version = "unknown"
 
     @property
@@ -629,8 +679,3 @@ class NfTables(FirewallManager):
 
     def _get_state_command(self):
         return ['nft', 'list', 'table', 'walinuxagent']
-
-
-
-
-

--- a/azurelinuxagent/ga/persist_firewall_rules.py
+++ b/azurelinuxagent/ga/persist_firewall_rules.py
@@ -118,10 +118,48 @@ if __name__ == '__main__':
             logger.info("The firewalld service is present, but not running: {0}".format(ustr(error)))
             return False
 
-    def setup(self):
+    def setup(self, runtime_uses_nftables):
+        """
+        Sets up persistence using a mechanism compatible with the runtime firewall manager.
 
-        if not self._is_firewall_service_running():
-            logger.info("Firewalld service not running/unavailable, trying to set up {0}".format(self.get_service_file_path()))
+        The rules created by the agent through firewalld's direct passthrough API require iptables in the backend.
+        Their arguments use iptables syntax and require iptables to be available and the xt_owner and xt_conntrack
+        kernel modules. This remains true even when firewalld itself uses an nftables backend. If runtime setup
+        selected NfTables as the manager because iptables capabilities are unavailable, attempting to apply the
+        firewalld passthrough rules during boot can fail and cause firewalld to reject its user configuration.
+
+        Previous versions of the agent did add these passthrough rules when iptables or its dependencies were not
+        available. When the agent detects that firewalld is running, but NfTables is being used for runtime
+        setup, it will attempt to remove any passthrough rules created by an older agent.
+
+        :param runtime_uses_nftables: A bool which indicates whether the FirewallManager selected for runtime rules is
+                                      NfTables.
+        """
+        firewalld_service_running = self._is_firewall_service_running()
+        if not firewalld_service_running or runtime_uses_nftables:
+            if not firewalld_service_running:
+                event.info(WALAEventOperation.PersistFirewallRules, "Firewalld service not running/unavailable, trying to set up {0}", self.get_service_file_path())
+            else:
+                # The firewalld passthrough rules created by the agent are only compatible with iptables. If NfTables
+                # is being used for runtime rules, the agent should use the custom network setup service for persistence.
+                # Previous versions of the agent always created firewalld passthrough rules if firewalld was running. Cleanup
+                # any existing rules if firewalld is running but NfTables is the selected runtime manager.
+                try:
+                    firewall_cmd = FirewallCmd(self._dst_ip)
+                    event.info(WALAEventOperation.PersistFirewallRules, "Runtime firewall rules use nftables; removing any iptables-based firewalld passthrough rules previously created by the agent")
+                    try:
+                        firewall_cmd.remove_legacy_rule()
+                    except Exception as error:
+                        event.error(WALAEventOperation.Firewall, "Unable to remove legacy firewall rule. Error: {0}", ustr(error))
+                    try:
+                        firewall_cmd.remove()
+                        event.info(WALAEventOperation.PersistFirewallRules, "Completed cleanup of iptables-based firewalld passthrough rules previously created by the agent")
+                    except Exception as error:
+                        event.error(WALAEventOperation.PersistFirewallRules, "Unable to remove firewalld passthrough rules previously created by the agent: {0}", ustr(error))
+                except Exception as error:
+                    event.error(WALAEventOperation.PersistFirewallRules, "Unable to check for iptables-based firewalld passthrough rules. Error: {0}", ustr(error))
+                event.warn(WALAEventOperation.PersistFirewallRules, "Firewalld service is running, but runtime firewall rules use nftables; trying to set up {0}", self.get_service_file_path())
+
             if systemd.is_systemd():
                 self._setup_network_setup_service()
             else:
@@ -363,4 +401,3 @@ if __name__ == '__main__':
         logger.info(
             "Unit file matches with expected version: {0} and exec start: {1}, not overwriting unit file".format(unit_file_version, unit_exec_start))
         return False
-

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -42,7 +42,7 @@ from azurelinuxagent.ga.agent_memory_restart_history import AgentMemoryRestartHi
 from azurelinuxagent.common.event import add_event, initialize_event_logger_vminfo_common_parameters_and_protocol, \
     WALAEventOperation, EVENTS_DIRECTORY
 from azurelinuxagent.common.exception import ExitException, AgentUpgradeExitException, AgentMemoryExceededException
-from azurelinuxagent.ga.firewall_manager import FirewallManager, FirewallStateError, IptablesInconsistencyError
+from azurelinuxagent.ga.firewall_manager import FirewallManager, FirewallStateError, IptablesInconsistencyError, NfTables
 from azurelinuxagent.common.future import ustr, UTC, datetime_min_utc
 from azurelinuxagent.common.osutil import get_osutil, systemd
 from azurelinuxagent.ga.persist_firewall_rules import PersistFirewallRulesHandler
@@ -1450,7 +1450,7 @@ class UpdateHandler(object):
             #
             event.info(WALAEventOperation.PersistFirewallRules, "Setting up persistent firewall rules")
             try:
-                PersistFirewallRulesHandler(dst_ip=wire_server_address).setup()
+                PersistFirewallRulesHandler(dst_ip=wire_server_address).setup(runtime_uses_nftables=isinstance(firewall_manager, NfTables))
             except Exception as error:
                 event.error(WALAEventOperation.PersistFirewallRules, "Unable to setup the persistent firewall rules: {0}", ustr(error))
 

--- a/tests/ga/test_firewall_manager.py
+++ b/tests/ga/test_firewall_manager.py
@@ -19,10 +19,11 @@ import os
 import unittest
 
 from azurelinuxagent.common.utils import shellutil
+from azurelinuxagent.common.utils.shellutil import CommandError
 from azurelinuxagent.ga.firewall_manager import FirewallManager, IpTables, FirewallCmd, NfTables, FirewallStateError, FirewallManagerNotAvailableError, event as firewall_manager_event
 
 from tests.lib.event import get_events_from_mock
-from tests.lib.tools import AgentTestCase, patch
+from tests.lib.tools import AgentTestCase, MagicMock, patch
 from tests.lib.mock_firewall_command import MockIpTables, MockFirewallCmd, MockNft
 
 
@@ -52,9 +53,54 @@ def firewall_command_exists_mock(iptables_exist=True, firewallcmd_exist=True, nf
 
 class TestFirewallManager(AgentTestCase):
     def test_create_should_prefer_iptables_when_both_iptables_and_nftables_exist(self):
-        with firewall_command_exists_mock(iptables_exist=True, nft_exists=True):
-            firewall = FirewallManager.create('168.63.129.16')
-            self.assertIsInstance(firewall, IpTables)
+        with patch.object(IpTables, "get_unresolved_modules", return_value=[]):
+            with firewall_command_exists_mock(iptables_exist=True, nft_exists=True):
+                firewall = FirewallManager.create('168.63.129.16')
+                self.assertIsInstance(firewall, IpTables)
+
+    def test_create_should_use_nftables_and_remove_iptables_rules_when_required_modules_are_unresolved(self):
+        iptables = MagicMock()
+        iptables.get_unresolved_modules.return_value = ["xt_owner", "xt_conntrack"]
+        nftables = MagicMock()
+
+        with patch("azurelinuxagent.ga.firewall_manager.IpTables", return_value=iptables):
+            with patch("azurelinuxagent.ga.firewall_manager.NfTables", return_value=nftables):
+                with patch.object(firewall_manager_event, "warn") as warn:
+                    firewall_manager = FirewallManager.create('168.63.129.16')
+
+        self.assertEqual(nftables, firewall_manager)
+        iptables.remove.assert_called_once_with()
+        warning_messages = [message for _, message in get_events_from_mock(warn)]
+        self.assertTrue(any("Falling back to nftables because required iptables kernel modules are unresolved" in message for message in warning_messages))
+
+    def test_create_should_use_nftables_even_if_removing_iptables_rules_fails(self):
+        iptables = MagicMock()
+        iptables.get_unresolved_modules.return_value = ["xt_owner", "xt_conntrack"]
+        iptables.remove.side_effect = Exception("iptables cleanup failed")
+        nftables = MagicMock()
+
+        with patch("azurelinuxagent.ga.firewall_manager.IpTables", return_value=iptables):
+            with patch("azurelinuxagent.ga.firewall_manager.NfTables", return_value=nftables):
+                with patch.object(firewall_manager_event, "warn") as warn:
+                    firewall = FirewallManager.create('168.63.129.16')
+
+        self.assertEqual(nftables, firewall)
+        warning_messages = [message for _, message in get_events_from_mock(warn)]
+        self.assertTrue(any("Unable to remove existing iptables rules while switching to nft: iptables cleanup failed" in message for message in warning_messages))
+
+    def test_create_should_use_iptables_as_best_effort_when_required_modules_are_unresolved_and_nftables_is_unavailable(self):
+        iptables = MagicMock()
+        iptables.get_unresolved_modules.return_value = ["xt_owner", "xt_conntrack"]
+
+        with patch("azurelinuxagent.ga.firewall_manager.IpTables", return_value=iptables):
+            with patch("azurelinuxagent.ga.firewall_manager.NfTables", side_effect=FirewallManagerNotAvailableError("nft is not available")):
+                with patch.object(firewall_manager_event, "warn") as warn:
+                    firewall = FirewallManager.create('168.63.129.16')
+
+        self.assertEqual(iptables, firewall)
+        iptables.remove.assert_not_called()
+        warning_messages = [message for _, message in get_events_from_mock(warn)]
+        self.assertTrue(any("continuing with iptables as best effort" in message for message in warning_messages))
 
     def test_create_should_use_nftables_when_iptables_does_not_exist(self):
         with firewall_command_exists_mock(iptables_exist=False, nft_exists=True):
@@ -195,6 +241,36 @@ class _TestFirewallCommand(AgentTestCase):
 
 
 class TestIpTables(_TestFirewallCommand):
+    def test_get_unresolved_modules_should_return_modules_modinfo_cannot_resolve(self):
+        def mock_run_command(command, *_, **__):
+            if command == ["modinfo", "--version"]:
+                return "kmod version 31"
+            if command == ["modinfo", "xt_owner"]:
+                raise CommandError(command=["modinfo", "xt_owner"], return_code=1, stdout="", stderr="module not found")
+            if command == ["modinfo", "xt_conntrack"]:
+                raise CommandError(command=["modinfo", "xt_conntrack"], return_code=1, stdout="", stderr="module not found")
+            raise Exception("Unexpected command: {0}".format(command))
+
+        with patch("azurelinuxagent.ga.firewall_manager.shellutil.run_command", side_effect=mock_run_command):
+            self.assertEqual(["xt_owner", "xt_conntrack"], IpTables.get_unresolved_modules())
+
+    def test_get_unresolved_modules_should_return_empty_list_when_modinfo_is_unavailable(self):
+        with patch("azurelinuxagent.ga.firewall_manager.shellutil.run_command", side_effect=OSError("modinfo unavailable")):
+            self.assertEqual([], IpTables.get_unresolved_modules())
+
+    def test_get_unresolved_modules_should_not_treat_unexpected_errors_as_unresolved(self):
+        def mock_run_command(command, *_, **__):
+            if command == ["modinfo", "--version"]:
+                return "kmod version 31"
+            if command == ["modinfo", "xt_owner"]:
+                raise Exception("unexpected error")
+            if command == ["modinfo", "xt_conntrack"]:
+                raise CommandError(command=["modinfo", "xt_conntrack"], return_code=1, stdout="", stderr="module not found")
+            return ""
+
+        with patch("azurelinuxagent.ga.firewall_manager.shellutil.run_command", side_effect=mock_run_command):
+            self.assertEqual(['xt_conntrack'], IpTables.get_unresolved_modules())
+
     def test_it_should_raise_FirewallManagerNotAvailableError_when_the_command_is_not_available(self):
         with firewall_command_exists_mock(iptables_exist=False):
             with self.assertRaises(FirewallManagerNotAvailableError):

--- a/tests/ga/test_persist_firewall_rules.py
+++ b/tests/ga/test_persist_firewall_rules.py
@@ -25,8 +25,9 @@ import uuid
 import azurelinuxagent.common.conf as conf
 from azurelinuxagent.common.future import ustr
 from azurelinuxagent.common.osutil.default import DefaultOSUtil
-from azurelinuxagent.ga.persist_firewall_rules import PersistFirewallRulesHandler
+from azurelinuxagent.ga.persist_firewall_rules import PersistFirewallRulesHandler, event as persist_firewall_event
 from azurelinuxagent.common.utils import fileutil, shellutil
+from tests.lib.event import get_events_from_mock
 from tests.lib.tools import AgentTestCase, MagicMock, patch
 
 
@@ -156,7 +157,7 @@ class TestPersistFirewallRulesHandler(AgentTestCase):
     def __setup_and_assert_network_service_setup_scenario(self, handler, mock_popen=None):
         mock_popen = TestPersistFirewallRulesHandler.__mock_network_setup_service_disabled if mock_popen is None else mock_popen
         self.__replace_popen_cmd = mock_popen
-        handler.setup()
+        handler.setup(runtime_uses_nftables=False)
 
         self.__assert_systemctl_called(cmd="is-enabled", validate_command_called=True)
         self.__assert_systemctl_called(cmd="enable", validate_command_called=True)
@@ -169,7 +170,7 @@ class TestPersistFirewallRulesHandler(AgentTestCase):
     def test_it_should_skip_setup_if_firewalld_already_enabled(self):
         self.__replace_popen_cmd = lambda cmd: ("firewall-cmd" in cmd, ["echo", "running"])
         with self._get_persist_firewall_rules_handler() as handler:
-            handler.setup()
+            handler.setup(runtime_uses_nftables=False)
 
         # Assert we verified that rules were set using firewall-cmd
         self.__assert_firewall_called(cmd="--query-passthrough", validate_command_called=True)
@@ -189,7 +190,7 @@ class TestPersistFirewallRulesHandler(AgentTestCase):
             self.__replace_popen_cmd = TestPersistFirewallRulesHandler.__mock_network_setup_service_enabled
             # Reset state
             self._executed_commands = []
-            handler.setup()
+            handler.setup(runtime_uses_nftables=False)
 
             self.__assert_systemctl_called(cmd="is-enabled", validate_command_called=True)
             self.__assert_systemctl_called(cmd="enable", validate_command_called=False)
@@ -218,7 +219,7 @@ class TestPersistFirewallRulesHandler(AgentTestCase):
         with self._get_persist_firewall_rules_handler() as handler:
             self.assertFalse(os.path.exists(self._binary_file), "Binary file should not be there")
             self.assertFalse(os.path.exists(self._network_service_unit_file), "Unit file should not be present")
-            handler.setup()
+            handler.setup(runtime_uses_nftables=False)
 
         orig_service_file_contents = "ExecStart={py_path} {binary_path}".format(py_path=sys.executable,
                                                                                 binary_path=self._binary_file)
@@ -239,7 +240,7 @@ class TestPersistFirewallRulesHandler(AgentTestCase):
         with self._get_persist_firewall_rules_handler() as handler:
             # The Binary file should be available on the 2nd run
             self.assertTrue(os.path.exists(self._binary_file), "Binary file should be there")
-            handler.setup()
+            handler.setup(runtime_uses_nftables=False)
 
         self.assertTrue(_find_in_file(
                 self._binary_file,
@@ -253,7 +254,7 @@ class TestPersistFirewallRulesHandler(AgentTestCase):
 
         self.__replace_popen_cmd = self.__mock_firewalld_running_and_not_applied
         with self._get_persist_firewall_rules_handler() as handler:
-            handler.setup()
+            handler.setup(runtime_uses_nftables=False)
 
         self.__assert_firewall_cmd_running_called(validate_command_called=True)
         self.__assert_firewall_called(cmd="--query-passthrough", validate_command_called=True)
@@ -261,12 +262,71 @@ class TestPersistFirewallRulesHandler(AgentTestCase):
         self.__assert_firewall_called(cmd="--remove-passthrough", validate_command_called=True)
         self.assertFalse(any("systemctl" in cmd for cmd in self._executed_commands), "Systemctl shouldn't be called")
 
+    def test_it_should_remove_firewalld_rules_and_set_up_custom_service_when_runtime_uses_nftables(self):
+        firewall_cmd = MagicMock()
+
+        with self._get_persist_firewall_rules_handler() as handler:
+            with patch.object(handler, "_is_firewall_service_running", return_value=True):
+                with patch("azurelinuxagent.ga.persist_firewall_rules.FirewallCmd", return_value=firewall_cmd):
+                    with patch.object(handler, "_setup_network_setup_service") as setup_network_service:
+                        with patch.object(persist_firewall_event, "warn") as warn:
+                            handler.setup(runtime_uses_nftables=True)
+
+        firewall_cmd.remove_legacy_rule.assert_called_once_with()
+        firewall_cmd.remove.assert_called_once_with()
+        firewall_cmd.setup.assert_not_called()
+        setup_network_service.assert_called_once_with()
+        warning_messages = [message for _, message in get_events_from_mock(warn)]
+        self.assertTrue(any("Firewalld service is running, but runtime firewall rules use nftables" in message for message in warning_messages))
+
+    def test_it_should_set_up_custom_service_even_when_firewalld_handler_cannot_be_initialized_for_cleanup(self):
+        with self._get_persist_firewall_rules_handler() as handler:
+            with patch.object(handler, "_is_firewall_service_running", return_value=True):
+                with patch("azurelinuxagent.ga.persist_firewall_rules.FirewallCmd", side_effect=Exception("initialization failed")):
+                    with patch.object(handler, "_setup_network_setup_service") as setup_network_service:
+                        with patch.object(persist_firewall_event, "error") as error:
+                            handler.setup(runtime_uses_nftables=True)
+
+        setup_network_service.assert_called_once_with()
+        error_messages = [message for _, message in get_events_from_mock(error)]
+        self.assertEqual(["Unable to check for iptables-based firewalld passthrough rules. Error: initialization failed"], error_messages)
+
+    def test_it_should_set_up_custom_service_when_removing_firewalld_rules_fails(self):
+        firewall_cmd = MagicMock()
+        firewall_cmd.remove_legacy_rule.side_effect = Exception("legacy cleanup failed")
+        firewall_cmd.remove.side_effect = Exception("cleanup failed")
+
+        with self._get_persist_firewall_rules_handler() as handler:
+            with patch.object(handler, "_is_firewall_service_running", return_value=True):
+                with patch("azurelinuxagent.ga.persist_firewall_rules.FirewallCmd", return_value=firewall_cmd):
+                    with patch.object(handler, "_setup_network_setup_service") as setup_network_service:
+                        with patch.object(persist_firewall_event, "error") as error:
+                            handler.setup(runtime_uses_nftables=True)
+
+        firewall_cmd.remove_legacy_rule.assert_called_once_with()
+        firewall_cmd.remove.assert_called_once_with()
+        setup_network_service.assert_called_once_with()
+        error_messages = [message for _, message in get_events_from_mock(error)]
+        self.assertEqual([
+                "Unable to remove legacy firewall rule. Error: legacy cleanup failed",
+                "Unable to remove firewalld passthrough rules previously created by the agent: cleanup failed"
+            ],
+            error_messages)
+
+    def test_it_should_set_up_custom_service_when_firewalld_is_not_running_and_runtime_uses_nftables(self):
+        with self._get_persist_firewall_rules_handler() as handler:
+            with patch.object(handler, "_is_firewall_service_running", return_value=False):
+                with patch.object(handler, "_setup_network_setup_service") as setup_network_service:
+                    handler.setup(runtime_uses_nftables=True)
+
+        setup_network_service.assert_called_once_with()
+
     def test_it_should_set_up_custom_service_if_no_firewalld(self):
         self.__replace_popen_cmd = TestPersistFirewallRulesHandler.__mock_network_setup_service_disabled
         with self._get_persist_firewall_rules_handler() as handler:
             self.assertFalse(os.path.exists(self._network_service_unit_file), "Service unit file should not be there")
             self.assertFalse(os.path.exists(self._binary_file), "Binary file should not be there")
-            handler.setup()
+            handler.setup(runtime_uses_nftables=False)
 
         self.__assert_network_service_setup_properly()
 
@@ -288,7 +348,7 @@ class TestPersistFirewallRulesHandler(AgentTestCase):
                 with patch("azurelinuxagent.ga.persist_firewall_rules.fileutil.write_file",
                            side_effect=mock_write_file):
                     with self.assertRaises(Exception) as context_manager:
-                        handler.setup()
+                        handler.setup(runtime_uses_nftables=False)
                     self.assertIn("Invalid file: {0}".format(file_to_fail), ustr(context_manager.exception))
                     self.assertFalse(os.path.exists(file_to_fail), "File should be deleted: {0}".format(file_to_fail))
 
@@ -304,7 +364,7 @@ class TestPersistFirewallRulesHandler(AgentTestCase):
         self.__replace_popen_cmd = TestPersistFirewallRulesHandler.__mock_network_setup_service_disabled
         with self._get_persist_firewall_rules_handler() as handler:
             self.assertFalse(os.path.exists(self._binary_file), "Binary file should not be there")
-            handler.setup()
+            handler.setup(runtime_uses_nftables=False)
 
             self.assertTrue(os.path.exists(self._binary_file), "Binary file not set properly")
 
@@ -316,7 +376,7 @@ class TestPersistFirewallRulesHandler(AgentTestCase):
         with patch("sys.argv", [test_str]):
             with self._get_persist_firewall_rules_handler() as handler:
                 self.assertFalse(os.path.exists(self._binary_file), "Binary file should not be there")
-                handler.setup()
+                handler.setup(runtime_uses_nftables=False)
                 output = shellutil.run_command([sys.executable, self._binary_file], stderr=subprocess.STDOUT)
                 expected_str = "{0} file not found, skipping execution of firewall execution setup for this boot".format(
                     os.path.join(os.getcwd(), test_str))
@@ -330,7 +390,7 @@ class TestPersistFirewallRulesHandler(AgentTestCase):
             # 2nd run - Enable Firewalld and ensure the agent sets firewall rules using firewalld and deletes custom service
             self._executed_commands = []
             self.__replace_popen_cmd = self.__mock_firewalld_running_and_not_applied
-            handler.setup()
+            handler.setup(runtime_uses_nftables=False)
 
             self.__assert_firewall_cmd_running_called(validate_command_called=True)
             self.__assert_firewall_called(cmd="--query-passthrough", validate_command_called=True)

--- a/tests/ga/test_update.py
+++ b/tests/ga/test_update.py
@@ -46,6 +46,7 @@ from azurelinuxagent.ga.update import  \
     get_update_handler, ORPHAN_POLL_INTERVAL, ORPHAN_WAIT_INTERVAL, \
     CHILD_LAUNCH_RESTART_MAX, CHILD_HEALTH_INTERVAL, GOAL_STATE_PERIOD_EXTENSIONS_DISABLED, UpdateHandler, \
     READONLY_FILE_GLOBS, ExtensionsSummary
+from azurelinuxagent.ga.firewall_manager import IpTables, NfTables
 from azurelinuxagent.ga.signing_certificate_util import _MICROSOFT_ROOT_CERT_2011_03_22, get_microsoft_signing_certificate_path
 from tests.lib.mock_firewall_command import MockIpTables, MockFirewallCmd
 from tests.lib.mock_update_handler import mock_update_handler
@@ -1221,6 +1222,30 @@ class TestUpdate(UpdateTestCase):
                             ],
                             mock_firewall_cmd.call_list,
                             "Expected 2 calls for the legacy rule (-C and -D), followed by 3 sets of calls for the current rules (-C and -A)")
+
+    def test_initialize_firewall_should_pass_True_to_persistence_when_nftables_is_selected(self):
+        firewall_manager = MagicMock(spec=NfTables)
+        firewall_manager.check.return_value = True
+        persistence_handler = MagicMock()
+
+        with patch("azurelinuxagent.ga.update.conf.enable_firewall", return_value=True):
+            with patch("azurelinuxagent.ga.update.FirewallManager.create", return_value=firewall_manager):
+                with patch("azurelinuxagent.ga.update.PersistFirewallRulesHandler", return_value=persistence_handler):
+                    UpdateHandler._initialize_firewall("168.63.129.16")
+
+        persistence_handler.setup.assert_called_once_with(runtime_uses_nftables=True)
+
+    def test_initialize_firewall_should_pass_False_to_persistence_when_iptables_is_selected(self):
+        firewall_manager = MagicMock(spec=IpTables)
+        firewall_manager.check.return_value = True
+        persistence_handler = MagicMock()
+
+        with patch("azurelinuxagent.ga.update.conf.enable_firewall", return_value=True):
+            with patch("azurelinuxagent.ga.update.FirewallManager.create", return_value=firewall_manager):
+                with patch("azurelinuxagent.ga.update.PersistFirewallRulesHandler", return_value=persistence_handler):
+                    UpdateHandler._initialize_firewall("168.63.129.16")
+
+        persistence_handler.setup.assert_called_once_with(runtime_uses_nftables=False)
 
     @contextlib.contextmanager
     def _setup_test_for_ext_event_dirs_retention(self):

--- a/tests/lib/mock_firewall_command.py
+++ b/tests/lib/mock_firewall_command.py
@@ -137,6 +137,8 @@ class MockIpTables(_MockFirewallCommand):
         self._check_matches_list = check_matches_list
 
     def _mock_run_command(self, command, *args, **kwargs):
+        if command[0] == 'modinfo':
+            return 'modinfo mocked'
         if command[0] == 'iptables' and command[1] == '--version':
             return self._original_run_command(['echo', 'iptables v{0} (nf_tables)'.format(self._version)], *args, **kwargs)
         return super(MockIpTables, self)._mock_run_command(command, *args, **kwargs)

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -24,9 +24,11 @@ from azurelinuxagent.common import conf
 from azurelinuxagent.common.exception import CGroupsException
 from azurelinuxagent.ga import logcollector, cgroupconfigurator
 from azurelinuxagent.common.utils import fileutil
+from azurelinuxagent.common.utils.shellutil import CommandError
 from azurelinuxagent.ga.cgroupapi import InvalidCgroupMountpointException, CgroupV1, CgroupV2
 from azurelinuxagent.ga.collect_logs import CollectLogsHandler
 from azurelinuxagent.ga.cgroupcontroller import AGENT_LOG_COLLECTOR
+from azurelinuxagent.ga.firewall_manager import IpTables, NfTables
 from tests.lib.mock_cgroup_environment import mock_cgroup_v1_environment, mock_cgroup_v2_environment
 from tests.lib.tools import AgentTestCase, data_dir, Mock, patch
 
@@ -510,6 +512,44 @@ class TestAgent(AgentTestCase):
         cmd, _, _, _, _, _, wire_server_address = parse_args(["-{0}".format(AgentCommands.Help)])
         self.assertEqual(cmd, AgentCommands.Help)
         self.assertEqual(None, wire_server_address)
+
+    def test_setup_firewall_should_return_early_when_firewalld_is_enabled(self):
+        firewall_manager = Mock(spec=IpTables)
+
+        with patch("azurelinuxagent.agent.FirewallManager.create", return_value=firewall_manager):
+            with patch("azurelinuxagent.agent.run_command", return_value="enabled"):
+                with patch("azurelinuxagent.agent.threading.current_thread"):
+                    with self.assertRaises(SystemExit) as context:
+                        Agent.setup_firewall("168.63.129.16")
+
+        self.assertEqual(0, context.exception.code)
+        firewall_manager.setup.assert_not_called()
+
+    def test_setup_firewall_should_not_return_early_when_firewalld_is_not_enabled(self):
+        firewall_manager = Mock(spec=IpTables)
+        firewalld_not_enabled = CommandError(
+            command=["systemctl", "is-enabled", "--type=service", "firewalld.service"],
+            return_code=1,
+            stdout="disabled",
+            stderr="")
+
+        with patch("azurelinuxagent.agent.FirewallManager.create", return_value=firewall_manager):
+            with patch("azurelinuxagent.agent.run_command", side_effect=firewalld_not_enabled):
+                with patch("azurelinuxagent.agent.threading.current_thread"):
+                    Agent.setup_firewall("168.63.129.16")
+
+        firewall_manager.setup.assert_called_once_with()
+
+    def test_setup_firewall_should_never_return_early_if_nftables_is_firewall_manager(self):
+        firewall_manager = Mock(spec=NfTables)
+
+        with patch("azurelinuxagent.agent.FirewallManager.create", return_value=firewall_manager):
+            with patch("azurelinuxagent.agent.run_command") as run_command:
+                with patch("azurelinuxagent.agent.threading.current_thread"):
+                    Agent.setup_firewall("168.63.129.16")
+
+        run_command.assert_not_called()
+        firewall_manager.setup.assert_called_once_with()
 
     def test_it_should_ignore_empty_arguments(self):
 

--- a/tests_e2e/test_suites/agent_firewall.yml
+++ b/tests_e2e/test_suites/agent_firewall.yml
@@ -12,4 +12,7 @@ tests:
 images:
   - "endorsed"
   - "endorsed-arm64"
+#  - "rocky_10"  # TODO: Rocky 10 does not ship the required kernel modules for iptables or nft by default. Once the distro fixes the dependency issue, this image needs to be tested
 owns_vm: true  # This vm cannot be shared with other tests because it modifies the firewall rules and agent status.
+skip_on_images:
+  - "alma_10"   # TODO: Alma 10 does not ship the required kernel modules for iptables or nft by default. Once the distro fixes the dependency issue, this image needs to be tested

--- a/tests_e2e/test_suites/agent_persist_firewall.yml
+++ b/tests_e2e/test_suites/agent_persist_firewall.yml
@@ -9,6 +9,7 @@ tests:
 images:
   - "endorsed"
   - "endorsed-arm64"
+#  - "rocky_10"  # TODO: Rocky 10 does not ship the required kernel modules for iptables or nft by default. Once the distro fixes the dependency issue, this image needs to be tested
 owns_vm: true  # This vm cannot be shared with other tests because it modifies the firewall rules and agent status.
 # agent persist firewall service not running on flatcar distro since agent can't install custom service due to read only filesystem.
 # so skipping the test run on flatcar distro.
@@ -16,3 +17,4 @@ owns_vm: true  # This vm cannot be shared with other tests because it modifies t
 skip_on_images:
   - "flatcar"
   - "flatcar_arm64"
+  - "alma_10"   # TODO: Alma 10 does not ship the required kernel modules for iptables or nft by default. Once the distro fixes the dependency issue, this image needs to be tested

--- a/tests_e2e/test_suites/images.yml
+++ b/tests_e2e/test_suites/images.yml
@@ -27,6 +27,7 @@ image-sets:
       - "rhel_79"
       - "rhel_810"
       - "rhel_95"
+      - "rhel_10_0"
       - "rhel_10"
       - "rocky_9"
       - "suse_12"
@@ -60,6 +61,7 @@ image-sets:
       - "rhel_83"
       - "rhel_95"
       - "rhel_95_arm64"
+      - "rhel_10_0"
       - "rhel_10"
       - "suse_15"
       - "ubuntu_1604"
@@ -90,6 +92,7 @@ image-sets:
       - "rhel_83"
       - "rhel_810"
       - "rhel_95"
+      - "rhel_10_0"
       - "rhel_10"
       - "suse_15"
       - "ubuntu_1604"
@@ -293,11 +296,16 @@ images:
       locations:
          AzureChinaCloud: []
          AzureUSGovernment: []
-   rhel_10:
+   rhel_10_0:
       urn: "RedHat:RHEL:10_0:latest"
       locations:
-        # TODO: Remove this once RHEL 10 is available in AzureChinaCloud
+         # TODO: Remove this once RHEL 10 is available in AzureChinaCloud
          AzureChinaCloud: []
+   rhel_10:
+        urn: "RedHat:RHEL:10-lvm-gen2:latest"
+        locations:
+           # TODO: Remove this once RHEL 10 is available in AzureChinaCloud
+           AzureChinaCloud: []
    rhel_94_cvm:
       urn: "RedHat rhel-cvm 9_4_cvm latest"
       security_type: "ConfidentialVM"
@@ -339,6 +347,10 @@ images:
          AzureCloud: ["westus2", "westcentralus", "southcentralus", "eastus2euap"] # If additional regions are required, we will need to request additional capacity for 'Standard DCasv6 Family vCPUs' in our Public test sub.
          AzureUSGovernment: ["usgovarizona"]       # If additional regions are required, we will need to request additional capacity for 'Standard DCasv6 Family vCPUs' in our Gov test sub.
          AzureChinaCloud: []                       # TODO: China cloud does not have CVM support yet. Remove this once CVM is available in China cloud.
+   rocky_10:
+      urn: "ciq:rocky-community-editions:rocky-community-10:latest"  # TODO: This image should be added to our 'endorsed' list once the iptables/nft dependency issue is resolved
+      locations:
+         AzureChinaCloud: []
    suse_12:
       urn: "SUSE:sles-12-sp5:gen1:latest"
       locations:

--- a/tests_e2e/tests/agent_persist_firewall/agent_persist_firewall.py
+++ b/tests_e2e/tests/agent_persist_firewall/agent_persist_firewall.py
@@ -22,6 +22,7 @@ from tests_e2e.tests.lib.agent_test import AgentVmTest
 from tests_e2e.tests.lib.agent_test_context import AgentVmTestContext
 from tests_e2e.tests.lib.firewall_utilities import FirewallUtilities
 from tests_e2e.tests.lib.logging import log
+from tests_e2e.tests.lib.shell import CommandError
 from tests_e2e.tests.lib.ssh_client import SshClient
 
 
@@ -33,9 +34,11 @@ class AgentPersistFirewallTest(AgentVmTest):
     def __init__(self, context: AgentVmTestContext):
         super().__init__(context)
         self._ssh_client: SshClient = self._context.create_ssh_client()
+        self._expect_firewalld_running = False
 
     def run(self):
         FirewallUtilities.skip_test_if_proxy_agent_is_managing_the_wireserver_endpoint(self._ssh_client)
+        self._expect_firewalld_running = self._is_firewalld_running()
 
         self._test_setup()
         # Test case 1: After test agent install, verify firewalld or network.setup is running
@@ -69,8 +72,19 @@ class AgentPersistFirewallTest(AgentVmTest):
 
     def _verify_persist_firewall_service_running(self):
         log.info("Verifying persist firewall service is running")
-        self._run_remote_test(self._ssh_client, "agent_persist_firewall-verify_persist_firewall_service_running.py", use_sudo=True)
+        command = "agent_persist_firewall-verify_persist_firewall_service_running.py"
+        if self._expect_firewalld_running:
+            command += " --expect-firewalld-running"
+        self._run_remote_test(self._ssh_client, command, use_sudo=True)
         log.info("Successfully verified persist firewall service is running\n")
+
+    def _is_firewalld_running(self):
+        try:
+            is_running = self._ssh_client.run_command("firewall-cmd --state", use_sudo=True).rstrip() == "running"
+        except CommandError:
+            is_running = False
+        log.info("Firewalld is running before test setup: {0}".format(is_running))
+        return is_running
 
     def _verify_firewall_rules_on_boot(self, boot_name):
         log.info("Verifying firewall rules on {0}".format(boot_name))

--- a/tests_e2e/tests/agent_persist_firewall/agent_persist_firewall.py
+++ b/tests_e2e/tests/agent_persist_firewall/agent_persist_firewall.py
@@ -65,6 +65,9 @@ class AgentPersistFirewallTest(AgentVmTest):
         # Test case 4: perform firewalld rules deletion and ensure deleted rules added back to rule set after agent start
         self._verify_firewall_rules_readded()
 
+        # Test case 5: ensure stale firewalld rules created by an older agent are removed when nftables is in use
+        self._verify_stale_firewalld_rules_removed()
+
     def _test_setup(self):
         log.info("Doing test setup")
         output = self._ssh_client.run_command(f"agent_persist_firewall-test_setup {self._context.username}", use_sudo=True)
@@ -95,6 +98,11 @@ class AgentPersistFirewallTest(AgentVmTest):
         log.info("Verifying firewall rules readded")
         self._run_remote_test(self._ssh_client, "agent_persist_firewall-verify_firewalld_rules_readded.py", use_sudo=True)
         log.info("Successfully verified firewall rules readded\n")
+
+    def _verify_stale_firewalld_rules_removed(self):
+        log.info("Verifying stale firewalld rules removed when nftables is the firewall manager")
+        self._run_remote_test(self._ssh_client, "agent_persist_firewall-verify_stale_firewalld_rules_removed.py", use_sudo=True)
+        log.info("Successfully verified stale firewalld rules removed when nftables is the firewall manager\n")
 
     def _enable_agent(self):
         log.info("Enabling agent")

--- a/tests_e2e/tests/lib/agent_log.py
+++ b/tests_e2e/tests/lib/agent_log.py
@@ -370,6 +370,32 @@ class AgentLog(object):
                            r"The permanent firewall rules for Azure Fabric are not setup correctly \(The following rules are missing: \['ACCEPT DNS'\]\).* will reset them.",
                 'if': lambda r: r.level == "WARNING"
             },
+            #
+            # AlmaLinux 10 does not include the xt_owner and xt_conntrack kernel modules or the nft command. The agent
+            # cannot create the UID-based allow rule or conntrack-based drop rule until the image provides a usable
+            # firewall backend. Ignore these known firewall errors when checking the agent log for other test suites.
+            # TODO: Remove this ignore rule once the distro resolves the dependency issue
+            #
+            {
+                'message': r"(Required iptables kernel modules are unresolved \(xt_owner, xt_conntrack\) and nft is not available, continuing with iptables as best effort)"
+                           "|"
+                           r"((Error initializing firewall|An error occurred while verifying the state of the firewall): .*iptables.*-m (owner|conntrack).*missing kernel module)"
+                           "|"
+                           r"(The firewall rules for Azure Fabric are not setup correctly \(the environment thread will fix it\): The following rules are missing: \['ACCEPT', 'DROP'\])"
+                           "|"
+                           r"(The firewall is not configured correctly. The following rules are missing: \['ACCEPT', 'DROP'\].*Will reset it.)",
+                'if': lambda r: DISTRO_NAME == "almalinux" and FlexibleVersion(DISTRO_VERSION).major == 10
+            },
+            #
+            # RHEL 10.2 does not include the kernel modules required by the iptables rules. These warnings are expected
+            # when the agent selects nftables for runtime and persistent firewall rules instead.
+            #
+            {
+                'message': r"(Falling back to nftables because required iptables kernel modules are unresolved:)"
+                           "|"
+                           r"(Firewalld service is running, but runtime firewall rules use nftables; trying to set up )",
+                'if': lambda r: r.level == "WARNING" and DISTRO_NAME in ["rhel", "redhat"] and FlexibleVersion(DISTRO_VERSION) == FlexibleVersion("10.2")
+            },
             # TODO: The Daemon has not been updated on Azure Linux 3; remove this message when it is.
             #
             # 2024-08-05T14:36:48.004865Z WARNING Daemon Daemon Unable to load distro implementation for azurelinux. Using default distro implementation instead.

--- a/tests_e2e/tests/lib/firewall_manager.py
+++ b/tests_e2e/tests/lib/firewall_manager.py
@@ -65,16 +65,27 @@ class FirewallManager:
         """
         try:
             shellutil.run_command(["sudo", "iptables", "--version"])  # On some distros, e.g. CentOS, iptables is not on the PATH for regular users
-            log.info("Using iptables to manage the firewall")
-            return IpTables()
+            iptables = IpTables()
+            unresolved_modules = iptables.get_unresolved_modules()
+            if len(unresolved_modules) == 0:
+                log.info("Using iptables to manage the firewall")
+                return iptables
+
+            try:
+                shellutil.run_command(["sudo", "nft", "--version"])
+                log.info(f"Required iptables kernel modules are unresolved ({', '.join(unresolved_modules)}); using nftables to manage the firewall")
+                return NfTables()
+            except CommandError:
+                log.info(f"Required iptables kernel modules are unresolved ({', '.join(unresolved_modules)}), but nft is not available; using iptables to manage the firewall")
+                return iptables
         except CommandError:
             pass
 
         try:
-            shellutil.run_command(["nft", "--version"])
+            shellutil.run_command(["sudo", "nft", "--version"])
             log.info("Using nftables to manage the firewall")
             return NfTables()
-        except FileNotFoundError:
+        except CommandError:
             pass
 
         raise Exception("No firewall commands are installed")
@@ -199,6 +210,24 @@ class IpTables(_IpTablesFirewalldManager):
     Implementation of Firewall using the iptables command
     """
 
+    @staticmethod
+    def get_unresolved_modules() -> List[str]:
+        try:
+            shellutil.run_command(["sudo", "modinfo", "--version"])
+        except Exception:
+            return []
+
+        unresolved_modules = []
+        for module_name in ["xt_owner", "xt_conntrack"]:
+            try:
+                shellutil.run_command(["sudo", "modinfo", module_name])
+            except CommandError:
+                unresolved_modules.append(module_name)
+            except Exception:
+                pass
+
+        return unresolved_modules
+
     def _get_state_command(self) -> str:
         return "sudo iptables -w -t security -L -nxv"
 
@@ -244,6 +273,11 @@ class Firewalld(_IpTablesFirewalldManager):
 
     def _get_delete_command_option(self) -> str:
         return "--remove-passthrough"
+
+    def add_rule(self, rule_name: str) -> None:
+        self._log_and_run_command(
+            self._commands[rule_name]("--passthrough")
+        )
 
     def _get_accept_dns_command(self, command_option: str) -> str:
         return f"firewall-cmd --permanent --direct {command_option} ipv4 -t security -A OUTPUT -d {self._wire_server_address} -p tcp --destination-port 53 -j ACCEPT"

--- a/tests_e2e/tests/scripts/agent_firewall-verify_all_firewall_rules.py
+++ b/tests_e2e/tests/scripts/agent_firewall-verify_all_firewall_rules.py
@@ -29,7 +29,7 @@ from azurelinuxagent.common.utils import shellutil
 from azurelinuxagent.common.utils.flexible_version import FlexibleVersion
 from azurelinuxagent.common.utils.textutil import format_exception
 from azurelinuxagent.common.version import DISTRO_NAME, DISTRO_VERSION
-from tests_e2e.tests.lib.firewall_manager import FirewallManager, IpTables, get_wireserver_ip
+from tests_e2e.tests.lib.firewall_manager import FirewallManager, IpTables, NfTables, get_wireserver_ip
 from tests_e2e.tests.lib.logging import log
 from tests_e2e.tests.lib.remote_test import run_remote_test
 import http.client as httpclient
@@ -68,15 +68,30 @@ class AgentFirewall:
     def run(self):
         self._prepare_agent()
 
+        if isinstance(self._firewall_manager, NfTables):
+            # On RHEL 10.2, older agents choose 'iptables' as the firewall manager, but the UID-based allow rule and
+            # conntrack-based drop rule cannot be created due to missing modules. Newer versions of the agent detect
+            # the missing modules and use NfTables instead, after cleaning up the old iptables DNS rule. As a result,
+            # we should ensure no iptables rules exist when NfTables is the firewall manager.
+            self._verify_iptables_rules_removed()
+
         self._firewall_manager.log_firewall_state("** Initial state of the firewall")
-        # Some versions of RHEL have a baked-in agent (2.7.0.6) that can produce duplicate DNS rules.
-        if DISTRO_NAME in ["rhel", "redhat"] and FlexibleVersion(DISTRO_VERSION).major >= 8:
+        # Some versions of RHEL have a baked-in agent (2.7.0.6) that can produce duplicate DNS rules. Rhel 10+ have
+        # baked-in version 2.13.1.1+ so this check is not necessary on those versions.
+        if DISTRO_NAME in ["rhel", "redhat"] and FlexibleVersion(DISTRO_VERSION).major >= 8 and FlexibleVersion(DISTRO_VERSION).major < 10:
             self._remove_duplicate_dns_rules()
         self._firewall_manager.assert_all_rules_are_set()
 
         self._test_accept_dns_rule()
         self._test_accept_rule()
         self._test_drop_rule()
+
+    @staticmethod
+    def _verify_iptables_rules_removed() -> None:
+        iptables = IpTables()
+        for rule in [IpTables.ACCEPT_DNS, IpTables.ACCEPT, IpTables.DROP]:
+            iptables.verify_rule_is_not_set(rule)
+        log.info("Confirmed no agent-owned iptables rules exist when NfTables is the firewall manager")
 
     def _remove_duplicate_dns_rules(self) -> None:
         log.info("Checking for duplicate DNS rules...")
@@ -321,4 +336,3 @@ parser = argparse.ArgumentParser()
 parser.add_argument('-u', '--user', required=True, help="Non root user")
 args = parser.parse_args()
 run_remote_test(lambda: AgentFirewall(args.user).run())
-

--- a/tests_e2e/tests/scripts/agent_firewall-verify_all_firewall_rules.py
+++ b/tests_e2e/tests/scripts/agent_firewall-verify_all_firewall_rules.py
@@ -88,6 +88,12 @@ class AgentFirewall:
 
     @staticmethod
     def _verify_iptables_rules_removed() -> None:
+        try:
+            shellutil.run_command(["sudo", "iptables", "--version"])
+        except shellutil.CommandError:
+            log.info("iptables is not available; there are no iptables rules to verify")
+            return
+
         iptables = IpTables()
         for rule in [IpTables.ACCEPT_DNS, IpTables.ACCEPT, IpTables.DROP]:
             iptables.verify_rule_is_not_set(rule)

--- a/tests_e2e/tests/scripts/agent_persist_firewall-access_wireserver
+++ b/tests_e2e/tests/scripts/agent_persist_firewall-access_wireserver
@@ -117,7 +117,7 @@ fi
 if [[ "$USER" != "root" ]]; then
   echo ""
   echo "checking tcp traffic to wireserver port 53 for non-root user ($USER)"
-  echo -n 2>/dev/null < /dev/tcp/$WIRE_IP/53 && echo 0 || echo 1  # Establish network connection for port 53
+  echo -n 2>/dev/null < /dev/tcp/$WIRE_IP/53  # Establish network connection for port 53
   TCP_EC=$?
   echo "TCP 53 Connection ExitCode: $TCP_EC"
 fi

--- a/tests_e2e/tests/scripts/agent_persist_firewall-verify_firewalld_rules_readded.py
+++ b/tests_e2e/tests/scripts/agent_persist_firewall-verify_firewalld_rules_readded.py
@@ -20,18 +20,55 @@
 
 from azurelinuxagent.common.osutil import get_osutil
 from azurelinuxagent.common.utils import shellutil
-from tests_e2e.tests.lib.firewall_manager import Firewalld
+from tests_e2e.tests.lib.firewall_manager import FirewallManager, Firewalld, NfTables
 from tests_e2e.tests.lib.logging import log
+from tests_e2e.tests.lib.retry import retry_if_false
+
+
+def verify_passthrough_rules_are_removed(firewall):
+    agent_name = get_osutil().get_service_name()
+    rules = [Firewalld.ACCEPT_DNS, Firewalld.ACCEPT, Firewalld.DROP]
+
+    log.info("Stopping the agent before adding stale firewalld passthrough rules")
+    shellutil.run_command(["systemctl", "stop", agent_name])
+
+    try:
+        for rule in rules:
+            firewall.add_rule(rule)
+            if not firewall.check_rule(rule):
+                raise Exception("Failed to add the stale {0} firewalld passthrough rule".format(rule))
+    finally:
+        log.info("Restarting the agent to remove stale firewalld passthrough rules")
+        shellutil.run_command(["systemctl", "restart", agent_name])
+
+    rules_are_removed = retry_if_false(
+        lambda: all(not firewall.check_rule(rule) for rule in rules),
+        attempts=5,
+        delay=30)
+
+    if not rules_are_removed:
+        raise Exception("The agent did not remove the stale firewalld passthrough rules. Current state: {0}".format(
+            firewall.get_state()))
+
+    log.info("The agent removed all stale firewalld passthrough rules")
 
 
 def main():
-
     if not Firewalld.is_service_running():
         log.info("firewalld.service is not running and skipping test")
         return
 
     firewall = Firewalld()
     firewall.log_firewall_state("** firewalld.service is running; initial state of the firewall")
+
+    if isinstance(FirewallManager.create(), NfTables):
+        # Older versions of the agent always used firewalld to create passthrough rules when it is in 'running' state.
+        # Newer versions of the agent do not use firewalld (even if it is in 'running' state) when NfTables is the
+        # runtime firewall manager because our passthrough rules are only compatible with Iptables. The agent should
+        # attempt to clean up any passthrough rules created by an old agent when NfTables is the runtime firewall
+        # manager.
+        verify_passthrough_rules_are_removed(firewall)
+        return
 
     for rule in [Firewalld.ACCEPT_DNS, Firewalld.ACCEPT, Firewalld.DROP]:
         log.info(f"***** Verifying {rule} rule")

--- a/tests_e2e/tests/scripts/agent_persist_firewall-verify_firewalld_rules_readded.py
+++ b/tests_e2e/tests/scripts/agent_persist_firewall-verify_firewalld_rules_readded.py
@@ -22,35 +22,6 @@ from azurelinuxagent.common.osutil import get_osutil
 from azurelinuxagent.common.utils import shellutil
 from tests_e2e.tests.lib.firewall_manager import FirewallManager, Firewalld, NfTables
 from tests_e2e.tests.lib.logging import log
-from tests_e2e.tests.lib.retry import retry_if_false
-
-
-def verify_passthrough_rules_are_removed(firewall):
-    agent_name = get_osutil().get_service_name()
-    rules = [Firewalld.ACCEPT_DNS, Firewalld.ACCEPT, Firewalld.DROP]
-
-    log.info("Stopping the agent before adding stale firewalld passthrough rules")
-    shellutil.run_command(["systemctl", "stop", agent_name])
-
-    try:
-        for rule in rules:
-            firewall.add_rule(rule)
-            if not firewall.check_rule(rule):
-                raise Exception("Failed to add the stale {0} firewalld passthrough rule".format(rule))
-    finally:
-        log.info("Restarting the agent to remove stale firewalld passthrough rules")
-        shellutil.run_command(["systemctl", "restart", agent_name])
-
-    rules_are_removed = retry_if_false(
-        lambda: all(not firewall.check_rule(rule) for rule in rules),
-        attempts=5,
-        delay=30)
-
-    if not rules_are_removed:
-        raise Exception("The agent did not remove the stale firewalld passthrough rules. Current state: {0}".format(
-            firewall.get_state()))
-
-    log.info("The agent removed all stale firewalld passthrough rules")
 
 
 def main():
@@ -62,12 +33,11 @@ def main():
     firewall.log_firewall_state("** firewalld.service is running; initial state of the firewall")
 
     if isinstance(FirewallManager.create(), NfTables):
-        # Older versions of the agent always used firewalld to create passthrough rules when it is in 'running' state.
-        # Newer versions of the agent do not use firewalld (even if it is in 'running' state) when NfTables is the
-        # runtime firewall manager because our passthrough rules are only compatible with Iptables. The agent should
-        # attempt to clean up any passthrough rules created by an old agent when NfTables is the runtime firewall
-        # manager.
-        verify_passthrough_rules_are_removed(firewall)
+        # This test deletes agent-owned firewalld passthrough rules and expects the agent to recreate them. Those rules
+        # use iptables syntax and are intentionally not used when NfTables is the runtime firewall manager. In that
+        # case, recreating them would be incorrect and could cause firewalld to fail when the rules are loaded. The
+        # separate stale-rule cleanup test verifies the expected nft behavior instead.
+        log.info("Runtime firewall rules use nftables; skipping the firewalld rule re-add test")
         return
 
     for rule in [Firewalld.ACCEPT_DNS, Firewalld.ACCEPT, Firewalld.DROP]:

--- a/tests_e2e/tests/scripts/agent_persist_firewall-verify_persist_firewall_service_running.py
+++ b/tests_e2e/tests/scripts/agent_persist_firewall-verify_persist_firewall_service_running.py
@@ -18,11 +18,13 @@
 #
 # This script verifies firewalld rules set on the vm if firewalld service is running and if it's not running, it verifies network-setup service is enabled by the agent
 #
+import argparse
+
 from assertpy import fail
 
 from azurelinuxagent.common.osutil import get_osutil
 from azurelinuxagent.common.utils import shellutil
-from tests_e2e.tests.lib.firewall_manager import Firewalld
+from tests_e2e.tests.lib.firewall_manager import FirewallManager, Firewalld, NfTables
 from tests_e2e.tests.lib.logging import log
 from tests_e2e.tests.lib.retry import retry_if_false
 
@@ -53,18 +55,47 @@ def verify_network_setup_service_enabled():
     log.info("network-setup.service is enabled")
 
 
-def verify_firewall_service_running():
+def verify_firewalld_rules_not_present():
+    firewall = Firewalld()
+    rules = [Firewalld.ACCEPT_DNS, Firewalld.ACCEPT, Firewalld.DROP]
+
+    rules_are_not_present = retry_if_false(
+        lambda: all(not firewall.check_rule(rule) for rule in rules),
+        attempts=5,
+        delay=30)
+
+    if not rules_are_not_present:
+        fail("Agent-owned firewalld passthrough rules should not be present when runtime uses nftables. Current state: {0}".format(
+            firewall.get_state()))
+
+    log.info("Asserted that agent-owned firewalld passthrough rules are not present")
+
+
+def verify_firewall_service_running(expect_firewalld_running):
     log.info("Ensure test agent initialize the firewalld/network service setup")
 
-    log.info("Checking if the firewalld service is active on the VM")
-    if Firewalld.is_service_running():
-        # Checking if firewalld rules are present in the rule set if firewall service is active
-        Firewalld().assert_all_rules_are_set()
-    else:
-        # Checking if network-setup service is enabled if firewall service is not active
-        log.info("Checking if network-setup service is enabled by the agent since firewall service is not active")
+    firewall_manager = FirewallManager.create()
+    firewalld_service_running = Firewalld.is_service_running()
+    if expect_firewalld_running and not firewalld_service_running:
+        fail("Firewalld was running before test setup, but it is no longer running")
+
+    if isinstance(firewall_manager, NfTables) or not firewalld_service_running:
+        # Checking if network-setup service is enabled if firewall service is not active or Nftables in use
+        log.info("Checking if network setup service is enabled by the agent since firewall service is not active or Nftables in use")
         verify_network_setup_service_enabled()
+    else:
+        # Checking if firewalld rules are present in the rule set if firewall service is active and Nftables not in use
+        Firewalld().assert_all_rules_are_set()
+
+    if isinstance(firewall_manager, NfTables) and firewalld_service_running:
+        # The agent should not create any firewalld passthrough rules when NfTables is the selected firewall manager,
+        # since those rules are only compatible with iptables.
+        log.info("Asserting that firewalld passthrough rules do not exist when custom setup network service is used for persistent rules")
+        verify_firewalld_rules_not_present()
 
 
 if __name__ == "__main__":
-    verify_firewall_service_running()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--expect-firewalld-running", action="store_true")
+    args = parser.parse_args()
+    verify_firewall_service_running(args.expect_firewalld_running)

--- a/tests_e2e/tests/scripts/agent_persist_firewall-verify_stale_firewalld_rules_removed.py
+++ b/tests_e2e/tests/scripts/agent_persist_firewall-verify_stale_firewalld_rules_removed.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env pypy3
+# Microsoft Azure Linux Agent
+#
+# Copyright 2018 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This script verifies that stale firewalld passthrough rules created by an older agent are removed when nftables is
+# the runtime firewall manager.
+#
+
+from azurelinuxagent.common.osutil import get_osutil
+from azurelinuxagent.common.utils import shellutil
+from tests_e2e.tests.lib.firewall_manager import FirewallManager, Firewalld, NfTables
+from tests_e2e.tests.lib.logging import log
+from tests_e2e.tests.lib.retry import retry_if_false
+
+
+def main():
+    if not Firewalld.is_service_running():
+        log.info("firewalld.service is not running; skipping the stale firewalld rule cleanup test")
+        return
+
+    if not isinstance(FirewallManager.create(), NfTables):
+        log.info("Runtime firewall rules do not use nftables; skipping the stale firewalld rule cleanup test")
+        return
+
+    firewall = Firewalld()
+    rules = [Firewalld.ACCEPT_DNS, Firewalld.ACCEPT, Firewalld.DROP]
+    agent_name = get_osutil().get_service_name()
+
+    firewall.log_firewall_state("** firewalld.service is running; initial state of the firewall")
+    log.info("Stopping the agent before adding stale firewalld passthrough rules")
+    shellutil.run_command(["systemctl", "stop", agent_name])
+
+    try:
+        for rule in rules:
+            firewall.add_rule(rule)
+            if not firewall.check_rule(rule):
+                raise Exception("Failed to add the stale {0} firewalld passthrough rule".format(rule))
+    finally:
+        log.info("Restarting the agent to remove stale firewalld passthrough rules")
+        shellutil.run_command(["systemctl", "restart", agent_name])
+
+    rules_are_removed = retry_if_false(
+        lambda: all(not firewall.check_rule(rule) for rule in rules),
+        attempts=5,
+        delay=30)
+
+    if not rules_are_removed:
+        raise Exception("The agent did not remove the stale firewalld passthrough rules. Current state: {0}".format(
+            firewall.get_state()))
+
+    log.info("The agent removed all stale firewalld passthrough rules")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->
<!--
Please add an informative description that covers that changes made by the pull request.
-->
## Description
Latest EL10 distros (RHEL 10.2 for example) are not packaging the 'kernel-modules-extra' modules which are required to setup firewall rules with the iptables cmd. Since the iptables command, the agent does not fallback to nftables to create the firewall rules. As a result, the firewall rules are not created on those images. The commands to create the firewalld passthrough rules do not fail, but when firewalld eventually loads the rules it will enter a failed state because the required kernel modules (xt_owner, xt_conntrack) to apply the rules aren't packaged.

This PR updates the agent to fallback to nftables if the required kernel modules aren't available (even if iptables cmd is). It also adds cleanup to remove the remaining iptables DNS rule when this fallback happens, and also to cleanup the firewalld passthrough rules when firewalld is running and the firewall manager uses nftables. 

Issue #3510 
---
<!--
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->
### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).
---
<!--
This checklist is used to track contributions from distro maintainers.
-->
### Distro maintenance information, if applicable
- [ ] This is a contribution from a distro maintainer
- [ ] The changes in this PR have been taken as a downstream patch (Note: it is not recommended to patch the agent without upstream review and approval)
