### PR TITLE
Add debian 12/13 to the e2e test matrix

### DIFF
--- a/tests_e2e/test_suites/images.yml
+++ b/tests_e2e/test_suites/images.yml
@@ -4,11 +4,6 @@
 image-sets:
    # Endorsed distros that are tested on the daily runs
    endorsed:
-#
-# TODO: Add Debian 8
-#
-#      - "debian_8"
-#
       - "alma_8"
       - "alma_9"
       - "alma_10"
@@ -20,6 +15,8 @@ image-sets:
       - "centos_82"
       - "debian_10"
       - "debian_11"
+      - "debian_12"
+      - "debian_13"
       - "flatcar"
       - "oracle_810"
       - "oracle_95"
@@ -43,6 +40,8 @@ image-sets:
    # Endorsed distros (ARM64) that are tested on the daily runs
    endorsed-arm64:
       - "debian_11_arm64"
+      - "debian_12_arm64"
+      - "debian_13_arm64"
       - "flatcar_arm64"
       - "mariner_2_arm64"
       - "azure-linux_3_arm64"
@@ -212,11 +211,28 @@ images:
          - "Standard_B2s"
    databricks_ubuntu:
       urn: "AzureDatabricks:Databricks:DatabricksWorker:latest"
-   debian_8: "credativ:Debian:8:latest"
    debian_10: "Debian:debian-10:10:latest"
    debian_11: "Debian:debian-11:11:latest"
    debian_11_arm64:
       urn: "Debian:debian-11:11-backports-arm64-v2:latest"
+      vm_sizes:
+         # See comment above wrt VM sizes for ARM64 machines
+         - "Standard_B2pls_v2"
+      locations:
+         AzureUSGovernment: []
+         AzureChinaCloud: []
+   debian_12: "Debian:debian-12:12:latest"
+   debian_12_arm64:
+      urn: "Debian:debian-12:12-arm64:latest"
+      vm_sizes:
+         # See comment above wrt VM sizes for ARM64 machines
+         - "Standard_B2pls_v2"
+      locations:
+         AzureUSGovernment: []
+         AzureChinaCloud: []
+   debian_13: "Debian:debian-13:13:latest"
+   debian_13_arm64:
+      urn: "Debian:debian-13:13-arm64:latest"
       vm_sizes:
          # See comment above wrt VM sizes for ARM64 machines
          - "Standard_B2pls_v2"

--- a/tests_e2e/tests/publish_hostname/publish_hostname.py
+++ b/tests_e2e/tests/publish_hostname/publish_hostname.py
@@ -124,7 +124,7 @@ class PublishHostname(AgentVmTest):
 
     def run(self):
         # TODO: Investigate why hostname is not being published on these distros.
-        distros_with_known_publishing_issues = ["alma", "oracle_95", "oracle_810", "redhat_810", "rhel_95", "rocky", "ubuntu"]
+        distros_with_known_publishing_issues = ["alma", "oracle_95", "oracle_810", "redhat_810", "rhel_95", "rocky", "ubuntu", "debian_12", "debian_13"]
         distro = self._ssh_client.run_command("get_distro.py").rstrip().lower()
         if any(d in distro for d in distros_with_known_publishing_issues):
             raise TestSkipped("Known issue with hostname publishing on this distro. Will skip test until we continue "


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->
<!--
Please add an informative description that covers that changes made by the pull request.
-->
## Description
Debian 10/11 have reached EOL and are starting to be removed from marketplace. This PR adds debian 12/13 to the daily test matrix. 

Hostname publishing is failing on debian 12/13 due to the 'ifdown' command no longer being available, so it's added to the list of distros with known publishing issues. We have a backlog item to investigate the failures on those distros

Issue # <!-- if any -->
---
<!--
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->
### PR information
- [ ] Ensure development PR is based on the `develop` branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).
---
<!--
This checklist is used to track contributions from distro maintainers.
-->
### Distro maintenance information, if applicable
- [ ] This is a contribution from a distro maintainer
- [ ] The changes in this PR have been taken as a downstream patch (Note: it is not recommended to patch the agent without upstream review and approval)
