### PR TITLE
Redact secret from certificate telemetry

### DIFF
--- a/azurelinuxagent/common/protocol/goal_state.py
+++ b/azurelinuxagent/common/protocol/goal_state.py
@@ -658,7 +658,7 @@ class Certificates(LogEvent):
                 self._crypt_util.convert_pfx_to_pem(pfx_file, nomacver, pem_file)
                 return pem_file
             except shellutil.CommandError as e:
-                self.warn(WALAEventOperation.GoalState, "Error converting PFX to PEM [-nomacver: {0}]: {1}", nomacver, ustr(e))
+                self.warn(WALAEventOperation.GoalState, "Error converting PFX to PEM [-nomacver: {0}]: {1}", nomacver, ustr(e).replace("-password pass:", "<redacted>"))
                 continue
 
         raise Exception("Cannot convert PFX to PEM")
@@ -805,5 +805,3 @@ class ExtensionManifest(object):
 
             pkg.isinternal = isinternal
             self.pkg_list.versions.append(pkg)
-
-


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->
<!--
Please add an informative description that covers that changes made by the pull request.
-->
## Description
When there is a command error while converting pfx to pem, the agent sends an event with the command and the stderr. Since the command contains a 'password' argument, the entire event is getting redacted:
<img width="1030" height="100" alt="image" src="https://github.com/user-attachments/assets/c1644d09-c266-4c77-9b9a-c2658abafe6b" />


Since the entire event is redacted, it is harder to debug issues. This PR redacts only the 'password' argument so that we can retain the rest of the event:
<img width="1324" height="103" alt="image" src="https://github.com/user-attachments/assets/fc11953a-58f8-4fae-85df-6cba8eca6410" />


Issue # <!-- if any -->
---
<!--
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->
### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).
---
<!--
This checklist is used to track contributions from distro maintainers.
-->
### Distro maintenance information, if applicable
- [ ] This is a contribution from a distro maintainer
- [ ] The changes in this PR have been taken as a downstream patch (Note: it is not recommended to patch the agent without upstream review and approval)
