### PR TITLE
Use host command for dns lookup in publish_hostname on debian

### DIFF
--- a/tests_e2e/tests/publish_hostname/publish_hostname.py
+++ b/tests_e2e/tests/publish_hostname/publish_hostname.py
@@ -61,7 +61,7 @@ class PublishHostname(AgentVmTest):
         lookup_cmd = "dig -x {0}".format(self._private_ip)
         dns_regex = r"[\S\s]*;; ANSWER SECTION:\s.*PTR\s*(?P<hostname>.*)\.internal\.(cloudapp\.net|chinacloudapp\.cn|usgovcloudapp\.net).*[\S\s]*"
 
-        # Not all distros come with dig. Use another DNS lookup tool or install dig if needed
+        # Not all distros come with dig. Install dig if not on machine or use host command
         try:
             self._ssh_client.run_command("dig -v")
         except CommandError as e:

--- a/tests_e2e/tests/publish_hostname/publish_hostname.py
+++ b/tests_e2e/tests/publish_hostname/publish_hostname.py
@@ -61,18 +61,16 @@ class PublishHostname(AgentVmTest):
         lookup_cmd = "dig -x {0}".format(self._private_ip)
         dns_regex = r"[\S\s]*;; ANSWER SECTION:\s.*PTR\s*(?P<hostname>.*)\.internal\.(cloudapp\.net|chinacloudapp\.cn|usgovcloudapp\.net).*[\S\s]*"
 
-        # Not all distros come with dig. Install dig if not on machine
+        # Not all distros come with dig. Use another DNS lookup tool or install dig if needed
         try:
             self._ssh_client.run_command("dig -v")
         except CommandError as e:
             if "dig: command not found" in e.stderr:
                 distro = self._ssh_client.run_command("get_distro.py").rstrip().lower()
-                if distro.startswith("debian_10"):
-                    # Debian 10 hostname look up needs to be done with "host" instead of dig
+                if "debian" in distro:
+                    # Debian includes host command, so we use it to avoid installing dig from repositories
                     lookup_cmd = "host {0}".format(self._private_ip)
                     dns_regex = r".*pointer\s(?P<hostname>.*)\.internal\.(cloudapp\.net|chinacloudapp\.cn|usgovcloudapp\.net).*"
-                elif "debian" in distro:
-                    self._ssh_client.run_command("apt install -y dnsutils", use_sudo=True)
                 elif "alma" in distro or "rocky" in distro:
                     self._ssh_client.run_command("dnf install -y bind-utils", use_sudo=True)
                 else:


### PR DESCRIPTION
Avoid installing dnsutils when dig is unavailable on Debian images by using the existing host command for reverse DNS lookups.

<!-- DO NOT DELETE THIS TEMPLATE -->
<!--
Please add an informative description that covers that changes made by the pull request.
-->
## Description
Debian 11 is end of life which is causing issues during the dnsutils install. Using the 'host' command instead for dns lookup to avoid doing any package installs

Issue # <!-- if any -->
---
<!--
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->
### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).
---
<!--
This checklist is used to track contributions from distro maintainers.
-->
### Distro maintenance information, if applicable
- [ ] This is a contribution from a distro maintainer
- [ ] The changes in this PR have been taken as a downstream patch (Note: it is not recommended to patch the agent without upstream review and approval)
